### PR TITLE
feat: add NumPy array support for vector representations

### DIFF
--- a/docs/docs/core/data_types.mdx
+++ b/docs/docs/core/data_types.mdx
@@ -36,8 +36,8 @@ This is the list of all basic types supported by CocoIndex:
 | LocalDatetime | Date and time without timezone | `cocoindex.LocalDateTime` | `datetime.datetime` |
 | OffsetDatetime | Date and time with a timezone offset | `cocoindex.OffsetDateTime` | `datetime.datetime` |
 | TimeDelta | A duration of time | `datetime.timedelta` | `datetime.timedelta` |
-| Vector[*T*, *Dim*?] | *T* must be basic type. *Dim* is a positive integer and optional. |`cocoindex.Vector[T]` or `cocoindex.Vector[T, Dim]` | `list[T]` | 
 | Json | | `cocoindex.Json` | Any data convertible to JSON by `json` package | 
+| Vector[*T*, *Dim*?] | A vector of numbers with type *T* (`np.float32`, `np.float64`, `np.int32`, `np.int64`, `np.uint8`, `np.uint16`, `np.uint32`, or `np.uint64`). *Dim* is a positive integer and optional. | `cocoindex.Vector[T]` or `cocoindex.Vector[T, Dim]` | `numpy.typing.NDArray[T]` or `list[T]` |
 
 Values of all data types can be represented by values in Python's native types (as described under the Native Python Type column).
 However, the underlying execution engine and some storage system (like Postgres) has finer distinctions for some types, specifically:

--- a/docs/docs/core/data_types.mdx
+++ b/docs/docs/core/data_types.mdx
@@ -37,15 +37,16 @@ This is the list of all basic types supported by CocoIndex:
 | OffsetDatetime | Date and time with a timezone offset | `cocoindex.OffsetDateTime` | `datetime.datetime` |
 | TimeDelta | A duration of time | `datetime.timedelta` | `datetime.timedelta` |
 | Json | | `cocoindex.Json` | Any data convertible to JSON by `json` package | 
-| Vector[*T*, *Dim*?] | A vector of numbers with type *T* (`np.float32`, `np.float64`, `np.int32`, `np.int64`, `np.uint8`, `np.uint16`, `np.uint32`, or `np.uint64`). *Dim* is a positive integer and optional. | `cocoindex.Vector[T]` or `cocoindex.Vector[T, Dim]` | `numpy.typing.NDArray[T]` or `list[T]` |
+| Vector[*T*, *Dim*?] | *T* can be a basic type or a numeric type. *Dim* is a positive integer and optional. | `cocoindex.Vector[T]` or `cocoindex.Vector[T, Dim]` | `numpy.typing.NDArray[T]` or `list[T]` |
 
 Values of all data types can be represented by values in Python's native types (as described under the Native Python Type column).
 However, the underlying execution engine and some storage system (like Postgres) has finer distinctions for some types, specifically:
 
 *   *Float32* and *Float64* for `float`, with different precision.
 *   *LocalDateTime* and *OffsetDateTime* for `datetime.datetime`, with different timezone awareness.
-*   *Vector* has optional dimension information.
 *   *Range* and *Json* provide a clear tag for the type, to clearly distinguish the type in CocoIndex.
+*   *Vector* holds elements of type *T*. If *T* is numeric (e.g., `np.float32` or `np.float64`), it's represented as `NDArray[T]`; otherwise, as `list[T]`.
+*   *Vector* also has optional dimension information.
 
 The native Python type is always more permissive and can represent a superset of possible values.
 *   Only when you annotate the return type of a custom function, you should use the specific type,

