### PR TITLE
fix(runtime): guard sync API inside async contexts (#1085)

### DIFF
--- a/python/cocoindex/runtime.py
+++ b/python/cocoindex/runtime.py
@@ -42,7 +42,7 @@ class _ExecutionContext:
         except RuntimeError:
             running_loop = None
 
-        loop = self.event_loop  
+        loop = self.event_loop
 
         if running_loop is not None:
             if running_loop is loop:


### PR DESCRIPTION
Guard sync API when called from async contexts.

- If called on the CocoIndex-managed loop: raise RuntimeError (prevents deadlock).
- If called on a different running loop: emit a warning and run safely.
- If no loop is running: run as usual.

Closes #1085.