### PR TITLE
fix: remove unsupported type casting in integer vector handling

### DIFF
--- a/python/cocoindex/tests/test_convert.py
+++ b/python/cocoindex/tests/test_convert.py
@@ -513,7 +513,7 @@ def test_roundtrip_ktable_struct_key() -> None:
     validate_full_roundtrip(value_nt, t_nt)
 
 
-IntVectorType = cocoindex.Vector[np.int32, Literal[5]]
+IntVectorType = cocoindex.Vector[np.int64, Literal[5]]
 
 
 def test_vector_as_vector() -> None:
@@ -611,37 +611,6 @@ def test_roundtrip_ndarray_vector():
     assert np.array_equal(decoded_nd_f64, value_nd_f64)
 
 
-def test_uint_support():
-    """Test encoding and decoding of unsigned integer vectors."""
-    value_uint8 = np.array([1, 2, 3, 4], dtype=np.uint8)
-    encoded = encode_engine_value(value_uint8)
-    assert np.array_equal(encoded, [1, 2, 3, 4])
-    decoder = make_engine_value_decoder(
-        [], {"kind": "Vector", "element_type": {"kind": "UInt8"}}, NDArray[np.uint8]
-    )
-    decoded = decoder(encoded)
-    assert np.array_equal(decoded, value_uint8)
-    assert decoded.dtype == np.uint8
-    value_uint16 = np.array([1, 2, 3, 4], dtype=np.uint16)
-    encoded = encode_engine_value(value_uint16)
-    assert np.array_equal(encoded, [1, 2, 3, 4])
-    decoder = make_engine_value_decoder(
-        [], {"kind": "Vector", "element_type": {"kind": "UInt16"}}, NDArray[np.uint16]
-    )
-    decoded = decoder(encoded)
-    assert np.array_equal(decoded, value_uint16)
-    assert decoded.dtype == np.uint16
-    value_uint32 = np.array([1, 2, 3], dtype=np.uint32)
-    encoded = encode_engine_value(value_uint32)
-    assert np.array_equal(encoded, [1, 2, 3])
-    decoder = make_engine_value_decoder(
-        [], {"kind": "Vector", "element_type": {"kind": "UInt32"}}, NDArray[np.uint32]
-    )
-    decoded = decoder(encoded)
-    assert np.array_equal(decoded, value_uint32)
-    assert decoded.dtype == np.uint32
-
-
 def test_ndarray_dimension_mismatch():
     """Test dimension enforcement for Vector with specified dimension."""
     value: Float32VectorType = np.array([1.0, 2.0], dtype=np.float32)
@@ -658,7 +627,7 @@ def test_list_vector_backward_compatibility():
     assert encoded == [1, 2, 3, 4, 5]
     decoded = build_engine_value_decoder(IntVectorType)(encoded)
     assert isinstance(decoded, np.ndarray)
-    assert decoded.dtype == np.int32
+    assert decoded.dtype == np.int64
     assert np.array_equal(decoded, np.array([1, 2, 3, 4, 5], dtype=np.int64))
     value_list: ListIntType = [1, 2, 3, 4, 5]
     encoded = encode_engine_value(value_list)
@@ -773,16 +742,20 @@ def test_full_roundtrip_vector_numeric_types() -> None:
         [1.0, 2.0, 3.0], dtype=np.float64
     )
     validate_full_roundtrip(value_f64, Vector[np.float64, Literal[3]])
-    value_i32: Vector[np.int32, Literal[3]] = np.array([1, 2, 3], dtype=np.int32)
-    validate_full_roundtrip(value_i32, Vector[np.int32, Literal[3]])
     value_i64: Vector[np.int64, Literal[3]] = np.array([1, 2, 3], dtype=np.int64)
     validate_full_roundtrip(value_i64, Vector[np.int64, Literal[3]])
+    value_i32: Vector[np.int32, Literal[3]] = np.array([1, 2, 3], dtype=np.int32)
+    with pytest.raises(ValueError, match="type unsupported yet"):
+        validate_full_roundtrip(value_i32, Vector[np.int32, Literal[3]])
     value_u8: Vector[np.uint8, Literal[3]] = np.array([1, 2, 3], dtype=np.uint8)
