### PR TITLE
Make the step of set extra environment variables work for both zsh and bash

### DIFF
--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -29,7 +29,7 @@ We love contributions from our community! This guide explains how to get involve
 
 -   (Optional) Before running a specific example, set extra environment variables, for exposing extra traces, allowing dev UI, etc.
     ```bash
-    . .env.lib_debug
+    . ./.env.lib_debug
     ```
 
 ## Submit Your Code


### PR DESCRIPTION
. .env.lib_debug don't work for my shell which is zsh. ptal

https://cocoindex.io/docs/about/contributing