### PR TITLE
fix: show continuous stats during batch updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "hyper-util",
  "indenter",
  "indexmap 2.10.0",
+ "indicatif",
  "indoc",
  "infer 0.19.0",
  "itertools 0.14.0",
@@ -1416,6 +1417,19 @@ dependencies = [
  "toml",
  "winnow",
  "yaml-rust2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1867,6 +1881,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3032,6 +3052,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,6 +3554,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numpy"
@@ -6067,6 +6106,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ blake2 = "0.10.6"
 pgvector = { version = "0.4.1", features = ["sqlx", "halfvec"] }
 phf = { version = "0.12.1", features = ["macros"] }
 indenter = "0.3.4"
+indicatif = "0.17.9"
 itertools = "0.14.0"
 derivative = "2.2.0"
 hex = "0.4.3"

--- a/src/execution/live_updater.rs
+++ b/src/execution/live_updater.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use super::stats;
 use futures::future::try_join_all;
+use indicatif::ProgressBar;
 use sqlx::PgPool;
 use tokio::{sync::watch, task::JoinSet, time::MissedTickBehavior};
 
@@ -331,34 +332,41 @@ impl SourceUpdateTask {
         let update_stats = Arc::new(stats::UpdateStats::default());
 
         // Spawn periodic stats reporting task if print_stats is enabled
-        let reporting_handle = if self.options.print_stats {
+        let (reporting_handle, progress_bar) = if self.options.print_stats {
             let update_stats_clone = update_stats.clone();
             let update_title_owned = update_title.to_string();
             let flow_name = self.flow.flow_instance.name.clone();
             let import_op_name = self.import_op().name.clone();
 
+            // Create a progress bar that will overwrite the same line
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                indicatif::ProgressStyle::default_spinner()
+                    .template("{msg}")
+                    .unwrap(),
+            );
+            let pb_clone = pb.clone();
+
             let report_task = async move {
                 let mut interval = tokio::time::interval(REPORT_INTERVAL);
-                let mut last_stats = update_stats_clone.as_ref().clone();
                 interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
                 interval.tick().await; // Skip first tick
+
                 loop {
                     interval.tick().await;
                     let current_stats = update_stats_clone.as_ref().clone();
-                    let delta = current_stats.delta(&last_stats);
-                    if delta.has_any_change() {
-                        // Print periodic progress (do NOT merge here, final report_stats will merge)
-                        println!(
+                    if current_stats.has_any_change() {
+                        // Show cumulative stats (always show latest total, not delta)
+                        pb_clone.set_message(format!(
                             "{}.{} ({update_title_owned}): {}",
-                            flow_name, import_op_name, delta
-                        );
-                        last_stats = current_stats;
+                            flow_name, import_op_name, current_stats
+                        ));
                     }
                 }
             };
-            Some(tokio::spawn(report_task))
+            (Some(tokio::spawn(report_task)), Some(pb))
         } else {
-            None
+            (None, None)
         };
 
         // Run the actual update
@@ -376,6 +384,11 @@ impl SourceUpdateTask {
         // Cancel the reporting task if it was spawned
         if let Some(handle) = reporting_handle {
             handle.abort();
+        }
+
+        // Clear the progress bar to ensure final stats appear on a new line
+        if let Some(pb) = progress_bar {
+            pb.finish_and_clear();
         }
 
         // Check update result


### PR DESCRIPTION
  ## Summary
  Fixes #939 
  
  ## Problem
  Previously, when running `cocoindex update`, stats about processed documents were only printed once a full processing pass completed. For long-running updates, users had no visibility into ongoing progress, making it unclear if the process was  still working.
  
  ## Solution
   Implemented continuous stats reporting by spawning a background task.
   
   ## Example Output
<img width="1086" height="411" alt="Screenshot 2025-10-20 at 11 14 13 AM" src="https://github.com/user-attachments/assets/5e79cb49-3b4d-46ba-9984-7f1f28defe08" />

   