### PR TITLE
`docs`: add Postgres server reminder to quickstart docs

### DIFF
--- a/docs/docs/getting_started/quickstart.md
+++ b/docs/docs/getting_started/quickstart.md
@@ -144,6 +144,12 @@ CocoIndex supports other vector databases as well, with 1-line switch.
     export COCOINDEX_DATABASE_URL="postgresql://cocoindex:cocoindex@localhost:5432/cocoindex"
     ```
 
+:::info Prerequisite
+
+Make sure your Postgres server is running before proceeding. See [how to launch CocoIndex](../core/settings#configure-cocoindex-settings) for details.
+
+:::
+
 - Build the index:
 
     ```sh


### PR DESCRIPTION
Adds a short info admonition in the quickstart guide reminding users to ensure their Postgres server is running before executing `cocoindex update main`. Links to the [`how to launch CocoIndex`](https://cocoindex.io/docs/core/settings#configure-cocoindex-settings) section for reference.

Fixes #1350