### PR TITLE
feat: make `LlmGenerationClient::generate` return json

### DIFF
--- a/rust/cocoindex/src/llm/anthropic.rs
+++ b/rust/cocoindex/src/llm/anthropic.rs
@@ -123,7 +123,7 @@ impl LlmGenerationClient for Client {
         }
         let text = if let Some(json) = extracted_json {
             // Try strict JSON serialization first
-            serde_json::to_string(&json)?
+            return Ok(LlmGenerateResponse::Json(json));
         } else {
             // Fallback: try text if no tool output found
             match &mut resp_json["content"][0]["text"] {
@@ -155,7 +155,7 @@ impl LlmGenerationClient for Client {
             }
         };
 
-        Ok(LlmGenerateResponse { text })
+        Ok(LlmGenerateResponse::Text(text))
     }
 
     fn json_schema_options(&self) -> ToJsonSchemaOptions {

--- a/rust/cocoindex/src/llm/bedrock.rs
+++ b/rust/cocoindex/src/llm/bedrock.rs
@@ -148,7 +148,7 @@ impl LlmGenerationClient for Client {
 
             if let Some(json) = extracted_json {
                 // Return the structured output as JSON
-                serde_json::to_string(&json)?
+                return Ok(LlmGenerateResponse::Json(json));
             } else {
                 // Fall back to text content
                 let mut text_parts = Vec::new();
@@ -165,7 +165,7 @@ impl LlmGenerationClient for Client {
             return Err(anyhow::anyhow!("No content found in Bedrock response"));
         };
 
-        Ok(LlmGenerateResponse { text })
+        Ok(LlmGenerateResponse::Text(text))
     }
 
     fn json_schema_options(&self) -> ToJsonSchemaOptions {

--- a/rust/cocoindex/src/llm/mod.rs
+++ b/rust/cocoindex/src/llm/mod.rs
@@ -66,8 +66,9 @@ pub struct LlmGenerateRequest<'a> {
 }
 
 #[derive(Debug)]
-pub struct LlmGenerateResponse {
-    pub text: String,
+pub enum LlmGenerateResponse {
+    Text(String),
+    Json(serde_json::Value),
 }
 
 #[async_trait]

--- a/rust/cocoindex/src/llm/ollama.rs
+++ b/rust/cocoindex/src/llm/ollama.rs
@@ -108,10 +108,8 @@ impl LlmGenerationClient for Client {
         })
         .await
         .context("Ollama API error")?;
-        let json: OllamaResponse = res.json().await?;
-        Ok(super::LlmGenerateResponse {
-            text: json.response,
-        })
+
+        Ok(super::LlmGenerateResponse::Json(res.json().await?))
     }
 
     fn json_schema_options(&self) -> super::ToJsonSchemaOptions {

--- a/rust/cocoindex/src/ops/functions/extract_by_llm.rs
+++ b/rust/cocoindex/src/ops/functions/extract_by_llm.rs
@@ -113,7 +113,10 @@ impl SimpleFunctionExecutor for Executor {
             }),
         };
         let res = self.client.generate(req).await?;
-        let json_value: serde_json::Value = utils::deser::from_json_str(res.text.as_str())?;
+        let json_value = match res {
+            crate::llm::LlmGenerateResponse::Text(text) => utils::deser::from_json_str(&text)?,
+            crate::llm::LlmGenerateResponse::Json(value) => value,
+        };
         let value = self.value_extractor.extract_value(json_value)?;
         Ok(value)
     }


### PR DESCRIPTION
This PR is to complete #400 .

To finish that, this PR completed following tasks:

- [x] change the `LlmGenerateResponse` to enum to contain the text or json
- [x] make all the LLM client that implements the `LlmGenerationClient` return json or text based on the output format.

But actually, I'm not sure about the json value that I choose is correct, I just follow the original logic to return the json value.