### PR TITLE
Update documentation to use `cocoindex update --setup main` with modu…

### DIFF
--- a/docs/docs/core/flow_methods.mdx
+++ b/docs/docs/core/flow_methods.mdx
@@ -153,7 +153,7 @@ cocoindex update main.py
 With a `--setup` option, it will also setup the flow first if needed.
 
 ```sh
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 With a `--reexport` option, it will reexport the targets even if there's no change.

--- a/docs/docs/examples/examples/codebase_index.md
+++ b/docs/docs/examples/examples/codebase_index.md
@@ -203,7 +203,7 @@ if __name__ == "__main__":
 
 - Setup and update the index
     ```sh
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
     You'll see the index updates state in the terminal
 

--- a/docs/docs/examples/examples/custom_targets.md
+++ b/docs/docs/examples/examples/custom_targets.md
@@ -192,7 +192,7 @@ output_html.export(
 
 ```bash
 pip install -e .
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 You can add, modify, or remove files in the `data/` directory — CocoIndex will only reprocess the changed files and update the target accordingly.

--- a/docs/docs/examples/examples/docs_to_knowledge_graph.md
+++ b/docs/docs/examples/examples/docs_to_knowledge_graph.md
@@ -334,7 +334,7 @@ It creates relationships by:
 
 2.  Run following commands to setup and update the index.
     ```sh
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
 
     You'll see the index updates state in the terminal. For example,

--- a/docs/docs/examples/examples/patient_form_extraction.md
+++ b/docs/docs/examples/examples/patient_form_extraction.md
@@ -229,7 +229,7 @@ patients_index.export(
 
 ### Setup and update the index
     ```sh
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
     You'll see the index updates state in the terminal
 

--- a/docs/docs/examples/examples/postgres_source.md
+++ b/docs/docs/examples/examples/postgres_source.md
@@ -196,7 +196,7 @@ For example, the following image shows the lineage of the `embedding` field, you
 3. Setup tables and update the index:
 
     ```bash
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
 
 4. Run CocoInsight:

--- a/docs/docs/examples/examples/product_recommendation.md
+++ b/docs/docs/examples/examples/product_recommendation.md
@@ -364,7 +364,7 @@ Note that different relationships may share the same source and target nodes.
 
 2.  Run the following command to setup and update the index.
     ```sh
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
 
     You'll see the index updates state in the terminal. For example, you'll see the following output:

--- a/docs/docs/examples/examples/simple_vector_index.md
+++ b/docs/docs/examples/examples/simple_vector_index.md
@@ -204,7 +204,7 @@ There're two CocoIndex-specific logic:
 - Run the following command to setup and update the index.
 
     ```sh
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
 
 - Start the interactive query in terminal.

--- a/docs/docs/getting_started/quickstart.md
+++ b/docs/docs/getting_started/quickstart.md
@@ -152,7 +152,7 @@ CocoIndex supports other vector databases as well, with 1-line switch.
 - Build the index:
 
     ```bash
-    cocoindex update --setup main.py
+    cocoindex update --setup main
     ```
 
 CocoIndex will run for a few seconds and populate the target table with data as declared by the flow. It will output the following statistics:

--- a/examples/custom_output_files/README.md
+++ b/examples/custom_output_files/README.md
@@ -28,7 +28,7 @@ pip install -e .
 Update the target:
 
 ```bash
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 You can add new files to the `data/` directory, delete or update existing files.

--- a/examples/face_recognition/README.md
+++ b/examples/face_recognition/README.md
@@ -37,7 +37,7 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 Update index, which will also setup the tables at the first time:
 
 ```bash
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 You can also run the command with `-L`, which will watch for file changes and update the index automatically.

--- a/examples/paper_metadata/README.md
+++ b/examples/paper_metadata/README.md
@@ -41,13 +41,13 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 Update index, which will also setup the tables at the first time:
 
 ```bash
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 You can also run the command with `-L`, which will watch for file changes and update the index automatically.
 
 ```bash
-cocoindex update --setup -L main.py
+cocoindex update --setup -L main
 ```
 
 ## CocoInsight

--- a/examples/postgres_source/README.md
+++ b/examples/postgres_source/README.md
@@ -38,7 +38,7 @@ Before running the example, you need to:
 Update index, which will also setup the tables at the first time:
 
 ```bash
-cocoindex update --setup main.py
+cocoindex update --setup main
 ```
 
 ## CocoInsight


### PR DESCRIPTION
**Update documentation to use `cocoindex update --setup main` with module name directly**

- Changed `cocoindex update --setup main.py` to `cocoindex update --setup main` across all examples and documentation
- Updated all README.md files in /examples directory
- Updated documentation files in /docs directory including quickstart and example guides
- Fixes #1089