### PR TITLE
refactor: `make_engine_value_decoder()` takes `AnalyzedTakesInfo`

### DIFF
--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -16,6 +16,7 @@ from .validation import (
     validate_full_flow_name,
     validate_target_name,
 )
+from .typing import analyze_type_info
 
 from dataclasses import dataclass
 from enum import Enum
@@ -1053,7 +1054,7 @@ class TransformFlow(Generic[T]):
             sig.return_annotation
         )
         result_decoder = make_engine_value_decoder(
-            [], engine_return_type["type"], python_return_type
+            [], engine_return_type["type"], analyze_type_info(python_return_type)
         )
 
         return TransformFlowInfo(engine_flow, result_decoder)

--- a/python/cocoindex/op.py
+++ b/python/cocoindex/op.py
@@ -220,7 +220,9 @@ def _register_op_factory(
                     )
                 self._args_decoders.append(
                     make_engine_value_decoder(
-                        [arg_name], arg.value_type["type"], arg_param.annotation
+                        [arg_name],
+                        arg.value_type["type"],
+                        analyze_type_info(arg_param.annotation),
                     )
                 )
                 process_attribute(arg_name, arg)
@@ -252,7 +254,9 @@ def _register_op_factory(
                     )
                 arg_param = expected_arg[1]
                 self._kwargs_decoders[kwarg_name] = make_engine_value_decoder(
-                    [kwarg_name], kwarg.value_type["type"], arg_param.annotation
+                    [kwarg_name],
+                    kwarg.value_type["type"],
+                    analyze_type_info(arg_param.annotation),
                 )
                 process_attribute(kwarg_name, kwarg)
 
@@ -505,7 +509,9 @@ class _TargetConnector:
 
         if len(key_fields_schema) == 1:
             key_decoder = make_engine_value_decoder(
-                ["(key)"], key_fields_schema[0]["type"], key_annotation
+                ["(key)"],
+                key_fields_schema[0]["type"],
+                analyze_type_info(key_annotation),
             )
         else:
             key_decoder = make_engine_struct_decoder(


### PR DESCRIPTION
This is for better composability.

We also cleaned up related logic and drop unnecessary support for cases that engine fields don't match engine type - which should not happen. This simplifies code and tests.