--- a/docs/docs/query.mdx
+++ b/docs/docs/query.mdx
@@ -41,7 +41,7 @@ The [quickstart](getting_started/quickstart#step-41-extract-common-transformatio
 
 ```python
 @cocoindex.transform_flow()
-def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[list[float]]:
+def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[NDArray[np.float32]]:
     return text.transform(
         cocoindex.functions.SentenceTransformerEmbed(
             model="sentence-transformers/all-MiniLM-L6-v2"))
@@ -61,7 +61,7 @@ with doc["chunks"].row() as chunk:
     chunk["embedding"] = chunk["text"].call(text_to_embedding)
 ```
 
-Any time, you can call the `eval()` method with specific string, which will return a `list[float]`:
+Any time, you can call the `eval()` method with specific string, which will return a `NDArray[np.float32]`:
 
 ```python
 print(text_to_embedding.eval("Hello, world!"))
@@ -93,7 +93,7 @@ For example:
 
 ```python
 table_name = cocoindex.utils.get_target_storage_default_name(text_embedding_flow, "doc_embeddings")
-query = f"SELECT filename, text FROM {table_name} ORDER BY embedding <=> %s::vector DESC LIMIT 5"
+query = f"SELECT filename, text FROM {table_name} ORDER BY embedding <=> %s DESC LIMIT 5"
 ...
 ```
 

--- a/examples/text_embedding/Text_Embedding.ipynb
+++ b/examples/text_embedding/Text_Embedding.ipynb
@@ -45,7 +45,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install cocoindex python-dotenv psycopg[binary,pool]"
+    "%pip install cocoindex numpy python-dotenv psycopg[binary,pool]"
    ]
   },
   {
@@ -164,7 +164,9 @@
     "from dotenv import load_dotenv\n",
     "import os\n",
     "from psycopg_pool import ConnectionPool\n",
-    "import cocoindex\n"
+    "import cocoindex\n",
+    "from numpy.typing import NDArray\n",
+    "import numpy as np\n"
    ]
   },
   {
@@ -187,7 +189,7 @@
     "%%writefile -a main.py\n",
     "\n",
     "@cocoindex.transform_flow()\n",
-    "def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[list[float]]:\n",
+    "def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[NDArray[np.float32]]:\n",
     "    \"\"\"\n",
     "    Embed the text using a SentenceTransformer model.\n",
     "    This is shared logic between indexing and querying.\n",
@@ -271,7 +273,7 @@
     "    # Get the table name, for the export target in the text_embedding_flow above.\n",
     "    table_name = cocoindex.utils.get_target_storage_default_name(text_embedding_flow, \"doc_embeddings\")\n",
     "    # Evaluate the transform flow defined above with the input query, to get the embedding.\n",
-    "    query_vector = text_to_embedding.eval(query)\n",
+    "    query_vector = text_to_embedding.eval(query).tolist()\n",
     "    # Run the query and get the results.\n",
     "    with pool.connection() as conn:\n",
     "        with conn.cursor() as cur:\n",

--- a/examples/text_embedding/Text_Embedding.ipynb
+++ b/examples/text_embedding/Text_Embedding.ipynb
@@ -45,7 +45,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install cocoindex numpy python-dotenv psycopg[binary,pool]"
+    "%pip install cocoindex numpy python-dotenv psycopg[binary,pool] pgvector"
    ]
   },
   {
@@ -164,6 +164,7 @@
     "from dotenv import load_dotenv\n",
     "import os\n",
     "from psycopg_pool import ConnectionPool\n",
+    "from pgvector.psycopg import register_vector\n",
     "import cocoindex\n",
     "from numpy.typing import NDArray\n",
     "import numpy as np\n"
@@ -273,12 +274,13 @@
     "    # Get the table name, for the export target in the text_embedding_flow above.\n",
     "    table_name = cocoindex.utils.get_target_storage_default_name(text_embedding_flow, \"doc_embeddings\")\n",
     "    # Evaluate the transform flow defined above with the input query, to get the embedding.\n",
-    "    query_vector = text_to_embedding.eval(query).tolist()\n",
+    "    query_vector = text_to_embedding.eval(query)\n",
     "    # Run the query and get the results.\n",
     "    with pool.connection() as conn:\n",
+    "        register_vector(conn)\n",
     "        with conn.cursor() as cur:\n",
     "            cur.execute(f\"\"\"\n",
-    "                SELECT filename, text, embedding <=> %s::vector AS distance\n",
+    "                SELECT filename, text, embedding <=> %s AS distance\n",
     "                FROM {table_name} ORDER BY distance LIMIT %s\n",
     "            \"\"\", (query_vector, top_k))\n",
     "            return [\n",

--- a/examples/text_embedding/main.py
+++ b/examples/text_embedding/main.py
@@ -2,12 +2,14 @@ from dotenv import load_dotenv
 from psycopg_pool import ConnectionPool
 import cocoindex
 import os
+from numpy.typing import NDArray
+import numpy as np
 
 
 @cocoindex.transform_flow()
 def text_to_embedding(
     text: cocoindex.DataSlice[str],
-) -> cocoindex.DataSlice[list[float]]:
+) -> cocoindex.DataSlice[NDArray[np.float32]]:
     """
     Embed the text using a SentenceTransformer model.
     This is a shared logic between indexing and querying, so extract it as a function.
@@ -68,7 +70,7 @@ def search(pool: ConnectionPool, query: str, top_k: int = 5):
         text_embedding_flow, "doc_embeddings"
     )
     # Evaluate the transform flow defined above with the input query, to get the embedding.
-    query_vector = text_to_embedding.eval(query)
+    query_vector = text_to_embedding.eval(query).tolist()
     # Run the query and get the results.
     with pool.connection() as conn:
         with conn.cursor() as cur:

--- a/examples/text_embedding/pyproject.toml
+++ b/examples/text_embedding/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cocoindex>=0.1.42",
     "python-dotenv>=1.0.1",
+    "pgvector>=0.4.1",
     "psycopg[binary,pool]",
     "numpy",
 ]

--- a/examples/text_embedding/pyproject.toml
+++ b/examples/text_embedding/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "cocoindex>=0.1.42",
     "python-dotenv>=1.0.1",
     "psycopg[binary,pool]",
+    "numpy",
 ]
 
 [tool.setuptools]

--- a/python/cocoindex/convert.py
+++ b/python/cocoindex/convert.py
@@ -151,7 +151,10 @@ def make_engine_value_decoder(
                     f"expected {expected_dim}, got {len(value)}"
                 )
 
-            return np.array(value, dtype=dtype_info.numpy_dtype)
+            # Use NDArray for supported numeric dtypes, else return list
+            if dtype_info is not None:
+                return np.array(value, dtype=dtype_info.numpy_dtype)
+            return value
 
         return decode_vector
 

--- a/python/cocoindex/convert.py
+++ b/python/cocoindex/convert.py
@@ -16,6 +16,7 @@ from .typing import (
     is_namedtuple_type,
     TABLE_TYPES,
     KEY_FIELD_NAME,
+    DtypeRegistry,
 )
 
 
@@ -125,38 +126,22 @@ def make_engine_value_decoder(
     if src_type_kind == "Uuid":
         return lambda value: uuid.UUID(bytes=value)
 
-    if dst_type_info.kind == "Vector":
+    if src_type_kind == "Vector":
         elem_coco_type_info = analyze_type_info(dst_type_info.elem_type)
-        elem_kind = elem_coco_type_info.kind
-
-        numpy_dtype: Any
-        if elem_kind == "Float32":
-            numpy_dtype = np.float32
-        elif elem_kind == "Float64":
-            numpy_dtype = np.float64
-        elif elem_kind == "Int32":
-            numpy_dtype = np.int32
-        elif elem_kind == "Int64":
-            numpy_dtype = np.int64
-        else:
-            raise ValueError(
-                f"Unsupported vector element kind for NDArray conversion: {elem_kind} for `{''.join(field_path)}`"
-            )
+        dtype_info = DtypeRegistry.get_by_kind(elem_coco_type_info.kind)
 
         def decode_vector(value: Any) -> Any | None:
             if value is None:
                 if dst_type_info.nullable:
                     return None
-                else:
-                    raise ValueError(
-                        f"Received null for non-nullable vector `{''.join(field_path)}`"
-                    )
+                raise ValueError(
+                    f"Received null for non-nullable vector `{''.join(field_path)}`"
+                )
 
             if not isinstance(value, list):
                 raise TypeError(
                     f"Expected a list for vector `{''.join(field_path)}`, got {type(value)}"
                 )
-
             expected_dim = (
                 dst_type_info.vector_info.dim if dst_type_info.vector_info else None
             )
@@ -166,7 +151,7 @@ def make_engine_value_decoder(
                     f"expected {expected_dim}, got {len(value)}"
                 )
 
-            return np.array(value, dtype=numpy_dtype)
+            return np.array(value, dtype=dtype_info.numpy_dtype)
 
         return decode_vector
 

--- a/python/cocoindex/convert.py
+++ b/python/cocoindex/convert.py
@@ -30,7 +30,7 @@ def encode_engine_value(value: Any) -> Any:
     if is_namedtuple_type(type(value)):
         return [encode_engine_value(getattr(value, name)) for name in value._fields]
     if isinstance(value, np.ndarray):
-        return value.tolist()
+        return value
     if isinstance(value, (list, tuple)):
         return [encode_engine_value(v) for v in value]
     if isinstance(value, dict):
@@ -138,9 +138,9 @@ def make_engine_value_decoder(
                     f"Received null for non-nullable vector `{''.join(field_path)}`"
                 )
 
-            if not isinstance(value, list):
+            if not isinstance(value, (np.ndarray, list)):
                 raise TypeError(
-                    f"Expected a list for vector `{''.join(field_path)}`, got {type(value)}"
+                    f"Expected NDArray or list for vector `{''.join(field_path)}`, got {type(value)}"
                 )
             expected_dim = (
                 dst_type_info.vector_info.dim if dst_type_info.vector_info else None

--- a/python/cocoindex/functions.py
+++ b/python/cocoindex/functions.py
@@ -56,11 +56,11 @@ class SentenceTransformerEmbedExecutor:
         self._model = sentence_transformers.SentenceTransformer(self.spec.model, **args)
         dim = self._model.get_sentence_embedding_dimension()
         result: type = Annotated[
-            Vector[np.float32, Literal[dim]],
+            Vector[np.float32, Literal[dim]],  # type: ignore
             TypeAttr("cocoindex.io/vector_origin_text", text.analyzed_value),
         ]
         return result
 
     def __call__(self, text: str) -> NDArray[np.float32]:
-        result: NDArray[np.float32] = self._model.encode(text)
+        result: NDArray[np.float32] = self._model.encode(text, convert_to_numpy=True)
         return result

--- a/python/cocoindex/functions.py
+++ b/python/cocoindex/functions.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any, TYPE_CHECKING, Literal
 import numpy as np
 from numpy.typing import NDArray
+import dataclasses
 
 from .typing import Float32, Vector, TypeAttr
 from . import op, llm
@@ -16,8 +17,19 @@ class ParseJson(op.FunctionSpec):
     """Parse a text into a JSON object."""
 
 
+@dataclasses.dataclass
+class CustomLanguageSpec:
+    """Custom language specification."""
+
+    language_name: str
+    separators_regex: list[str]
+    aliases: list[str] = dataclasses.field(default_factory=list)
+
+
 class SplitRecursively(op.FunctionSpec):
     """Split a document (in string) recursively."""
+
+    custom_languages: list[CustomLanguageSpec] = dataclasses.field(default_factory=list)
 
 
 class ExtractByLlm(op.FunctionSpec):

--- a/python/cocoindex/functions.py
+++ b/python/cocoindex/functions.py
@@ -1,6 +1,8 @@
 """All builtin functions."""
 
-from typing import Annotated, Any, TYPE_CHECKING
+from typing import Annotated, Any, TYPE_CHECKING, Literal
+import numpy as np
+from numpy.typing import NDArray
 
 from .typing import Float32, Vector, TypeAttr
 from . import op, llm
@@ -54,11 +56,11 @@ class SentenceTransformerEmbedExecutor:
         self._model = sentence_transformers.SentenceTransformer(self.spec.model, **args)
         dim = self._model.get_sentence_embedding_dimension()
         result: type = Annotated[
-            Vector[Float32, dim],  # type: ignore
+            Vector[np.float32, Literal[dim]],
             TypeAttr("cocoindex.io/vector_origin_text", text.analyzed_value),
         ]
         return result
 
-    def __call__(self, text: str) -> list[Float32]:
-        result: list[Float32] = self._model.encode(text).tolist()
+    def __call__(self, text: str) -> NDArray[np.float32]:
+        result: NDArray[np.float32] = self._model.encode(text)
         return result

--- a/python/cocoindex/tests/test_convert.py
+++ b/python/cocoindex/tests/test_convert.py
@@ -729,6 +729,17 @@ def test_decode_nullable_ndarray_none_or_value_input():
     )
 
 
+def test_decode_vector_string():
+    """Test decoding a vector of strings works for Python native list type."""
+    src_type_dict = {
+        "kind": "Vector",
+        "element_type": {"kind": "Str"},
+        "dimension": None,
+    }
+    decoder = make_engine_value_decoder([], src_type_dict, Vector[str])
+    assert decoder(["hello", "world"]) == ["hello", "world"]
+
+
 def test_decode_error_non_nullable_or_non_list_vector():
     """Test decoding errors for non-nullable vectors or non-list inputs."""
     src_type_dict = {

--- a/python/cocoindex/tests/test_convert.py
+++ b/python/cocoindex/tests/test_convert.py
@@ -561,13 +561,13 @@ NDArrayInt64Type = NDArray[np.int64]
 def test_encode_engine_value_ndarray():
     """Test encoding NDArray vectors to lists for the Rust engine."""
     vec_f32: Float32VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    assert encode_engine_value(vec_f32) == [1.0, 2.0, 3.0]
+    assert np.array_equal(encode_engine_value(vec_f32), [1.0, 2.0, 3.0])
     vec_f64: Float64VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-    assert encode_engine_value(vec_f64) == [1.0, 2.0, 3.0]
+    assert np.array_equal(encode_engine_value(vec_f64), [1.0, 2.0, 3.0])
     vec_i64: Int64VectorType = np.array([1, 2, 3], dtype=np.int64)
-    assert encode_engine_value(vec_i64) == [1, 2, 3]
+    assert np.array_equal(encode_engine_value(vec_i64), [1, 2, 3])
     vec_nd_f32: NDArrayFloat32Type = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    assert encode_engine_value(vec_nd_f32) == [1.0, 2.0, 3.0]
+    assert np.array_equal(encode_engine_value(vec_nd_f32), [1.0, 2.0, 3.0])
 
 
 def test_make_engine_value_decoder_ndarray():
@@ -598,21 +598,21 @@ def test_roundtrip_ndarray_vector():
     """Test roundtrip encoding and decoding of NDArray vectors."""
     value_f32: Float32VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float32)
     encoded_f32 = encode_engine_value(value_f32)
-    assert encoded_f32 == [1.0, 2.0, 3.0]
+    np.array_equal(encoded_f32, [1.0, 2.0, 3.0])
     decoded_f32 = build_engine_value_decoder(Float32VectorType)(encoded_f32)
     assert isinstance(decoded_f32, np.ndarray)
     assert decoded_f32.dtype == np.float32
     assert np.array_equal(decoded_f32, value_f32)
     value_i64: Int64VectorType = np.array([1, 2, 3], dtype=np.int64)
     encoded_i64 = encode_engine_value(value_i64)
-    assert encoded_i64 == [1, 2, 3]
+    assert np.array_equal(encoded_i64, [1, 2, 3])
     decoded_i64 = build_engine_value_decoder(Int64VectorType)(encoded_i64)
     assert isinstance(decoded_i64, np.ndarray)
     assert decoded_i64.dtype == np.int64
     assert np.array_equal(decoded_i64, value_i64)
     value_nd_f64: NDArrayFloat64Type = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     encoded_nd_f64 = encode_engine_value(value_nd_f64)
-    assert encoded_nd_f64 == [1.0, 2.0, 3.0]
+    assert np.array_equal(encoded_nd_f64, [1.0, 2.0, 3.0])
     decoded_nd_f64 = build_engine_value_decoder(NDArrayFloat64Type)(encoded_nd_f64)
     assert isinstance(decoded_nd_f64, np.ndarray)
     assert decoded_nd_f64.dtype == np.float64
@@ -623,7 +623,7 @@ def test_uint_support():
     """Test encoding and decoding of unsigned integer vectors."""
     value_uint8 = np.array([1, 2, 3, 4], dtype=np.uint8)
     encoded = encode_engine_value(value_uint8)
-    assert encoded == [1, 2, 3, 4]
+    assert np.array_equal(encoded, [1, 2, 3, 4])
     decoder = make_engine_value_decoder(
         [], {"kind": "Vector", "element_type": {"kind": "UInt8"}}, NDArray[np.uint8]
     )
@@ -632,7 +632,7 @@ def test_uint_support():
     assert decoded.dtype == np.uint8
     value_uint16 = np.array([1, 2, 3, 4], dtype=np.uint16)
     encoded = encode_engine_value(value_uint16)
-    assert encoded == [1, 2, 3, 4]
+    assert np.array_equal(encoded, [1, 2, 3, 4])
     decoder = make_engine_value_decoder(
         [], {"kind": "Vector", "element_type": {"kind": "UInt16"}}, NDArray[np.uint16]
     )
@@ -641,7 +641,7 @@ def test_uint_support():
     assert decoded.dtype == np.uint16
     value_uint32 = np.array([1, 2, 3], dtype=np.uint32)
     encoded = encode_engine_value(value_uint32)
-    assert encoded == [1, 2, 3]
+    assert np.array_equal(encoded, [1, 2, 3])
     decoder = make_engine_value_decoder(
         [], {"kind": "Vector", "element_type": {"kind": "UInt32"}}, NDArray[np.uint32]
     )
@@ -650,7 +650,7 @@ def test_uint_support():
     assert decoded.dtype == np.uint32
     value_uint64 = np.array([1, 2, 3], dtype=np.uint64)
     encoded = encode_engine_value(value_uint64)
-    assert encoded == [1, 2, 3]
+    assert np.array_equal(encoded, [1, 2, 3])
     decoder = make_engine_value_decoder(
         [], {"kind": "Vector", "element_type": {"kind": "UInt8"}}, NDArray[np.uint64]
     )
@@ -663,7 +663,7 @@ def test_ndarray_dimension_mismatch():
     """Test dimension enforcement for Vector with specified dimension."""
     value: Float32VectorType = np.array([1.0, 2.0], dtype=np.float32)
     encoded = encode_engine_value(value)
-    assert encoded == [1.0, 2.0]
+    assert np.array_equal(encoded, [1.0, 2.0])
     with pytest.raises(ValueError, match="Vector dimension mismatch"):
         build_engine_value_decoder(Float32VectorType)(encoded)
 
@@ -679,9 +679,9 @@ def test_list_vector_backward_compatibility():
     assert np.array_equal(decoded, np.array([1, 2, 3, 4, 5], dtype=np.int64))
     value_list: ListIntType = [1, 2, 3, 4, 5]
     encoded = encode_engine_value(value_list)
-    assert encoded == [1, 2, 3, 4, 5]
+    assert np.array_equal(encoded, [1, 2, 3, 4, 5])
     decoded = build_engine_value_decoder(ListIntType)(encoded)
-    assert decoded.tolist() == [1, 2, 3, 4, 5]
+    assert np.array_equal(decoded, [1, 2, 3, 4, 5])
 
 
 def test_encode_complex_structure_with_ndarray():
@@ -702,7 +702,9 @@ def test_encode_complex_structure_with_ndarray():
         [1.0, 0.5],
         100,
     ]
-    assert encoded == expected
+    assert encoded[0] == expected[0]
+    assert np.array_equal(encoded[1], expected[1])
+    assert encoded[2] == expected[2]
 
 
 def test_decode_nullable_ndarray_none_or_value_input():
@@ -750,7 +752,7 @@ def test_decode_error_non_nullable_or_non_list_vector():
     decoder = make_engine_value_decoder([], src_type_dict, NDArrayFloat32Type)
     with pytest.raises(ValueError, match="Received null for non-nullable vector"):
         decoder(None)
-    with pytest.raises(TypeError, match="Expected a list for vector"):
+    with pytest.raises(TypeError, match="Expected NDArray or list for vector"):
         decoder("not a list")
 
 

--- a/python/cocoindex/tests/test_convert.py
+++ b/python/cocoindex/tests/test_convert.py
@@ -4,8 +4,17 @@ from dataclasses import dataclass, make_dataclass
 from typing import NamedTuple, Literal
 import pytest
 import cocoindex
-from cocoindex.typing import encode_enriched_type
-from cocoindex.convert import encode_engine_value, make_engine_value_decoder
+from cocoindex.typing import (
+    encode_enriched_type,
+    Vector,
+)
+from cocoindex.convert import (
+    encode_engine_value,
+    make_engine_value_decoder,
+    dump_engine_object,
+)
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
@@ -517,7 +526,7 @@ def test_roundtrip_ktable_struct_key():
     assert decoded == value_nt
 
 
-IntVectorType = cocoindex.Vector[int, Literal[5]]
+IntVectorType = cocoindex.Vector[np.int32, Literal[5]]
 
 
 def test_vector_as_vector() -> None:
@@ -525,7 +534,7 @@ def test_vector_as_vector() -> None:
     encoded = encode_engine_value(value)
     assert encoded == [1, 2, 3, 4, 5]
     decoded = build_engine_value_decoder(IntVectorType)(encoded)
-    assert decoded == value
+    assert np.array_equal(decoded, value)
 
 
 ListIntType = list[int]
@@ -536,4 +545,223 @@ def test_vector_as_list() -> None:
     encoded = encode_engine_value(value)
     assert encoded == [1, 2, 3, 4, 5]
     decoded = build_engine_value_decoder(ListIntType)(encoded)
-    assert decoded == value
+    assert np.array_equal(decoded, value)
+
+
+Float64VectorTypeNoDim = Vector[np.float64]
+Float32VectorType = Vector[np.float32, Literal[3]]
+Float64VectorType = Vector[np.float64, Literal[3]]
+Int64VectorType = Vector[np.int64, Literal[3]]
+Int32VectorType = Vector[np.int32, Literal[3]]
+NDArrayFloat32Type = NDArray[np.float32]
+NDArrayFloat64Type = NDArray[np.float64]
+NDArrayInt64Type = NDArray[np.int64]
+
+
+def test_encode_engine_value_ndarray():
+    """Test encoding NDArray vectors to lists for the Rust engine."""
+    vec_f32: Float32VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    assert encode_engine_value(vec_f32) == [1.0, 2.0, 3.0]
+    vec_f64: Float64VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    assert encode_engine_value(vec_f64) == [1.0, 2.0, 3.0]
+    vec_i64: Int64VectorType = np.array([1, 2, 3], dtype=np.int64)
+    assert encode_engine_value(vec_i64) == [1, 2, 3]
+    vec_nd_f32: NDArrayFloat32Type = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    assert encode_engine_value(vec_nd_f32) == [1.0, 2.0, 3.0]
+
+
+def test_make_engine_value_decoder_ndarray():
+    """Test decoding engine lists to NDArray vectors."""
+    decoder_f32 = build_engine_value_decoder(Float32VectorType)
+    result_f32 = decoder_f32([1.0, 2.0, 3.0])
+    assert isinstance(result_f32, np.ndarray)
+    assert result_f32.dtype == np.float32
+    assert np.array_equal(result_f32, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    decoder_f64 = build_engine_value_decoder(Float64VectorType)
+    result_f64 = decoder_f64([1.0, 2.0, 3.0])
+    assert isinstance(result_f64, np.ndarray)
+    assert result_f64.dtype == np.float64
+    assert np.array_equal(result_f64, np.array([1.0, 2.0, 3.0], dtype=np.float64))
+    decoder_i64 = build_engine_value_decoder(Int64VectorType)
+    result_i64 = decoder_i64([1, 2, 3])
+    assert isinstance(result_i64, np.ndarray)
+    assert result_i64.dtype == np.int64
+    assert np.array_equal(result_i64, np.array([1, 2, 3], dtype=np.int64))
+    decoder_nd_f32 = build_engine_value_decoder(NDArrayFloat32Type)
+    result_nd_f32 = decoder_nd_f32([1.0, 2.0, 3.0])
+    assert isinstance(result_nd_f32, np.ndarray)
+    assert result_nd_f32.dtype == np.float32
+    assert np.array_equal(result_nd_f32, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+
+
+def test_roundtrip_ndarray_vector():
+    """Test roundtrip encoding and decoding of NDArray vectors."""
+    value_f32: Float32VectorType = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    encoded_f32 = encode_engine_value(value_f32)
+    assert encoded_f32 == [1.0, 2.0, 3.0]
+    decoded_f32 = build_engine_value_decoder(Float32VectorType)(encoded_f32)
+    assert isinstance(decoded_f32, np.ndarray)
+    assert decoded_f32.dtype == np.float32
+    assert np.array_equal(decoded_f32, value_f32)
+    value_i64: Int64VectorType = np.array([1, 2, 3], dtype=np.int64)
+    encoded_i64 = encode_engine_value(value_i64)
+    assert encoded_i64 == [1, 2, 3]
+    decoded_i64 = build_engine_value_decoder(Int64VectorType)(encoded_i64)
+    assert isinstance(decoded_i64, np.ndarray)
+    assert decoded_i64.dtype == np.int64
+    assert np.array_equal(decoded_i64, value_i64)
+    value_nd_f64: NDArrayFloat64Type = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    encoded_nd_f64 = encode_engine_value(value_nd_f64)
+    assert encoded_nd_f64 == [1.0, 2.0, 3.0]
+    decoded_nd_f64 = build_engine_value_decoder(NDArrayFloat64Type)(encoded_nd_f64)
+    assert isinstance(decoded_nd_f64, np.ndarray)
+    assert decoded_nd_f64.dtype == np.float64
+    assert np.array_equal(decoded_nd_f64, value_nd_f64)
+
+
+def test_uint_support():
+    """Test encoding and decoding of unsigned integer vectors."""
+    value_uint8 = np.array([1, 2, 3, 4], dtype=np.uint8)
+    encoded = encode_engine_value(value_uint8)
+    assert encoded == [1, 2, 3, 4]
+    decoder = make_engine_value_decoder(
+        [], {"kind": "Vector", "element_type": {"kind": "UInt8"}}, NDArray[np.uint8]
+    )
+    decoded = decoder(encoded)
+    assert np.array_equal(decoded, value_uint8)
+    assert decoded.dtype == np.uint8
+    value_uint16 = np.array([1, 2, 3, 4], dtype=np.uint16)
+    encoded = encode_engine_value(value_uint16)
+    assert encoded == [1, 2, 3, 4]
+    decoder = make_engine_value_decoder(
+        [], {"kind": "Vector", "element_type": {"kind": "UInt16"}}, NDArray[np.uint16]
+    )
+    decoded = decoder(encoded)
+    assert np.array_equal(decoded, value_uint16)
+    assert decoded.dtype == np.uint16
+    value_uint32 = np.array([1, 2, 3], dtype=np.uint32)
+    encoded = encode_engine_value(value_uint32)
+    assert encoded == [1, 2, 3]
+    decoder = make_engine_value_decoder(
+        [], {"kind": "Vector", "element_type": {"kind": "UInt32"}}, NDArray[np.uint32]
+    )
+    decoded = decoder(encoded)
+    assert np.array_equal(decoded, value_uint32)
+    assert decoded.dtype == np.uint32
+    value_uint64 = np.array([1, 2, 3], dtype=np.uint64)
+    encoded = encode_engine_value(value_uint64)
+    assert encoded == [1, 2, 3]
+    decoder = make_engine_value_decoder(
+        [], {"kind": "Vector", "element_type": {"kind": "UInt8"}}, NDArray[np.uint64]
+    )
+    decoded = decoder(encoded)
+    assert np.array_equal(decoded, value_uint64)
+    assert decoded.dtype == np.uint64
+
+
+def test_ndarray_dimension_mismatch():
+    """Test dimension enforcement for Vector with specified dimension."""
+    value: Float32VectorType = np.array([1.0, 2.0], dtype=np.float32)
+    encoded = encode_engine_value(value)
+    assert encoded == [1.0, 2.0]
+    with pytest.raises(ValueError, match="Vector dimension mismatch"):
+        build_engine_value_decoder(Float32VectorType)(encoded)
+
+
+def test_list_vector_backward_compatibility():
+    """Test that list-based vectors still work for backward compatibility."""
+    value: IntVectorType = [1, 2, 3, 4, 5]
+    encoded = encode_engine_value(value)
+    assert encoded == [1, 2, 3, 4, 5]
+    decoded = build_engine_value_decoder(IntVectorType)(encoded)
+    assert isinstance(decoded, np.ndarray)
+    assert decoded.dtype == np.int32
+    assert np.array_equal(decoded, np.array([1, 2, 3, 4, 5], dtype=np.int64))
+    value_list: ListIntType = [1, 2, 3, 4, 5]
+    encoded = encode_engine_value(value_list)
+    assert encoded == [1, 2, 3, 4, 5]
+    decoded = build_engine_value_decoder(ListIntType)(encoded)
+    assert decoded.tolist() == [1, 2, 3, 4, 5]
+
+
+def test_encode_complex_structure_with_ndarray():
+    """Test encoding a complex structure that includes an NDArray."""
+
+    @dataclass
+    class MyStructWithNDArray:
+        name: str
+        data: NDArray[np.float32]
+        value: int
+
+    original = MyStructWithNDArray(
+        name="test_np", data=np.array([1.0, 0.5], dtype=np.float32), value=100
+    )
+    encoded = encode_engine_value(original)
+    expected = [
+        "test_np",
+        [1.0, 0.5],
+        100,
+    ]
+    assert encoded == expected
+
+
+def test_decode_nullable_ndarray_none_or_value_input():
+    """Test decoding a nullable NDArray with None or value inputs."""
+    src_type_dict = {
+        "kind": "Vector",
+        "element_type": {"kind": "Float32"},
+        "dimension": None,
+    }
+    dst_annotation = NDArrayFloat32Type | None
+    decoder = make_engine_value_decoder([], src_type_dict, dst_annotation)
+
+    none_engine_value = None
+    decoded_array = decoder(none_engine_value)
+    assert decoded_array is None
+
+    engine_value = [1.0, 2.0, 3.0]
+    decoded_array = decoder(engine_value)
+
+    assert isinstance(decoded_array, np.ndarray)
+    assert decoded_array.dtype == np.float32
+    np.testing.assert_array_equal(
+        decoded_array, np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    )
+
+
+def test_decode_error_non_nullable_or_non_list_vector():
+    """Test decoding errors for non-nullable vectors or non-list inputs."""
+    src_type_dict = {
+        "kind": "Vector",
+        "element_type": {"kind": "Float32"},
+        "dimension": None,
+    }
+    decoder = make_engine_value_decoder([], src_type_dict, NDArrayFloat32Type)
+    with pytest.raises(ValueError, match="Received null for non-nullable vector"):
+        decoder(None)
+    with pytest.raises(TypeError, match="Expected a list for vector"):
+        decoder("not a list")
+
+
+def test_dump_vector_type_annotation_with_dim():
+    """Test dumping a vector type annotation with a specified dimension."""
+    expected_dump = {
+        "type": {
+            "kind": "Vector",
+            "element_type": {"kind": "Float32"},
+            "dimension": 3,
+        }
+    }
+    assert dump_engine_object(Float32VectorType) == expected_dump
+
+
+def test_dump_vector_type_annotation_no_dim():
+    """Test dumping a vector type annotation with no dimension."""
+    expected_dump_no_dim = {
+        "type": {
+            "kind": "Vector",
+            "element_type": {"kind": "Float64"},
+            "dimension": None,
+        }
+    }
+    assert dump_engine_object(Float64VectorTypeNoDim) == expected_dump_no_dim

--- a/python/cocoindex/tests/test_typing.py
+++ b/python/cocoindex/tests/test_typing.py
@@ -1,0 +1,492 @@
+import dataclasses
+import datetime
+import uuid
+from typing import (
+    Annotated,
+    List,
+    Dict,
+    Literal,
+    Any,
+    get_args,
+    NamedTuple,
+)
+from collections.abc import Sequence, Mapping
+import pytest
+import numpy as np
+from numpy.typing import NDArray
+
+from cocoindex.typing import (
+    analyze_type_info,
+    Vector,
+    VectorInfo,
+    TypeKind,
+    TypeAttr,
+    Float32,
+    Float64,
+    encode_enriched_type,
+    AnalyzedTypeInfo,
+)
+
+
+@dataclasses.dataclass
+class SimpleDataclass:
+    name: str
+    value: int
+
+
+class SimpleNamedTuple(NamedTuple):
+    name: str
+    value: Any
+
+
+def test_ndarray_float32_no_dim():
+    typ = NDArray[np.float32]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=None),
+        elem_type=Float32,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_vector_float32_no_dim():
+    typ = Vector[np.float32]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=None),
+        elem_type=Float32,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_ndarray_float64_with_dim():
+    typ = Annotated[NDArray[np.float64], VectorInfo(dim=128)]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=128),
+        elem_type=Float64,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_vector_float32_with_dim():
+    typ = Vector[np.float32, Literal[384]]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=384),
+        elem_type=Float32,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_ndarray_int64_no_dim():
+    typ = NDArray[np.int64]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.vector_info == VectorInfo(dim=None)
+    assert get_args(result.elem_type) == (int, TypeKind("Int64"))
+    assert not result.nullable
+
+
+def test_ndarray_int32_with_dim():
+    typ = Annotated[NDArray[np.int32], VectorInfo(dim=10)]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.vector_info == VectorInfo(dim=10)
+    assert get_args(result.elem_type) == (int, TypeKind("Int32"))
+    assert not result.nullable
+
+
+def test_ndarray_uint8_no_dim():
+    typ = NDArray[np.uint8]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.vector_info == VectorInfo(dim=None)
+    assert get_args(result.elem_type) == (int, TypeKind("UInt8"))
+    assert not result.nullable
+
+
+def test_nullable_ndarray():
+    typ = NDArray[np.float32] | None
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=None),
+        elem_type=Float32,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=True,
+    )
+
+
+def test_unsupported_dtype():
+    typ = NDArray[np.complex64]
+    with pytest.raises(
+        ValueError,
+        match="Unsupported NumPy dtype: <class 'numpy.complex64'>",
+    ):
+        analyze_type_info(typ)
+
+
+def test_ndarray_any_dtype():
+    typ = NDArray[Any]
+    with pytest.raises(
+        TypeError, match="NDArray for Vector must use a concrete numpy dtype"
+    ):
+        analyze_type_info(typ)
+
+
+def test_non_numpy_vector():
+    with pytest.raises(
+        TypeError, match="Vector dtype must be a NumPy dtype, got <class 'float'>"
+    ):
+        typ = Vector[float, Literal[3]]
+        analyze_type_info(typ)
+
+
+def test_list_of_primitives():
+    typ = List[str]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=None),
+        elem_type=str,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_list_of_structs():
+    typ = List[SimpleDataclass]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="LTable",
+        vector_info=None,
+        elem_type=SimpleDataclass,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_sequence_of_int():
+    typ = Sequence[int]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=None),
+        elem_type=int,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_list_with_vector_info():
+    typ = Annotated[List[int], VectorInfo(dim=5)]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Vector",
+        vector_info=VectorInfo(dim=5),
+        elem_type=int,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_dict_str_int():
+    typ = Dict[str, int]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="KTable",
+        vector_info=None,
+        elem_type=(str, int),
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_mapping_str_dataclass():
+    typ = Mapping[str, SimpleDataclass]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="KTable",
+        vector_info=None,
+        elem_type=(str, SimpleDataclass),
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_dataclass():
+    typ = SimpleDataclass
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Struct",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=SimpleDataclass,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_named_tuple():
+    typ = SimpleNamedTuple
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Struct",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=SimpleNamedTuple,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_tuple_key_value():
+    typ = (str, int)
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Int64",
+        vector_info=None,
+        elem_type=None,
+        key_type=str,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_str():
+    typ = str
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Str",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_bool():
+    typ = bool
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Bool",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_bytes():
+    typ = bytes
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Bytes",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_uuid():
+    typ = uuid.UUID
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Uuid",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_date():
+    typ = datetime.date
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Date",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_time():
+    typ = datetime.time
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Time",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_timedelta():
+    typ = datetime.timedelta
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="TimeDelta",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_float():
+    typ = float
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Float64",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_int():
+    typ = int
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Int64",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs=None,
+        nullable=False,
+    )
+
+
+def test_type_with_attributes():
+    typ = Annotated[str, TypeAttr("key", "value")]
+    result = analyze_type_info(typ)
+    assert result == AnalyzedTypeInfo(
+        kind="Str",
+        vector_info=None,
+        elem_type=None,
+        key_type=None,
+        struct_type=None,
+        attrs={"key": "value"},
+        nullable=False,
+    )
+
+
+def test_encode_enriched_type_none():
+    typ = None
+    result = encode_enriched_type(typ)
+    assert result is None
+
+
+def test_encode_enriched_type_struct():
+    typ = SimpleDataclass
+    result = encode_enriched_type(typ)
+    assert result["type"]["kind"] == "Struct"
+    assert len(result["type"]["fields"]) == 2
+    assert result["type"]["fields"][0]["name"] == "name"
+    assert result["type"]["fields"][0]["type"]["kind"] == "Str"
+    assert result["type"]["fields"][1]["name"] == "value"
+    assert result["type"]["fields"][1]["type"]["kind"] == "Int64"
+
+
+def test_encode_enriched_type_vector():
+    typ = NDArray[np.float32]
+    result = encode_enriched_type(typ)
+    assert result["type"]["kind"] == "Vector"
+    assert result["type"]["element_type"]["kind"] == "Float32"
+    assert result["type"]["dimension"] is None
+
+
+def test_encode_enriched_type_ltable():
+    typ = List[SimpleDataclass]
+    result = encode_enriched_type(typ)
+    assert result["type"]["kind"] == "LTable"
+    assert result["type"]["row"]["kind"] == "Struct"
+    assert len(result["type"]["row"]["fields"]) == 2
+
+
+def test_encode_enriched_type_with_attrs():
+    typ = Annotated[str, TypeAttr("key", "value")]
+    result = encode_enriched_type(typ)
+    assert result["type"]["kind"] == "Str"
+    assert result["attrs"] == {"key": "value"}
+
+
+def test_encode_enriched_type_nullable():
+    typ = str | None
+    result = encode_enriched_type(typ)
+    assert result["type"]["kind"] == "Str"
+    assert result["nullable"] is True
+
+
+def test_invalid_struct_kind():
+    typ = Annotated[SimpleDataclass, TypeKind("Vector")]
+    with pytest.raises(ValueError, match="Unexpected type kind for struct: Vector"):
+        analyze_type_info(typ)
+
+
+def test_invalid_list_kind():
+    typ = Annotated[List[int], TypeKind("Struct")]
+    with pytest.raises(ValueError, match="Unexpected type kind for list: Struct"):
+        analyze_type_info(typ)
+
+
+def test_unsupported_type():
+    typ = set
+    with pytest.raises(ValueError, match="type unsupported yet: <class 'set'>"):
+        analyze_type_info(typ)

--- a/python/cocoindex/tests/test_typing.py
+++ b/python/cocoindex/tests/test_typing.py
@@ -136,13 +136,28 @@ def test_nullable_ndarray():
     )
 
 
-def test_unsupported_dtype():
-    typ = NDArray[np.complex64]
-    with pytest.raises(
-        ValueError,
-        match="Unsupported NumPy dtype: <class 'numpy.complex64'>",
-    ):
-        analyze_type_info(typ)
+def test_vector_str():
+    typ = Vector[str]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.elem_type == str
+    assert result.vector_info == VectorInfo(dim=None)
+
+
+def test_vector_complex64():
+    typ = Vector[np.complex64]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.elem_type == np.complex64
+    assert result.vector_info == VectorInfo(dim=None)
+
+
+def test_non_numpy_vector():
+    typ = Vector[float, Literal[3]]
+    result = analyze_type_info(typ)
+    assert result.kind == "Vector"
+    assert result.elem_type == float
+    assert result.vector_info == VectorInfo(dim=3)
 
 
 def test_ndarray_any_dtype():
@@ -150,14 +165,6 @@ def test_ndarray_any_dtype():
     with pytest.raises(
         TypeError, match="NDArray for Vector must use a concrete numpy dtype"
     ):
-        analyze_type_info(typ)
-
-
-def test_non_numpy_vector():
-    with pytest.raises(
-        TypeError, match="Vector dtype must be a NumPy dtype, got <class 'float'>"
-    ):
-        typ = Vector[float, Literal[3]]
         analyze_type_info(typ)
 
 


### PR DESCRIPTION
Three main contents have been done in this PR:
1. We added the NDArray support as vector representations.
2. We added a few test suites for verifying this.
3. We updated the code examples and documentation accordingly.

Closed #525.