### PR TITLE
fix: make python stack trace propagatable from end to end

### DIFF
--- a/rust/cocoindex/src/base/value.rs
+++ b/rust/cocoindex/src/base/value.rs
@@ -206,22 +206,22 @@ impl KeyPart {
                     .ok_or_else(|| api_error!("Key parts less than expected"))?;
                 match basic_type {
                     BasicValueType::Bytes => {
-                        KeyPart::Bytes(Bytes::from(BASE64_STANDARD.decode(v).internal()?))
+                        KeyPart::Bytes(Bytes::from(BASE64_STANDARD.decode(v)?))
                     }
                     BasicValueType::Str => KeyPart::Str(Arc::from(v)),
-                    BasicValueType::Bool => KeyPart::Bool(v.parse().internal()?),
-                    BasicValueType::Int64 => KeyPart::Int64(v.parse().internal()?),
+                    BasicValueType::Bool => KeyPart::Bool(v.parse()?),
+                    BasicValueType::Int64 => KeyPart::Int64(v.parse()?),
                     BasicValueType::Range => {
                         let v2 = values_iter
                             .next()
                             .ok_or_else(|| api_error!("Key parts less than expected"))?;
                         KeyPart::Range(RangeValue {
-                            start: v.parse().internal()?,
-                            end: v2.parse().internal()?,
+                            start: v.parse()?,
+                            end: v2.parse()?,
                         })
                     }
-                    BasicValueType::Uuid => KeyPart::Uuid(v.parse().internal()?),
-                    BasicValueType::Date => KeyPart::Date(v.parse().internal()?),
+                    BasicValueType::Uuid => KeyPart::Uuid(v.parse()?),
+                    BasicValueType::Date => KeyPart::Date(v.parse()?),
                     schema => api_bail!("Invalid key type {schema}"),
                 }
             }
