### PR TITLE
Refactor: migrate from Arc<[u8]> to bytes::Bytes

### DIFF
--- a/src/ops/storages/neo4j.rs
+++ b/src/ops/storages/neo4j.rs
@@ -281,9 +281,7 @@ fn mapped_field_values_to_bolt<'a>(
 
 fn basic_value_to_bolt(value: &BasicValue, schema: &BasicValueType) -> Result<BoltType> {
     let bolt_value = match value {
-        BasicValue::Bytes(v) => {
-            BoltType::Bytes(neo4rs::BoltBytes::new(bytes::Bytes::from_owner(v.clone())))
-        }
+        BasicValue::Bytes(v) => BoltType::Bytes(neo4rs::BoltBytes::new(v.clone())),
         BasicValue::Str(v) => BoltType::String(neo4rs::BoltString::new(v)),
         BasicValue::Bool(v) => BoltType::Boolean(neo4rs::BoltBoolean::new(*v)),
         BasicValue::Int64(v) => BoltType::Integer(neo4rs::BoltInteger::new(*v)),

--- a/src/ops/storages/postgres.rs
+++ b/src/ops/storages/postgres.rs
@@ -17,6 +17,7 @@ use sqlx::postgres::PgRow;
 use sqlx::{PgPool, Row};
 use std::ops::Bound;
 use uuid::Uuid;
+use bytes::Bytes;
 
 #[derive(Debug, Deserialize)]
 pub struct Spec {
@@ -175,7 +176,7 @@ fn from_pg_value(row: &PgRow, field_idx: usize, typ: &ValueType) -> Result<Value
             let basic_value = match basic_type {
                 BasicValueType::Bytes => row
                     .try_get::<Option<Vec<u8>>, _>(field_idx)?
-                    .map(|v| BasicValue::Bytes(Arc::from(v))),
+                    .map(|v| BasicValue::Bytes(Bytes::from(v))),
                 BasicValueType::Str => row
                     .try_get::<Option<String>, _>(field_idx)?
                     .map(|v| BasicValue::Str(Arc::from(v))),
@@ -855,7 +856,8 @@ impl setup::ResourceSetupStatusCheck for SetupStatusCheck {
                 TableUpsertionAction::Create { keys, values } => {
                     let mut fields = (keys
                         .iter()
-                        .map(|(k, v)| format!("{} {} NOT NULL", k, to_column_type_sql(v))))
+                        .map(|(k, v)| format!("{} {} NOT NULL", k, to_column_type_sql(v)))
+                    )
                     .chain(
                         values
                             .iter()

--- a/src/py/convert.rs
+++ b/src/py/convert.rs
@@ -6,7 +6,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::ops::Deref;
-use std::sync::Arc;
+use std::sync::Arc; // Added missing Arc import
+use bytes::Bytes;
 
 use super::IntoPyResult;
 use crate::base::{schema, value};
@@ -123,7 +124,7 @@ fn basic_value_from_py_object<'py>(
 ) -> PyResult<value::BasicValue> {
     let result = match typ {
         schema::BasicValueType::Bytes => {
-            value::BasicValue::Bytes(Arc::from(v.extract::<Vec<u8>>()?))
+            value::BasicValue::Bytes(Bytes::from(v.extract::<Vec<u8>>()?))
         }
         schema::BasicValueType::Str => value::BasicValue::Str(Arc::from(v.extract::<String>()?)),
         schema::BasicValueType::Bool => value::BasicValue::Bool(v.extract::<bool>()?),

--- a/src/py/convert.rs
+++ b/src/py/convert.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::ops::Deref;
-use std::sync::Arc; // Added missing Arc import
+use std::sync::Arc; 
 use bytes::Bytes;
 
 use super::IntoPyResult;


### PR DESCRIPTION
Implements https://github.com/cocoindex-io/cocoindex/issues/317
This PR migrates all usages of `Arc<[u8]>` to `bytes::Bytes` for bytes representation.

