### PR TITLE
feat:support @coco.function decorator for class's member methods

### DIFF
--- a/python/cocoindex/__init__.py
+++ b/python/cocoindex/__init__.py
@@ -52,6 +52,7 @@ from .typing import (
     Vector,
     Json,
 )
+from .op import function
 
 _engine.init_pyo3_runtime()
 
@@ -66,6 +67,7 @@ __all__ = [
     "storages",
     "cli",
     "op",
+    "function",
     "utils",
     # Auth registry
     "AuthEntryReference",

--- a/python/cocoindex/tests/test_function_decorator_methods.py
+++ b/python/cocoindex/tests/test_function_decorator_methods.py
@@ -1,0 +1,75 @@
+import pytest
+
+import cocoindex as coco
+
+
+def test_instance_method_scope_position_enforced() -> None:
+    with pytest.raises(ValueError):
+
+        class C:
+            @coco.function()
+            def m(self, x, scope, y):  # type: ignore[no-untyped-def]
+                pass
+
+
+def test_classmethod_scope_position_enforced_after_decorator() -> None:
+    with pytest.raises(ValueError):
+
+        class C:
+            @classmethod
+            @coco.function()
+            def m(cls, x, scope, y):  # type: ignore[no-untyped-def]
+                pass
+
+
+def test_classmethod_scope_position_enforced_before_decorator() -> None:
+    with pytest.raises(ValueError):
+
+        class C:
+            @coco.function()
+            @classmethod
+            def m(cls, x, scope, y):  # type: ignore[no-untyped-def]
+                pass
+
+
+def test_static_method_scope_position_enforced() -> None:
+    with pytest.raises(ValueError):
+
+        class C:
+            @coco.function()
+            @staticmethod
+            def sm(x, scope, y):  # type: ignore[no-untyped-def]
+                pass
+
+
+def test_valid_decorations_do_not_raise_and_set_op_kind() -> None:
+    class C:
+        @coco.function()
+        def im(self, scope=None):  # type: ignore[no-untyped-def]
+            pass
+
+        @classmethod
+        @coco.function()
+        def cm(cls, scope=None):  # type: ignore[no-untyped-def]
+            pass
+
+        @coco.function()
+        @classmethod
+        def cm2(cls, scope=None):  # type: ignore[no-untyped-def]
+            pass
+
+        @staticmethod
+        @coco.function()
+        def sm(scope=None):  # type: ignore[no-untyped-def]
+            pass
+
+        @coco.function()
+        @staticmethod
+        def sm2(scope=None):  # type: ignore[no-untyped-def]
+            pass
+
+    assert C.__dict__["im"].__cocoindex_op_kind__ == "Im"
+    assert C.__dict__["cm"].__func__.__cocoindex_op_kind__ == "Cm"
+    assert C.__dict__["cm2"].__func__.__cocoindex_op_kind__ == "Cm2"
+    assert C.__dict__["sm"].__func__.__cocoindex_op_kind__ == "Sm"
+    assert C.__dict__["sm2"].__func__.__cocoindex_op_kind__ == "Sm2"


### PR DESCRIPTION
Now function decorator can support the class members methods as well along with standalone.

Closes issue: #1555
Files affected:
```bash
op.py
__init__.py
```
Added tests to test the behaviour for new support.
```bash
test_function_decorator_methods.py
```
example taken from tests added below (one):
```python

def test_valid_decorations_do_not_raise_and_set_op_kind() -> None:
    class C:
        @coco.function()
        def im(self, scope=None):  # type: ignore[no-untyped-def]
            pass

        @classmethod
        @coco.function()
        def cm(cls, scope=None):  # type: ignore[no-untyped-def]
            pass

        @coco.function()
        @classmethod
        def cm2(cls, scope=None):  # type: ignore[no-untyped-def]
            pass

        @staticmethod
        @coco.function()
        def sm(scope=None):  # type: ignore[no-untyped-def]
            pass

        @coco.function()
        @staticmethod
        def sm2(scope=None):  # type: ignore[no-untyped-def]
            pass

    assert C.__dict__["im"].__cocoindex_op_kind__ == "Im"
    assert C.__dict__["cm"].__func__.__cocoindex_op_kind__ == "Cm"
    assert C.__dict__["cm2"].__func__.__cocoindex_op_kind__ == "Cm2"
    assert C.__dict__["sm"].__func__.__cocoindex_op_kind__ == "Sm"
    assert C.__dict__["sm2"].__func__.__cocoindex_op_kind__ == "Sm2"
```
Tests
- all tests are passing

@georgeh0 pls review it whenever you get a chance. I appreciate any feedback or suggestions to improve this PR.