### PR TITLE
docs: move Query Support above Built-in Sources

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -26,6 +26,11 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
+      type: 'doc',
+      id: 'query',
+      label: 'Query Support',
+    },
+    {
       type: 'category',
       label: 'Built-in Sources',
       link: { type: 'doc', id: 'sources/index' },
@@ -78,11 +83,6 @@ const sidebars: SidebarsConfig = {
       type: 'doc',
       id: 'cocoinsight_access',
       label: 'CocoInsight Access',
-    },
-    {
-      type: 'doc',
-      id: 'query',
-      label: 'Query Support',
     },
     {
       type: 'category',


### PR DESCRIPTION
	•	“Moves Query Support in docs sidebar to sit between CocoIndex Core and Built-in Sources for discoverability.”
	•	“Closes #1344.”