### PR TITLE
feat: Add field-level descriptions to FieldSchema

### DIFF
--- a/python/cocoindex/tests/test_convert.py
+++ b/python/cocoindex/tests/test_convert.py
@@ -1715,3 +1715,81 @@ def test_pydantic_mixed_with_dataclass() -> None:
     order = OrderPydantic(order_id="O1", name="item1", price=10.0)
     mixed = MixedStruct(name="test", pydantic_order=order)
     validate_full_roundtrip(mixed, MixedStruct)
+
+
+@pytest.mark.skipif(not PYDANTIC_AVAILABLE, reason="Pydantic not available")
+def test_pydantic_field_descriptions() -> None:
+    """Test that Pydantic field descriptions are extracted and included in schema."""
+    from pydantic import BaseModel, Field
+
+    class UserWithDescriptions(BaseModel):
+        """A user model with field descriptions."""
+        name: str = Field(description="The user's full name")
+        age: int = Field(description="The user's age in years", ge=0, le=150)
+        email: str = Field(description="The user's email address")
+        is_active: bool = Field(description="Whether the user account is active", default=True)
+
+    # Test that field descriptions are extracted
+    encoded_schema = dump_engine_object(UserWithDescriptions)
+    
+    # Check that the schema contains field descriptions
+    assert "fields" in encoded_schema["type"]
+    fields = encoded_schema["type"]["fields"]
+    
+    # Find fields by name and check descriptions
+    field_descriptions = {field["name"]: field.get("description") for field in fields}
+    
+    assert field_descriptions["name"] == "The user's full name"
+    assert field_descriptions["age"] == "The user's age in years"
+    assert field_descriptions["email"] == "The user's email address"
+    assert field_descriptions["is_active"] == "Whether the user account is active"
+
+
+@pytest.mark.skipif(not PYDANTIC_AVAILABLE, reason="Pydantic not available")
+def test_pydantic_field_descriptions_without_field() -> None:
+    """Test that Pydantic models without field descriptions work correctly."""
+    from pydantic import BaseModel
+
+    class UserWithoutDescriptions(BaseModel):
+        """A user model without field descriptions."""
+        name: str
+        age: int
+        email: str
+
+    # Test that the schema works without descriptions
+    encoded_schema = dump_engine_object(UserWithoutDescriptions)
+    
+    # Check that the schema contains fields but no descriptions
+    assert "fields" in encoded_schema["type"]
+    fields = encoded_schema["type"]["fields"]
+    
+    # Verify no descriptions are present
+    for field in fields:
+        assert "description" not in field or field["description"] is None
+
+
+@pytest.mark.skipif(not PYDANTIC_AVAILABLE, reason="Pydantic not available")
+def test_pydantic_mixed_descriptions() -> None:
+    """Test Pydantic model with some fields having descriptions and others not."""
+    from pydantic import BaseModel, Field
+
+    class MixedDescriptions(BaseModel):
+        """A model with mixed field descriptions."""
+        name: str = Field(description="The name field")
+        age: int  # No description
+        email: str = Field(description="The email field")
+        active: bool  # No description
+
+    # Test that only fields with descriptions have them in the schema
+    encoded_schema = dump_engine_object(MixedDescriptions)
+    
+    assert "fields" in encoded_schema["type"]
+    fields = encoded_schema["type"]["fields"]
+    
+    # Find fields by name and check descriptions
+    field_descriptions = {field["name"]: field.get("description") for field in fields}
+    
+    assert field_descriptions["name"] == "The name field"
+    assert field_descriptions["age"] is None
+    assert field_descriptions["email"] == "The email field"
+    assert field_descriptions["active"] is None

--- a/python/cocoindex/typing.py
+++ b/python/cocoindex/typing.py
@@ -359,7 +359,7 @@ def _encode_struct_schema(
 ) -> tuple[dict[str, Any], int | None]:
     fields = []
 
-    def add_field(name: str, analyzed_type: AnalyzedTypeInfo) -> None:
+    def add_field(name: str, analyzed_type: AnalyzedTypeInfo, description: str | None = None) -> None:
         try:
             type_info = encode_enriched_type_info(analyzed_type)
         except ValueError as e:
@@ -369,6 +369,8 @@ def _encode_struct_schema(
             )
             raise
         type_info["name"] = name
+        if description is not None:
+            type_info["description"] = description
         fields.append(type_info)
 
     def add_fields_from_struct(struct_type: type) -> None:
