### PR TITLE
fix(ci): add numpy to dependencies and pass typing checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "rich>=14.0.0",
     "python-dotenv>=1.1.0",
     "watchfiles>=1.1.0",
-    "numpy>=2.3.1",
+    "numpy>=1.23.2",
 ]
 license = "Apache-2.0"
 urls = { Homepage = "https://cocoindex.io/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "rich>=14.0.0",
     "python-dotenv>=1.1.0",
     "watchfiles>=1.1.0",
+    "numpy>=2.3.1",
 ]
 license = "Apache-2.0"
 urls = { Homepage = "https://cocoindex.io/" }

--- a/python/cocoindex/functions.py
+++ b/python/cocoindex/functions.py
@@ -1,20 +1,17 @@
 """All builtin functions."""
 
-from typing import Annotated, Any, TYPE_CHECKING, Literal
+import dataclasses
+from typing import Annotated, Any, Literal
+
 import numpy as np
 from numpy.typing import NDArray
-import dataclasses
 
-from .typing import Float32, Vector, TypeAttr
-from . import op, llm
-
-# Libraries that are heavy to import. Lazily import them later.
-if TYPE_CHECKING:
-    import sentence_transformers
+from . import llm, op
+from .typing import TypeAttr, Vector
 
 # Check if sentence_transformers is available
 try:
-    import sentence_transformers
+    import sentence_transformers  # type: ignore
 
     _SENTENCE_TRANSFORMERS_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
This PR fixes the CI failure.

1. The `numpy` dep is missing, after making `sentence-transformers` optional since #674. Because `sentence-transformers` pulled in numpy as one of its dependencies, our code used numpy implicitly.
2. The `mypy` type checks failed, cuz imports won't be found, after `sentence-transformers` is optional.