### PR TITLE
dev: wrap cargo test to avoid embedded Python stdlib discovery crash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
         - id: cargo-test
           name: cargo test
-          entry: cargo test
+          entry: dev/run_cargo_test.sh
           language: system
           files: ^(rust/|Cargo\.toml)
           pass_filenames: false

--- a/dev/run_cargo_test.sh
+++ b/dev/run_cargo_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from repo root (important for cargo workspace + relative paths)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Prefer an in-repo venv if present, so this works even if user didn't "source .venv/bin/activate"
+# Users can override with COCOINDEX_PYTHON if they want a different interpreter.
+if [[ -n "${COCOINDEX_PYTHON:-}" ]]; then
+  PY="$COCOINDEX_PYTHON"
+elif [[ -x "$ROOT/.venv/bin/python" ]]; then
+  PY="$ROOT/.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PY="python3"
+elif command -v python >/dev/null 2>&1; then
+  PY="python"
+else
+  echo "error: python not found." >&2
+  echo "hint: create/activate a venv (.venv) or set COCOINDEX_PYTHON=/path/to/python" >&2
+  exit 1
+fi
+
+# Compute PYTHONHOME + PYTHONPATH based on the selected interpreter.
+# This is specifically to help embedded Python (pyo3) locate stdlib + site-packages.
+PYTHONHOME_DETECTED="$("$PY" -c 'import sys; print(sys.base_prefix)')"
+
+PYTHONPATH_DETECTED="$("$PY" - <<'PY'
+import os
+import site
+import sysconfig
+
+paths = []
+
+for key in ("stdlib", "platstdlib"):
+    p = sysconfig.get_path(key)
+    if p:
+        paths.append(p)
+
+for p in site.getsitepackages():
+    if p:
+        paths.append(p)
+
+# Include repo python/ package path (safe + helps imports in embedded contexts)
+repo_python = os.path.abspath("python")
+if os.path.isdir(repo_python):
+    paths.append(repo_python)
+
+# de-dupe while preserving order
+seen = set()
+out = []
+for p in paths:
+    if p not in seen:
+        seen.add(p)
+        out.append(p)
+
+print(":".join(out))
+PY
+)"
+
+# Only set these if not already set, so we don't stomp custom setups.
+export PYTHONHOME="${PYTHONHOME:-$PYTHONHOME_DETECTED}"
+
+if [[ -n "${PYTHONPATH_DETECTED}" ]]; then
+  if [[ -n "${PYTHONPATH:-}" ]]; then
+    export PYTHONPATH="${PYTHONPATH_DETECTED}:${PYTHONPATH}"
+  else
+    export PYTHONPATH="${PYTHONPATH_DETECTED}"
+  fi
+fi
+
+exec cargo test "$@"

--- a/docs/docs/contributing/setup_dev_environment.md
+++ b/docs/docs/contributing/setup_dev_environment.md
@@ -48,3 +48,22 @@ Follow the steps below to get CocoIndex built on the latest codebase locally - i
     ```sh
     . ./.env.lib_debug
     ```
+
+## Troubleshooting
+
+### `cargo test` fails with `ModuleNotFoundError: encodings` (embedded Python can't find stdlib)
+
+On some setups (notably when using `uv venv` with an `uv`-managed Python), `cargo test` may crash with:
+
+`ModuleNotFoundError: No module named 'encodings'`
+
+This can happen when the embedded Python interpreter (used by Rust tests) cannot locate the Python stdlib (you may see `sys.prefix=/install` in the crash output).
+
+Workaround:
+- Run cargo tests via:
+
+  `./dev/run_cargo_test.sh -p cocoindex --lib`
+
+This wrapper sets `PYTHONHOME`/`PYTHONPATH` for that command only, so embedded Python can locate the stdlib and site-packages.
+
+Note: the cargo-test pre-commit hook uses this wrapper.


### PR DESCRIPTION
	•	What: Adds dev/run_cargo_test.sh, updates pre-commit cargo-test hook to use it, adds docs workaround.
	•	Why: cargo test can crash with ModuleNotFoundError: encodings when using uv-managed Python (embedded Python reports sys.prefix=/install and can’t locate stdlib).
	•	Scope: Dev-only. No runtime/engine behavior change.
	•	Refs: Refs [1396](https://github.com/cocoindex-io/cocoindex/issues/1396)