### PR TITLE
`docs`: fix broken workflow badge in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
 [![License](https://img.shields.io/badge/license-Apache%202.0-5B5BD6?logo=opensourceinitiative&logoColor=white)](https://opensource.org/licenses/Apache-2.0)
-[![docs](https://github.com/cocoindex-io/cocoindex/actions/workflows/docs.yml/badge.svg?event=push&color=5B5BD6)](https://github.com/cocoindex-io/cocoindex/actions/workflows/docs.yml)
+[![docs](https://github.com/cocoindex-io/cocoindex/actions/workflows/docs_test.yml/badge.svg)](https://github.com/cocoindex-io/cocoindex/actions/workflows/docs_test.yml)
 
 </div>
 


### PR DESCRIPTION
The docs badge in [`docs/README.md`](https://github.com/cocoindex-io/cocoindex/blob/main/docs/README.md) was pointing to a non-existent `docs.yml` workflow. Updated it to point to the `docs_test.yml` workflow instead.

_PS: Sorry for the separate PR—noticed this right after submitting the [quickstart docs PR](https://github.com/cocoindex-io/cocoindex/pull/1368)!_