### PR TITLE
`docs`: remove (redundant) unnecessary quick start link

### DIFF
--- a/docs/docs/getting_started/overview.md
+++ b/docs/docs/getting_started/overview.md
@@ -30,6 +30,3 @@ collector.collect(...)
 # export to db, vector db, graph db ...
 collector.export(...)
 ```
-
-Get Started:
-- [Quick Start](https://cocoindex.io/docs/getting_started/quickstart)


### PR DESCRIPTION
Remove unnecessary "Quick Start" link at the bottom of the [`Overview`](https://cocoindex.io/docs/) docs page.

The docusaurus nav takes you to the next page anyway.

<details>
<summary>Screenshot: </summary>

<img width="725" height="281" alt="image" src="https://github.com/user-attachments/assets/4a78e999-8591-4306-b0ab-6fd01bd89181" />

</details>

