### PR TITLE
feat: add max_file_size support to AmazonS3 source

### DIFF
--- a/docs/docs/sources/amazons3.md
+++ b/docs/docs/sources/amazons3.md
@@ -131,6 +131,9 @@ The spec takes the following fields:
 
     :::
 
+*   `max_file_size` (`int`, optional): if provided, files exceeding this size in bytes will be treated as non-existent and skipped during processing.
+    This is useful to avoid processing large files that are not relevant to your use case, such as videos or backups.
+    If not specified, no size limit is applied.
 *   `sqs_queue_url` (`str`, optional): if provided, the source will receive change event notifications from Amazon S3 via this SQS queue.
 
     :::info

--- a/python/cocoindex/sources/_engine_builtin_specs.py
+++ b/python/cocoindex/sources/_engine_builtin_specs.py
@@ -55,6 +55,7 @@ class AmazonS3(op.SourceSpec):
     binary: bool = False
     included_patterns: list[str] | None = None
     excluded_patterns: list[str] | None = None
+    max_file_size: int | None = None
     sqs_queue_url: str | None = None
     redis: RedisNotification | None = None
 


### PR DESCRIPTION
## Description

Add optional `max_file_size` parameter to the AmazonS3 source to filter files by size in both `list()` and `get_value()` APIs. Files exceeding the specified limit are treated as non-existent and skipped during processing.

## Changes

- Added `max_file_size: Option<i64>` field to AmazonS3 Spec and Executor
- Implemented file size filtering in `list()` method using S3 metadata
- Implemented file size filtering in `get_value()` method using head_object()
- Updated Python spec to expose the new parameter
- Added documentation for the new parameter

## Closes #1252