### PR TITLE
feat(pyo3): implement flow spec pretty print and add verbose mode

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -55,16 +55,17 @@ def ls(show_all: bool):
 
 @cli.command()
 @click.argument("flow_name", type=str, required=False)
-@click.option("--color/--no-color", default=True)
-def show(flow_name: str | None, color: bool):
+@click.option("--color/--no-color", default=True, help="Enable or disable colored output.")
+@click.option("--verbose", is_flag=True, help="Show verbose output with full details.")
+def show(flow_name: str | None, color: bool, verbose: bool):
     """
-    Show the flow spec in a readable format with colored output,
-    including the schema.
+    Show the flow spec and schema in a readable format with colored output.
     """
     flow = _flow_by_name(flow_name)
     console = Console(no_color=not color)
-    console.print(flow._render_text())
+    console.print(flow._render_spec(verbose=verbose))
 
+    console.print()
     table = Table(
         title=f"Schema for Flow: {flow.name}",
         show_header=True,
@@ -74,7 +75,7 @@ def show(flow_name: str | None, color: bool):
     table.add_column("Type", style="green")
     table.add_column("Attributes", style="yellow")
 
-    for field_name, field_type, attr_str in flow._render_schema():
+    for field_name, field_type, attr_str in flow._get_schema():
         table.add_row(field_name, field_type, attr_str)
 
     console.print(table)

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -493,7 +493,7 @@ class Flow:
         return tree
 
     def _get_spec(self, verbose: bool = False) -> list[tuple[str, str, int]]:
-        return self._lazy_engine_flow().get_spec(format_mode="verbose" if verbose else "concise")
+        return self._lazy_engine_flow().get_spec(output_mode="verbose" if verbose else "concise")
     
     def _get_schema(self) -> list[tuple[str, str, str]]:
         return self._lazy_engine_flow().get_schema()

--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -493,7 +493,7 @@ class Flow:
         return tree
 
     def _get_spec(self, verbose: bool = False) -> list[tuple[str, str, int]]:
-        return self._lazy_engine_flow().get_spec(verbose=verbose)
+        return self._lazy_engine_flow().get_spec(format_mode="verbose" if verbose else "concise")
     
     def _get_schema(self) -> list[tuple[str, str, str]]:
         return self._lazy_engine_flow().get_schema()

--- a/src/base/spec.rs
+++ b/src/base/spec.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 
 use super::schema::{EnrichedValueType, FieldSchema};
-use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
@@ -17,27 +16,6 @@ pub enum OutputMode {
 /// Formatting spec per output mode
 pub trait SpecFormatter {
     fn format(&self, mode: OutputMode) -> String;
-}
-
-/// A single line in the rendered spec, with optional scope and children
-#[pyclass(get_all, set_all)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RenderedSpecLine {
-    /// The formatted content of the line (e.g., "Import: name=documents, source=LocalFile")
-    pub content: String,
-    /// The scope name, if applicable (e.g., "documents_1" for ForEach scopes)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scope: Option<String>,
-    /// Child lines in the hierarchy
-    pub children: Vec<RenderedSpecLine>,
-}
-
-/// A rendered specification, grouped by sections
-#[pyclass(get_all, set_all)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RenderedSpec {
-    /// List of (section_name, lines) pairs
-    pub sections: Vec<(String, Vec<RenderedSpecLine>)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -1,9 +1,9 @@
 use crate::prelude::*;
 
 use crate::base::schema::{FieldSchema, ValueType};
-use crate::base::spec::SpecFormatMode;
 use crate::base::spec::VectorSimilarityMetric;
 use crate::base::spec::{NamedSpec, ReactiveOpSpec};
+use crate::base::spec::{OutputMode, SpecFormatter};
 use crate::execution::query;
 use crate::lib_context::{clear_lib_context, get_auth_registry, init_lib_context};
 use crate::ops::interface::{QueryResult, QueryResults};
@@ -198,10 +198,9 @@ impl Flow {
         })
     }
 
-    #[pyo3(signature = (format_mode="concise"))]
-    pub fn get_spec(&self, format_mode: &str) -> PyResult<Vec<(String, String, u32)>> {
-        let mode = SpecFormatMode::from_str(format_mode)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e))?;
+    #[pyo3(signature = (output_mode="concise"))]
+    pub fn get_spec(&self, output_mode: &str) -> PyResult<Vec<(String, String, u32)>> {
+        let mode = OutputMode::from_str(output_mode);
         let spec = &self.0.flow.flow_instance;
         let mut result = Vec::with_capacity(
             1 + spec.import_ops.len()
@@ -234,7 +233,7 @@ impl Flow {
         fn walk(
             op: &NamedSpec<ReactiveOpSpec>,
             indent: u32,
-            mode: SpecFormatMode,
+            mode: OutputMode,
             out: &mut Vec<(String, String, u32)>,
         ) {
             out.push((


### PR DESCRIPTION
Following #427 and #404, this PR implements the flow spec pretty print in Rust and adds `--verbose` mode to enable more detailed output.

#### Changes on Rust side
1. We first port the code from #404, using Rust, and then rewrite it using idiomatic Rust style, largely via `Display` trait.
2. We add verbose mode to the spec getter method.

#### Changes on Python side
1. We change it to use `get_spec` from Rust side.
2. We use `rich.Tree` instead of `rich.Console` for clearer readability.

#### Preview
`python main.py cocoindex show DocsToKG`

<img width="725" alt="image" src="https://github.com/user-attachments/assets/55894d76-9e93-475f-a294-055c2b2a75ac" />

After adding `--verbose` flag, it will then produce a more detailed output with full operation specs, including all fields and JSON-like formatting, similar to preview in #404.

Resolves #410.