### PR TITLE
Documentation: Adds onBrokenAnchors config to report errors

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Configures Docusaurus to throw error when broken anchors are found in the docs. This will prevent documentation with broken anchors from being built. 

Tested by manually adding a broken anchor to docs and running ` npm run build`. New config successfully caught broken anchor. 

Fixes #1117 