### PR TITLE
chore: update requires-python to >=3.11 in examples

### DIFF
--- a/examples/code_embedding/pyproject.toml
+++ b/examples/code_embedding/pyproject.toml
@@ -2,7 +2,7 @@
 name = "code-embedding"
 version = "0.1.0"
 description = "Simple example for cocoindex: build embedding index based on source code."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["cocoindex>=0.1.42", "python-dotenv>=1.0.1"]
 
 [tool.setuptools]

--- a/examples/docs_to_knowledge_graph/pyproject.toml
+++ b/examples/docs_to_knowledge_graph/pyproject.toml
@@ -2,7 +2,7 @@
 name = "manuals-to-kg"
 version = "0.1.0"
 description = "Simple example for cocoindex: extract triples from files and build knowledge graph."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["cocoindex>=0.1.42"]
 
 [tool.setuptools]

--- a/examples/manuals_llm_extraction/pyproject.toml
+++ b/examples/manuals_llm_extraction/pyproject.toml
@@ -2,7 +2,7 @@
 name = "manuals-llm-extraction"
 version = "0.1.0"
 description = "Simple example for cocoindex: extract structured information from a Markdown file using LLM."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["cocoindex>=0.1.42", "marker-pdf>=1.5.2"]
 
 [tool.setuptools]

--- a/examples/pdf_embedding/pyproject.toml
+++ b/examples/pdf_embedding/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pdf-embedding"
 version = "0.1.0"
 description = "Simple example for cocoindex: build embedding index based on local PDF files."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cocoindex>=0.1.42",
     "python-dotenv>=1.0.1",

--- a/examples/product_recommendation/pyproject.toml
+++ b/examples/product_recommendation/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cocoindex-ecommerce-taxonomy"
 version = "0.1.0"
 description = "Simple example for CocoIndex: extract taxonomy from e-commerce products and build knowledge graph."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["cocoindex>=0.1.42", "jinja2>=3.1.6"]
 
 [tool.setuptools]

--- a/examples/text_embedding/pyproject.toml
+++ b/examples/text_embedding/pyproject.toml
@@ -2,7 +2,7 @@
 name = "text-embedding"
 version = "0.1.0"
 description = "Simple example for cocoindex: build embedding index based on local text files."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cocoindex>=0.1.42",
     "python-dotenv>=1.0.1",

--- a/examples/text_embedding_qdrant/pyproject.toml
+++ b/examples/text_embedding_qdrant/pyproject.toml
@@ -2,7 +2,7 @@
 name = "text-embedding-qdrant"
 version = "0.1.0"
 description = "Simple example for cocoindex: build embedding index based on local text files."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cocoindex>=0.1.42",
     "python-dotenv>=1.0.1",


### PR DESCRIPTION
Our project states Python 3.11+ is supported. This is also reflected in `pyproject.toml` and the installation section in our documentation.

However, some example projects set `requires-python = ">=3.10"` in `pyproject.toml`. This will cause issues when we use some management tools like `uv`, which considers this value when resolving dependencies.

Closes #612.