### PR TITLE
`docs`: add env file sourcing tip to `meeting_notes_graph` example

### DIFF
--- a/examples/meeting_notes_graph/README.md
+++ b/examples/meeting_notes_graph/README.md
@@ -50,6 +50,12 @@ export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/absolute/path/to/service_account.json
 export GOOGLE_DRIVE_ROOT_FOLDER_IDS=folderId1,folderId2
 ```
 
+Alternatively, fill in your values in `.env.example` and source it:
+
+```sh
+set -a && source .env.example && set +a
+```
+
 Notes:
 
 - `GOOGLE_DRIVE_ROOT_FOLDER_IDS` accepts a comma-separated list of folder IDs


### PR DESCRIPTION
Added an alternative (better?) approach for setting environment variables in the meeting notes graph example.

Simply export .env variables with `set -a && source .env && set +a` instead of manually exporting each variable (might get tedious for non-CLI folks).