### PR TITLE
`ci`: reduce link checker false positives

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,4 +20,3 @@
 ^https://aws\.amazon\.com/console/
 
 ^https://platform\.openai\.com/api/ # may require auth
-


### PR DESCRIPTION
_Follow-up_ to #1425 to reduce false positives in the daily link checker. The [`latest report`](https://github.com/cocoindex-io/cocoindex/actions/runs/20566376385/job/59065278951) showed a bunch of (internal) doc errors that should not be coming up (all valid URLs) and docusaurus already checks for their validity during build and docs-ci.

Change:
Add to `.lycheeignore` to exclude internal `file://` links (relevant comment: https://github.com/cocoindex-io/cocoindex/issues/1415#issuecomment-3695581996) which should resolve the "errors" that show up in the reports.