### PR TITLE
fix(examples): fastapi_docker_example requirements not including pg17 binaries for local running

### DIFF
--- a/examples/fastapi_server_docker/requirements.txt
+++ b/examples/fastapi_server_docker/requirements.txt
@@ -3,5 +3,5 @@ python-dotenv>=1.0.1
 fastapi==0.115.12
 fastapi-cli==0.0.7
 uvicorn==0.34.2
-psycopg==3.2.6
+psycopg[binary]==3.2.6
 psycopg_pool==3.2.6


### PR DESCRIPTION
This fixes issue number #556