@@ -1149,7 +1149,7 @@ impl BasicValue {
     pub fn from_json(value: serde_json::Value, schema: &BasicValueType) -> Result<Self> {
         let result = match (value, schema) {
             (serde_json::Value::String(v), BasicValueType::Bytes) => {
-                BasicValue::Bytes(Bytes::from(BASE64_STANDARD.decode(v).internal()?))
+                BasicValue::Bytes(Bytes::from(BASE64_STANDARD.decode(v)?))
             }
             (serde_json::Value::String(v), BasicValueType::Str) => BasicValue::Str(Arc::from(v)),
             (serde_json::Value::Bool(v), BasicValueType::Bool) => BasicValue::Bool(v),
@@ -1166,17 +1166,11 @@ impl BasicValue {
                     .ok_or_else(|| client_error!("invalid fp64 value {v}"))?,
             ),
             (v, BasicValueType::Range) => BasicValue::Range(utils::deser::from_json_value(v)?),
-            (serde_json::Value::String(v), BasicValueType::Uuid) => {
-                BasicValue::Uuid(v.parse().internal()?)
-            }
-            (serde_json::Value::String(v), BasicValueType::Date) => {
-                BasicValue::Date(v.parse().internal()?)
-            }
-            (serde_json::Value::String(v), BasicValueType::Time) => {
-                BasicValue::Time(v.parse().internal()?)
-            }
+            (serde_json::Value::String(v), BasicValueType::Uuid) => BasicValue::Uuid(v.parse()?),
+            (serde_json::Value::String(v), BasicValueType::Date) => BasicValue::Date(v.parse()?),
+            (serde_json::Value::String(v), BasicValueType::Time) => BasicValue::Time(v.parse()?),
             (serde_json::Value::String(v), BasicValueType::LocalDateTime) => {
-                BasicValue::LocalDateTime(v.parse().internal()?)
+                BasicValue::LocalDateTime(v.parse()?)
             }
             (serde_json::Value::String(v), BasicValueType::OffsetDateTime) => {
                 match chrono::DateTime::parse_from_rfc3339(&v) {
@@ -1189,7 +1183,7 @@ impl BasicValue {
                                 chrono::Utc.fix(),
                             ))
                         } else {
-                            Err(e).internal()?
+                            Err(e)?
                         }
                     }
                 }

--- a/rust/cocoindex/src/execution/dumper.rs
+++ b/rust/cocoindex/src/execution/dumper.rs
@@ -151,8 +151,7 @@ impl<'a> Dumper<'a> {
         let _permit = import_op
             .concurrency_controller
             .acquire(concur_control::BYTES_UNKNOWN_YET)
-            .await
-            .internal()?;
+            .await?;
         let mut collected_values_buffer = Vec::new();
         let (exports, error) = match self
             .evaluate_source_entry(
@@ -180,11 +179,11 @@ impl<'a> Dumper<'a> {
 
         let yaml_output = {
             let mut yaml_output = String::new();
-            let yaml_data = YamlSerializer::serialize(&file_data).internal()?;
+            let yaml_data = YamlSerializer::serialize(&file_data)?;
             let mut yaml_emitter = YamlEmitter::new(&mut yaml_output);
             yaml_emitter.multiline_strings(true);
             yaml_emitter.compact(true);
-            yaml_emitter.dump(&yaml_data).internal()?;
+            yaml_emitter.dump(&yaml_data)?;
             yaml_output
         };
         tokio::fs::write(file_path, yaml_output).await?;

--- a/rust/cocoindex/src/execution/evaluator.rs
+++ b/rust/cocoindex/src/execution/evaluator.rs
@@ -342,8 +342,7 @@ async fn evaluate_child_op_scope(
                 .map(|f| f.get().map_or(0, |v| v.estimated_byte_size()))
                 .sum()
         }))
-        .await
-        .internal()?;
+        .await?;
     evaluate_op_scope(
         op_scope,
         scoped_entries.prepend(&child_scope_entry),
@@ -432,13 +431,13 @@ async fn evaluate_op_scope(
 
                 let result = if op.function_exec_info.enable_cache {
                     let output_value_cell = memory.get_cache_entry(
-                        || {
-                            op.function_exec_info
+                        || -> Result<_> {
+                            Ok(op
+                                .function_exec_info
                                 .fingerprinter
                                 .clone()
                                 .with(&input_values)
-                                .map(|fp| fp.into_fingerprint())
-                                .internal()
+                                .map(|fp| fp.into_fingerprint())?)
                         },
                         &op.function_exec_info.output_type,
                         /*ttl=*/ None,
@@ -658,8 +657,7 @@ pub async fn evaluate_source_entry(
         .import_op
         .concurrency_controller
         .acquire_bytes_with_reservation(|| source_value.estimated_byte_size())
-        .await
-        .internal()?;
+        .await?;
     let root_schema = &src_eval_ctx.schema.schema;
     let root_scope_value = ScopeValueBuilder::new(root_schema.fields.len());
     let root_scope_entry = ScopeEntry::new(

--- a/rust/cocoindex/src/execution/live_updater.rs
+++ b/rust/cocoindex/src/execution/live_updater.rs
@@ -117,9 +117,8 @@ impl SourceUpdateTask {
         if !self.options.print_stats || self.multi_progress_bar.is_hidden() {
             return Ok(None);
         }
-        let style = indicatif::ProgressStyle::default_spinner()
-            .template("{spinner}{spinner} {msg}")
-            .internal()?;
+        let style =
+            indicatif::ProgressStyle::default_spinner().template("{spinner}{spinner} {msg}")?;
         let pb = ProgressBar::new_spinner().with_finish(ProgressFinish::AndClear);
         pb.set_style(style);
         Ok(Some(pb))
@@ -242,8 +241,7 @@ impl SourceUpdateTask {
                         let concur_permit = import_op
                             .concurrency_controller
                             .acquire(concur_control::BYTES_UNKNOWN_YET)
-                            .await
-                            .internal()?;
+                            .await?;
                         tokio::spawn(source_indexing_context.clone().process_source_row(
                             ProcessSourceRowInput {
                                 key: change.key,
@@ -576,7 +574,7 @@ impl FlowLiveUpdater {
     pub async fn wait(&self) -> Result<()> {
         {
             let mut rx = self.num_remaining_tasks_rx.clone();
-            rx.wait_for(|v| *v == 0).await.internal()?;
+            rx.wait_for(|v| *v == 0).await?;
         }
 
         let Some(mut join_set) = self.join_set.lock().unwrap().take() else {
@@ -590,7 +588,7 @@ impl FlowLiveUpdater {
                 }
                 Err(err) if err.is_cancelled() => {}
                 Err(err) => {
-                    return Err(err).internal();
+                    return Err(err.into());
                 }
             }
         }
@@ -629,7 +627,7 @@ impl FlowLiveUpdater {
             });
         }
 
-        recv_state.status_rx.changed().await.internal()?;
+        recv_state.status_rx.changed().await?;
         let status = recv_state.status_rx.borrow_and_update();
         let updates = FlowLiveUpdaterUpdates {
             active_sources: status

--- a/rust/cocoindex/src/execution/memoization.rs
+++ b/rust/cocoindex/src/execution/memoization.rs
@@ -132,8 +132,7 @@ impl EvaluationMemory {
         }
         let cache = if let Some(cache) = self.cache {
             cache
-                .into_inner()
-                .internal()?
+                .into_inner()?
                 .into_iter()
                 .filter_map(|(k, e)| match e.data {
                     CacheData::Previous(_) => None,
@@ -156,8 +155,7 @@ impl EvaluationMemory {
         };
         let uuids = self
             .uuids
-            .into_inner()
-            .internal()?
+            .into_inner()?
             .into_iter()
             .filter_map(|(k, v)| v.into_stored().map(|uuids| (k, uuids)))
             .collect();

--- a/rust/cocoindex/src/execution/row_indexer.rs
+++ b/rust/cocoindex/src/execution/row_indexer.rs
@@ -467,8 +467,7 @@ impl<'a> RowIndexer<'a> {
                     .and_then(|info| info.0.as_ref())
                     .and_then(|stored_info| stored_info.content_hash.as_ref())
                     .map(|content_hash| BASE64_STANDARD.decode(content_hash))
-                    .transpose()
-                    .internal()?
+                    .transpose()?
                     .map(Cow::Owned)
             }
         };

--- a/rust/cocoindex/src/lib_context.rs
+++ b/rust/cocoindex/src/lib_context.rs
@@ -205,7 +205,6 @@ impl DbPools {
                     let pool = pool_options
                         .connect_with(pg_options.clone())
                         .await
-                        .internal()
                         .with_context(|| {
                             format!("Failed to connect to database {}", conn_spec.url)
                         })?;
@@ -222,7 +221,6 @@ impl DbPools {
                 let pool = pool_options
                     .connect_with(pg_options)
                     .await
-                    .internal()
                     .with_context(|| "Failed to connect to database")?;
                 Ok::<_, Error>(pool)
             })

--- a/rust/cocoindex/src/llm/anthropic.rs
+++ b/rust/cocoindex/src/llm/anthropic.rs
@@ -5,7 +5,6 @@ use crate::llm::{
     GeneratedOutput, LlmGenerateRequest, LlmGenerateResponse, LlmGenerationClient, OutputFormat,
     ToJsonSchemaOptions, detect_image_mime_type,
 };
-use anyhow::Context;
 use urlencoding::encode;
 
 pub struct Client {

--- a/rust/cocoindex/src/llm/bedrock.rs
+++ b/rust/cocoindex/src/llm/bedrock.rs
@@ -5,7 +5,6 @@ use crate::llm::{
     GeneratedOutput, LlmGenerateRequest, LlmGenerateResponse, LlmGenerationClient, OutputFormat,
     ToJsonSchemaOptions, detect_image_mime_type,
 };
-use anyhow::Context;
 use urlencoding::encode;
 
 pub struct Client {

--- a/rust/cocoindex/src/llm/gemini.rs
+++ b/rust/cocoindex/src/llm/gemini.rs
@@ -153,11 +153,7 @@ impl LlmGenerationClient for AiStudioClient {
         .await
         .map_err(Error::from)
         .with_context(|| "Gemini API error")?;
-        let resp_json: Value = resp
-            .json()
-            .await
-            .internal()
-            .with_context(|| "Invalid JSON")?;
+        let resp_json: Value = resp.json().await.with_context(|| "Invalid JSON")?;
 
         if let Some(error) = resp_json.get("error") {
             client_bail!("Gemini API error: {:?}", error);
@@ -220,11 +216,8 @@ impl LlmEmbeddingClient for AiStudioClient {
         .await
         .map_err(Error::from)
         .with_context(|| "Gemini API error")?;
-        let embedding_resp: BatchEmbedContentResponse = resp
-            .json()
-            .await
-            .internal()
-            .with_context(|| "Invalid JSON")?;
+        let embedding_resp: BatchEmbedContentResponse =
+            resp.json().await.with_context(|| "Invalid JSON")?;
         Ok(super::LlmEmbeddingResponse {
             embeddings: embedding_resp
                 .embeddings
@@ -299,8 +292,7 @@ impl VertexAiClient {
             .with_backoff_policy(ExponentialBackoff::default())
             .with_retry_throttler(SHARED_RETRY_THROTTLER.clone())
             .build()
-            .await
-            .internal()?;
+            .await?;
         Ok(Self { client, config })
     }
 
@@ -373,7 +365,7 @@ impl LlmGenerationClient for VertexAiClient {
         }
 
         // Call the API
-        let resp = req.send().await.internal()?;
+        let resp = req.send().await?;
         // Extract text from response
         let Some(Data::Text(text)) = resp
             .candidates
@@ -443,8 +435,7 @@ impl LlmEmbeddingClient for VertexAiClient {
             .set_parameters(parameters)
             .with_idempotency(true)
             .send()
-            .await
-            .internal()?;
+            .await?;
 
         // Extract the embeddings from the response
         let embeddings: Vec<Vec<f32>> = response

--- a/rust/cocoindex/src/llm/ollama.rs
+++ b/rust/cocoindex/src/llm/ollama.rs
@@ -113,7 +113,6 @@ impl LlmGenerationClient for Client {
         let json: OllamaResponse = res
             .json()
             .await
-            .internal()
             .with_context(|| "Invalid JSON from Ollama")?;
 
         let output = if has_json_schema {
@@ -152,11 +151,8 @@ impl LlmEmbeddingClient for Client {
             .map_err(Error::from)
             .with_context(|| "Ollama API error")?;
 
-        let embedding_resp: OllamaEmbeddingResponse = resp
-            .json()
-            .await
-            .internal()
-            .with_context(|| "Invalid JSON")?;
+        let embedding_resp: OllamaEmbeddingResponse =
+            resp.json().await.with_context(|| "Invalid JSON")?;
 
         Ok(super::LlmEmbeddingResponse {
             embeddings: embedding_resp.embeddings,

--- a/rust/cocoindex/src/llm/openai.rs
+++ b/rust/cocoindex/src/llm/openai.rs
@@ -188,7 +188,7 @@ where
         let request = &request;
         let response = retryable::run(
             || async {
-                let req = create_llm_generation_request(request).map_err(anyhow::Error::from)?;
+                let req = create_llm_generation_request(request)?;
                 let response = self.client.chat().create(req).await?;
                 retryable::Ok(response)
             },

--- a/rust/cocoindex/src/llm/voyage.rs
+++ b/rust/cocoindex/src/llm/voyage.rs
@@ -90,11 +90,7 @@ impl LlmEmbeddingClient for Client {
         .map_err(Error::from)
         .with_context(|| "Voyage AI API error")?;
 
-        let embedding_resp: EmbedResponse = resp
-            .json()
-            .await
-            .internal()
-            .with_context(|| "Invalid JSON")?;
+        let embedding_resp: EmbedResponse = resp.json().await.with_context(|| "Invalid JSON")?;
 
         Ok(LlmEmbeddingResponse {
             embeddings: embedding_resp

--- a/rust/cocoindex/src/ops/factory_bases.rs
+++ b/rust/cocoindex/src/ops/factory_bases.rs
@@ -399,13 +399,8 @@ impl<E: BatchedFunctionExecutor> batching::Runner for BatchedFunctionExecutorRun
     async fn run(
         &self,
         inputs: Vec<Self::Input>,
-    ) -> anyhow::Result<impl ExactSizeIterator<Item = Self::Output>> {
-        Ok(self
-            .0
-            .evaluate_batch(inputs)
-            .await
-            .map_err(anyhow::Error::from)?
-            .into_iter())
+    ) -> Result<impl ExactSizeIterator<Item = Self::Output>> {
+        Ok(self.0.evaluate_batch(inputs).await?.into_iter())
     }
 }
 

--- a/rust/cocoindex/src/ops/functions/split_by_separators.rs
+++ b/rust/cocoindex/src/ops/functions/split_by_separators.rs
@@ -45,11 +45,7 @@ impl Executor {
                     .collect::<Vec<_>>()
                     .join("|")
             );
-            Some(
-                Regex::new(&pattern)
-                    .internal()
-                    .with_context(|| "failed to compile separators_regex")?,
-            )
+            Some(Regex::new(&pattern).with_context(|| "failed to compile separators_regex")?)
         };
         Ok(Self { args, spec, regex })
     }

--- a/rust/cocoindex/src/ops/functions/split_recursively.rs
+++ b/rust/cocoindex/src/ops/functions/split_recursively.rs
@@ -585,7 +585,7 @@ impl Executor {
             let separator_regex = lang
                 .separators_regex
                 .iter()
-                .map(|s| Regex::new(s).internal())
+                .map(|s| Regex::new(s))
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .with_context(|| {
                     format!(
@@ -673,9 +673,7 @@ impl SimpleFunctionExecutor for Executor {
             && let Some(tree_sitter_info) = lang_info.treesitter_info.as_ref()
         {
             let mut parser = tree_sitter::Parser::new();
-            parser
-                .set_language(&tree_sitter_info.tree_sitter_lang)
-                .internal()?;
+            parser.set_language(&tree_sitter_info.tree_sitter_lang)?;
             let tree = parser.parse(full_text.as_ref(), None).ok_or_else(|| {
                 internal_error!("failed in parsing text in language: {}", lang_info.name)
             })?;

--- a/rust/cocoindex/src/ops/functions/test_utils.rs
+++ b/rust/cocoindex/src/ops/functions/test_utils.rs
@@ -6,7 +6,6 @@ use crate::ops::sdk::{
     SimpleFunctionFactory, Value, make_output_type,
 };
 use crate::prelude::*;
-use anyhow::Result;
 use std::sync::Arc;
 
 // This function builds an argument schema for a flow function.

--- a/rust/cocoindex/src/ops/py_factory.rs
+++ b/rust/cocoindex/src/ops/py_factory.rs
@@ -10,7 +10,7 @@ use crate::{
     base::{schema, value},
     builder::plan,
     ops::sdk::SetupStateCompatibility,
-    py::{self, ToResultWithPyTrace},
+    py::{self},
 };
 use py_utils::from_py_future;
 
@@ -53,7 +53,7 @@ impl PyFunctionExecutor {
     ) -> Result<pyo3::Bound<'py, pyo3::PyAny>> {
         let mut args = Vec::with_capacity(self.num_positional_args);
         for v in input[0..self.num_positional_args].iter() {
-            args.push(py::value_to_py_object(py, v).map_err(Error::host)?);
+            args.push(py::value_to_py_object(py, v).from_py_result()?);
         }
 
         let kwargs = if self.kw_args_names.is_empty() {
@@ -67,7 +67,7 @@ impl PyFunctionExecutor {
             {
                 kwargs.push((
                     name.bind(py),
-                    py::value_to_py_object(py, v).map_err(Error::host)?,
+                    py::value_to_py_object(py, v).from_py_result()?,
                 ));
             }
             Some(kwargs)
@@ -77,16 +77,13 @@ impl PyFunctionExecutor {
             .py_function_executor
             .call(
                 py,
-                PyTuple::new(py, args.into_iter()).map_err(Error::host)?,
+                PyTuple::new(py, args.into_iter()).from_py_result()?,
                 kwargs
-                    .map(|kwargs| -> Result<_> {
-                        Ok(kwargs.into_py_dict(py).map_err(Error::host)?)
-                    })
+                    .map(|kwargs| -> Result<_> { Ok(kwargs.into_py_dict(py).from_py_result()?) })
                     .transpose()?
                     .as_ref(),
             )
-            .to_result_with_py_trace(py)
-            .map_err(Error::from)
+            .from_py_result()
             .context("while calling user-configured function")?;
         Ok(result.into_bound(py))
     }
@@ -100,14 +97,14 @@ impl interface::SimpleFunctionExecutor for Arc<PyFunctionExecutor> {
             let result_coro = self.call_py_fn(py, input)?;
             let task_locals =
                 pyo3_async_runtimes::TaskLocals::new(self.py_exec_ctx.event_loop.bind(py).clone());
-            Ok(from_py_future(py, &task_locals, result_coro).map_err(Error::host)?)
+            Ok(from_py_future(py, &task_locals, result_coro).from_py_result()?)
         })?;
         let result = result_fut.await;
         Python::attach(|py| -> Result<_> {
-            let result = result.to_result_with_py_trace(py)?;
+            let result = result.from_py_result()?;
             Ok(
                 py::value_from_py_object(&self.result_type.typ, &result.into_bound(py))
-                    .map_err(Error::host)?,
+                    .from_py_result()?,
             )
         })
     }
@@ -159,19 +156,19 @@ impl BatchedFunctionExecutor for PyBatchedFunctionExecutor {
                 result_coro.into_bound(py),
             )?)
         })
-        .map_err(Error::host)?;
+        .from_py_result()?;
         let result = result_fut.await;
         Python::attach(|py| -> Result<_> {
-            let result = result.to_result_with_py_trace(py)?;
+            let result = result.from_py_result()?;
             let result_bound = result.into_bound(py);
             let result_list = result_bound
                 .extract::<Vec<Bound<'_, PyAny>>>()
-                .map_err(Error::host)?;
+                .from_py_result()?;
             Ok(result_list
                 .into_iter()
                 .map(|v| py::value_from_py_object(&self.result_type.typ, &v))
                 .collect::<pyo3::PyResult<Vec<_>>>()
-                .map_err(Error::host)?)
+                .from_py_result()?)
         })
     }
     fn enable_cache(&self) -> bool {
@@ -199,7 +196,7 @@ impl interface::SimpleFunctionFactory for PyFunctionFactory {
     ) -> Result<interface::SimpleFunctionBuildOutput> {
         let (result_type, executor, kw_args_names, num_positional_args, behavior_version) =
             Python::attach(|py| -> Result<_> {
-                let mut args = vec![pythonize(py, &spec).internal()?];
+                let mut args = vec![pythonize(py, &spec)?];
                 let mut kwargs = vec![];
                 let mut num_positional_args = 0;
                 for arg in input_schema.into_iter() {
@@ -212,7 +209,7 @@ impl interface::SimpleFunctionFactory for PyFunctionFactory {
                             kwargs.push((name.clone(), py_arg_schema));
                         }
                         None => {
-                            args.push(py_arg_schema.into_bound_py_any(py).map_err(Error::host)?);
+                            args.push(py_arg_schema.into_bound_py_any(py).from_py_result()?);
                             num_positional_args += 1;
                         }
                     }
@@ -226,21 +223,19 @@ impl interface::SimpleFunctionFactory for PyFunctionFactory {
                     .py_function_factory
                     .call(
                         py,
-                        PyTuple::new(py, args.into_iter()).map_err(Error::host)?,
-                        Some(&kwargs.into_py_dict(py).map_err(Error::host)?),
+                        PyTuple::new(py, args.into_iter()).from_py_result()?,
+                        Some(&kwargs.into_py_dict(py).from_py_result()?),
                     )
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
+                    .from_py_result()
                     .context("while building user-configured function")?;
                 let (result_type, executor) = result
                     .extract::<(crate::py::Pythonized<schema::EnrichedValueType>, Py<PyAny>)>(py)
-                    .map_err(Error::host)?;
+                    .from_py_result()?;
                 let behavior_version = executor
                     .call_method(py, "behavior_version", (), None)
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)?
+                    .from_py_result()?
                     .extract::<Option<u32>>(py)
-                    .map_err(Error::host)?;
+                    .from_py_result()?;
                 Ok((
                     result_type.into_inner(),
                     executor,
@@ -262,8 +257,7 @@ impl interface::SimpleFunctionFactory for PyFunctionFactory {
                     Python::attach(|py| -> Result<_> {
                         let prepare_coro = executor
                             .call_method(py, "prepare", (), None)
-                            .to_result_with_py_trace(py)
-                            .map_err(Error::from)
+                            .from_py_result()
                             .context("while preparing user-configured function")?;
                         let prepare_fut = from_py_future(
                             py,
@@ -272,38 +266,35 @@ impl interface::SimpleFunctionFactory for PyFunctionFactory {
                             ),
                             prepare_coro.into_bound(py),
                         )
-                        .map_err(Error::host)?;
+                        .from_py_result()?;
                         let enable_cache = executor
                             .call_method(py, "enable_cache", (), None)
-                            .to_result_with_py_trace(py)
-                            .map_err(Error::from)?
+                            .from_py_result()?
                             .extract::<bool>(py)
-                            .map_err(Error::host)?;
+                            .from_py_result()?;
                         let timeout = executor
                             .call_method(py, "timeout", (), None)
-                            .to_result_with_py_trace(py)
-                            .map_err(Error::from)?;
+                            .from_py_result()?;
                         let timeout = if timeout.is_none(py) {
                             None
                         } else {
                             let td = timeout.into_bound(py);
                             let total_seconds = td
                                 .call_method0("total_seconds")
-                                .map_err(Error::host)?
+                                .from_py_result()?
                                 .extract::<f64>()
-                                .map_err(Error::host)?;
+                                .from_py_result()?;
                             Some(std::time::Duration::from_secs_f64(total_seconds))
                         };
                         let batching_options = executor
                             .call_method(py, "batching_options", (), None)
-                            .to_result_with_py_trace(py)
-                            .map_err(Error::from)?
+                            .from_py_result()?
                             .extract::<crate::py::Pythonized<Option<batching::BatchingOptions>>>(py)
-                            .map_err(Error::host)?
+                            .from_py_result()?
                             .into_inner();
                         Ok((prepare_fut, enable_cache, timeout, batching_options))
                     })?;
-                prepare_fut.await.map_err(Error::host)?;
+                prepare_fut.await.from_py_result()?;
                 let executor: Box<dyn interface::SimpleFunctionExecutor> =
                     if let Some(batching_options) = batching_options {
                         Box::new(
@@ -368,14 +359,8 @@ impl interface::SourceExecutor for PySourceExecutor {
         // Get the Python async iterator
         let py_async_iter = Python::attach(|py| {
             py_source_executor
-                .call_method(
-                    py,
-                    "list_async",
-                    (pythonize(py, options).internal()?,),
-                    None,
-                )
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .call_method(py, "list_async", (pythonize(py, options)?,), None)
+                .from_py_result()
                 .context("while listing user-configured source")
         })?;
 
@@ -405,33 +390,30 @@ impl interface::SourceExecutor for PySourceExecutor {
         let py_source_executor = Python::attach(|py| self.py_source_executor.clone_ref(py));
         let key_clone = key.clone();
 
-        let py_result =
-            Python::attach(|py| -> Result<_> {
-                let result_coro = py_source_executor
-                    .call_method(
-                        py,
-                        "get_value_async",
-                        (
-                            py::key_to_py_object(py, &key_clone).map_err(Error::host)?,
-                            pythonize(py, options).internal()?,
-                        ),
-                        None,
-                    )
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
-                    .context(format!(
-                        "while fetching user-configured source for key: {:?}",
-                        &key_clone
-                    ))?;
-                let task_locals =
-                    pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
-                Ok(from_py_future(py, &task_locals, result_coro.into_bound(py))
-                    .map_err(Error::host)?)
-            })?
-            .await;
+        let py_result = Python::attach(|py| -> Result<_> {
+            let result_coro = py_source_executor
+                .call_method(
+                    py,
+                    "get_value_async",
+                    (
+                        py::key_to_py_object(py, &key_clone).from_py_result()?,
+                        pythonize(py, options)?,
+                    ),
+                    None,
+                )
+                .from_py_result()
+                .context(format!(
+                    "while fetching user-configured source for key: {:?}",
+                    &key_clone
+                ))?;
+            let task_locals =
+                pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
+            Ok(from_py_future(py, &task_locals, result_coro.into_bound(py)).from_py_result()?)
+        })?
+        .await;
 
         Python::attach(|py| -> Result<_> {
-            let result = py_result.to_result_with_py_trace(py)?;
+            let result = py_result.from_py_result()?;
             let result_bound = result.into_bound(py);
             let data = self.parse_partial_source_row_data(py, &result_bound)?;
             Ok(data)
@@ -459,12 +441,11 @@ impl PySourceExecutor {
         let next_item_coro = Python::attach(|py| -> Result<_> {
             let coro = py_async_iter
                 .call_method0(py, "__anext__")
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .from_py_result()
                 .with_context(|| format!("while iterating over user-configured source"))?;
             let task_locals =
                 pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
-            Ok(from_py_future(py, &task_locals, coro.into_bound(py)).internal()?)
+            Ok(from_py_future(py, &task_locals, coro.into_bound(py))?)
         })?;
 
         // Await the future to get the next item
@@ -483,7 +464,7 @@ impl PySourceExecutor {
                     if py_err.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py) {
                         Ok(None)
                     } else {
-                        Err(py_err).to_result_with_py_trace(py).map_err(Error::from)
+                        Err(Error::host(py_err))
                     }
                 }
             }
@@ -503,8 +484,8 @@ impl PySourceExecutor {
             api_bail!("Expected tuple of length 2 from Python source iterator");
         }
 
-        let key_py = tuple.get_item(0).map_err(Error::host)?;
-        let data_py = tuple.get_item(1).map_err(Error::host)?;
+        let key_py = tuple.get_item(0).from_py_result()?;
+        let data_py = tuple.get_item(1).from_py_result()?;
 
         // key_aux_info is always Null now
         let key_aux_info = serde_json::Value::Null;
@@ -514,7 +495,7 @@ impl PySourceExecutor {
 
         // Convert key using py::field_values_from_py_seq
         let key_field_values =
-            py::field_values_from_py_seq(&self.key_fields, &key_py).map_err(Error::host)?;
+            py::field_values_from_py_seq(&self.key_fields, &key_py).from_py_result()?;
         let key_parts = key_field_values
             .fields
             .into_iter()
@@ -539,7 +520,7 @@ impl PySourceExecutor {
             && !ordinal_py.is_none()
         {
             if ordinal_py.is_instance_of::<PyString>()
-                && ordinal_py.extract::<&str>().map_err(Error::host)? == "NO_ORDINAL"
+                && ordinal_py.extract::<&str>().from_py_result()? == "NO_ORDINAL"
             {
                 Some(interface::Ordinal::unavailable())
             } else if let Ok(ordinal) = ordinal_py.extract::<i64>() {
@@ -569,7 +550,7 @@ impl PySourceExecutor {
             && !value_py.is_none()
         {
             if value_py.is_instance_of::<PyString>()
-                && value_py.extract::<&str>().map_err(Error::host)? == "NON_EXISTENCE"
+                && value_py.extract::<&str>().from_py_result()? == "NON_EXISTENCE"
             {
                 Some(interface::SourceValue::NonExistence)
             } else if let Ok(field_values) =
@@ -613,8 +594,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
             let value_type_result = self
                 .py_source_connector
                 .call_method(py, "get_table_type", (), None)
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .from_py_result()
                 .with_context(|| {
                     format!(
                         "while fetching table type from user-configured source `{}`",
@@ -622,7 +602,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
                     )
                 })?;
             let table_type: schema::EnrichedValueType =
-                depythonize(&value_type_result.into_bound(py)).internal()?;
+                depythonize(&value_type_result.into_bound(py))?;
             Ok(table_type)
         })?;
 
@@ -655,14 +635,8 @@ impl interface::SourceFactory for PySourceConnectorFactory {
             let create_future = Python::attach(|py| -> Result<_> {
                 let create_coro = self
                     .py_source_connector
-                    .call_method(
-                        py,
-                        "create_executor",
-                        (pythonize(py, &spec).internal()?,),
-                        None,
-                    )
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
+                    .call_method(py, "create_executor", (pythonize(py, &spec)?,), None)
+                    .from_py_result()
                     .with_context(|| {
                         format!(
                             "while constructing executor for user-configured source `{}`",
@@ -672,7 +646,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
                 let task_locals =
                     pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
                 let create_future = from_py_future(py, &task_locals, create_coro.into_bound(py))
-                    .map_err(Error::host)?;
+                    .from_py_result()?;
                 Ok(create_future)
             })?;
 
@@ -681,8 +655,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
             let (py_source_executor_context, provides_ordinal) =
                 Python::attach(|py| -> Result<_> {
                     let executor_context = py_executor_context_result
-                        .to_result_with_py_trace(py)
-                        .map_err(Error::from)
+                        .from_py_result()
                         .with_context(|| {
                             format!(
                                 "while getting executor context for user-configured source `{}`",
@@ -693,8 +666,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
                     // Get provides_ordinal from the executor context
                     let provides_ordinal = executor_context
                         .call_method(py, "provides_ordinal", (), None)
-                        .to_result_with_py_trace(py)
-                        .map_err(Error::from)
+                        .from_py_result()
                         .with_context(|| {
                             format!(
                                 "while calling provides_ordinal for user-configured source `{}`",
@@ -702,7 +674,7 @@ impl interface::SourceFactory for PySourceConnectorFactory {
                             )
                         })?
                         .extract::<bool>(py)
-                        .map_err(Error::host)?;
+                        .from_py_result()?;
 
                     Ok((executor_context, provides_ordinal))
                 })?;
@@ -794,15 +766,14 @@ impl interface::TargetFactory for PyExportTargetFactory {
                         "create_export_context",
                         (
                             &data_collection.name,
-                            pythonize(py, &data_collection.spec).internal()?,
-                            pythonize(py, &data_collection.key_fields_schema).internal()?,
-                            pythonize(py, &data_collection.value_fields_schema).internal()?,
-                            pythonize(py, &data_collection.index_options).internal()?,
+                            pythonize(py, &data_collection.spec)?,
+                            pythonize(py, &data_collection.key_fields_schema)?,
+                            pythonize(py, &data_collection.value_fields_schema)?,
+                            pythonize(py, &data_collection.index_options)?,
                         ),
                         None,
                     )
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
+                    .from_py_result()
                     .with_context(|| {
                         format!(
                             "while setting up export context for user-configured target `{}`",
@@ -814,8 +785,7 @@ impl interface::TargetFactory for PyExportTargetFactory {
                 let persistent_key = self
                     .py_target_connector
                     .call_method(py, "get_persistent_key", (&py_export_ctx,), None)
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
+                    .from_py_result()
                     .with_context(|| {
                         format!(
                             "while getting persistent key for user-configured target `{}`",
@@ -823,21 +793,19 @@ impl interface::TargetFactory for PyExportTargetFactory {
                         )
                     })?;
                 let persistent_key: serde_json::Value =
-                    depythonize(&persistent_key.into_bound(py)).internal()?;
+                    depythonize(&persistent_key.into_bound(py))?;
 
                 let setup_state = self
                     .py_target_connector
                     .call_method(py, "get_setup_state", (&py_export_ctx,), None)
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
+                    .from_py_result()
                     .with_context(|| {
                         format!(
                             "while getting setup state for user-configured target `{}`",
                             &data_collection.name
                         )
                     })?;
-                let setup_state: serde_json::Value =
-                    depythonize(&setup_state.into_bound(py)).internal()?;
+                let setup_state: serde_json::Value = depythonize(&setup_state.into_bound(py))?;
 
                 Ok::<_, Error>((py_export_ctx, persistent_key, setup_state))
             })?;
@@ -850,8 +818,7 @@ impl interface::TargetFactory for PyExportTargetFactory {
                         let prepare_coro = factory
                             .py_target_connector
                             .call_method(py, "prepare_async", (&py_export_ctx,), None)
-                            .to_result_with_py_trace(py)
-                            .map_err(Error::from)
+                            .from_py_result()
                             .with_context(|| {
                                 format!(
                                     "while preparing user-configured target `{}`",
@@ -863,11 +830,11 @@ impl interface::TargetFactory for PyExportTargetFactory {
                         );
                         Ok::<_, Error>(
                             from_py_future(py, &task_locals, prepare_coro.into_bound(py))
-                                .map_err(Error::host)?,
+                                .from_py_result()?,
                         )
                     })?
                     .await
-                    .map_err(Error::host)?;
+                    .from_py_result()?;
                     Ok::<_, Error>(Arc::new(PyTargetExecutorContext {
                         py_export_ctx,
                         py_exec_ctx,
@@ -921,18 +888,16 @@ impl interface::TargetFactory for PyExportTargetFactory {
                     py,
                     "check_state_compatibility",
                     (
-                        pythonize(py, desired_state).internal()?,
-                        pythonize(py, existing_state).internal()?,
+                        pythonize(py, desired_state)?,
+                        pythonize(py, existing_state)?,
                     ),
                     None,
                 )
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .from_py_result()
                 .with_context(|| {
                     format!("while calling check_state_compatibility in user-configured target")
                 })?;
-            let compatibility: SetupStateCompatibility =
-                depythonize(&result.into_bound(py)).internal()?;
+            let compatibility: SetupStateCompatibility = depythonize(&result.into_bound(py))?;
             Ok(compatibility)
         })?;
         Ok(compatibility)
@@ -942,18 +907,12 @@ impl interface::TargetFactory for PyExportTargetFactory {
         Python::attach(|py| -> Result<String> {
             let result = self
                 .py_target_connector
-                .call_method(
-                    py,
-                    "describe_resource",
-                    (pythonize(py, key).internal()?,),
-                    None,
-                )
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .call_method(py, "describe_resource", (pythonize(py, key)?,), None)
+                .from_py_result()
                 .with_context(|| {
                     format!("while calling describe_resource in user-configured target")
                 })?;
-            let description = result.extract::<String>(py).map_err(Error::host)?;
+            let description = result.extract::<String>(py).from_py_result()?;
             Ok(description)
         })
     }
@@ -1000,31 +959,27 @@ impl interface::TargetFactory for PyExportTargetFactory {
             .as_ref()
             .ok_or_else(|| internal_error!("Python execution context is missing"))?
             .clone();
-        let py_result =
-            Python::attach(move |py| -> Result<_> {
-                let result_coro = self
-                    .py_target_connector
-                    .call_method(
-                        py,
-                        "apply_setup_changes_async",
-                        (pythonize(py, &setup_changes).internal()?,),
-                        None,
-                    )
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
-                    .with_context(|| {
-                        format!("while calling apply_setup_changes_async in user-configured target")
-                    })?;
-                let task_locals =
-                    pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
-                Ok(from_py_future(py, &task_locals, result_coro.into_bound(py))
-                    .map_err(Error::host)?)
-            })?
-            .await;
-        Python::attach(move |py| {
+        let py_result = Python::attach(move |py| -> Result<_> {
+            let result_coro = self
+                .py_target_connector
+                .call_method(
+                    py,
+                    "apply_setup_changes_async",
+                    (pythonize(py, &setup_changes)?,),
+                    None,
+                )
+                .from_py_result()
+                .with_context(|| {
+                    format!("while calling apply_setup_changes_async in user-configured target")
+                })?;
+            let task_locals =
+                pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
+            Ok(from_py_future(py, &task_locals, result_coro.into_bound(py)).from_py_result()?)
+        })?
+        .await;
+        Python::attach(move |_py| {
             py_result
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .from_py_result()
                 .with_context(|| format!("while applying setup changes in user-configured target"))
         })?;
 
@@ -1041,60 +996,56 @@ impl interface::TargetFactory for PyExportTargetFactory {
             return Ok(());
         }
 
-        let py_result =
-            Python::attach(|py| -> Result<_> {
-                // Create a `list[tuple[export_ctx, list[tuple[key, value | None]]]]` for Python, and collect `py_exec_ctx`.
-                let mut py_args = Vec::with_capacity(mutations.len());
-                let mut py_exec_ctx: Option<&Arc<crate::py::PythonExecutionContext>> = None;
-                for mutation in mutations.into_iter() {
-                    // Downcast export_context to PyTargetExecutorContext.
-                    let export_context = (mutation.export_context as &dyn Any)
-                        .downcast_ref::<PyTargetExecutorContext>()
-                        .ok_or_else(invariance_violation)?;
+        let py_result = Python::attach(|py| -> Result<_> {
+            // Create a `list[tuple[export_ctx, list[tuple[key, value | None]]]]` for Python, and collect `py_exec_ctx`.
+            let mut py_args = Vec::with_capacity(mutations.len());
+            let mut py_exec_ctx: Option<&Arc<crate::py::PythonExecutionContext>> = None;
+            for mutation in mutations.into_iter() {
+                // Downcast export_context to PyTargetExecutorContext.
+                let export_context = (mutation.export_context as &dyn Any)
+                    .downcast_ref::<PyTargetExecutorContext>()
+                    .ok_or_else(invariance_violation)?;
 
-                    let mut flattened_mutations = Vec::with_capacity(
-                        mutation.mutation.upserts.len() + mutation.mutation.deletes.len(),
-                    );
-                    for upsert in mutation.mutation.upserts.into_iter() {
-                        flattened_mutations.push((
-                            py::key_to_py_object(py, &upsert.key).map_err(Error::host)?,
-                            py::field_values_to_py_object(py, upsert.value.fields.iter())
-                                .map_err(Error::host)?,
-                        ));
-                    }
-                    for delete in mutation.mutation.deletes.into_iter() {
-                        flattened_mutations.push((
-                            py::key_to_py_object(py, &delete.key).map_err(Error::host)?,
-                            py.None().into_bound(py),
-                        ));
-                    }
-                    py_args.push((
-                        &export_context.py_export_ctx,
-                        PyList::new(py, flattened_mutations)
-                            .map_err(Error::host)?
-                            .into_any(),
+                let mut flattened_mutations = Vec::with_capacity(
+                    mutation.mutation.upserts.len() + mutation.mutation.deletes.len(),
+                );
+                for upsert in mutation.mutation.upserts.into_iter() {
+                    flattened_mutations.push((
+                        py::key_to_py_object(py, &upsert.key).from_py_result()?,
+                        py::field_values_to_py_object(py, upsert.value.fields.iter())
+                            .from_py_result()?,
                     ));
-                    py_exec_ctx = py_exec_ctx.or(Some(&export_context.py_exec_ctx));
                 }
-                let py_exec_ctx = py_exec_ctx.ok_or_else(invariance_violation)?;
+                for delete in mutation.mutation.deletes.into_iter() {
+                    flattened_mutations.push((
+                        py::key_to_py_object(py, &delete.key).from_py_result()?,
+                        py.None().into_bound(py),
+                    ));
+                }
+                py_args.push((
+                    &export_context.py_export_ctx,
+                    PyList::new(py, flattened_mutations)
+                        .from_py_result()?
+                        .into_any(),
+                ));
+                py_exec_ctx = py_exec_ctx.or(Some(&export_context.py_exec_ctx));
+            }
+            let py_exec_ctx = py_exec_ctx.ok_or_else(invariance_violation)?;
 
-                let result_coro = self
-                    .py_target_connector
-                    .call_method(py, "mutate_async", (py_args,), None)
-                    .to_result_with_py_trace(py)
-                    .map_err(Error::from)
-                    .with_context(|| "while calling mutate_async in user-configured target")?;
-                let task_locals =
-                    pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
-                Ok(from_py_future(py, &task_locals, result_coro.into_bound(py))
-                    .map_err(Error::host)?)
-            })?
-            .await;
+            let result_coro = self
+                .py_target_connector
+                .call_method(py, "mutate_async", (py_args,), None)
+                .from_py_result()
+                .with_context(|| "while calling mutate_async in user-configured target")?;
+            let task_locals =
+                pyo3_async_runtimes::TaskLocals::new(py_exec_ctx.event_loop.bind(py).clone());
+            Ok(from_py_future(py, &task_locals, result_coro.into_bound(py)).from_py_result()?)
+        })?
+        .await;
 
-        Python::attach(move |py| {
+        Python::attach(move |_py| {
             py_result
-                .to_result_with_py_trace(py)
-                .map_err(Error::from)
+                .from_py_result()
                 .with_context(|| format!("while applying mutations in user-configured target"))
         })?;
         Ok(())

--- a/rust/cocoindex/src/ops/sources/azure_blob.rs
+++ b/rust/cocoindex/src/ops/sources/azure_blob.rs
@@ -66,7 +66,7 @@ impl SourceExecutor for Executor {
                     break;
                 };
 
-                let page = page_result.internal()?;
+                let page = page_result?;
                 let mut batch = Vec::new();
 
                 for blob in page.blobs.blobs() {
@@ -130,7 +130,7 @@ impl SourceExecutor for Executor {
                 .client
                 .container_client(&self.container_name)
                 .blob_client(key_str.as_ref());
-            let properties = blob_client.get_properties().await.internal()?;
+            let properties = blob_client.get_properties().await?;
             if properties.blob.properties.content_length > max_size as u64 {
                 return Ok(PartialSourceRowData {
                     value: Some(SourceValue::NonExistence),
@@ -149,7 +149,7 @@ impl SourceExecutor for Executor {
         let result = stream.next().await;
 
         let blob_response = match result {
-            Some(response) => response.internal()?,
+            Some(response) => response?,
             None => {
                 return Ok(PartialSourceRowData {
                     value: Some(SourceValue::NonExistence),
@@ -168,7 +168,7 @@ impl SourceExecutor for Executor {
         };
 
         let value = if options.include_value {
-            let bytes = blob_response.data.collect().await.internal()?;
+            let bytes = blob_response.data.collect().await?;
             Some(SourceValue::Existence(if self.binary {
                 fields_value!(bytes)
             } else {
@@ -245,14 +245,14 @@ impl SourceFactoryBase for Factory {
     ) -> Result<Box<dyn SourceExecutor>> {
         let credential = if let Some(sas_token) = spec.sas_token {
             let sas_token = context.auth_registry.get(&sas_token)?;
-            StorageCredentials::sas_token(sas_token).internal()?
+            StorageCredentials::sas_token(sas_token)?
         } else if let Some(account_access_key) = spec.account_access_key {
             let account_access_key = context.auth_registry.get(&account_access_key)?;
             StorageCredentials::access_key(spec.account_name.clone(), account_access_key)
         } else {
-            let default_credential = Arc::new(
-                DefaultAzureCredential::create(TokenCredentialOptions::default()).internal()?,
-            );
+            let default_credential = Arc::new(DefaultAzureCredential::create(
+                TokenCredentialOptions::default(),
+            )?);
             StorageCredentials::token_credential(default_credential)
         };
 

--- a/rust/cocoindex/src/ops/sources/postgres.rs
+++ b/rust/cocoindex/src/ops/sources/postgres.rs
@@ -778,7 +778,7 @@ impl PostgresSourceExecutor {
                 BasicValue::Bool(b).into()
             }
             (ValueType::Basic(BasicValueType::Bytes), serde_json::Value::String(s)) => {
-                let bytes = BASE64_STANDARD.decode(&s).internal()?;
+                let bytes = BASE64_STANDARD.decode(&s)?;
                 BasicValue::Bytes(bytes::Bytes::from(bytes)).into()
             }
             (ValueType::Basic(BasicValueType::Str), serde_json::Value::String(s)) => {
@@ -792,21 +792,19 @@ impl PostgresSourceExecutor {
                 }
             }
             (ValueType::Basic(BasicValueType::Uuid), serde_json::Value::String(s)) => {
-                let uuid = s.parse::<uuid::Uuid>().internal()?;
+                let uuid = s.parse::<uuid::Uuid>()?;
                 BasicValue::Uuid(uuid).into()
             }
             (ValueType::Basic(BasicValueType::Date), serde_json::Value::String(s)) => {
-                let dt = s.parse::<chrono::NaiveDate>().internal()?;
+                let dt = s.parse::<chrono::NaiveDate>()?;
                 BasicValue::Date(dt).into()
             }
             (ValueType::Basic(BasicValueType::LocalDateTime), serde_json::Value::String(s)) => {
-                let dt = s.parse::<chrono::NaiveDateTime>().internal()?;
+                let dt = s.parse::<chrono::NaiveDateTime>()?;
                 BasicValue::LocalDateTime(dt).into()
             }
             (ValueType::Basic(BasicValueType::OffsetDateTime), serde_json::Value::String(s)) => {
-                let dt = s
-                    .parse::<chrono::DateTime<chrono::FixedOffset>>()
-                    .internal()?;
+                let dt = s.parse::<chrono::DateTime<chrono::FixedOffset>>()?;
                 BasicValue::OffsetDateTime(dt).into()
             }
             (_, json_value) => {

--- a/rust/cocoindex/src/ops/sources/shared/pattern_matcher.rs
+++ b/rust/cocoindex/src/ops/sources/shared/pattern_matcher.rs
@@ -5,9 +5,9 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 fn build_glob_set(patterns: Vec<String>) -> Result<GlobSet> {
     let mut builder = GlobSetBuilder::new();
     for pattern in patterns {
-        builder.add(Glob::new(pattern.as_str()).internal()?);
+        builder.add(Glob::new(pattern.as_str())?);
     }
-    Ok(builder.build().internal()?)
+    Ok(builder.build()?)
 }
 
 /// Pattern matcher that handles include and exclude patterns for files

--- a/rust/cocoindex/src/ops/targets/qdrant.rs
+++ b/rust/cocoindex/src/ops/targets/qdrant.rs
@@ -206,10 +206,7 @@ impl setup::ResourceSetupChange for SetupChange {
 impl SetupChange {
     async fn apply_delete(&self, collection_name: &String, qdrant_client: &Qdrant) -> Result<()> {
         if self.delete_collection {
-            qdrant_client
-                .delete_collection(collection_name)
-                .await
-                .internal()?;
+            qdrant_client.delete_collection(collection_name).await?;
         }
         Ok(())
     }
@@ -239,7 +236,7 @@ impl SetupChange {
                 }
                 builder = builder.vectors_config(vectors_config);
             }
-            qdrant_client.create_collection(builder).await.internal()?;
+            qdrant_client.create_collection(builder).await?;
         }
         Ok(())
     }
@@ -268,8 +265,7 @@ impl ExportContext {
         if !points.is_empty() {
             self.qdrant_client
                 .upsert_points(UpsertPointsBuilder::new(&self.collection_name, points).wait(true))
-                .await
-                .internal()?;
+                .await?;
         }
 
         let ids = mutation
@@ -285,8 +281,7 @@ impl ExportContext {
                         .points(PointsIdsList { ids })
                         .wait(true),
                 )
-                .await
-                .internal()?;
+                .await?;
         }
 
         Ok(())
@@ -594,8 +589,7 @@ impl Factory {
             Qdrant::from_url(&spec.grpc_url)
                 .api_key(spec.api_key)
                 .skip_compatibility_check()
-                .build()
-                .internal()?,
+                .build()?,
         );
         clients.insert(auth_entry.clone(), client.clone());
         Ok(client)

--- a/rust/cocoindex/src/prelude.rs
+++ b/rust/cocoindex/src/prelude.rs
@@ -24,9 +24,8 @@ pub(crate) use crate::lib_context::{FlowContext, LibContext, get_lib_context, ge
 pub(crate) use crate::ops::interface;
 pub(crate) use crate::setup;
 pub(crate) use crate::setup::AuthRegistry;
+
 pub(crate) use cocoindex_utils as utils;
-pub(crate) use cocoindex_utils::error::{ApiError, invariance_violation};
-pub(crate) use cocoindex_utils::error::{ContextExt, Error, IntoInternal, Result, ResultExt};
 pub(crate) use cocoindex_utils::{api_bail, api_error};
 pub(crate) use cocoindex_utils::{batching, concur_control, http, retryable};
 pub(crate) use cocoindex_utils::{client_bail, client_error, internal_bail, internal_error};
@@ -38,4 +37,6 @@ pub(crate) use derivative::Derivative;
 
 pub(crate) use cocoindex_py_utils as py_utils;
 pub(crate) use cocoindex_py_utils::IntoPyResult;
-pub(crate) use cocoindex_py_utils::{ToCResult, cerror_to_pyerr};
+
+pub use py_utils::prelude::*;
+pub use utils::prelude::*;

--- a/rust/cocoindex/src/py/convert.rs
+++ b/rust/cocoindex/src/py/convert.rs
@@ -10,8 +10,6 @@ use pyo3::types::{PyList, PyTuple};
 use pyo3::{exceptions::PyException, prelude::*};
 use pythonize::{depythonize, pythonize};
 
-use py_utils::IntoPyResult;
-
 fn basic_value_to_py_object<'py>(
     py: Python<'py>,
     v: &value::BasicValue,
@@ -23,14 +21,14 @@ fn basic_value_to_py_object<'py>(
         value::BasicValue::Int64(v) => v.into_bound_py_any(py)?,
         value::BasicValue::Float32(v) => v.into_bound_py_any(py)?,
         value::BasicValue::Float64(v) => v.into_bound_py_any(py)?,
-        value::BasicValue::Range(v) => pythonize(py, v).into_py_result()?,
+        value::BasicValue::Range(v) => pythonize(py, v)?,
         value::BasicValue::Uuid(uuid_val) => uuid_val.into_bound_py_any(py)?,
         value::BasicValue::Date(v) => v.into_bound_py_any(py)?,
         value::BasicValue::Time(v) => v.into_bound_py_any(py)?,
         value::BasicValue::LocalDateTime(v) => v.into_bound_py_any(py)?,
         value::BasicValue::OffsetDateTime(v) => v.into_bound_py_any(py)?,
         value::BasicValue::TimeDelta(v) => v.into_bound_py_any(py)?,
-        value::BasicValue::Json(v) => pythonize(py, v).into_py_result()?,
+        value::BasicValue::Json(v) => pythonize(py, v)?,
         value::BasicValue::Vector(v) => handle_vector_to_py(py, v)?,
         value::BasicValue::UnionVariant { tag_id, value } => {
             (*tag_id, basic_value_to_py_object(py, value)?).into_bound_py_any(py)?
@@ -62,7 +60,7 @@ pub fn key_to_py_object<'py, 'a>(
             value::KeyPart::Str(v) => v.into_bound_py_any(py)?,
             value::KeyPart::Bool(v) => v.into_bound_py_any(py)?,
             value::KeyPart::Int64(v) => v.into_bound_py_any(py)?,
-            value::KeyPart::Range(v) => pythonize(py, v).into_py_result()?,
+            value::KeyPart::Range(v) => pythonize(py, v)?,
             value::KeyPart::Uuid(v) => v.into_bound_py_any(py)?,
             value::KeyPart::Date(v) => v.into_bound_py_any(py)?,
             value::KeyPart::Struct(v) => key_to_py_object(py, v)?,

--- a/rust/cocoindex/src/server.rs
+++ b/rust/cocoindex/src/server.rs
@@ -26,7 +26,7 @@ pub async fn init_server(
         let origins: Vec<_> = settings
             .cors_origins
             .iter()
-            .map(|origin| origin.parse().internal())
+            .map(|origin| origin.parse())
             .collect::<std::result::Result<_, _>>()?;
         cors = cors
             .allow_origin(AllowOrigin::list(origins))
@@ -85,7 +85,6 @@ pub async fn init_server(
 
     let listener = tokio::net::TcpListener::bind(&settings.address)
         .await
-        .internal()
         .with_context(|| format!("Failed to bind to address: {}", settings.address))?;
 
     println!(

--- a/rust/py_utils/src/convert.rs
+++ b/rust/py_utils/src/convert.rs
@@ -3,8 +3,6 @@ use pythonize::{depythonize, pythonize};
 use serde::{Serialize, de::DeserializeOwned};
 use std::ops::Deref;
 
-use crate::error::IntoPyResult;
-
 #[derive(Debug)]
 pub struct Pythonized<T>(pub T);
 
@@ -13,7 +11,7 @@ impl<'py, T: DeserializeOwned> FromPyObject<'_, '_> for Pythonized<T> {
 
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let bound = obj.into_bound();
-        Ok(Pythonized(depythonize(&bound).into_py_result()?))
+        Ok(Pythonized(depythonize(&bound)?))
     }
 }
 
@@ -23,7 +21,7 @@ impl<'py, T: Serialize> IntoPyObject<'py> for &Pythonized<T> {
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
-        pythonize(py, &self.0).into_py_result()
+        Ok(pythonize(py, &self.0)?)
     }
 }
 

--- a/rust/py_utils/src/error.rs
+++ b/rust/py_utils/src/error.rs
@@ -1,9 +1,9 @@
 use cocoindex_utils::error::{CError, CResult};
-use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule, PyString};
 use std::any::Any;
-use std::fmt::Write;
+use std::fmt::{Debug, Display};
 
 pub struct PythonExecutionContext {
     pub event_loop: Py<PyAny>,
@@ -15,91 +15,79 @@ impl PythonExecutionContext {
     }
 }
 
-pub fn cerror_to_pyerr(err: CError) -> PyErr {
-    if let CError::HostLang(host_err) = err.without_contexts() {
-        // if tunneled Python error
-        let any: &dyn Any = host_err.as_ref();
-        if let Some(py_err) = any.downcast_ref::<PyErr>() {
-            return Python::attach(|py| py_err.clone_ref(py));
-        }
-    }
+pub struct HostedPyErr(PyErr);
 
-    match err.without_contexts() {
-        CError::Client { .. } => PyValueError::new_err(format_error_chain_no_backtrace(&err)),
-        _ => PyRuntimeError::new_err(format_error_chain(&err)),
+impl Display for HostedPyErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 
-fn format_error_chain(err: &CError) -> String {
-    let mut s = err.to_string();
-    let mut current = err;
-    while let CError::Context { source, .. } = current {
-        write!(&mut s, "\nCaused by: {}", source).ok();
-        current = source;
-    }
-    if let Some(bt) = err.backtrace() {
-        write!(&mut s, "\n\n{}", bt).ok();
-    }
-    s
-}
+impl Debug for HostedPyErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let err = &self.0;
+        Python::attach(|py| {
+            let full_trace: PyResult<String> = (|| {
+                let exc = err.value(py);
+                let traceback = PyModule::import(py, "traceback")?;
+                let tbe_class = traceback.getattr("TracebackException")?;
+                let tbe = tbe_class.call_method1("from_exception", (exc,))?;
+                let kwargs = PyDict::new(py);
+                kwargs.set_item("chain", true)?;
+                let lines = tbe.call_method("format", (), Some(&kwargs))?;
+                let joined = PyString::new(py, "").call_method1("join", (lines,))?;
+                joined.extract::<String>()
+            })();
 
-fn format_error_chain_no_backtrace(err: &CError) -> String {
-    let mut s = err.to_string();
-    let mut current = err;
-    while let CError::Context { source, .. } = current {
-        write!(&mut s, "\nCaused by: {}", source).ok();
-        current = source;
-    }
-    s
-}
-
-pub trait ToCResult<T> {
-    fn to_cresult(self) -> CResult<T>;
-}
-
-impl<T> ToCResult<T> for PyResult<T> {
-    fn to_cresult(self) -> CResult<T> {
-        self.map_err(|err| CError::host(err))
-    }
-}
-
-// Legacy traits down below - kept for backwards compatibility during migration
-
-pub trait ToResultWithPyTrace<T> {
-    fn to_result_with_py_trace(self, py: Python<'_>) -> anyhow::Result<T>;
-}
-
-impl<T> ToResultWithPyTrace<T> for Result<T, PyErr> {
-    fn to_result_with_py_trace(self, py: Python<'_>) -> anyhow::Result<T> {
-        match self {
-            Ok(value) => Ok(value),
-            Err(err) => {
-                let full_trace: PyResult<String> = (|| {
-                    let exc = err.value(py);
-                    let traceback = PyModule::import(py, "traceback")?;
-                    let tbe_class = traceback.getattr("TracebackException")?;
-                    let tbe = tbe_class.call_method1("from_exception", (exc,))?;
-                    let kwargs = PyDict::new(py);
-                    kwargs.set_item("chain", true)?;
-                    let lines = tbe.call_method("format", (), Some(&kwargs))?;
-                    let joined = PyString::new(py, "").call_method1("join", (lines,))?;
-                    joined.extract::<String>()
-                })();
-
-                let err_str = match full_trace {
-                    Ok(trace) => format!("Error calling Python function:\n{trace}"),
-                    Err(_) => {
-                        let mut s = format!("Error calling Python function: {err}");
-                        if let Some(tb) = err.traceback(py) {
-                            write!(&mut s, "\n{}", tb.format()?).ok();
-                        }
-                        s
+            match full_trace {
+                Ok(trace) => {
+                    write!(f, "Error calling Python function:\n{trace}")?;
+                }
+                Err(_) => {
+                    write!(f, "Error calling Python function: {err}")?;
+                    if let Some(tb) = err.traceback(py) {
+                        write!(f, "\n{}", tb.format().unwrap_or_default())?;
                     }
-                };
+                }
+            };
+            Ok(())
+        })
+    }
+}
 
-                Err(anyhow::anyhow!(err_str))
+impl std::error::Error for HostedPyErr {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+fn cerror_to_pyerr(err: CError) -> PyErr {
+    match err.without_contexts() {
+        CError::HostLang(host_err) => {
+            // if tunneled Python error
+            let any: &dyn Any = host_err.as_ref();
+            if let Some(hosted_py_err) = any.downcast_ref::<HostedPyErr>() {
+                return Python::attach(|py| hosted_py_err.0.clone_ref(py));
+            }
+            if let Some(py_err) = any.downcast_ref::<PyErr>() {
+                return Python::attach(|py| py_err.clone_ref(py));
             }
         }
+        CError::Client { .. } => {
+            return PyValueError::new_err(format!("{}", err));
+        }
+        _ => {}
+    };
+    PyRuntimeError::new_err(format!("{:?}", err))
+}
+
+pub trait FromPyResult<T> {
+    fn from_py_result(self) -> CResult<T>;
+}
+
+impl<T> FromPyResult<T> for PyResult<T> {
+    fn from_py_result(self) -> CResult<T> {
+        self.map_err(|err| CError::host(HostedPyErr(err)))
     }
 }
 
@@ -107,24 +95,8 @@ pub trait IntoPyResult<T> {
     fn into_py_result(self) -> PyResult<T>;
 }
 
-impl<T, E: std::error::Error> IntoPyResult<T> for Result<T, E> {
+impl<T> IntoPyResult<T> for CResult<T> {
     fn into_py_result(self) -> PyResult<T> {
-        match self {
-            Ok(value) => Ok(value),
-            Err(err) => Err(PyException::new_err(format!("{err:?}"))),
-        }
-    }
-}
-
-pub trait AnyhowIntoPyResult<T> {
-    fn into_py_result(self) -> PyResult<T>;
-}
-
-impl<T> AnyhowIntoPyResult<T> for anyhow::Result<T> {
-    fn into_py_result(self) -> PyResult<T> {
-        match self {
-            Ok(value) => Ok(value),
-            Err(err) => Err(PyException::new_err(format!("{err:?}"))),
-        }
+        self.map_err(cerror_to_pyerr)
     }
 }

--- a/rust/py_utils/src/lib.rs
+++ b/rust/py_utils/src/lib.rs
@@ -5,3 +5,5 @@ mod future;
 pub use convert::*;
 pub use error::*;
 pub use future::*;
+
+pub mod prelude;

--- a/rust/py_utils/src/prelude.rs
+++ b/rust/py_utils/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::error::{FromPyResult, IntoPyResult};

--- a/rust/utils/src/fingerprint.rs
+++ b/rust/utils/src/fingerprint.rs
@@ -1,6 +1,6 @@
 use crate::{
     client_bail,
-    error::{Error, IntoInternal, Result},
+    error::{Error, Result},
 };
 use base64::prelude::*;
 use blake2::digest::typenum;
@@ -43,10 +43,10 @@ impl Fingerprint {
 
     pub fn from_base64(s: &str) -> Result<Self> {
         let bytes = match s.len() {
-            24 => BASE64_STANDARD.decode(s).internal()?,
+            24 => BASE64_STANDARD.decode(s)?,
 
             // For backward compatibility. Some old version (<= v0.1.2) is using hex encoding.
-            32 => hex::decode(s).internal()?,
+            32 => hex::decode(s)?,
             _ => client_bail!("Encoded fingerprint length is unexpected: {}", s.len()),
         };
         let bytes: [u8; 16] = bytes.try_into().map_err(|e: Vec<u8>| {

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -7,6 +7,8 @@ pub mod fingerprint;
 pub mod immutable;
 pub mod retryable;
 
+pub mod prelude;
+
 #[cfg(feature = "bytes_decode")]
 pub mod bytes_decode;
 #[cfg(feature = "reqwest")]

--- a/rust/utils/src/prelude.rs
+++ b/rust/utils/src/prelude.rs
@@ -1,0 +1,2 @@
+pub use crate::error::{ApiError, invariance_violation};
+pub use crate::error::{ContextExt, Error, Result};

--- a/rust/utils/src/retryable.rs
+++ b/rust/utils/src/retryable.rs
@@ -9,7 +9,7 @@ pub trait IsRetryable {
 }
 
 pub struct Error {
-    pub error: anyhow::Error,
+    pub error: crate::error::Error,
     pub is_retryable: bool,
 }
 
@@ -64,25 +64,16 @@ impl IsRetryable for neo4rs::Error {
 }
 
 impl Error {
-    pub fn retryable<E: Into<anyhow::Error>>(error: E) -> Self {
+    pub fn retryable<E: Into<crate::error::Error>>(error: E) -> Self {
         Self {
             error: error.into(),
             is_retryable: true,
         }
     }
 
-    pub fn not_retryable<E: Into<anyhow::Error>>(error: E) -> Self {
+    pub fn not_retryable<E: Into<crate::error::Error>>(error: E) -> Self {
         Self {
             error: error.into(),
-            is_retryable: false,
-        }
-    }
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(error: anyhow::Error) -> Self {
-        Self {
-            error,
             is_retryable: false,
         }
     }
@@ -91,13 +82,13 @@ impl From<anyhow::Error> for Error {
 impl From<crate::error::Error> for Error {
     fn from(error: crate::error::Error) -> Self {
         Self {
-            error: anyhow::Error::from(error),
+            error,
             is_retryable: false,
         }
     }
 }
 
-impl From<Error> for anyhow::Error {
+impl From<Error> for crate::error::Error {
     fn from(val: Error) -> Self {
         val.error
     }
@@ -107,7 +98,7 @@ impl<E: IsRetryable + std::error::Error + Send + Sync + 'static> From<E> for Err
     fn from(error: E) -> Self {
         Self {
             is_retryable: error.is_retryable(),
-            error: anyhow::Error::new(error),
+            error: error.into(),
         }
     }
 }


### PR DESCRIPTION
1. Makes the current error propagation mechanism (#1377) more ergonomic and avoid unintentionally wrapping host language (Python) exceptions as "internal error".
    - For all non-cocoindex-Error (e.g. `std::error::Error` coming from other libraries), enable directly using `?`. No longer need to do `.internal()?` (which will wrap exceptions as internal error, and easily being misused to wrap host error / client error / etc.).
    - This is achieved by `impl <E: Into<anyhow::Error>> From<E> for Error`.
    - We switch to always using `anyhow::Error` as internal error representation.
    - We removed `std::error::Error` trait implementation on `Error` (this pattern is similar to `anyhow::Error`), and create a `SError` wrapper to implement `std::error::Error.

2. Manually implemented a `Debug` for `Error` so error will show nicely in our logs, which leverages the debugging format of the underlying error.
    - For PyErr, created a wrapper `HostedPyErr`, so pretty-formatted traces are generated.

3. Remove a few more usages of `anyhow::Error`.
