### PR TITLE
`ci`: add lychee link-checker workflow file

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,49 @@
+name: Link Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**/*.md"
+      - "docs/**/*.mdx"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run link checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --cache --max-cache-age 1d --verbose --no-progress 'docs/**/*.md' 'docs/**/*.mdx'
+          fail: true
+          format: markdown
+          jobSummary: true
+          output: ./lychee/out.md
+
+      - name: Create issue from report
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
Closes #1415

Adds a GitHub Actions workflow that uses [`lychee`](https://github.com/lycheeverse/lychee) to catch broken links in the docs before they go live. It runs on PRs that touch any `.md` or `.mdx` files under [`/docs`](https://github.com/cocoindex-io/cocoindex/tree/main/docs), plus there's a daily scheduled run at midnight UTC to catch ext-links that might've gone stale/outdated over time.

When lychee finds broken links, it'll automatically open an issue with an appropriate report for the same.

Kept it scoped to just [`/docs`](https://github.com/cocoindex-io/cocoindex/tree/main/docs) since `examples/` got moved to their [own repo](https://github.com/cocoindex-io/examples) in #1412. If we want to add this over there too at some point, it's pretty much copy-paste.

_PS: My first time trying out claude-code (which is why you see the `co-authored` tag); given the inclusion of `CLAUDE.md` in [`6804ea6`](https://github.com/cocoindex-io/cocoindex/pull/1417/commits/6804ea698703371bcf8481063110e88e94efd0db) and the (optional) installation recommendation of [claude-code-skills in docs](https://cocoindex.io/docs/getting_started/installation#-install-claude-code-skill-optional), I thought it would be alright to experiment with this (since this is a small PR). Hope that's alright! I anyway put up disclaimers for when AI-assisted code is used in my PRs._