### PR TITLE
chore: add back the missing `format` dep group for local

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,11 @@ ci = [
 ]
 
 dev-local = ["pre-commit"]
-dev = [{ include-group = "ci" }, { include-group = "dev-local" }]
+dev = [
+    { include-group = "ci" },
+    { include-group = "format" },
+    { include-group = "dev-local" },
+]
 
 [tool.uv]
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -205,6 +205,7 @@ dev = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
     { name = "types-psutil" },
 ]
 dev-local = [
@@ -260,6 +261,7 @@ dev = [
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
     { name = "types-psutil", specifier = ">=7.2.1" },
 ]
 dev-local = [{ name = "pre-commit" }]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures local development includes formatting tools.
> 
> - Adds the `format` group to the `dev` dependency group in `pyproject.toml` so `ruff` is included
> - Updates `uv.lock` to reflect `ruff` in `dev` and the `format` group
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8219670661da1d4fb956a027e1d0eb1bd31d42e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->