### PR TITLE
Trigger the docs `deploy` job only when `GH_PAGES_DEPLOY` secret is set.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: yarn build
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' && github.secrets.GH_PAGES_DEPLOY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,13 +56,13 @@ jobs:
           cache: yarn
       - uses: webfactory/ssh-agent@v0.5.0
         with:
-          ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
+          ssh-private-key: ${{ github.secrets.GH_PAGES_DEPLOY }}
       - name: Deploy to GitHub Pages
         env:
           USE_SSH: true
         run: |
-          export COCOINDEX_DOCS_POSTHOG_API_KEY=${{ secrets.COCOINDEX_DOCS_POSTHOG_API_KEY }}
-          export COCOINDEX_DOCS_MIXPANEL_API_KEY=${{ secrets.COCOINDEX_DOCS_MIXPANEL_API_KEY }}
+          export COCOINDEX_DOCS_POSTHOG_API_KEY=${{ github.secrets.COCOINDEX_DOCS_POSTHOG_API_KEY }}
+          export COCOINDEX_DOCS_MIXPANEL_API_KEY=${{ github.secrets.COCOINDEX_DOCS_MIXPANEL_API_KEY }}
           git config --global user.email "cocoindex.io@gmail.com"
           git config --global user.name "CocoIndex"
           yarn install --frozen-lockfile


### PR DESCRIPTION
This is to avoid a forked repo triggering this job which is deemed to fail.