### PR TITLE
Make setup management more flexible and straightforward.

### DIFF
--- a/python/cocoindex/setup.py
+++ b/python/cocoindex/setup.py
@@ -1,15 +1,16 @@
-from dataclasses import dataclass
-
 from . import flow
 from . import _engine
 
-@dataclass
-class CheckSetupStatusOptions:
-    delete_legacy_flows: bool
-
-def check_setup_status(options: CheckSetupStatusOptions) -> _engine.SetupStatusCheck:
+def sync_setup() -> _engine.SetupStatusCheck:
     flow.ensure_all_flows_built()
-    return _engine.check_setup_status(vars(options))
+    return _engine.sync_setup()
+
+def drop_setup(flow_names: list[str]) -> _engine.SetupStatusCheck:
+    flow.ensure_all_flows_built()
+    return _engine.drop_setup(flow_names)
+
+def flow_names_with_setup() -> list[str]:
+    return _engine.flow_names_with_setup()
 
 def apply_setup_changes(status_check: _engine.SetupStatusCheck):
     _engine.apply_setup_changes(status_check)

--- a/src/builder/flow_builder.rs
+++ b/src/builder/flow_builder.rs
@@ -340,7 +340,7 @@ impl FlowBuilder {
     pub fn new(name: &str) -> PyResult<Self> {
         let lib_context = get_lib_context().into_py_result()?;
         let existing_flow_ss = lib_context
-            .combined_setup_states
+            .all_setup_states
             .read()
             .unwrap()
             .flows


### PR DESCRIPTION
- Explicit support for setup deletions, no matter if present in the current process.
- Clearly show persisted setup in `ls` even if not in the current process.