### PR TITLE
fix(colpali): Fix crash when using ColPali/ColQwen models with organization prefixes

### DIFF
--- a/python/cocoindex/functions/colpali.py
+++ b/python/cocoindex/functions/colpali.py
@@ -35,7 +35,8 @@ def _get_colpali_model_and_processor(model_name: str) -> ColPaliModelInfo:
         ) from e
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    lower_model_name = model_name.lower()
+    # Strip any organization prefix to isolate the raw model name (e.g., `vidore/colqwen2-v1.0` -> `colqwen2-v1.0`)
+    lower_model_name = model_name.split("/")[-1].lower()
 
     # Determine model type from name
     if lower_model_name.startswith("colpali"):


### PR DESCRIPTION
## Description of Changes

This PR modifies `python/cocoindex/functions/colpali.py` to strip the organization prefix from the model name (e.g., `vidore/colqwen2-v1.0` -> `colqwen2-v1.0`) before determining the model type. This ensures that valid ColPali/ColQwen models from different organizations (or with explicit prefixes) are correctly identified and loaded.

## Motivation and Context

Cocoindex currently crashes when a user attempts to use a `ColPaliEmbedImage` instance initiated with any non-ColPali models, such as `vidore/colqwen2.5-v0.2` mentioned in the [class docstring](https://github.com/cocoindex-io/cocoindex/blob/e3ab51e98fdb455db8fb80f0739186a23215a877/python/cocoindex/functions/colpali.py#L112).

## Root Cause

The organization prefix in the model name stored in `ColPaliEmbedImage` is being passed to [_get_colpali_model_and_processor](https://github.com/cocoindex-io/cocoindex/blob/e3ab51e98fdb455db8fb80f0739186a23215a877/python/cocoindex/functions/colpali.py#L26) by [ColPaliEmbedImageExecutor](https://github.com/cocoindex-io/cocoindex/blob/e3ab51e98fdb455db8fb80f0739186a23215a877/python/cocoindex/functions/colpali.py#L139) without any change. 

The `_get_colpali_model_and_processor` function expected no organization prefix [in its logic](https://github.com/cocoindex-io/cocoindex/blob/e3ab51e98fdb455db8fb80f0739186a23215a877/python/cocoindex/functions/colpali.py#L41) for determining the model type. This causes all model names with an organization prefix to trigger the fallback logic that treats the model as a `ColPali`. The `ColPali` model class then fails to load the downloaded weights for non-ColPali models (like ColQwen).

## How to Reproduce

Replace line 14 in [examples/multi_format_indexing/main.py](https://github.com/cocoindex-io/cocoindex/blob/e3ab51e98fdb455db8fb80f0739186a23215a877/examples/multi_format_indexing/main.py#L14)

```python
COLPALI_MODEL_NAME = os.getenv("COLPALI_MODEL", "vidore/colpali-v1.2")
```

with

```python
COLPALI_MODEL_NAME = os.getenv("COLPALI_MODEL", "vidore/colqwen2-v1.0")
```

Running this script would crash the program with this error: 

> AttributeError: 'Qwen2VLConfig' object has no attribute 'image_size'

<img width="1277" height="1231" alt="image" src="https://github.com/user-attachments/assets/90f7a162-967b-4ec4-a0f9-cc667608a595" />

## Breaking Change

- [ ] Yes
- [x] No

This change is backward-compatible. It strictly fixes a bug where valid model names were being misidentified.

## Related Issues

None that I'm aware of.

## AI Use Disclosure

I used Gemini CLI to review and revise the description of the pull request I wrote.
