### PR TITLE
feat: collect additional counter for number of rows that are being processed for stats

### DIFF
--- a/src/builder/analyzer.rs
+++ b/src/builder/analyzer.rs
@@ -982,13 +982,13 @@ impl AnalyzerContext {
 
     fn build_scope_qualifier(&self, op_scope: &Arc<OpScope>) -> String {
         let mut scope_names = Vec::new();
-        let mut current_scope = Some(op_scope.as_ref());
+        let mut current_scope = op_scope.as_ref();
 
         // Walk up the parent chain to collect scope names
-        while let Some(scope) = current_scope {
-            if let Some((parent, _)) = &scope.parent {
-                scope_names.push(scope.name.clone());
-                current_scope = Some(parent.as_ref());
+        loop {
+            if let Some((parent, _)) = &current_scope.parent {
+                scope_names.push(current_scope.name.clone());
+                current_scope = parent.as_ref();
             } else {
                 break;
             }

--- a/src/builder/analyzer.rs
+++ b/src/builder/analyzer.rs
@@ -985,24 +985,21 @@ impl AnalyzerContext {
         let mut current_scope = op_scope.as_ref();
 
         // Walk up the parent chain to collect scope names
-        loop {
-            if let Some((parent, _)) = &current_scope.parent {
-                scope_names.push(current_scope.name.clone());
-                current_scope = parent.as_ref();
-            } else {
-                break;
-            }
+        while let Some((parent, _)) = &current_scope.parent {
+            scope_names.push(current_scope.name.as_str());
+            current_scope = parent.as_ref();
         }
 
         // Reverse to get the correct order (root to leaf)
         scope_names.reverse();
 
-        // Build the qualifier string: "" for root, "name." for single level, "parent.child." for nested
-        if scope_names.is_empty() {
-            String::new()
-        } else {
-            format!("{}.", scope_names.join("."))
+        // Build the qualifier string
+        let mut result = String::new();
+        for name in scope_names {
+            result.push_str(&name);
+            result.push('.');
         }
+        result
     }
 }
 

--- a/src/builder/analyzer.rs
+++ b/src/builder/analyzer.rs
@@ -1059,6 +1059,7 @@ pub async fn analyze_flow(
         let target_factory = get_target_factory(&target_kind)?;
         let analyzed_target_op_group = AnalyzedExportTargetOpGroup {
             target_factory,
+            target_kind: target_kind.clone(),
             op_idx: op_ids.export_op_ids,
         };
         export_ops_futs.extend(

--- a/src/builder/plan.rs
+++ b/src/builder/plan.rs
@@ -130,6 +130,7 @@ pub enum AnalyzedReactiveOp {
 pub struct AnalyzedOpScope {
     pub reactive_ops: Vec<AnalyzedReactiveOp>,
     pub collector_len: usize,
+    pub scope_qualifier: String,
 }
 
 pub struct ExecutionPlan {

--- a/src/builder/plan.rs
+++ b/src/builder/plan.rs
@@ -117,6 +117,7 @@ pub struct AnalyzedExportOp {
 
 pub struct AnalyzedExportTargetOpGroup {
     pub target_factory: Arc<dyn TargetFactory + Send + Sync>,
+    pub target_kind: String,
     pub op_idx: Vec<usize>,
 }
 

--- a/src/execution/evaluator.rs
+++ b/src/execution/evaluator.rs
@@ -322,7 +322,7 @@ async fn evaluate_child_op_scope(
     child_scope_entry: ScopeEntry<'_>,
     concurrency_controller: &concur_control::ConcurrencyController,
     memory: &EvaluationMemory,
-    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
+    operation_in_process_stats: Option<&execution::stats::OperationInProcessStats>,
 ) -> Result<()> {
     let _permit = concurrency_controller
         .acquire(Some(|| {
@@ -356,7 +356,7 @@ async fn evaluate_op_scope(
     op_scope: &AnalyzedOpScope,
     scoped_entries: RefList<'_, &ScopeEntry<'_>>,
     memory: &EvaluationMemory,
-    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
+    operation_in_process_stats: Option<&execution::stats::OperationInProcessStats>,
 ) -> Result<()> {
     let head_scope = *scoped_entries.head().unwrap();
     for reactive_op in op_scope.reactive_ops.iter() {
@@ -364,7 +364,8 @@ async fn evaluate_op_scope(
             AnalyzedReactiveOp::Transform(op) => {
                 // Track transform operation start
                 if let Some(ref op_stats) = operation_in_process_stats {
-                    op_stats.start_processing(&op.name, 1);
+                    let transform_key = format!("transform/{}", op.name);
+                    op_stats.start_processing(&transform_key, 1);
                 }
 
                 let mut input_values = Vec::with_capacity(op.inputs.len());
@@ -399,7 +400,8 @@ async fn evaluate_op_scope(
 
                 // Track transform operation completion
                 if let Some(ref op_stats) = operation_in_process_stats {
-                    op_stats.finish_processing(&op.name, 1);
+                    let transform_key = format!("transform/{}", op.name);
+                    op_stats.finish_processing(&transform_key, 1);
                 }
 
                 result?
@@ -532,7 +534,7 @@ pub async fn evaluate_source_entry(
     src_eval_ctx: &SourceRowEvaluationContext<'_>,
     source_value: value::FieldValues,
     memory: &EvaluationMemory,
-    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
+    operation_in_process_stats: Option<&execution::stats::OperationInProcessStats>,
 ) -> Result<EvaluateSourceEntryOutput> {
     let _permit = src_eval_ctx
         .import_op

--- a/src/execution/evaluator.rs
+++ b/src/execution/evaluator.rs
@@ -364,7 +364,8 @@ async fn evaluate_op_scope(
             AnalyzedReactiveOp::Transform(op) => {
                 // Track transform operation start
                 if let Some(ref op_stats) = operation_in_process_stats {
-                    let transform_key = format!("transform/{}", op.name);
+                    let transform_key =
+                        format!("transform/{}{}", op_scope.scope_qualifier, op.name);
                     op_stats.start_processing(&transform_key, 1);
                 }
 
@@ -400,7 +401,8 @@ async fn evaluate_op_scope(
 
                 // Track transform operation completion
                 if let Some(ref op_stats) = operation_in_process_stats {
-                    let transform_key = format!("transform/{}", op.name);
+                    let transform_key =
+                        format!("transform/{}{}", op_scope.scope_qualifier, op.name);
                     op_stats.finish_processing(&transform_key, 1);
                 }
 

--- a/src/execution/evaluator.rs
+++ b/src/execution/evaluator.rs
@@ -322,6 +322,7 @@ async fn evaluate_child_op_scope(
     child_scope_entry: ScopeEntry<'_>,
     concurrency_controller: &concur_control::ConcurrencyController,
     memory: &EvaluationMemory,
+    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
 ) -> Result<()> {
     let _permit = concurrency_controller
         .acquire(Some(|| {
@@ -333,32 +334,44 @@ async fn evaluate_child_op_scope(
                 .sum()
         }))
         .await?;
-    evaluate_op_scope(op_scope, scoped_entries.prepend(&child_scope_entry), memory)
-        .await
-        .with_context(|| {
-            format!(
-                "Evaluating in scope with key {}",
-                match child_scope_entry.key.key() {
-                    Some(k) => k.to_string(),
-                    None => "()".to_string(),
-                }
-            )
-        })
+    evaluate_op_scope(
+        op_scope,
+        scoped_entries.prepend(&child_scope_entry),
+        memory,
+        operation_in_process_stats,
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "Evaluating in scope with key {}",
+            match child_scope_entry.key.key() {
+                Some(k) => k.to_string(),
+                None => "()".to_string(),
+            }
+        )
+    })
 }
 
 async fn evaluate_op_scope(
     op_scope: &AnalyzedOpScope,
     scoped_entries: RefList<'_, &ScopeEntry<'_>>,
     memory: &EvaluationMemory,
+    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
 ) -> Result<()> {
     let head_scope = *scoped_entries.head().unwrap();
     for reactive_op in op_scope.reactive_ops.iter() {
         match reactive_op {
             AnalyzedReactiveOp::Transform(op) => {
+                // Track transform operation start
+                if let Some(ref op_stats) = operation_in_process_stats {
+                    op_stats.start_processing(&op.name, 1);
+                }
+
                 let mut input_values = Vec::with_capacity(op.inputs.len());
                 input_values
                     .extend(assemble_input_values(&op.inputs, scoped_entries).collect::<Vec<_>>());
-                if op.function_exec_info.enable_cache {
+
+                let result = if op.function_exec_info.enable_cache {
                     let output_value_cell = memory.get_cache_entry(
                         || {
                             Ok(op
@@ -382,7 +395,14 @@ async fn evaluate_op_scope(
                         .await
                         .and_then(|v| head_scope.define_field(&op.output, &v))
                 }
-                .with_context(|| format!("Evaluating Transform op `{}`", op.name,))?
+                .with_context(|| format!("Evaluating Transform op `{}`", op.name,));
+
+                // Track transform operation completion
+                if let Some(ref op_stats) = operation_in_process_stats {
+                    op_stats.finish_processing(&op.name, 1);
+                }
+
+                result?
             }
 
             AnalyzedReactiveOp::ForEach(op) => {
@@ -408,6 +428,7 @@ async fn evaluate_op_scope(
                                 ),
                                 &op.concurrency_controller,
                                 memory,
+                                operation_in_process_stats,
                             )
                         })
                         .collect::<Vec<_>>(),
@@ -425,6 +446,7 @@ async fn evaluate_op_scope(
                                 ),
                                 &op.concurrency_controller,
                                 memory,
+                                operation_in_process_stats,
                             )
                         })
                         .collect::<Vec<_>>(),
@@ -443,6 +465,7 @@ async fn evaluate_op_scope(
                                 ),
                                 &op.concurrency_controller,
                                 memory,
+                                operation_in_process_stats,
                             )
                         })
                         .collect::<Vec<_>>(),
@@ -509,6 +532,7 @@ pub async fn evaluate_source_entry(
     src_eval_ctx: &SourceRowEvaluationContext<'_>,
     source_value: value::FieldValues,
     memory: &EvaluationMemory,
+    operation_in_process_stats: Option<&crate::execution::stats::OperationInProcessStats>,
 ) -> Result<EvaluateSourceEntryOutput> {
     let _permit = src_eval_ctx
         .import_op
@@ -556,6 +580,7 @@ pub async fn evaluate_source_entry(
         &src_eval_ctx.plan.op_scope,
         RefList::Nil.prepend(&root_scope_entry),
         memory,
+        operation_in_process_stats,
     )
     .await?;
     let collected_values = root_scope_entry
@@ -604,6 +629,7 @@ pub async fn evaluate_transient_flow(
         &flow.execution_plan.op_scope,
         RefList::Nil.prepend(&root_scope_entry),
         &eval_memory,
+        None, // No operation stats for transient flows
     )
     .await?;
     let output_value = assemble_value(

--- a/src/execution/live_updater.rs
+++ b/src/execution/live_updater.rs
@@ -28,7 +28,7 @@ pub struct FlowLiveUpdater {
     join_set: Mutex<Option<JoinSet<Result<()>>>>,
     stats_per_task: Vec<Arc<stats::UpdateStats>>,
     /// Global tracking of in-process rows per operation
-    operation_in_process_stats: Arc<stats::OperationInProcessStats>,
+    pub operation_in_process_stats: Arc<stats::OperationInProcessStats>,
     recv_state: tokio::sync::Mutex<UpdateReceiveState>,
     num_remaining_tasks_rx: watch::Receiver<usize>,
 
@@ -413,23 +413,6 @@ impl FlowLiveUpdater {
             })
             .collect(),
         }
-    }
-
-    /// Get the total number of rows currently being processed across all operations.
-    pub fn get_total_in_process_count(&self) -> i64 {
-        self.operation_in_process_stats.get_total_in_process_count()
-    }
-
-    /// Get the number of rows currently being processed for a specific operation.
-    pub fn get_operation_in_process_count(&self, operation_name: &str) -> i64 {
-        self.operation_in_process_stats
-            .get_operation_in_process_count(operation_name)
-    }
-
-    /// Get a snapshot of all operation in-process counts.
-    pub fn get_all_operations_in_process(&self) -> std::collections::HashMap<String, i64> {
-        self.operation_in_process_stats
-            .get_all_operations_in_process()
     }
 
     pub async fn next_status_updates(&self) -> Result<FlowLiveUpdaterUpdates> {

--- a/src/execution/live_updater.rs
+++ b/src/execution/live_updater.rs
@@ -27,6 +27,8 @@ pub struct FlowLiveUpdater {
     flow_ctx: Arc<FlowContext>,
     join_set: Mutex<Option<JoinSet<Result<()>>>>,
     stats_per_task: Vec<Arc<stats::UpdateStats>>,
+    /// Global tracking of in-process rows per operation
+    operation_in_process_stats: Arc<stats::OperationInProcessStats>,
     recv_state: tokio::sync::Mutex<UpdateReceiveState>,
     num_remaining_tasks_rx: watch::Receiver<usize>,
 
@@ -83,6 +85,7 @@ struct SourceUpdateTask {
     plan: Arc<plan::ExecutionPlan>,
     execution_ctx: Arc<tokio::sync::OwnedRwLockReadGuard<crate::lib_context::FlowExecutionContext>>,
     source_update_stats: Arc<stats::UpdateStats>,
+    operation_in_process_stats: Arc<stats::OperationInProcessStats>,
     pool: PgPool,
     options: FlowLiveUpdaterOptions,
 
@@ -137,6 +140,7 @@ impl SourceUpdateTask {
                         let change_stream_stats = change_stream_stats.clone();
                         let pool = self.pool.clone();
                         let status_tx = self.status_tx.clone();
+                        let operation_in_process_stats = self.operation_in_process_stats.clone();
                         async move {
                             let mut change_stream = change_stream;
                             let retry_options = retryable::RetryOptions {
@@ -203,6 +207,7 @@ impl SourceUpdateTask {
                                         },
                                         super::source_indexer::UpdateMode::Normal,
                                         update_stats.clone(),
+                                        Some(operation_in_process_stats.clone()),
                                         concur_permit,
                                         Some(move || async move {
                                             SharedAckFn::ack(&shared_ack_fn).await
@@ -328,6 +333,7 @@ impl FlowLiveUpdater {
 
         let mut join_set = JoinSet::new();
         let mut stats_per_task = Vec::new();
+        let operation_in_process_stats = Arc::new(stats::OperationInProcessStats::default());
 
         for source_idx in 0..plan.import_ops.len() {
             let source_update_stats = Arc::new(stats::UpdateStats::default());
@@ -337,6 +343,7 @@ impl FlowLiveUpdater {
                 plan: plan.clone(),
                 execution_ctx: execution_ctx.clone(),
                 source_update_stats: source_update_stats.clone(),
+                operation_in_process_stats: operation_in_process_stats.clone(),
                 pool: pool.clone(),
                 options: options.clone(),
                 status_tx: status_tx.clone(),
@@ -345,10 +352,12 @@ impl FlowLiveUpdater {
             join_set.spawn(source_update_task.run());
             stats_per_task.push(source_update_stats);
         }
+
         Ok(Self {
             flow_ctx,
             join_set: Mutex::new(Some(join_set)),
             stats_per_task,
+            operation_in_process_stats,
             recv_state: tokio::sync::Mutex::new(UpdateReceiveState {
                 status_rx,
                 last_num_source_updates: vec![0; plan.import_ops.len()],
@@ -404,6 +413,23 @@ impl FlowLiveUpdater {
             })
             .collect(),
         }
+    }
+
+    /// Get the total number of rows currently being processed across all operations.
+    pub fn get_total_in_process_count(&self) -> i64 {
+        self.operation_in_process_stats.get_total_in_process_count()
+    }
+
+    /// Get the number of rows currently being processed for a specific operation.
+    pub fn get_operation_in_process_count(&self, operation_name: &str) -> i64 {
+        self.operation_in_process_stats
+            .get_operation_in_process_count(operation_name)
+    }
+
+    /// Get a snapshot of all operation in-process counts.
+    pub fn get_all_operations_in_process(&self) -> std::collections::HashMap<String, i64> {
+        self.operation_in_process_stats
+            .get_all_operations_in_process()
     }
 
     pub async fn next_status_updates(&self) -> Result<FlowLiveUpdaterUpdates> {

--- a/src/execution/row_indexer.rs
+++ b/src/execution/row_indexer.rs
@@ -375,16 +375,15 @@ impl<'a> RowIndexer<'a> {
                         })
                         .collect();
                     (!mutations_w_ctx.is_empty()).then(|| {
-                        // Track export operation start
-                        if let Some(ref op_stats) = self.operation_in_process_stats {
-                            let export_key = format!("export/{}", export_op_group.target_kind);
-                            op_stats.start_processing(&export_key, 1);
-                        }
-
                         let export_key = format!("export/{}", export_op_group.target_kind);
                         let operation_in_process_stats = self.operation_in_process_stats;
 
                         async move {
+                            // Track export operation start
+                            if let Some(ref op_stats) = operation_in_process_stats {
+                                op_stats.start_processing(&export_key, 1);
+                            }
+
                             let result = export_op_group
                                 .target_factory
                                 .apply_mutation(mutations_w_ctx)

--- a/src/execution/row_indexer.rs
+++ b/src/execution/row_indexer.rs
@@ -377,17 +377,11 @@ impl<'a> RowIndexer<'a> {
                     (!mutations_w_ctx.is_empty()).then(|| {
                         // Track export operation start
                         if let Some(ref op_stats) = self.operation_in_process_stats {
-                            for export_op_idx in &export_op_group.op_idx {
-                                let export_op = &self.src_eval_ctx.plan.export_ops[*export_op_idx];
-                                op_stats.start_processing(&export_op.name, 1);
-                            }
+                            let export_key = format!("export/{}", export_op_group.target_kind);
+                            op_stats.start_processing(&export_key, 1);
                         }
 
-                        let export_op_names: Vec<String> = export_op_group
-                            .op_idx
-                            .iter()
-                            .map(|idx| self.src_eval_ctx.plan.export_ops[*idx].name.clone())
-                            .collect();
+                        let export_key = format!("export/{}", export_op_group.target_kind);
                         let operation_in_process_stats = self.operation_in_process_stats;
 
                         async move {
@@ -398,9 +392,7 @@ impl<'a> RowIndexer<'a> {
 
                             // Track export operation completion
                             if let Some(ref op_stats) = operation_in_process_stats {
-                                for export_op_name in &export_op_names {
-                                    op_stats.finish_processing(export_op_name, 1);
-                                }
+                                op_stats.finish_processing(&export_key, 1);
                             }
 
                             result

--- a/src/execution/source_indexer.rs
+++ b/src/execution/source_indexer.rs
@@ -326,8 +326,8 @@ impl SourceIndexingContext {
         let operation_name = {
             let plan_result = self.flow.get_execution_plan().await;
             match plan_result {
-                Ok(plan) => plan.import_ops[self.source_idx].name.clone(),
-                Err(_) => "unknown".to_string(),
+                Ok(plan) => format!("import/{}", plan.import_ops[self.source_idx].name),
+                Err(_) => "import/unknown".to_string(),
             }
         };
 
@@ -339,7 +339,8 @@ impl SourceIndexingContext {
             // Track that we're starting to process this row
             update_stats.processing.start(1);
             if let Some(ref op_stats) = operation_in_process_stats {
-                op_stats.start_processing(&import_op.name, 1);
+                let import_key = format!("import/{}", import_op.name);
+                op_stats.start_processing(&import_key, 1);
             }
 
             let eval_ctx = SourceRowEvaluationContext {

--- a/src/execution/source_indexer.rs
+++ b/src/execution/source_indexer.rs
@@ -337,7 +337,7 @@ impl SourceIndexingContext {
             let schema = &self.flow.data_schema;
 
             // Track that we're starting to process this row
-            update_stats.start_processing(1);
+            update_stats.processing.start(1);
             if let Some(ref op_stats) = operation_in_process_stats {
                 op_stats.start_processing(&import_op.name, 1);
             }
@@ -356,6 +356,7 @@ impl SourceIndexingContext {
                 mode,
                 process_time,
                 &update_stats,
+                operation_in_process_stats.as_ref().map(|s| s.as_ref()),
                 &pool,
             )?;
 
@@ -493,7 +494,7 @@ impl SourceIndexingContext {
             let result = process.await;
 
             // Track that we're finishing processing this row (regardless of success/failure)
-            update_stats.finish_processing(1);
+            update_stats.processing.end(1);
             if let Some(ref op_stats) = operation_in_process_stats {
                 op_stats.finish_processing(&operation_name, 1);
             }

--- a/src/execution/stats.rs
+++ b/src/execution/stats.rs
@@ -64,6 +64,8 @@ pub struct UpdateStats {
     /// Number of source rows that were reprocessed because of logic change.
     pub num_reprocesses: Counter,
     pub num_errors: Counter,
+    /// Number of source rows currently being processed.
+    pub num_in_process: Counter,
 }
 
 impl UpdateStats {
@@ -75,6 +77,7 @@ impl UpdateStats {
             num_updates: self.num_updates.delta(&base.num_updates),
             num_reprocesses: self.num_reprocesses.delta(&base.num_reprocesses),
             num_errors: self.num_errors.delta(&base.num_errors),
+            num_in_process: self.num_in_process.delta(&base.num_in_process),
         }
     }
 
@@ -85,6 +88,7 @@ impl UpdateStats {
         self.num_updates.merge(&delta.num_updates);
         self.num_reprocesses.merge(&delta.num_reprocesses);
         self.num_errors.merge(&delta.num_errors);
+        self.num_in_process.merge(&delta.num_in_process);
     }
 
     pub fn has_any_change(&self) -> bool {
@@ -93,6 +97,70 @@ impl UpdateStats {
             || self.num_updates.get() > 0
             || self.num_reprocesses.get() > 0
             || self.num_errors.get() > 0
+    }
+
+    /// Start processing the specified number of rows.
+    /// Increments the in-process counter and is called when beginning row processing.
+    pub fn start_processing(&self, count: i64) {
+        self.num_in_process.inc(count);
+    }
+
+    /// Finish processing the specified number of rows.
+    /// Decrements the in-process counter and is called when row processing completes.
+    pub fn finish_processing(&self, count: i64) {
+        self.num_in_process.inc(-count);
+    }
+
+    /// Get the current number of rows being processed.
+    pub fn get_in_process_count(&self) -> i64 {
+        self.num_in_process.get()
+    }
+}
+
+/// Per-operation tracking of in-process row counts.
+#[derive(Debug, Default)]
+pub struct OperationInProcessStats {
+    /// Maps operation names to their current in-process row counts.
+    operation_counters: std::sync::RwLock<std::collections::HashMap<String, Counter>>,
+}
+
+impl OperationInProcessStats {
+    /// Start processing rows for the specified operation.
+    pub fn start_processing(&self, operation_name: &str, count: i64) {
+        let mut counters = self.operation_counters.write().unwrap();
+        let counter = counters.entry(operation_name.to_string()).or_default();
+        counter.inc(count);
+    }
+
+    /// Finish processing rows for the specified operation.
+    pub fn finish_processing(&self, operation_name: &str, count: i64) {
+        let counters = self.operation_counters.write().unwrap();
+        if let Some(counter) = counters.get(operation_name) {
+            counter.inc(-count);
+        }
+    }
+
+    /// Get the current in-process count for a specific operation.
+    pub fn get_operation_in_process_count(&self, operation_name: &str) -> i64 {
+        let counters = self.operation_counters.read().unwrap();
+        counters
+            .get(operation_name)
+            .map_or(0, |counter| counter.get())
+    }
+
+    /// Get a snapshot of all operation in-process counts.
+    pub fn get_all_operations_in_process(&self) -> std::collections::HashMap<String, i64> {
+        let counters = self.operation_counters.read().unwrap();
+        counters
+            .iter()
+            .map(|(name, counter)| (name.clone(), counter.get()))
+            .collect()
+    }
+
+    /// Get the total in-process count across all operations.
+    pub fn get_total_in_process_count(&self) -> i64 {
+        let counters = self.operation_counters.read().unwrap();
+        counters.values().map(|counter| counter.get()).sum()
     }
 }
 
@@ -136,6 +204,11 @@ impl std::fmt::Display for UpdateStats {
             ));
         }
 
+        let num_in_process = self.num_in_process.get();
+        if num_in_process > 0 {
+            messages.push(format!("{num_in_process} source rows IN PROCESS"));
+        }
+
         if !messages.is_empty() {
             write!(f, "{}", messages.join("; "))?;
         } else {
@@ -169,5 +242,195 @@ impl std::fmt::Display for IndexUpdateInfo {
             writeln!(f, "{source}")?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn test_update_stats_in_process_tracking() {
+        let stats = UpdateStats::default();
+
+        // Initially should be zero
+        assert_eq!(stats.get_in_process_count(), 0);
+
+        // Start processing some rows
+        stats.start_processing(5);
+        assert_eq!(stats.get_in_process_count(), 5);
+
+        // Start processing more rows
+        stats.start_processing(3);
+        assert_eq!(stats.get_in_process_count(), 8);
+
+        // Finish processing some rows
+        stats.finish_processing(2);
+        assert_eq!(stats.get_in_process_count(), 6);
+
+        // Finish processing remaining rows
+        stats.finish_processing(6);
+        assert_eq!(stats.get_in_process_count(), 0);
+    }
+
+    #[test]
+    fn test_update_stats_thread_safety() {
+        let stats = Arc::new(UpdateStats::default());
+        let mut handles = Vec::new();
+
+        // Spawn multiple threads that concurrently increment and decrement
+        for i in 0..10 {
+            let stats_clone = Arc::clone(&stats);
+            let handle = thread::spawn(move || {
+                // Each thread processes 100 rows
+                stats_clone.start_processing(100);
+
+                // Simulate some work
+                thread::sleep(std::time::Duration::from_millis(i * 10));
+
+                // Finish processing
+                stats_clone.finish_processing(100);
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Should be back to zero
+        assert_eq!(stats.get_in_process_count(), 0);
+    }
+
+    #[test]
+    fn test_operation_in_process_stats() {
+        let op_stats = OperationInProcessStats::default();
+
+        // Initially should be zero for all operations
+        assert_eq!(op_stats.get_operation_in_process_count("op1"), 0);
+        assert_eq!(op_stats.get_total_in_process_count(), 0);
+
+        // Start processing rows for different operations
+        op_stats.start_processing("op1", 5);
+        op_stats.start_processing("op2", 3);
+
+        assert_eq!(op_stats.get_operation_in_process_count("op1"), 5);
+        assert_eq!(op_stats.get_operation_in_process_count("op2"), 3);
+        assert_eq!(op_stats.get_total_in_process_count(), 8);
+
+        // Get all operations snapshot
+        let all_ops = op_stats.get_all_operations_in_process();
+        assert_eq!(all_ops.len(), 2);
+        assert_eq!(all_ops.get("op1"), Some(&5));
+        assert_eq!(all_ops.get("op2"), Some(&3));
+
+        // Finish processing some rows
+        op_stats.finish_processing("op1", 2);
+        assert_eq!(op_stats.get_operation_in_process_count("op1"), 3);
+        assert_eq!(op_stats.get_total_in_process_count(), 6);
+
+        // Finish processing all remaining rows
+        op_stats.finish_processing("op1", 3);
+        op_stats.finish_processing("op2", 3);
+        assert_eq!(op_stats.get_total_in_process_count(), 0);
+    }
+
+    #[test]
+    fn test_operation_in_process_stats_thread_safety() {
+        let op_stats = Arc::new(OperationInProcessStats::default());
+        let mut handles = Vec::new();
+
+        // Spawn threads for different operations
+        for i in 0..5 {
+            let op_stats_clone = Arc::clone(&op_stats);
+            let op_name = format!("operation_{}", i);
+
+            let handle = thread::spawn(move || {
+                // Each operation processes 50 rows
+                op_stats_clone.start_processing(&op_name, 50);
+
+                // Simulate some work
+                thread::sleep(std::time::Duration::from_millis(i * 20));
+
+                // Finish processing
+                op_stats_clone.finish_processing(&op_name, 50);
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Should be back to zero
+        assert_eq!(op_stats.get_total_in_process_count(), 0);
+    }
+
+    #[test]
+    fn test_update_stats_merge_with_in_process() {
+        let stats1 = UpdateStats::default();
+        let stats2 = UpdateStats::default();
+
+        // Set up different counts
+        stats1.start_processing(10);
+        stats1.num_insertions.inc(5);
+
+        stats2.start_processing(15);
+        stats2.num_updates.inc(3);
+
+        // Merge stats2 into stats1
+        stats1.merge(&stats2);
+
+        // Check that all counters were merged correctly
+        assert_eq!(stats1.get_in_process_count(), 25); // 10 + 15
+        assert_eq!(stats1.num_insertions.get(), 5);
+        assert_eq!(stats1.num_updates.get(), 3);
+    }
+
+    #[test]
+    fn test_update_stats_delta_with_in_process() {
+        let base = UpdateStats::default();
+        let current = UpdateStats::default();
+
+        // Set up base state
+        base.start_processing(5);
+        base.num_insertions.inc(2);
+
+        // Set up current state
+        current.start_processing(12);
+        current.num_insertions.inc(7);
+        current.num_updates.inc(3);
+
+        // Calculate delta
+        let delta = current.delta(&base);
+
+        // Check that delta contains the differences
+        assert_eq!(delta.get_in_process_count(), 7); // 12 - 5
+        assert_eq!(delta.num_insertions.get(), 5); // 7 - 2
+        assert_eq!(delta.num_updates.get(), 3); // 3 - 0
+    }
+
+    #[test]
+    fn test_update_stats_display_with_in_process() {
+        let stats = UpdateStats::default();
+
+        // Test with no activity
+        assert_eq!(format!("{}", stats), "No changes");
+
+        // Test with in-process rows
+        stats.start_processing(5);
+        assert!(format!("{}", stats).contains("5 source rows IN PROCESS"));
+
+        // Test with mixed activity
+        stats.num_insertions.inc(3);
+        stats.num_errors.inc(1);
+        let display = format!("{}", stats);
+        assert!(display.contains("1 source rows FAILED"));
+        assert!(display.contains("3 source rows processed"));
+        assert!(display.contains("5 source rows IN PROCESS"));
     }
 }


### PR DESCRIPTION
### Description
can now collect additional counter for number of rows that are being processed - for stats

- [x] Ran precommit hooks
- [x] tests written for new counter added 

Written 7 tests status
<img width="1222" height="264" alt="image" src="https://github.com/user-attachments/assets/c68b4bf5-4602-48df-970d-c80a318f9351" />
 