### PR TITLE
 fix: make example paths os-friendly using os.path.join()

### DIFF
--- a/docs/docs/examples/examples/codebase_index.md
+++ b/docs/docs/examples/examples/codebase_index.md
@@ -55,10 +55,12 @@ The flow is composed of the following steps:
 We will index the CocoIndex codebase. Here we use the `LocalFile` source to ingest files from the CocoIndex codebase root directory.
 
 ```python
+import os
+
 @cocoindex.flow_def(name="CodeEmbedding")
 def code_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
     data_scope["files"] = flow_builder.add_source(
-        cocoindex.sources.LocalFile(path="../..",
+        cocoindex.sources.LocalFile(path=os.path.join('..', '..'),
                                     included_patterns=["*.py", "*.rs", "*.toml", "*.md", "*.mdx"],
                                     excluded_patterns=[".*", "target", "**/node_modules"]))
     code_embeddings = data_scope.add_collector()

--- a/docs/docs/examples/examples/docs_to_knowledge_graph.md
+++ b/docs/docs/examples/examples/docs_to_knowledge_graph.md
@@ -54,10 +54,12 @@ and then build a knowledge graph.
 We will process CocoIndex documentation markdown files (`.md`, `.mdx`) from the `docs/core` directory ([markdown files](https://github.com/cocoindex-io/cocoindex/tree/main/docs/docs/core), [deployed docs](https://cocoindex.io/docs/core/basics)).
 
 ```python
+import os
+
 @cocoindex.flow_def(name="DocsToKG")
 def docs_to_kg_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
     data_scope["documents"] = flow_builder.add_source(
-        cocoindex.sources.LocalFile(path="../../docs/docs/core",
+        cocoindex.sources.LocalFile(path=os.path.join('..', '..', 'docs', 'docs', 'core'),
                                     included_patterns=["*.md", "*.mdx"]))
 ```
 

--- a/docs/docs/examples/examples/patient_form_extraction.md
+++ b/docs/docs/examples/examples/patient_form_extraction.md
@@ -50,6 +50,8 @@ Alternatively, we have native support for Gemini, Ollama, LiteLLM. You can choos
 Add source from local files.
 
 ```python
+import os
+
 @cocoindex.flow_def(name="PatientIntakeExtraction")
 def patient_intake_extraction_flow(
     flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
@@ -58,7 +60,7 @@ def patient_intake_extraction_flow(
     Define a flow that extracts patient information from intake forms.
     """
     data_scope["documents"] = flow_builder.add_source(
-        cocoindex.sources.LocalFile(path="data/patient_forms", binary=True)
+        cocoindex.sources.LocalFile(path=os.path.join('data', 'patient_forms'), binary=True)
     )
 ```
 

--- a/examples/code_embedding/main.py
+++ b/examples/code_embedding/main.py
@@ -45,7 +45,7 @@ def code_embedding_flow(
     """
     data_scope["files"] = flow_builder.add_source(
         cocoindex.sources.LocalFile(
-            path="../..",
+            path=os.path.join('..', '..'),
             included_patterns=["*.py", "*.rs", "*.toml", "*.md", "*.mdx"],
             excluded_patterns=["**/.*", "target", "**/node_modules"],
         )

--- a/examples/docs_to_knowledge_graph/main.py
+++ b/examples/docs_to_knowledge_graph/main.py
@@ -4,6 +4,7 @@ This example shows how to extract relationships from documents and build a knowl
 
 import dataclasses
 import cocoindex
+import os
 
 neo4j_conn_spec = cocoindex.add_auth_entry(
     "Neo4jConnection",
@@ -66,7 +67,7 @@ def docs_to_kg_flow(
     """
     data_scope["documents"] = flow_builder.add_source(
         cocoindex.sources.LocalFile(
-            path="../../docs/docs/core", included_patterns=["*.md", "*.mdx"]
+            path=os.path.join('..', '..','docs','docs','core'), included_patterns=["*.md", "*.mdx"]
         )
     )
 

--- a/examples/patient_intake_extraction/main.py
+++ b/examples/patient_intake_extraction/main.py
@@ -118,7 +118,7 @@ def patient_intake_extraction_flow(
     Define a flow that extracts patient information from intake forms.
     """
     data_scope["documents"] = flow_builder.add_source(
-        cocoindex.sources.LocalFile(path="data/patient_forms", binary=True)
+        cocoindex.sources.LocalFile(path=os.path.join('data', 'patient_forms'), binary=True)
     )
 
     patients_index = data_scope.add_collector()


### PR DESCRIPTION
## Description

Replaces hardcoded forward slash path separators with `os.path.join()` in 3 examples and their corresponding documentation files 


## Related issues
  Fixes #973