### PR TITLE
feat: deprecate setup flag

### DIFF
--- a/docs/docs/core/cli-commands.md
+++ b/docs/docs/core/cli-commands.md
@@ -108,7 +108,7 @@ cocoindex server [OPTIONS] APP_TARGET
 | `-ci, --cors-cocoindex` | Allow `https://cocoindex.io` to access the server. |
 | `-cl, --cors-local INTEGER` | Allow `http://localhost:<port>` to access the server. |
 | `-L, --live-update` | Continuously watch changes from data sources and apply to the target index. |
-| `--setup` | Automatically setup backends for the flow if it's not setup yet. |
+| `--setup` | (DEPRECATED) Automatically setup backends for the flow if it's not setup yet. This is now the default behavior.  [default: True] |
 | `--reset` | Drop existing setup before starting server (equivalent to running 'cocoindex drop' first). `--reset` implies `--setup`. |
 | `--reexport` | Reexport to targets even if there's no change. |
 | `-f, --force` | Force setup without confirmation prompts. |
@@ -194,7 +194,7 @@ cocoindex update [OPTIONS] APP_FLOW_SPECIFIER
 |--------|-------------|
 | `-L, --live` | Continuously watch changes from data sources and apply to the target index. |
 | `--reexport` | Reexport to targets even if there's no change. |
-| `--setup` | Automatically setup backends for the flow if it's not setup yet. |
+| `--setup` | (DEPRECATED) Automatically setup backends for the flow if it's not setup yet. This is now the default behavior.  [default: True] |
 | `--reset` | Drop existing setup before updating (equivalent to running 'cocoindex drop' first). `--reset` implies `--setup`. |
 | `-f, --force` | Force setup without confirmation prompts. |
 | `-q, --quiet` | Avoid printing anything to the standard output, e.g. statistics. |

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -251,6 +251,23 @@ def _drop_flows(flows: Iterable[flow.Flow], app_ref: str, force: bool = False) -
     setup_bundle.apply(report_to_stdout=True)
 
 
+def _deprecate_setup_flag(
+    ctx: click.Context, param: click.Parameter, value: bool
+) -> bool:
+    """Callback to warn users that --setup flag is deprecated."""
+    # Check if the parameter was explicitly provided by the user
+    if param.name is not None:
+        param_source = ctx.get_parameter_source(param.name)
+        if param_source == click.core.ParameterSource.COMMANDLINE:
+            click.secho(
+                "Warning: The --setup flag is deprecated and will be removed in a future version. "
+                "Setup is now always enabled by default.",
+                fg="yellow",
+                err=True,
+            )
+    return value
+
+
 def _setup_flows(
     flow_iter: Iterable[flow.Flow],
     *,
@@ -392,8 +409,9 @@ def drop(app_target: str | None, flow_name: tuple[str, ...], force: bool) -> Non
     "--setup",
     is_flag=True,
     show_default=True,
-    default=False,
-    help="Automatically setup backends for the flow if it's not setup yet.",
+    default=True,
+    callback=_deprecate_setup_flag,
+    help="(DEPRECATED) Automatically setup backends for the flow if it's not setup yet. This is now the default behavior.",
 )
 @click.option(
     "--reset",
@@ -553,8 +571,9 @@ def evaluate(
     "--setup",
     is_flag=True,
     show_default=True,
-    default=False,
-    help="Automatically setup backends for the flow if it's not setup yet.",
+    default=True,
+    callback=_deprecate_setup_flag,
+    help="(DEPRECATED) Automatically setup backends for the flow if it's not setup yet. This is now the default behavior.",
 )
 @click.option(
     "--reset",


### PR DESCRIPTION
Implements [#1211](https://github.com/cocoindex-io/cocoindex/issues/1211) 
Makes `--setup` the default behavior for `update` and `server` commands and deprecates the flag for future removal.

## Changes
- The `--setup` flag now defaults to `True` (previously `False`) for both `cocoindex update` and `cocoindex server` commands
- Added a callback that displays a warning when users explicitly use `--setup`, informing them the flag is deprecated
- Flag description now shows `(DEPRECATED)` and indicates it's enabled by default