### PR TITLE
feat(null-propagation): Null value for required args -> Null return

### DIFF
--- a/src/base/schema.rs
+++ b/src/base/schema.rs
@@ -262,6 +262,11 @@ impl EnrichedValueType {
             attrs: Default::default(),
         }
     }
+
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = nullable;
+        self
+    }
 }
 
 impl<DataType> EnrichedValueType<DataType> {

--- a/src/ops/functions/embed_text.rs
+++ b/src/ops/functions/embed_text.rs
@@ -5,7 +5,7 @@ use crate::{
     ops::sdk::*,
 };
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct Spec {
     api_type: LlmApiType,
     model: String,
@@ -92,8 +92,8 @@ impl SimpleFunctionFactoryBase for Factory {
         spec: Spec,
         args: Args,
         _context: Arc<FlowInstanceContext>,
-    ) -> Result<Box<dyn SimpleFunctionExecutor>> {
-        Ok(Box::new(Executor { spec, args }))
+    ) -> Result<impl SimpleFunctionExecutor> {
+        Ok(Executor { spec, args })
     }
 }
 
@@ -123,9 +123,10 @@ mod tests {
 
         let input_args_values = vec![text_content.to_string().into()];
 
-        let input_arg_schemas = vec![build_arg_schema("text", BasicValueType::Str)];
+        let input_arg_schemas = &[build_arg_schema("text", BasicValueType::Str)];
 
-        let result = test_flow_function(factory, spec, input_arg_schemas, input_args_values).await;
+        let result =
+            test_flow_function(&factory, &spec, input_arg_schemas, input_args_values).await;
 
         if result.is_err() {
             eprintln!(

--- a/src/ops/functions/extract_by_llm.rs
+++ b/src/ops/functions/extract_by_llm.rs
@@ -81,19 +81,21 @@ impl SimpleFunctionExecutor for Executor {
     }
 
     async fn evaluate(&self, input: Vec<Value>) -> Result<Value> {
-        let image_bytes: Option<Cow<'_, [u8]>> = self
-            .args
-            .image
-            .as_ref()
-            .map(|arg| arg.value(&input)?.as_bytes())
-            .transpose()?
-            .map(|bytes| Cow::Borrowed(bytes.as_ref()));
-        let text = self
-            .args
-            .text
-            .as_ref()
-            .map(|arg| arg.value(&input)?.as_str())
-            .transpose()?;
+        let image_bytes: Option<Cow<'_, [u8]>> = if let Some(arg) = self.args.image.as_ref()
+            && let Some(value) = arg.value(&input)?.optional()
+        {
+            Some(Cow::Borrowed(value.as_bytes()?))
+        } else {
+            None
+        };
+
+        let text = if let Some(arg) = self.args.text.as_ref()
+            && let Some(value) = arg.value(&input)?.optional()
+        {
+            Some(value.as_str()?)
+        } else {
+            None
+        };
 
         if text.is_none() && image_bytes.is_none() {
             return Ok(Value::Null);
@@ -161,8 +163,8 @@ impl SimpleFunctionFactoryBase for Factory {
         spec: Spec,
         resolved_input_schema: Args,
         _context: Arc<FlowInstanceContext>,
-    ) -> Result<Box<dyn SimpleFunctionExecutor>> {
-        Ok(Box::new(Executor::new(spec, resolved_input_schema).await?))
+    ) -> Result<impl SimpleFunctionExecutor> {
+        Executor::new(spec, resolved_input_schema).await
     }
 }
 
@@ -211,9 +213,10 @@ mod tests {
 
         let input_args_values = vec![text_content.to_string().into()];
 
-        let input_arg_schemas = vec![build_arg_schema("text", BasicValueType::Str)];
+        let input_arg_schemas = &[build_arg_schema("text", BasicValueType::Str)];
 
-        let result = test_flow_function(factory, spec, input_arg_schemas, input_args_values).await;
+        let result =
+            test_flow_function(&factory, &spec, input_arg_schemas, input_args_values).await;
 
         if result.is_err() {
             eprintln!(
@@ -258,5 +261,35 @@ mod tests {
             }
             _ => panic!("Expected Value::Struct, got {value:?}"),
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "This test requires an OpenAI API key or a configured local LLM and may make network calls."]
+    async fn test_null_inputs() {
+        let factory = Arc::new(Factory);
+        let spec = Spec {
+            llm_spec: LlmSpec {
+                api_type: crate::llm::LlmApiType::OpenAi,
+                model: "gpt-4o".to_string(),
+                address: None,
+                api_config: None,
+            },
+            output_type: make_output_type(BasicValueType::Str),
+            instruction: None,
+        };
+        let input_arg_schemas = &[
+            (
+                Some("text"),
+                make_output_type(BasicValueType::Str).with_nullable(true),
+            ),
+            (
+                Some("image"),
+                make_output_type(BasicValueType::Bytes).with_nullable(true),
+            ),
+        ];
+        let input_args_values = vec![Value::Null, Value::Null];
+        let result =
+            test_flow_function(&factory, &spec, input_arg_schemas, input_args_values).await;
+        assert_eq!(result.unwrap(), Value::Null);
     }
 }

--- a/src/ops/functions/parse_json.rs
+++ b/src/ops/functions/parse_json.rs
@@ -98,8 +98,8 @@ impl SimpleFunctionFactoryBase for Factory {
         _spec: EmptySpec,
         args: Args,
         _context: Arc<FlowInstanceContext>,
-    ) -> Result<Box<dyn SimpleFunctionExecutor>> {
-        Ok(Box::new(Executor { args }))
+    ) -> Result<impl SimpleFunctionExecutor> {
+        Ok(Executor { args })
     }
 }
 
@@ -119,12 +119,13 @@ mod tests {
 
         let input_args_values = vec![json_string_content.to_string().into(), lang_value.clone()];
 
-        let input_arg_schemas = vec![
+        let input_arg_schemas = &[
             build_arg_schema("text", BasicValueType::Str),
             build_arg_schema("language", BasicValueType::Str),
         ];
 
-        let result = test_flow_function(factory, spec, input_arg_schemas, input_args_values).await;
+        let result =
+            test_flow_function(&factory, &spec, input_arg_schemas, input_args_values).await;
 
         assert!(
             result.is_ok(),

--- a/src/ops/sdk.rs
+++ b/src/ops/sdk.rs
@@ -44,7 +44,7 @@ pub fn make_output_type<Type: TypeCore>(value_type: Type) -> EnrichedValueType {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EmptySpec {}
 
 #[macro_export]


### PR DESCRIPTION
For a CocoIndex functions, for any required argument, when the argument value is _Null_, we automatically return with _Null_ value. It's one step to enable conditional logic, i.e. once a certaiin input value is missing the transformation can be skipped.

It's similar to (most) SQL function's behavior on NULL values.

This PR touches both schema and data.

This PR only implements it for CocoIndex functions in Rust. We need a separate implementation for Python functions.