### PR TITLE
feat(qdrant): Add vector index support method

### DIFF
--- a/docs/docs/targets/index.md
+++ b/docs/docs/targets/index.md
@@ -333,6 +333,3 @@ You can find end-to-end examples fitting into any of supported property graphs i
 *   <ExampleButton href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/docs_to_knowledge_graph" text="Docs to Knowledge Graph" margin="0 0 16px 0" />
 
 *   <ExampleButton href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/product_recommendation" text="Product Recommendation" margin="0 0 16px 0" />
-
-
-

--- a/docs/docs/targets/kuzu.md
+++ b/docs/docs/targets/kuzu.md
@@ -11,7 +11,7 @@ Exports data to a [Kuzu](https://kuzu.com/) graph database.
 
 ## Get Started
 
-Read [Property Graph Targets](./index.md#property-graph-targets) for more information to get started on how it works in CocoIndex. 
+Read [Property Graph Targets](./index.md#property-graph-targets) for more information to get started on how it works in CocoIndex.
 
 ## Spec
 

--- a/docs/docs/targets/neo4j.md
+++ b/docs/docs/targets/neo4j.md
@@ -11,7 +11,7 @@ import { ExampleButton } from '../../src/components/GitHubButton';
 
 
 ## Get Started
-Read [Property Graph Targets](./index.md#property-graph-targets) for more information to get started on how it works in CocoIndex. 
+Read [Property Graph Targets](./index.md#property-graph-targets) for more information to get started on how it works in CocoIndex.
 
 
 ## Spec

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -49,7 +49,7 @@ const sidebars: SidebarsConfig = {
       link: { type: 'doc', id: 'targets/index' },
       collapsed: true,
       items: [
-      
+
             'targets/postgres',
             'targets/qdrant',
             'targets/lancedb',


### PR DESCRIPTION
This PR introduces HNSW vector index support for qdrant, allowing users to create collections with fully configurable vector indexes. 

- Enabled per-field vector metric configuration (Cosine, L2, InnerProduct).
- Enhanced SetupState and SetupChange to manage collection creation, deletion, and updates with vector indexes.
- Validates vector fields for fixed dimensions; unsupported vectors are stored in payload.
- Export mutations now correctly convert typed values into DenseVector or MultiDenseVector.
- Cached Qdrant clients per connection for efficient repeated operations.
- Clear error handling for unsupported vector index methods or duplicate vector index definitions.

fixes #1052 