### PR TITLE
fix: issues for `--full-reprocess` (#1385)

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -636,6 +636,7 @@ def server(
     setup: bool,  # pylint: disable=redefined-outer-name
     reset: bool,
     reexport: bool,
+    full_reprocess: bool,
     force: bool,
     quiet: bool,
     cors_origin: str | None,
@@ -659,6 +660,7 @@ def server(
         cors_local,
         live_update,
         reexport,
+        full_reprocess,
         quiet,
     )
     kwargs = {
@@ -719,6 +721,7 @@ def _run_server(
     cors_local: int | None = None,
     live_update: bool = False,
     reexport: bool = False,
+    full_reprocess: bool = False,
     quiet: bool = False,
     /,
     *,
@@ -783,6 +786,7 @@ def _run_server(
         options = flow.FlowLiveUpdaterOptions(
             live_mode=live_update,
             reexport_targets=reexport,
+            full_reprocess=full_reprocess,
             print_stats=not quiet,
         )
         asyncio.run_coroutine_threadsafe(

--- a/rust/cocoindex/src/execution/source_indexer.rs
+++ b/rust/cocoindex/src/execution/source_indexer.rs
@@ -422,9 +422,9 @@ impl SourceIndexingContext {
                             } => {
                                 // Fast path optimization: may collapse the row based on source version fingerprint.
                                 // Still need to update the tracking table as the processed ordinal advanced.
-                                if let Some(prev_content_version_fp) =
-                                    &prev_version_state.content_version_fp
-                                    && mode == UpdateMode::Normal
+                                if !mode.needs_full_export()
+                                    && let Some(prev_content_version_fp) =
+                                        &prev_version_state.content_version_fp
                                 {
                                     let collapse_result = row_indexer
                                         .try_collapse(
@@ -611,7 +611,7 @@ impl SourceIndexingContext {
                     let scan_generation = state.scan_generation;
                     let row_state = state.rows.entry(row.key.clone()).or_default();
                     row_state.touched_generation = scan_generation;
-                    if update_options.mode == UpdateMode::Normal
+                    if !update_options.mode.needs_full_export()
                         && row_state
                             .version_state
                             .source_version


### PR DESCRIPTION
fix issues for #1385:

- `full-reprocess` is in options but not in function arguments for `cocoindex server`
- Correctly classify update vs reprocess in stats when there's full-reprocess
- Use `needs_full_export()` when appropriate