### PR TITLE
feat(cli): enhance flow display with schema rendering support

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -65,16 +65,19 @@ def show(flow_name: str | None, color: bool):
     console = Console(no_color=not color)
     console.print(flow._render_text())
 
-    async def render_schema_and_print():
-        table = Table(title=f"Schema for Flow: {flow.name}", show_header=True, header_style="bold magenta")
-        table.add_column("Field", style="cyan")
-        table.add_column("Type", style="green")
-        table.add_column("Attributes", style="yellow")
-        for field_name, field_type, attr_str in await flow._render_schema():
-            table.add_row(field_name, field_type, attr_str)
-        console.print(table)
+    table = Table(
+        title=f"Schema for Flow: {flow.name}",
+        show_header=True,
+        header_style="bold magenta"
+    )
+    table.add_column("Field", style="cyan")
+    table.add_column("Type", style="green")
+    table.add_column("Attributes", style="yellow")
 
-    asyncio.run(render_schema_and_print())
+    for field_name, field_type, attr_str in flow._render_schema():
+        table.add_row(field_name, field_type, attr_str)
+
+    console.print(table)
 
 @cli.command()
 def setup():

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -54,13 +54,26 @@ def ls(show_all: bool):
 @cli.command()
 @click.argument("flow_name", type=str, required=False)
 @click.option("--color/--no-color", default=True)
-def show(flow_name: str | None, color: bool):
+@click.option(
+    "--schema", is_flag=True, show_default=True, default=False,
+    help="Also show the schema of the flow.")
+def show(flow_name: str | None, color: bool, schema: bool):
     """
     Show the flow spec in a readable format with colored output.
+    Optionally display the schema if --schema is provided.
     """
-    fl = _flow_by_name(flow_name)
+    from rich.table import Table
+    flow = _flow_by_name(flow_name)
     console = Console(no_color=not color)
-    console.print(fl._render_text())
+    console.print(flow._render_text())
+    if schema:
+        table = Table(title=f"Schema for Flow: {flow.name}", show_header=True, header_style="bold magenta")
+        table.add_column("Field", style="cyan")
+        table.add_column("Type", style="green")
+        table.add_column("Attributes", style="yellow")
+        for field_name, field_type, attr_str in flow._render_schema():
+            table.add_row(field_name, field_type, attr_str)
+        console.print(table)
 
 @cli.command()
 def setup():

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -504,11 +504,8 @@ class Flow:
         except json.JSONDecodeError:
             return Text(flow_spec_str)
     
-    async def _render_schema(self) -> list[tuple[str, str, str]]:
-        """
-        Render the schema as a list of (field_name, field_type, attributes) tuples.
-        """
-        return await _engine.format_flow_schema(self.name)
+    def _render_schema(self) -> list[tuple[str, str, str]]:
+        return self._lazy_engine_flow().get_schema()
 
     def __str__(self):
         return str(self._render_text())

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -504,11 +504,11 @@ class Flow:
         except json.JSONDecodeError:
             return Text(flow_spec_str)
     
-    def _render_schema(self) -> list[tuple[str, str, str]]:
+    async def _render_schema(self) -> list[tuple[str, str, str]]:
         """
         Render the schema as a list of (field_name, field_type, attributes) tuples.
         """
-        return _engine.get_flow_schema(self.name)
+        return await _engine.format_flow_schema(self.name)
 
     def __str__(self):
         return str(self._render_text())

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -503,6 +503,12 @@ class Flow:
             return self._format_flow(flow_dict)
         except json.JSONDecodeError:
             return Text(flow_spec_str)
+    
+    def _render_schema(self) -> list[tuple[str, str, str]]:
+        """
+        Render the schema as a list of (field_name, field_type, attributes) tuples.
+        """
+        return _engine.get_flow_schema(self.name)
 
     def __str__(self):
         return str(self._render_text())

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use crate::base::schema::{BasicValueType, FieldSchema, ValueType};
+use crate::base::schema::{FieldSchema, ValueType};
 use crate::base::spec::VectorSimilarityMetric;
 use crate::execution::query;
 use crate::lib_context::{clear_lib_context, get_auth_registry, init_lib_context};
@@ -209,19 +209,8 @@ impl Flow {
                 let field_name = format!("{}{}", prefix, field.name);
 
                 let mut field_type = match &field.value_type.typ {
-                    ValueType::Basic(basic) => match basic {
-                        BasicValueType::Vector(v) => {
-                            let dim = v.dimension.map_or("*".to_string(), |d| d.to_string());
-                            let elem = match *v.element_type {
-                                BasicValueType::Float32 => "Float32",
-                                BasicValueType::Float64 => "Float64",
-                                _ => "Unknown",
-                            };
-                            format!("Vector[{}, {}]", dim, elem)
-                        }
-                        other => format!("{:?}", other),
-                    },
-                    ValueType::Table(t) => format!("{:?}", t.kind),
+                    ValueType::Basic(basic) => format!("{}", basic),
+                    ValueType::Table(t) => format!("{}", t.kind),
                     ValueType::Struct(_) => "Struct".to_string(),
                 };
 
@@ -248,7 +237,7 @@ impl Flow {
                         process_fields(&s.fields, &format!("{}.", field_name), result);
                     }
                     ValueType::Table(t) => {
-                        process_fields(&t.row.fields, &format!("{}.", field_name), result);
+                        process_fields(&t.row.fields, &format!("{}[].", field_name), result);
                     }
                     ValueType::Basic(_) => {}
                 }


### PR DESCRIPTION
This PR tries to resolve #411.

We implement a flow schema function on Rust side, and expose it to Python, so the `show` command can directly use. Aside, we use `rich.Table` to beautify the schema information of each flow.

Now, when using `cocoindex show`, aside from spec info, schema info will also print out at last as follows:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/49577402-9858-441f-ad18-377467d7b2bb" />
