### PR TITLE
feat: add max_file_size support to LocalFile source

### DIFF
--- a/docs/docs/sources/localfile.md
+++ b/docs/docs/sources/localfile.md
@@ -23,6 +23,10 @@ The spec takes the following fields:
 
     :::
 
+*   `max_file_size` (`int`, optional): if provided, files exceeding this size in bytes will be treated as non-existent and skipped during processing.
+    This is useful to avoid processing large files that are not relevant to your use case, such as videos or backups.
+    If not specified, no size limit is applied.
+
 ### Schema
 
 The output is a [*KTable*](/docs/core/data_types#ktable) with the following sub fields:

--- a/python/cocoindex/sources/_engine_builtin_specs.py
+++ b/python/cocoindex/sources/_engine_builtin_specs.py
@@ -23,6 +23,9 @@ class LocalFile(op.SourceSpec):
     # See https://docs.rs/globset/latest/globset/index.html#syntax for the syntax of the patterns.
     excluded_patterns: list[str] | None = None
 
+    # If provided, files exceeding this size in bytes will be treated as non-existent.
+    max_file_size: int | None = None
+
 
 class GoogleDrive(op.SourceSpec):
     """Import data from Google Drive."""


### PR DESCRIPTION
Add optional max_file_size parameter to filter files by size in both list() and get_value() APIs. Files exceeding the limit are treated as non-existent. Closes #1249