### PR TITLE
fix: make flow name retrieval efficient

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -4,6 +4,7 @@ import datetime
 from rich.console import Console
 
 from . import flow, lib
+from .flow import flow_names
 from .setup import sync_setup, drop_setup, flow_names_with_setup, apply_setup_changes
 from .runtime import execution_context
 
@@ -21,7 +22,7 @@ def ls(show_all: bool):
     """
     List all flows.
     """
-    current_flow_names = [fl.name for fl in flow.flows()]
+    current_flow_names = flow_names()
     persisted_flow_names = flow_names_with_setup()
     remaining_persisted_flow_names = set(persisted_flow_names)
 


### PR DESCRIPTION
This PR will make `cocoindex ls` command way more efficient than before, and fix #412.

### Context

In the previous versions, we tried to access each Flow’s name property in the list comprehension:
```py
current_flow_names = [fl.name for fl in flow.flows()]
```

The name property of a Flow is defined as:
```py
@property
def name(self) -> str:
    return self._lazy_engine_flow().name()
```
Each call to `self._lazy_engine_flow()` triggers the creation of the underlying `_engine.Flow` if it hasn’t been built yet. Till now, you can see we have done a lot of unnecessary jobs here, since only we need here is to retrieve flow names.

### Solution

We use the helper now to quickly get flow names as a list.
```py
def flow_names() -> list[str]:
    """
    Get the names of all flows.
    """
    with _flows_lock:
        return list(_flows.keys())
```

### Result

Compared to the result in #412, now we've made it 10 times faster.
```sh
 cocoindex  time uv run main.py cocoindex ls
CodeEmbedding [+]
DocsToKG [+]
TextEmbedding [+]
GoogleDriveTextEmbedding [+]

Notes:
  [+]: Flows present in the current process, but missing setup.
uv run main.py cocoindex ls  2.01s user 0.47s system 68% cpu 3.647 total
```