@@ -384,7 +386,9 @@ def _encode_struct_schema(
                 for name, field_info in struct_type.model_fields.items():  # type: ignore[attr-defined]
                     # Get the annotation from the field info
                     field_type = field_info.annotation
-                    add_field(name, analyze_type_info(field_type))
+                    # Extract description from Pydantic field info
+                    description = getattr(field_info, 'description', None)
+                    add_field(name, analyze_type_info(field_type), description)
             else:
                 raise ValueError(f"Invalid Pydantic model: {struct_type}")
         else:
@@ -624,14 +628,21 @@ class EnrichedValueType:
 class FieldSchema:
     name: str
     value_type: EnrichedValueType
+    description: str | None = None
 
     @staticmethod
     def decode(obj: dict[str, Any]) -> "FieldSchema":
-        return FieldSchema(name=obj["name"], value_type=EnrichedValueType.decode(obj))
+        return FieldSchema(
+            name=obj["name"], 
+            value_type=EnrichedValueType.decode(obj),
+            description=obj.get("description")
+        )
 
     def encode(self) -> dict[str, Any]:
         result = self.value_type.encode()
         result["name"] = self.name
+        if self.description is not None:
+            result["description"] = self.description
         return result
 
 

--- a/src/base/json_schema.rs
+++ b/src/base/json_schema.rs
@@ -45,10 +45,27 @@ impl JsonSchemaBuilder {
         if self.options.extract_descriptions {
             let mut fields: Vec<_> = field_path.iter().map(|f| f.as_str()).collect();
             fields.reverse();
-            self.extra_instructions_per_field
-                .insert(fields.join("."), description.to_string());
+            let field_path_str = fields.join(".");
+            
+            // Check if we already have a description for this field
+            if let Some(existing_description) = self.extra_instructions_per_field.get(&field_path_str) {
+                // Concatenate descriptions with newline separator
+                let combined_description = format!("{}\n{}", existing_description, description.to_string());
+                self.extra_instructions_per_field
+                    .insert(field_path_str, combined_description);
+            } else {
+                self.extra_instructions_per_field
+                    .insert(field_path_str, description.to_string());
+            }
         } else {
-            schema.metadata.get_or_insert_default().description = Some(description.to_string());
+            let metadata = schema.metadata.get_or_insert_default();
+            if let Some(existing_description) = &metadata.description {
+                // Concatenate descriptions with newline separator
+                let combined_description = format!("{}\n{}", existing_description, description.to_string());
+                metadata.description = Some(combined_description);
+            } else {
+                metadata.description = Some(description.to_string());
+            }
         }
     }
 
@@ -334,6 +351,7 @@ pub fn build_json_schema(
             fields: Arc::new(vec![schema::FieldSchema {
                 name: object_wrapper_field_name.clone(),
                 value_type: value_type.clone(),
+                description: None,
             }]),
             description: None,
         };
@@ -355,4 +373,72 @@ pub fn build_json_schema(
             object_wrapper_field_name,
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::schema::{BasicValueType, EnrichedValueType, FieldSchema, StructSchema, ValueType};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_description_concatenation() {
+        // Create a struct with a field that has both field-level and type-level descriptions
+        let struct_schema = StructSchema {
+            description: Some(Arc::from("Test struct description")),
+            fields: Arc::new(vec![
+                FieldSchema {
+                    name: "uuid_field".to_string(),
+                    value_type: EnrichedValueType {
+                        typ: ValueType::Basic(BasicValueType::Uuid),
+                        nullable: false,
+                        attrs: Default::default(),
+                    },
+                    description: Some(Arc::from("This is a field-level description for UUID")),
+                },
+            ]),
+        };
+
+        let enriched_value_type = EnrichedValueType {
+            typ: ValueType::Struct(struct_schema),
+            nullable: false,
+            attrs: Default::default(),
+        };
+
+        let options = ToJsonSchemaOptions {
+            fields_always_required: false,
+            supports_format: true,
+            extract_descriptions: false, // We want to see the description in the schema
+            top_level_must_be_object: false,
+        };
+
+        let result = build_json_schema(enriched_value_type, options).unwrap();
+        
+        // Check if the description contains both field and type descriptions
+        if let Some(properties) = &result.schema.object {
+            if let Some(uuid_field_schema) = properties.properties.get("uuid_field") {
+                if let Schema::Object(schema_object) = uuid_field_schema {
+                    if let Some(description) = &schema_object.metadata.as_ref().and_then(|m| m.description.as_ref()) {
+                        // Check if both descriptions are present
+                        assert!(description.contains("This is a field-level description for UUID"), 
+                            "Field-level description not found in: {}", description);
+                        assert!(description.contains("A UUID, e.g. 123e4567-e89b-12d3-a456-426614174000"), 
+                            "Type-level description not found in: {}", description);
+                        
+                        // Check that they are separated by a newline
+                        assert!(description.contains("\n"), 
+                            "Descriptions should be separated by newline: {}", description);
+                    } else {
+                        panic!("No description found in the schema");
+                    }
+                } else {
+                    panic!("uuid_field schema is not a SchemaObject");
+                }
+            } else {
+                panic!("uuid_field not found in properties");
+            }
+        } else {
+            panic!("No object properties found in schema");
+        }
+    }
 }

--- a/src/base/json_schema.rs
+++ b/src/base/json_schema.rs
@@ -219,6 +219,10 @@ impl JsonSchemaBuilder {
                             *instance_type = SingleOrVec::Vec(types);
                         }
                     }
