### PR TITLE
Update Colab Link to Match Github

### DIFF
--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -1,6 +1,6 @@
 Simple example for cocoindex: build embedding index based on local files.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1e2KgjVUQp8u-0Va28C3WjfVnSjrjobQA?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cocoindex-io/cocoindex/blob/main/examples/text_embedding/Text_Embedding.ipynb)
 
 ## Prerequisite
 


### PR DESCRIPTION
README of text embedding example now points to https://colab.research.google.com/github/cocoindex-io/cocoindex/blob/main/examples/text_embedding/Text_Embedding.ipynb