### PR TITLE
feat: implemented transient arguement for the coindex.flow_def decorator

### DIFF
--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -1033,7 +1033,7 @@ class TransientFlowWrapper(Flow):
         flow_builder_state = _FlowBuilderState(flow_full_name)
 
         # Add direct inputs for each input value and collect the data slices
-        input_data_slices = {}
+        input_data_slices: dict[str, DataSlice[Any]] = {}
         for key, value in input_values.items():
             encoded_type = encode_enriched_type(type(value))
             if encoded_type is None:


### PR DESCRIPTION
Issue : https://github.com/cocoindex-io/cocoindex/issues/998

I have successfully implemented the transient argument for the @cocoindex.flow_def decorator as requested.

Updated flow_def decorator
Updated open_flow function
Updated _create_lazy_function
Created TransientFlowWrapper class

Now users can create transient flows like this : 
@cocoindex.flow_def(name="MyFlow", transient=True)
def my_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
    # Flow definition that works with inputs and produces outputs
    # but doesn't maintain persistent state
    pass
    
    