### PR TITLE
For OpenAI, make all fields required in JSON schema.

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -5,6 +5,8 @@ use async_trait::async_trait;
 use schemars::schema::SchemaObject;
 use serde::{Deserialize, Serialize};
 
+use crate::base::json_schema::ToJsonSchemaOptions;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LlmApiType {
     Ollama,
@@ -44,6 +46,19 @@ pub trait LlmGenerationClient: Send + Sync {
         &self,
         request: LlmGenerateRequest<'req>,
     ) -> Result<LlmGenerateResponse>;
+
+    /// If true, the LLM only accepts a JSON schema with all fields required.
+    /// This is a limitation of LLM models such as OpenAI.
+    /// Otherwise, the LLM will accept a JSON schema with optional fields.
+    fn json_schema_fields_always_required(&self) -> bool {
+        false
+    }
+
+    fn to_json_schema_options(&self) -> ToJsonSchemaOptions {
+        ToJsonSchemaOptions {
+            fields_always_required: self.json_schema_fields_always_required(),
+        }
+    }
 }
 
 mod ollama;

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -97,4 +97,8 @@ impl LlmGenerationClient for Client {
 
         Ok(super::LlmGenerateResponse { text })
     }
+
+    fn json_schema_fields_always_required(&self) -> bool {
+        true
+    }
 }

--- a/src/ops/functions/extract_by_llm.rs
+++ b/src/ops/functions/extract_by_llm.rs
@@ -47,10 +47,14 @@ Output only the JSON without any additional messages or explanations."
 
 impl Executor {
     async fn new(spec: Spec, args: Args) -> Result<Self> {
+        let client = new_llm_generation_client(spec.llm_spec).await?;
+        let output_json_schema = spec
+            .output_type
+            .to_json_schema(&client.to_json_schema_options());
         Ok(Self {
             args,
-            client: new_llm_generation_client(spec.llm_spec).await?,
-            output_json_schema: spec.output_type.to_json_schema(),
+            client,
+            output_json_schema,
             output_type: spec.output_type,
             system_prompt: get_system_prompt(&spec.instruction),
         })


### PR DESCRIPTION
We use union type (with `null`) to mark fields optional.

Background:
https://platform.openai.com/docs/guides/structured-outputs/supported-schemas#all-fields-must-be-required