### PR TITLE
Added Gemini API support to CocoIndex

### DIFF
--- a/examples/manuals_llm_extraction/main.py
+++ b/examples/manuals_llm_extraction/main.py
@@ -85,14 +85,17 @@ def manual_extraction_flow(flow_builder: cocoindex.FlowBuilder, data_scope: coco
         doc["markdown"] = doc["content"].transform(PdfToMarkdown())
         doc["module_info"] = doc["markdown"].transform(
             cocoindex.functions.ExtractByLlm(
-                llm_spec=cocoindex.LlmSpec(
-                     api_type=cocoindex.LlmApiType.OLLAMA,
-                     # See the full list of models: https://ollama.com/library
-                     model="llama3.2"
-                ),
+                # llm_spec=cocoindex.LlmSpec(
+                #      api_type=cocoindex.LlmApiType.OLLAMA,
+                #      # See the full list of models: https://ollama.com/library
+                #      model="llama3.2"
+                # ),
                 # Replace by this spec below, to use OpenAI API model instead of ollama
                 #   llm_spec=cocoindex.LlmSpec(
                 #       api_type=cocoindex.LlmApiType.OPENAI, model="gpt-4o"),
+                # Replace by this spec below, to use Gemini API model instead of ollama
+                  llm_spec=cocoindex.LlmSpec(
+                      api_type=cocoindex.LlmApiType.GEMINI, model="gemini-1.5-flash"),
                 output_type=ModuleInfo,
                 instruction="Please extract Python module information from the manual."))
         doc["module_summary"] = doc["module_info"].transform(summarize_module)

--- a/src/llm/gemini.rs
+++ b/src/llm/gemini.rs
@@ -1,0 +1,138 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+use super::{LlmGenerateRequest, LlmGenerateResponse, LlmGenerationClient, ToJsonSchemaOptions};
+
+#[derive(Debug)]
+pub struct Client {
+    client: reqwest::Client,
+    model: String,
+    api_key: String,
+}
+
+// Request/Response Structs based on Gemini API documentation
+#[derive(Serialize)]
+struct GeminiRequest<'a> {
+    contents: Vec<Content<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<Content<'a>>,
+    // TODO: Add generationConfig, safetySettings if needed
+}
+
+#[derive(Serialize)]
+struct Content<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role: Option<&'a str>, // "user" or "model"
+    parts: Vec<Part<'a>>,
+}
+
+#[derive(Serialize)]
+struct Part<'a> {
+    text: Cow<'a, str>,
+    // TODO: Add support for other part types if needed (e.g., inline_data for images)
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<Candidate>,
+    // TODO: Add promptFeedback if needed
+}
+
+#[derive(Deserialize)]
+struct Candidate {
+    content: ResponseContent,
+    // TODO: Add finishReason, safetyRatings if needed
+}
+
+#[derive(Deserialize)]
+struct ResponseContent {
+    parts: Vec<ResponsePart>,
+    // role is usually "model"
+}
+
+#[derive(Deserialize)]
+struct ResponsePart {
+    text: String,
+}
+
+impl Client {
+    pub async fn new(spec: super::LlmSpec) -> Result<Self> {
+        // Gemini doesn't have a specific address parameter like Ollama
+        // API Key is expected via env var
+        let api_key = std::env::var("GEMINI_API_KEY")
+            .map_err(|_| anyhow::anyhow!("GEMINI_API_KEY environment variable must be set"))?;
+
+        Ok(Self {
+            client: reqwest::Client::new(),
+            model: spec.model,
+            api_key,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmGenerationClient for Client {
+    async fn generate<'req>(
+        &self,
+        request: LlmGenerateRequest<'req>,
+    ) -> Result<LlmGenerateResponse> {
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+            self.model,
+            self.api_key
+        );
+
+        let mut contents = Vec::new();
+
+        // Currently, CocoIndex LlmGenerateRequest doesn't explicitly support chat history.
+        // We'll map system prompt and user prompt accordingly.
+        // If chat history is needed later, LlmGenerateRequest needs modification.
+
+        // Add user message
+        contents.push(Content {
+            role: Some("user"), // Explicitly set role
+            parts: vec![Part { text: request.user_prompt }],
+        });
+
+        let gemini_request = GeminiRequest {
+            contents,
+            system_instruction: request.system_prompt.map(|sp| Content {
+                role: None, // System instruction doesn't have a role in the Gemini API struct
+                parts: vec![Part { text: sp }],
+            }),
+        };
+
+        let response = self.client.post(&url)
+            .json(&gemini_request)
+            .send()
+            .await?
+            .error_for_status()? // Ensure we handle HTTP errors
+            .json::<GeminiResponse>()
+            .await?;
+
+        // Extract the response text
+        let text = response
+            .candidates
+            .into_iter()
+            .next()
+            .and_then(|c| c.content.parts.into_iter().next())
+            .map(|p| p.text)
+            .ok_or_else(|| anyhow::anyhow!("No response text found in Gemini response"))?;
+
+        Ok(LlmGenerateResponse { text })
+    }
+
+    // Define how Gemini handles JSON schema constraints.
+    // This might need refinement based on actual Gemini capabilities for JSON mode.
+    // For now, using defaults similar to OpenAI but noting differences.
+    fn json_schema_options(&self) -> ToJsonSchemaOptions {
+        ToJsonSchemaOptions {
+            fields_always_required: true, // Assuming similar behavior to OpenAI's strict mode
+            supports_format: false,      // Unsure if Gemini supports 'format' keyword well
+            extract_descriptions: false, // Unsure if Gemini uses descriptions
+            top_level_must_be_object: true, // Assuming similar JSON mode constraints
+        }
+    }
+} 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use schemars::schema::SchemaObject;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::base::json_schema::ToJsonSchemaOptions;
 
@@ -11,6 +12,7 @@ use crate::base::json_schema::ToJsonSchemaOptions;
 pub enum LlmApiType {
     Ollama,
     OpenAi,
+    Gemini,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,6 +54,7 @@ pub trait LlmGenerationClient: Send + Sync {
 
 mod ollama;
 mod openai;
+mod gemini;
 
 pub async fn new_llm_generation_client(spec: LlmSpec) -> Result<Box<dyn LlmGenerationClient>> {
     let client = match spec.api_type {
@@ -60,6 +63,9 @@ pub async fn new_llm_generation_client(spec: LlmSpec) -> Result<Box<dyn LlmGener
         }
         LlmApiType::OpenAi => {
             Box::new(openai::Client::new(spec).await?) as Box<dyn LlmGenerationClient>
+        }
+        LlmApiType::Gemini => {
+            Box::new(gemini::Client::new(spec).await?) as Box<dyn LlmGenerationClient>
         }
     };
     Ok(client)


### PR DESCRIPTION
📌 Summary
This PR adds support for the Gemini API to the CocoIndex project, extending the existing LLM integration that currently supports OpenAI and Ollama. The implementation follows the structure and conventions used by the OpenAI client to ensure consistency and maintainability.

✅ Changes Made
Rust Codebase:
--> Added Gemini variant to the LlmApiType enum.
-->Created src/llm/gemini.rs:
      Handles request/response data structures for Gemini.
      Implements proper API key-based authentication.
      Adds robust error handling and JSON parsing.
-->Updated new_llm_generation_client router in mod.rs to support Gemini.
-->Updated examples/manuals_llm_extraction/main.py with a Gemini usage example.
-->Added new LlmSpec config using LlmApiType.GEMINI.

 Documentation:
Updated relevant docs: https://cocoindex.io/docs/ai/llm
Issue #350 