+                    // Set field description if available
+                    if let Some(description) = &f.description {
+                        self.set_description(&mut schema, description, field_path.prepend(&f.name));
+                    }
                     (f.name.to_string(), schema.into())
                 })
                 .collect(),

--- a/src/base/schema.rs
+++ b/src/base/schema.rs
@@ -325,6 +325,10 @@ pub struct FieldSchema<DataType = ValueType> {
 
     #[serde(flatten)]
     pub value_type: EnrichedValueType<DataType>,
+
+    /// Optional description for the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<Arc<str>>,
 }
 
 impl FieldSchema {
@@ -332,6 +336,19 @@ impl FieldSchema {
         Self {
             name: name.to_string(),
             value_type,
+            description: None,
+        }
+    }
+
+    pub fn new_with_description(
+        name: impl ToString,
+        value_type: EnrichedValueType,
+        description: Option<impl ToString>,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            value_type,
+            description: description.map(|d| d.to_string().into()),
         }
     }
 
@@ -339,6 +356,7 @@ impl FieldSchema {
         Self {
             name: self.name.clone(),
             value_type: self.value_type.without_attrs(),
+            description: None,
         }
     }
 }
@@ -351,6 +369,7 @@ impl<DataType> FieldSchema<DataType> {
         Ok(Self {
             name: field.name.clone(),
             value_type: EnrichedValueType::from_alternative(&field.value_type)?,
+            description: field.description.clone(),
         })
     }
 }

--- a/src/builder/analyzer.rs
+++ b/src/builder/analyzer.rs
@@ -229,6 +229,7 @@ fn try_merge_fields_schemas(
         result_fields.push(FieldSchema {
             name: field1.name.clone(),
             value_type: try_make_common_value_type(&field1.value_type, &field2.value_type)?,
+            description: None,
         });
     }
     Ok(result_fields)
@@ -316,6 +317,7 @@ impl DataScopeBuilder {
         let field_index = self.data.add_field(FieldSchema {
             name,
             value_type: EnrichedValueType::from_alternative(value_type)?,
+            description: None,
         })?;
         Ok(AnalyzedOpOutput {
             field_idx: field_index,
@@ -567,6 +569,7 @@ fn analyze_struct_mapping(
         field_schemas.push(FieldSchema {
             name: field.name.clone(),
             value_type,
+            description: None,
         });
     }
     Ok((

--- a/src/builder/flow_builder.rs
+++ b/src/builder/flow_builder.rs
@@ -365,7 +365,7 @@ impl FlowBuilder {
         }
         let result = Self::last_field_to_data_slice(&self.root_op_scope).into_py_result()?;
         self.direct_input_fields
-            .push(FieldSchema { name, value_type });
+            .push(FieldSchema { name, value_type, description: None });
         Ok(result)
     }
 
@@ -527,6 +527,7 @@ impl FlowBuilder {
                     Ok(FieldSchema {
                         name,
                         value_type: ds.value_type()?,
+                        description: None,
                     })
                 })
                 .collect::<Result<Vec<FieldSchema>>>()

--- a/src/py/convert.rs
+++ b/src/py/convert.rs
@@ -459,6 +459,7 @@ mod tests {
                         nullable: false,
                         attrs: Default::default(),
                     },
+                    description: None,
                 },
                 schema::FieldSchema {
                     name: "b".to_string(),
@@ -467,6 +468,7 @@ mod tests {
                         nullable: false,
                         attrs: Default::default(),
                     },
+                    description: None,
                 },
             ]),
         };
@@ -496,6 +498,7 @@ mod tests {
                         nullable: false,
                         attrs: Default::default(),
                     },
+                    description: None,
                 },
                 schema::FieldSchema {
                     name: "data_col_1".to_string(),
@@ -504,6 +507,7 @@ mod tests {
                         nullable: false,
                         attrs: Default::default(),
                     },
+                    description: None,
                 },
                 schema::FieldSchema {
                     name: "data_col_2".to_string(),
@@ -512,6 +516,7 @@ mod tests {
                         nullable: false,
                         attrs: Default::default(),
                     },
+                    description: None,
                 },
             ]),
         });


### PR DESCRIPTION
- Add description field to Rust FieldSchema struct (`Arc<str>`)
- Update Python FieldSchema to include description field
- Extract Pydantic field descriptions during schema creation
- Update JSON schema builder to include field descriptions
- Add comprehensive tests for field description functionality

Resolves #1074