### PR TITLE
fix:Add support for TimeDelta type in Python and Rust

### DIFF
--- a/docs/docs/core/data_types.mdx
+++ b/docs/docs/core/data_types.mdx
@@ -29,6 +29,7 @@ This is the list of all basic types supported by CocoIndex:
 | Time | | `datetime.time` | `datetime.time` |
 | LocalDatetime | Date and time without timezone | `cocoindex.typing.LocalDateTime` | `datetime.datetime` |
 | OffsetDatetime | Date and time with a timezone offset | `cocoindex.typing.OffsetDateTime` | `datetime.datetime` |
+| TimeDelta | A duration of time | `cocoindex.typing.TimeDelta` | `datetime.timedelta` |
 | Vector[*type*, *N*?] | |`Annotated[list[type], cocoindex.typing.Vector(dim=N)]` | `list[type]` | 
 | Json | | `cocoindex.typing.Json` | Any type convertible to JSON by `json` package | 
 

--- a/python/cocoindex/typing.py
+++ b/python/cocoindex/typing.py
@@ -29,6 +29,7 @@ Range = Annotated[tuple[int, int], TypeKind('Range')]
 Json = Annotated[Any, TypeKind('Json')]
 LocalDateTime = Annotated[datetime.datetime, TypeKind('LocalDateTime')]
 OffsetDateTime = Annotated[datetime.datetime, TypeKind('OffsetDateTime')]
+TimeDelta = Annotated[datetime.timedelta, TypeKind('TimeDelta')]
 
 COLLECTION_TYPES = ('Table', 'List')
 
@@ -142,6 +143,8 @@ def analyze_type_info(t) -> AnalyzedTypeInfo:
             kind = 'Time'
         elif t is datetime.datetime:
             kind = 'OffsetDateTime'
+        elif t is datetime.timedelta:
+            kind = 'TimeDelta'
         else:
             raise ValueError(f"type unsupported yet: {t}")
 

--- a/src/base/schema.rs
+++ b/src/base/schema.rs
@@ -50,6 +50,9 @@ pub enum BasicValueType {
     /// Date and time with timezone.
     OffsetDateTime,
 
+    /// A time duration.
+    TimeDelta,
+
     /// A JSON value.
     Json,
 
@@ -72,6 +75,7 @@ impl std::fmt::Display for BasicValueType {
             BasicValueType::Time => write!(f, "time"),
             BasicValueType::LocalDateTime => write!(f, "local_datetime"),
             BasicValueType::OffsetDateTime => write!(f, "offset_datetime"),
+            BasicValueType::TimeDelta => write!(f, "timedelta"),
             BasicValueType::Json => write!(f, "json"),
             BasicValueType::Vector(s) => write!(
                 f,

--- a/src/ops/storages/postgres.rs
+++ b/src/ops/storages/postgres.rs
@@ -134,6 +134,9 @@ fn bind_value_field<'arg>(
             BasicValue::OffsetDateTime(v) => {
                 builder.push_bind(v);
             }
+            BasicValue::TimeDelta(v) => {
+                builder.push_bind(v);
+            }
             BasicValue::Json(v) => {
                 builder.push_bind(sqlx::types::Json(&**v));
             }
@@ -219,6 +222,9 @@ fn from_pg_value(row: &PgRow, field_idx: usize, typ: &ValueType) -> Result<Value
                 BasicValueType::OffsetDateTime => row
                     .try_get::<Option<chrono::DateTime<chrono::FixedOffset>>, _>(field_idx)?
                     .map(BasicValue::OffsetDateTime),
+                BasicValueType::TimeDelta => row
+                    .try_get::<Option<chrono::Duration>, _>(field_idx)?
+                    .map(BasicValue::TimeDelta),
                 BasicValueType::Json => row
                     .try_get::<Option<serde_json::Value>, _>(field_idx)?
                     .map(|v| BasicValue::Json(Arc::from(v))),
@@ -701,6 +707,7 @@ fn to_column_type_sql(column_type: &ValueType) -> Cow<'static, str> {
             BasicValueType::Time => "time".into(),
             BasicValueType::LocalDateTime => "timestamp".into(),
             BasicValueType::OffsetDateTime => "timestamp with time zone".into(),
+            BasicValueType::TimeDelta => "interval".into(),
             BasicValueType::Json => "jsonb".into(),
             BasicValueType::Vector(vec_schema) => {
                 if convertible_to_pgvector(vec_schema) {


### PR DESCRIPTION
PR Description:
Issue #344 
This PR implements support for the TimeDelta type in CocoIndex as requested in issue #344.

Changes:
-->Added TimeDelta = Annotated[datetime.timedelta, TypeKind('TimeDelta')] in Python typing module
-->Added TimeDelta variant to Rust's type system
-->Implemented conversion between Python's datetime.timedelta and Rust's chrono::Duration
-->Added PostgreSQL storage support using the native interval type

Testing:
-->Tests should be added to verify:
-->Python type analysis correctly identifies datetime.timedelta objects
-->Conversion between Python and Rust time delta representations works correctly
-->PostgreSQL storage and retrieval works as expected
This addresses #344.