-    validate_full_roundtrip(value_u8, Vector[np.uint8, Literal[3]])
+    with pytest.raises(ValueError, match="type unsupported yet"):
+        validate_full_roundtrip(value_u8, Vector[np.uint8, Literal[3]])
     value_u16: Vector[np.uint16, Literal[3]] = np.array([1, 2, 3], dtype=np.uint16)
-    validate_full_roundtrip(value_u16, Vector[np.uint16, Literal[3]])
+    with pytest.raises(ValueError, match="type unsupported yet"):
+        validate_full_roundtrip(value_u16, Vector[np.uint16, Literal[3]])
     value_u32: Vector[np.uint32, Literal[3]] = np.array([1, 2, 3], dtype=np.uint32)
-    validate_full_roundtrip(value_u32, Vector[np.uint32, Literal[3]])
+    with pytest.raises(ValueError, match="type unsupported yet"):
+        validate_full_roundtrip(value_u32, Vector[np.uint32, Literal[3]])
     value_u64: Vector[np.uint64, Literal[3]] = np.array([1, 2, 3], dtype=np.uint64)
     with pytest.raises(ValueError, match="type unsupported yet"):
         validate_full_roundtrip(value_u64, Vector[np.uint64, Literal[3]])

--- a/python/cocoindex/tests/test_typing.py
+++ b/python/cocoindex/tests/test_typing.py
@@ -108,24 +108,6 @@ def test_ndarray_int64_no_dim():
     assert not result.nullable
 
 
-def test_ndarray_int32_with_dim():
-    typ = Annotated[NDArray[np.int32], VectorInfo(dim=10)]
-    result = analyze_type_info(typ)
-    assert result.kind == "Vector"
-    assert result.vector_info == VectorInfo(dim=10)
-    assert get_args(result.elem_type) == (int, TypeKind("Int64"))
-    assert not result.nullable
-
-
-def test_ndarray_uint8_no_dim():
-    typ = NDArray[np.uint8]
-    result = analyze_type_info(typ)
-    assert result.kind == "Vector"
-    assert result.vector_info == VectorInfo(dim=None)
-    assert get_args(result.elem_type) == (int, TypeKind("Int64"))
-    assert not result.nullable
-
-
 def test_nullable_ndarray():
     typ = NDArray[np.float32] | None
     result = analyze_type_info(typ)

--- a/python/cocoindex/typing.py
+++ b/python/cocoindex/typing.py
@@ -119,11 +119,7 @@ class DtypeRegistry:
     _mappings: dict[type, DtypeInfo] = {
         np.float32: DtypeInfo(np.float32, "Float32", float),
         np.float64: DtypeInfo(np.float64, "Float64", float),
-        np.int32: DtypeInfo(np.int32, "Int64", int),
         np.int64: DtypeInfo(np.int64, "Int64", int),
-        np.uint8: DtypeInfo(np.uint8, "Int64", int),
-        np.uint16: DtypeInfo(np.uint16, "Int64", int),
-        np.uint32: DtypeInfo(np.uint32, "Int64", int),
     }
 
     @classmethod

--- a/src/py/convert.rs
+++ b/src/py/convert.rs
@@ -184,13 +184,7 @@ fn handle_ndarray_from_py<'py>(
     match elem_type {
         &schema::BasicValueType::Float32 => try_convert!(f32, value::BasicValue::Float32),
         &schema::BasicValueType::Float64 => try_convert!(f64, value::BasicValue::Float64),
-        &schema::BasicValueType::Int64 => {
-            try_convert!(i32, |v| value::BasicValue::Int64(v as i64));
-            try_convert!(i64, value::BasicValue::Int64);
-            try_convert!(u8, |v| value::BasicValue::Int64(v as i64));
-            try_convert!(u16, |v| value::BasicValue::Int64(v as i64));
-            try_convert!(u32, |v| value::BasicValue::Int64(v as i64));
-        }
+        &schema::BasicValueType::Int64 => try_convert!(i64, value::BasicValue::Int64),
         _ => {}
     }
 


### PR DESCRIPTION
In #595 and #586, we added support for numeric types in numpy array annotations. `np.uint` types and `np.int32` were included even though in cocoindex data types we could only handle `Int64`, `Float64` and `Float32`. We achieved this by type casting.

This PR attempts to remove the casting, and only supports `np.int64`, `np.float64` and `np.float32` for consistency.

> Relevant proposal: https://github.com/cocoindex-io/cocoindex/pull/586#discussion_r2140826971