### PR TITLE
feat: beautify show cli command with colorful structured output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "With CocoIndex, users declare the transformation, CocoIndex creat
 authors = [{ name = "CocoIndex", email = "cocoindex.io@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["sentence-transformers>=3.3.1", "click>=8.1.8"]
+dependencies = ["sentence-transformers>=3.3.1", "click>=8.1.8", "rich>=14.0.0"]
 license = "Apache-2.0"
 urls = { Homepage = "https://cocoindex.io/" }
 

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -52,11 +52,31 @@ def ls(show_all: bool):
 
 @cli.command()
 @click.argument("flow_name", type=str, required=False)
-def show(flow_name: str | None):
+@click.option("--no-color", is_flag=True, help="Disable colored output.")
+def show(flow_name: str | None, no_color: bool):
     """
-    Show the flow spec.
+    Show the flow spec in a readable format with colored output.
     """
-    click.echo(str(_flow_by_name(flow_name)))
+    flow = _flow_by_name(flow_name)
+    flow_str = str(flow)
+
+    for line in flow_str.splitlines():
+        line = line.rstrip()
+        if not line:
+            click.echo(line, color=not no_color)
+            continue
+
+        if line.startswith("Flow:") or line in ("Sources:", "Processing:", "Targets:"):
+            click.secho(line, fg="cyan", bold=True, color=not no_color)
+            continue
+
+        if ":" in line:
+            key, value = line.split(":", 1)
+            click.secho(f"{key}:", fg="green", nl=False, color=not no_color)
+            click.secho(value, fg="yellow", color=not no_color)
+            continue
+
+        click.secho(line, fg="yellow", color=not no_color)
 
 @cli.command()
 def setup():

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import click
 import datetime
+from rich.console import Console
 
 from . import flow, lib
 from .setup import sync_setup, drop_setup, flow_names_with_setup, apply_setup_changes
@@ -52,31 +53,14 @@ def ls(show_all: bool):
 
 @cli.command()
 @click.argument("flow_name", type=str, required=False)
-@click.option("--no-color", is_flag=True, help="Disable colored output.")
-def show(flow_name: str | None, no_color: bool):
+@click.option("--color/--no-color", default=True)
+def show(flow_name: str | None, color: bool):
     """
     Show the flow spec in a readable format with colored output.
     """
     flow = _flow_by_name(flow_name)
-    flow_str = str(flow)
-
-    for line in flow_str.splitlines():
-        line = line.rstrip()
-        if not line:
-            click.echo(line, color=not no_color)
-            continue
-
-        if line.startswith("Flow:") or line in ("Sources:", "Processing:", "Targets:"):
-            click.secho(line, fg="cyan", bold=True, color=not no_color)
-            continue
-
-        if ":" in line:
-            key, value = line.split(":", 1)
-            click.secho(f"{key}:", fg="green", nl=False, color=not no_color)
-            click.secho(value, fg="yellow", color=not no_color)
-            continue
-
-        click.secho(line, fg="yellow", color=not no_color)
+    console = Console(no_color=not color)
+    console.print(flow._render_text())
 
 @cli.command()
 def setup():

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -453,12 +453,12 @@ class Flow:
         self._lazy_engine_flow = _lazy_engine_flow
 
     def __str__(self):
+        flow_spec_str = str(self._lazy_engine_flow())
         try:
-            flow_spec_str = str(self._lazy_engine_flow())
             flow_spec = json.loads(flow_spec_str)
             return self._format_flow(flow_spec)
         except json.JSONDecodeError:
-            return f"Flow (spec not parseable): {flow_spec_str}"
+            return flow_spec_str
 
     def _format_flow(self, flow_dict: dict) -> str:
         lines = [f"Flow: {flow_dict.get('name', 'Unnamed')}"]

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -462,29 +462,27 @@ class Flow:
             output.append(content, style=style)
             output.append(end)
 
-        # Header
-        flow_name = flow_dict.get("name", "Unnamed")
-        add_line(f"Flow: {flow_name}", style="bold cyan")
+        def format_key_value(key, value, indent):
+            if isinstance(value, (dict, list)):
+                add_line(f"- {key}:", indent, style="green")
+                format_data(value, indent + 2)
+            else:
+                add_line(f"- {key}:", indent, style="green", end="")
+                add_line(f" {value}", style="yellow")
 
         def format_data(data, indent=0):
             if isinstance(data, dict):
                 for key, value in data.items():
-                    if isinstance(value, (dict, list)):
-                        add_line(f"- {key}:", indent, style="green")
-                        format_data(value, indent + 2)
-                    else:
-                        add_line(f"- {key}:", indent, style="green", end="")
-                        add_line(f" {value}", style="yellow")
+                    format_key_value(key, value, indent)
             elif isinstance(data, list):
                 for i, item in enumerate(data):
-                    if isinstance(item, (dict, list)):
-                        add_line(f"- [{i}]:", indent, style="green")
-                        format_data(item, indent + 2)
-                    else:
-                        add_line(f"- [{i}]:", indent, style="green", end="")
-                        add_line(f" {item}", style="yellow")
+                    format_key_value(f"[{i}]", item, indent)
             else:
                 add_line(str(data), indent, style="yellow")
+
+        # Header
+        flow_name = flow_dict.get("name", "Unnamed")
+        add_line(f"Flow: {flow_name}", style="bold cyan")
 
         # Section
         for section_title, section_key in [


### PR DESCRIPTION
As the title states, this PR creates a helper method to make the output spec info more structured in a way that users can appreciate, and also modifies the show command to use colorful output mode by default.

Resolves #324

before:
```
{
  "name": "TextEmbedding",
  "import_ops": [
    {...}
  ],
  "reactive_ops": [
    {...}
  ],
  "export_ops": [
    {...}
  ]
}
```

after:
\
<img width='240' alt='show-cli' src='https://github.com/user-attachments/assets/4191d3fc-c983-46b7-aeb7-b81233fbead4'>
