### PR TITLE
Updates both GitHub workflow and pre-commit hooks to include mypy type checking for the examples directory

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -56,7 +56,7 @@ jobs:
             ${{ matrix.platform.python_exec }} -m maturin develop -E all
         - name: Python type check (mypy)
           run: |
-            ${{ matrix.platform.python_exec }} -m mypy python
+            ${{ matrix.platform.python_exec }} -m mypy python examples
         - name: Python tests
           run: |
             ${{ matrix.platform.python_exec }} -m pytest --capture=no python/cocoindex/tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
         - id: mypy-check
           name: mypy type check
-          entry: dmypy run python
+          entry: dmypy run python examples
           language: system
           types: [python]
           pass_filenames: false


### PR DESCRIPTION
# Fix: Add mypy type checking for examples directory

## Description
Updates both GitHub workflow and pre-commit hooks to include mypy type checking for the `examples` directory, resolving issue #1092.

## Changes Made
- **`.github/workflows/_test.yml`**: Updated mypy command to check both `python` and `examples` directories
- **`.pre-commit-config.yaml`**: Updated mypy hook to include `examples` directory in type checking

## Files Modified
- `.github/workflows/_test.yml` (line 59)
- `.pre-commit-config.yaml` (line 52)

## Testing
- [x] Verified examples directory exists with Python files
- [x] Updated mypy commands to include both directories
- [x] Pre-commit hook configuration matches workflow changes

Fixes #1092