### PR TITLE
feat(targets): add Turbopuffer target connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ colpali = ["colpali-engine"]
 lancedb = ["lancedb>=0.25.0", "pyarrow>=19.0.0"]
 chromadb = ["chromadb>=0.4.0"]
 doris = ["aiohttp>=3.8.0", "aiomysql>=0.2.0", "pymysql>=1.0.0"]
+turbopuffer = ["turbopuffer>=1.0.0"]
 
 all = [
     "sentence-transformers>=3.3.1",
@@ -83,6 +84,7 @@ all = [
     "aiohttp>=3.8.0",
     "aiomysql>=0.2.0",
     "pymysql>=1.0.0",
+    "turbopuffer>=1.0.0",
 ]
 
 [dependency-groups]
@@ -132,7 +134,7 @@ disable_error_code = ["unused-ignore"]
 
 [[tool.mypy.overrides]]
 # Ignore missing imports for optional dependencies from cocoindex library
-module = ["sentence_transformers", "torch", "colpali_engine", "PIL", "aiohttp", "aiomysql", "pymysql", "chromadb"]
+module = ["sentence_transformers", "torch", "colpali_engine", "PIL", "aiohttp", "aiomysql", "pymysql", "chromadb", "turbopuffer"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/python/cocoindex/targets/turbopuffer.py
+++ b/python/cocoindex/targets/turbopuffer.py
@@ -1,15 +1,30 @@
 import dataclasses
 import json
 import logging
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-import turbopuffer  # type: ignore
+if TYPE_CHECKING:
+    import turbopuffer  # type: ignore
 
 from cocoindex import op
 from cocoindex.engine_type import FieldSchema, BasicValueType
 from cocoindex.index import IndexOptions, VectorSimilarityMetric
 
 _logger = logging.getLogger(__name__)
+
+
+def _get_turbopuffer() -> Any:
+    """Lazily import turbopuffer to avoid import errors when not installed."""
+    try:
+        import turbopuffer  # type: ignore
+
+        return turbopuffer
+    except ImportError:
+        raise ImportError(
+            "turbopuffer is required for Turbopuffer connector. "
+            "Install it with: pip install turbopuffer"
+        )
+
 
 _TURBOPUFFER_DISTANCE_METRIC: dict[VectorSimilarityMetric, str] = {
     VectorSimilarityMetric.COSINE_SIMILARITY: "cosine_distance",
@@ -48,7 +63,8 @@ class _MutateContext:
 
 
 def _get_client(spec: Turbopuffer) -> Any:
-    return turbopuffer.Turbopuffer(
+    tpuf = _get_turbopuffer()
+    return tpuf.Turbopuffer(
         api_key=spec.api_key,
         region=spec.region,
     )
@@ -162,7 +178,8 @@ class _Connector:
             )
             if should_delete:
                 try:
-                    client = turbopuffer.Turbopuffer(
+                    tpuf = _get_turbopuffer()
+                    client = tpuf.Turbopuffer(
                         api_key=state.api_key,
                         region=key.region,
                     )

--- a/python/cocoindex/targets/turbopuffer.py
+++ b/python/cocoindex/targets/turbopuffer.py
@@ -1,0 +1,254 @@
+import dataclasses
+import json
+import logging
+from typing import Any
+
+import turbopuffer  # type: ignore
+
+from cocoindex import op
+from cocoindex.engine_type import FieldSchema, BasicValueType
+from cocoindex.index import IndexOptions, VectorSimilarityMetric
+
+_logger = logging.getLogger(__name__)
+
+_TURBOPUFFER_DISTANCE_METRIC: dict[VectorSimilarityMetric, str] = {
+    VectorSimilarityMetric.COSINE_SIMILARITY: "cosine_distance",
+    VectorSimilarityMetric.L2_DISTANCE: "euclidean_squared",
+    VectorSimilarityMetric.INNER_PRODUCT: "dot_product",
+}
+
+
+class Turbopuffer(op.TargetSpec):
+    namespace_name: str
+    api_key: str
+    region: str = "gcp-us-central1"
+
+
+@dataclasses.dataclass
+class _NamespaceKey:
+    region: str
+    namespace_name: str
+
+
+@dataclasses.dataclass
+class _State:
+    key_field_schema: FieldSchema
+    value_fields_schema: list[FieldSchema]
+    distance_metric: str
+    api_key: str
+
+
+@dataclasses.dataclass
+class _MutateContext:
+    client: Any  # turbopuffer.Turbopuffer
+    namespace: Any  # turbopuffer.lib.namespace.Namespace
+    key_field_schema: FieldSchema
+    value_fields_schema: list[FieldSchema]
+    distance_metric: str
+
+
+def _get_client(spec: Turbopuffer) -> Any:
+    return turbopuffer.Turbopuffer(
+        api_key=spec.api_key,
+        region=spec.region,
+    )
+
+
+def _convert_key_to_id(key: Any) -> str:
+    if isinstance(key, str):
+        return key
+    elif isinstance(key, (int, float, bool)):
+        return str(key)
+    else:
+        return json.dumps(key, sort_keys=True, default=str)
+
+
+def _convert_value_to_attribute(value: Any) -> str | int | float | bool | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def _is_vector_field(field: FieldSchema) -> bool:
+    value_type = field.value_type.type
+    if isinstance(value_type, BasicValueType):
+        return value_type.kind == "Vector"
+    return False
+
+
+@op.target_connector(
+    spec_cls=Turbopuffer, persistent_key_type=_NamespaceKey, setup_state_cls=_State
+)
+class _Connector:
+    @staticmethod
+    def get_persistent_key(spec: Turbopuffer) -> _NamespaceKey:
+        return _NamespaceKey(
+            region=spec.region,
+            namespace_name=spec.namespace_name,
+        )
+
+    @staticmethod
+    def get_setup_state(
+        spec: Turbopuffer,
+        key_fields_schema: list[FieldSchema],
+        value_fields_schema: list[FieldSchema],
+        index_options: IndexOptions,
+    ) -> _State:
+        if len(key_fields_schema) != 1:
+            raise ValueError("Turbopuffer only supports a single key field")
+
+        vector_fields = [f for f in value_fields_schema if _is_vector_field(f)]
+        if not vector_fields:
+            raise ValueError(
+                "Turbopuffer requires a vector field in the value schema for embeddings."
+            )
+        if len(vector_fields) > 1:
+            raise ValueError(
+                f"Turbopuffer only supports a single vector field per namespace, "
+                f"but found {len(vector_fields)}: {[f.name for f in vector_fields]}. "
+                f"Consider using LanceDB or Qdrant for multiple vector fields."
+            )
+
+        distance_metric = "cosine_distance"  # Default
+        if index_options.vector_indexes:
+            if len(index_options.vector_indexes) > 1:
+                raise ValueError(
+                    "Turbopuffer only supports a single vector index per namespace"
+                )
+            vector_index = index_options.vector_indexes[0]
+            distance_metric = _TURBOPUFFER_DISTANCE_METRIC.get(
+                vector_index.metric, "cosine_distance"
+            )
+
+        return _State(
+            key_field_schema=key_fields_schema[0],
+            value_fields_schema=value_fields_schema,
+            distance_metric=distance_metric,
+            api_key=spec.api_key,
+        )
+
+    @staticmethod
+    def describe(key: _NamespaceKey) -> str:
+        return f"Turbopuffer namespace {key.namespace_name}@{key.region}"
+
+    @staticmethod
+    def check_state_compatibility(
+        previous: _State, current: _State
+    ) -> op.TargetStateCompatibility:
+        if previous.key_field_schema != current.key_field_schema:
+            return op.TargetStateCompatibility.NOT_COMPATIBLE
+        if previous.distance_metric != current.distance_metric:
+            return op.TargetStateCompatibility.NOT_COMPATIBLE
+
+        return op.TargetStateCompatibility.COMPATIBLE
+
+    @staticmethod
+    def apply_setup_change(
+        key: _NamespaceKey, previous: _State | None, current: _State | None
+    ) -> None:
+        if previous is None and current is None:
+            return
+        state = current or previous
+        if state is None:
+            return
+
+        # Delete namespace data if previous state exists and we're removing or recreating
+        if previous is not None:
+            should_delete = current is None or (
+                previous.key_field_schema != current.key_field_schema
+                or previous.distance_metric != current.distance_metric
+            )
+            if should_delete:
+                try:
+                    client = turbopuffer.Turbopuffer(
+                        api_key=state.api_key,
+                        region=key.region,
+                    )
+                    ns = client.namespace(key.namespace_name)
+                    ns.delete_all()
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    _logger.debug(
+                        "Namespace %s not found for deletion: %s",
+                        key.namespace_name,
+                        e,
+                    )
+
+        # Turbopuffer namespaces are created implicitly on first write — no setup needed.
+
+    @staticmethod
+    def prepare(
+        spec: Turbopuffer,
+        setup_state: _State,
+    ) -> _MutateContext:
+        client = _get_client(spec)
+        ns = client.namespace(spec.namespace_name)
+
+        return _MutateContext(
+            client=client,
+            namespace=ns,
+            key_field_schema=setup_state.key_field_schema,
+            value_fields_schema=setup_state.value_fields_schema,
+            distance_metric=setup_state.distance_metric,
+        )
+
+    @staticmethod
+    def mutate(
+        *all_mutations: tuple[_MutateContext, dict[Any, dict[str, Any] | None]],
+    ) -> None:
+        for context, mutations in all_mutations:
+            if not mutations:
+                continue
+
+            ids_to_delete: list[str] = []
+            rows_to_upsert: list[dict[str, Any]] = []
+
+            # Find the vector field name
+            vector_field_name: str | None = None
+            for field in context.value_fields_schema:
+                if _is_vector_field(field):
+                    vector_field_name = field.name
+                    break
+
+            for key, value in mutations.items():
+                doc_id = _convert_key_to_id(key)
+
+                if value is None:
+                    ids_to_delete.append(doc_id)
+                else:
+                    row: dict[str, Any] = {"id": doc_id}
+
+                    # Extract vector
+                    if vector_field_name and vector_field_name in value:
+                        embedding = value[vector_field_name]
+                        if embedding is None:
+                            raise ValueError(
+                                f"Missing embedding for document {doc_id}. "
+                                f"Turbopuffer requires an embedding for each document."
+                            )
+                        row["vector"] = embedding
+
+                    # Build attributes from non-vector fields
+                    for field in context.value_fields_schema:
+                        if field.name == vector_field_name:
+                            continue
+                        if field.name in value:
+                            converted = _convert_value_to_attribute(value[field.name])
+                            if converted is not None:
+                                row[field.name] = converted
+
+                    rows_to_upsert.append(row)
+
+            # Execute upserts
+            if rows_to_upsert:
+                context.namespace.write(
+                    upsert_rows=rows_to_upsert,
+                    distance_metric=context.distance_metric,
+                )
+
+            # Execute deletes
+            if ids_to_delete:
+                context.namespace.write(
+                    deletes=ids_to_delete,
+                )

--- a/python/cocoindex/targets/turbopuffer.py
+++ b/python/cocoindex/targets/turbopuffer.py
@@ -257,15 +257,10 @@ class _Connector:
 
                     rows_to_upsert.append(row)
 
-            # Execute upserts
-            if rows_to_upsert:
+            # Execute upserts and deletes atomically in a single write call
+            if rows_to_upsert or ids_to_delete:
                 context.namespace.write(
-                    upsert_rows=rows_to_upsert,
+                    upsert_rows=rows_to_upsert if rows_to_upsert else None,
+                    deletes=ids_to_delete if ids_to_delete else None,
                     distance_metric=context.distance_metric,
-                )
-
-            # Execute deletes
-            if ids_to_delete:
-                context.namespace.write(
-                    deletes=ids_to_delete,
                 )

--- a/python/cocoindex/tests/targets/test_turbopuffer_unit.py
+++ b/python/cocoindex/tests/targets/test_turbopuffer_unit.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for Turbopuffer connector (no turbopuffer account required).
+"""
+# mypy: disable-error-code="no-untyped-def"
+
+from typing import Literal
+import pytest
+
+from cocoindex.targets.turbopuffer import (
+    Turbopuffer,
+    _NamespaceKey,
+    _State,
+    _Connector,
+    _convert_key_to_id,
+    _convert_value_to_attribute,
+    _is_vector_field,
+)
+from cocoindex.engine_type import (
+    FieldSchema,
+    EnrichedValueType,
+    BasicValueType,
+    VectorTypeSchema,
+)
+from cocoindex import op
+from cocoindex.index import (
+    IndexOptions,
+    VectorIndexDef,
+    VectorSimilarityMetric,
+)
+
+_BasicKind = Literal[
+    "Bytes",
+    "Str",
+    "Bool",
+    "Int64",
+    "Float32",
+    "Float64",
+    "Range",
+    "Uuid",
+    "Date",
+    "Time",
+    "LocalDateTime",
+    "OffsetDateTime",
+    "TimeDelta",
+    "Json",
+    "Vector",
+    "Union",
+]
+
+
+def _mock_field(
+    name: str, kind: _BasicKind, nullable: bool = False, dim: int | None = None
+) -> FieldSchema:
+    """Create mock FieldSchema for testing."""
+    if kind == "Vector":
+        vec_schema = VectorTypeSchema(
+            element_type=BasicValueType(kind="Float32"),
+            dimension=dim,
+        )
+        basic_type = BasicValueType(kind=kind, vector=vec_schema)
+    else:
+        basic_type = BasicValueType(kind=kind)
+    return FieldSchema(
+        name=name,
+        value_type=EnrichedValueType(type=basic_type, nullable=nullable),
+    )
+
+
+# ============================================================
+# PERSISTENT KEY TESTS
+# ============================================================
+
+
+class TestGetPersistentKey:
+    def test_returns_correct_namespace_key(self):
+        spec = Turbopuffer(
+            namespace_name="my-ns", api_key="tpuf_test", region="aws-us-east-1"
+        )
+        key = _Connector.get_persistent_key(spec)
+        assert isinstance(key, _NamespaceKey)
+        assert key.namespace_name == "my-ns"
+        assert key.region == "aws-us-east-1"
+
+    def test_uses_default_region(self):
+        spec = Turbopuffer(namespace_name="my-ns", api_key="tpuf_test")
+        key = _Connector.get_persistent_key(spec)
+        assert key.region == "gcp-us-central1"
+
+
+# ============================================================
+# SETUP STATE TESTS
+# ============================================================
+
+
+class TestGetSetupState:
+    def _make_index_options(
+        self, metric: VectorSimilarityMetric = VectorSimilarityMetric.COSINE_SIMILARITY
+    ) -> IndexOptions:
+        return IndexOptions(
+            primary_key_fields=["id"],
+            vector_indexes=[VectorIndexDef(field_name="embedding", metric=metric)],
+        )
+
+    def test_single_key_single_vector(self):
+        spec = Turbopuffer(namespace_name="ns", api_key="key")
+        key_fields = [_mock_field("id", "Str")]
+        value_fields = [
+            _mock_field("embedding", "Vector", dim=384),
+            _mock_field("text", "Str"),
+        ]
+        state = _Connector.get_setup_state(
+            spec, key_fields, value_fields, self._make_index_options()
+        )
+        assert state.key_field_schema == key_fields[0]
+        assert state.value_fields_schema == value_fields
+        assert state.distance_metric == "cosine_distance"
+        assert state.api_key == "key"
+
+    def test_rejects_multiple_keys(self):
+        spec = Turbopuffer(namespace_name="ns", api_key="key")
+        key_fields = [_mock_field("id1", "Str"), _mock_field("id2", "Str")]
+        value_fields = [_mock_field("embedding", "Vector", dim=384)]
+        with pytest.raises(ValueError, match="single key field"):
+            _Connector.get_setup_state(
+                spec, key_fields, value_fields, self._make_index_options()
+            )
+
+    def test_rejects_no_vector(self):
+        spec = Turbopuffer(namespace_name="ns", api_key="key")
+        key_fields = [_mock_field("id", "Str")]
+        value_fields = [_mock_field("text", "Str")]
+        with pytest.raises(ValueError, match="vector field"):
+            _Connector.get_setup_state(
+                spec,
+                key_fields,
+                value_fields,
+                IndexOptions(primary_key_fields=["id"]),
+            )
+
+    def test_rejects_multiple_vectors(self):
+        spec = Turbopuffer(namespace_name="ns", api_key="key")
+        key_fields = [_mock_field("id", "Str")]
+        value_fields = [
+            _mock_field("emb1", "Vector", dim=384),
+            _mock_field("emb2", "Vector", dim=768),
+        ]
+        with pytest.raises(ValueError, match="single vector field"):
+            _Connector.get_setup_state(
+                spec, key_fields, value_fields, self._make_index_options()
+            )
+
+    @pytest.mark.parametrize(
+        "metric,expected",
+        [
+            (VectorSimilarityMetric.COSINE_SIMILARITY, "cosine_distance"),
+            (VectorSimilarityMetric.L2_DISTANCE, "euclidean_squared"),
+            (VectorSimilarityMetric.INNER_PRODUCT, "dot_product"),
+        ],
+    )
+    def test_distance_metric_mapping(self, metric, expected):
+        spec = Turbopuffer(namespace_name="ns", api_key="key")
+        key_fields = [_mock_field("id", "Str")]
+        value_fields = [_mock_field("embedding", "Vector", dim=384)]
+        index_options = IndexOptions(
+            primary_key_fields=["id"],
+            vector_indexes=[VectorIndexDef(field_name="embedding", metric=metric)],
+        )
+        state = _Connector.get_setup_state(
+            spec, key_fields, value_fields, index_options
+        )
+        assert state.distance_metric == expected
+
+
+# ============================================================
+# STATE COMPATIBILITY TESTS
+# ============================================================
+
+
+class TestCheckStateCompatibility:
+    def _make_state(
+        self,
+        key_name: str = "id",
+        metric: str = "cosine_distance",
+        value_name: str = "text",
+    ) -> _State:
+        return _State(
+            key_field_schema=_mock_field(key_name, "Str"),
+            value_fields_schema=[
+                _mock_field("embedding", "Vector", dim=384),
+                _mock_field(value_name, "Str"),
+            ],
+            distance_metric=metric,
+            api_key="key",
+        )
+
+    def test_compatible_when_same(self):
+        s1 = self._make_state()
+        s2 = self._make_state()
+        assert (
+            _Connector.check_state_compatibility(s1, s2)
+            == op.TargetStateCompatibility.COMPATIBLE
+        )
+
+    def test_not_compatible_on_key_change(self):
+        s1 = self._make_state(key_name="id")
+        s2 = self._make_state(key_name="new_id")
+        assert (
+            _Connector.check_state_compatibility(s1, s2)
+            == op.TargetStateCompatibility.NOT_COMPATIBLE
+        )
+
+    def test_not_compatible_on_metric_change(self):
+        s1 = self._make_state(metric="cosine_distance")
+        s2 = self._make_state(metric="euclidean_squared")
+        assert (
+            _Connector.check_state_compatibility(s1, s2)
+            == op.TargetStateCompatibility.NOT_COMPATIBLE
+        )
+
+    def test_compatible_on_value_field_change(self):
+        s1 = self._make_state(value_name="text")
+        s2 = self._make_state(value_name="content")
+        assert (
+            _Connector.check_state_compatibility(s1, s2)
+            == op.TargetStateCompatibility.COMPATIBLE
+        )
+
+
+# ============================================================
+# DESCRIBE TESTS
+# ============================================================
+
+
+class TestDescribe:
+    def test_format(self):
+        key = _NamespaceKey(region="gcp-us-central1", namespace_name="my-ns")
+        assert _Connector.describe(key) == "Turbopuffer namespace my-ns@gcp-us-central1"
+
+
+# ============================================================
+# HELPER FUNCTION TESTS
+# ============================================================
+
+
+class TestConvertKeyToId:
+    def test_string_passthrough(self):
+        assert _convert_key_to_id("abc") == "abc"
+
+    def test_int_to_str(self):
+        assert _convert_key_to_id(42) == "42"
+
+    def test_float_to_str(self):
+        assert _convert_key_to_id(3.14) == "3.14"
+
+    def test_bool_to_str(self):
+        assert _convert_key_to_id(True) == "True"
+
+    def test_complex_to_json(self):
+        result = _convert_key_to_id({"a": 1, "b": 2})
+        assert result == '{"a": 1, "b": 2}'
+
+    def test_list_to_json(self):
+        result = _convert_key_to_id([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+
+class TestConvertValueToAttribute:
+    def test_string_passthrough(self):
+        assert _convert_value_to_attribute("hello") == "hello"
+
+    def test_int_passthrough(self):
+        assert _convert_value_to_attribute(42) == 42
+
+    def test_float_passthrough(self):
+        assert _convert_value_to_attribute(3.14) == 3.14
+
+    def test_bool_passthrough(self):
+        assert _convert_value_to_attribute(True) is True
+
+    def test_none_returns_none(self):
+        assert _convert_value_to_attribute(None) is None
+
+    def test_complex_to_json(self):
+        result = _convert_value_to_attribute({"key": "value"})
+        assert result == '{"key": "value"}'
+
+    def test_list_to_json(self):
+        result = _convert_value_to_attribute([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+
+class TestIsVectorField:
+    def test_vector_field(self):
+        field = _mock_field("embedding", "Vector", dim=384)
+        assert _is_vector_field(field) is True
+
+    def test_non_vector_field(self):
+        field = _mock_field("text", "Str")
+        assert _is_vector_field(field) is False
+
+    def test_int_field(self):
+        field = _mock_field("count", "Int64")
+        assert _is_vector_field(field) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -444,6 +444,7 @@ all = [
     { name = "pyarrow" },
     { name = "pymysql" },
     { name = "sentence-transformers" },
+    { name = "turbopuffer" },
 ]
 chromadb = [
     { name = "chromadb" },
@@ -462,6 +463,9 @@ embeddings = [
 lancedb = [
     { name = "lancedb" },
     { name = "pyarrow" },
+]
+turbopuffer = [
+    { name = "turbopuffer" },
 ]
 
 [package.dev-dependencies]
@@ -527,10 +531,12 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=3.3.1" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=3.3.1" },
+    { name = "turbopuffer", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "turbopuffer", marker = "extra == 'turbopuffer'", specifier = ">=1.0.0" },
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchfiles", specifier = ">=1.1.0" },
 ]
-provides-extras = ["all", "chromadb", "colpali", "doris", "embeddings", "lancedb"]
+provides-extras = ["all", "chromadb", "colpali", "doris", "embeddings", "lancedb", "turbopuffer"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -3254,6 +3260,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3429,6 +3444,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
     { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
+]
+
+[[package]]
+name = "turbopuffer"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/95/cd21fad366bd8b56df7f053317d03d4a60b1b3a0bc867e7c92f4e5458ae5/turbopuffer-1.15.0.tar.gz", hash = "sha256:503f1451394f80846e9c8ad2dc869b5213a506cf78e448b0f056a996dc10f861", size = 153942, upload-time = "2026-02-08T06:26:34.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/7c/76161c6482f5e876cf021af0e5e0a703f3deb16268380fcd08d4aac1b46a/turbopuffer-1.15.0-py3-none-any.whl", hash = "sha256:064f558fe97e0337b7d9cb6b161502df9ca0628f04ae70fe4e5cc03900ee8430", size = 115658, upload-time = "2026-02-08T06:26:33.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a new target connector for [Turbopuffer](https://turbopuffer.com/) vector database, following the same pattern as the existing ChromaDB connector
- Supports cosine distance, euclidean squared, and dot product similarity metrics
- Includes 30 unit tests covering all connector logic and helper functions (no turbopuffer account required)

## Changes

- **`python/cocoindex/targets/turbopuffer.py`** — Connector implementation with `Turbopuffer` spec class and `_Connector` with all 7 required static methods
- **`python/cocoindex/tests/targets/test_turbopuffer_unit.py`** — Unit tests for persistent key, setup state validation, state compatibility, describe, and all helper functions
- **`pyproject.toml`** — Added `turbopuffer` optional dependency, added to `all` group, added to mypy ignore list

## Test plan

- [x] `ruff check` passes with no issues
- [x] `mypy` passes with no issues
- [x] `pytest python/cocoindex/tests/targets/test_turbopuffer_unit.py -v` — 30/30 tests pass
- [x] `python -c "import cocoindex.targets.turbopuffer"` succeeds

Closes #1562