### PR TITLE
chore: use theme aligning with user system preferences

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -86,6 +86,11 @@ const config: Config = {
     // Replace with your project's social card
     image: 'img/social-card.jpg',
     metadata: [{ name: 'description', content: 'Official documentation for CocoIndex - Learn how to use CocoIndex to build robust data indexing pipelines for AI applications. Comprehensive guides, API references, and best practices for implementing efficient data processing workflows.' }],
+    colorMode: {
+      defaultMode: 'light',
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'CocoIndex',
       logo: {


### PR DESCRIPTION
A small change on top of our existing docs site.

According to https://docusaurus.io/docs/api/themes/configuration, the current behavior defaults it to "light" color mode and allows users to toggle theme mode as needed. This PR changes it to check user's system preference first.
