### PR TITLE
fix(examples): clean up SEC EDGAR tutorial for end-to-end demo

### DIFF
--- a/examples/sec_edgar_analytics/README.md
+++ b/examples/sec_edgar_analytics/README.md
@@ -134,10 +134,12 @@ jupyter notebook tutorial.ipynb
 ```
 
 The notebook will:
-1. Create sample data (Apple, Microsoft, JPMorgan)
+1. Create simplified sample data (Apple, Microsoft, JPMorgan) for offline demo
 2. Set up database tables
 3. Build the search index
 4. Run example queries
+
+> The sample data is synthetic and condensed for demonstration purposes. It includes realistic filing structure, PII patterns (emails, phones, SSNs) for the scrubbing pipeline, and multi-format sources (TXT, JSON, PDF). See [About the Sample Data](#about-the-sample-data) for links to real SEC filings.
 
 ## Example Queries
 
@@ -292,6 +294,39 @@ This demo validates techniques needed for healthcare document search:
 | Temporal relevance (encounters) | Filing date recency scoring | ✅ Tested |
 | PHI de-identification | PII scrubbing | ✅ Implemented |
 | Audit lineage | CocoInsight visualization | ✅ Built-in |
+
+## About the Sample Data
+
+This tutorial uses **simplified synthetic data** for offline demonstration. The sample filings include realistic structure (risk factors, metadata, contact information) but are condensed to keep the demo fast and self-contained.
+
+To work with real SEC filings, you can download directly from EDGAR:
+
+### Real Data Sources
+
+| Data Type | API / URL | Example |
+|-----------|-----------|---------|
+| **Company Facts (JSON)** | `https://data.sec.gov/api/xbrl/companyfacts/CIK{number}.json` | [Apple](https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json), [Microsoft](https://data.sec.gov/api/xbrl/companyfacts/CIK0000789019.json), [JPMorgan](https://data.sec.gov/api/xbrl/companyfacts/CIK0000019617.json) |
+| **Full-Text Filings** | [EDGAR Full-Text Search](https://efts.sec.gov/LATEST/search-index?q=%2210-K%22&forms=10-K) | Search and download 10-K/10-Q filings |
+| **Filing Submissions** | `https://data.sec.gov/submissions/CIK{number}.json` | [Apple](https://data.sec.gov/submissions/CIK0000320193.json) |
+| **PDF Exhibits** | Linked from each filing's index page on EDGAR | See examples below |
+
+### Real Filing Exhibits (HTML)
+
+| Company | Exhibit 21 (Subsidiaries) | Exhibit 31 (SOX Certification) |
+|---------|---------------------------|-------------------------------|
+| **Apple** | [EX-21.1](https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/a10-kexhibit21109272025.htm) | [EX-31.1](https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/a10-kexhibit31109272025.htm) |
+| **Microsoft** | [EX-21](https://www.sec.gov/Archives/edgar/data/789019/000095017025100235/msft-ex21.htm) | [EX-31.1](https://www.sec.gov/Archives/edgar/data/789019/000095017025100235/msft-ex31_1.htm) |
+| **JPMorgan** | [EX-21](https://www.sec.gov/Archives/edgar/data/19617/000001961725000270/corp10k2024exhibit21.htm) | [EX-31.1](https://www.sec.gov/Archives/edgar/data/19617/000001961725000270/corp10k2024exhibit311.htm) |
+
+### Real Proxy Statements (PDF)
+
+| Company | DEF 14A Proxy Statement |
+|---------|------------------------|
+| **Apple** | [2026 Proxy Statement](https://www.sec.gov/Archives/edgar/data/320193/000130817926000008/aapl_courtesy-pdf.pdf) (2.3 MB) |
+| **Microsoft** | [2025 Proxy Statement](https://www.sec.gov/Archives/edgar/data/789019/000119312525245150/d908201ddef14a1.pdf) (8.4 MB) |
+| **JPMorgan** | [2025 Proxy Statement](https://www.jpmorganchase.com/content/dam/jpmc/jpmorgan-chase-and-co/investor-relations/documents/proxy-statement2025.pdf) (31.4 MB) |
+
+> **Note**: SEC EDGAR requires a `User-Agent` header with your name and email for programmatic access. Rate limit is 10 requests/second. See [Accessing EDGAR Data](https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data).
 
 ## Project Structure
 

--- a/examples/sec_edgar_analytics/download.py
+++ b/examples/sec_edgar_analytics/download.py
@@ -68,13 +68,18 @@ def _create_synthetic_sample_data() -> None:
 
     # TXT FILINGS (10-K Risk Factors)
     sample_filings = {
-        "0000320193_2024-11-01_10-K.txt": """APPLE INC. FORM 10-K ANNUAL REPORT
+        "0000320193_2025-11-01_10-K.txt": """APPLE INC. FORM 10-K ANNUAL REPORT
+Filed with the Securities and Exchange Commission
+Registrant's telephone number, including area code: (555) 012-3456
+Investor Relations Contact: investor.relations@example.com
+
 ITEM 1A. RISK FACTORS
 
 CYBERSECURITY RISKS
 The Company faces significant cybersecurity risks, including potential data breaches,
 ransomware attacks, and unauthorized access to our systems. We have invested heavily
-in security infrastructure to mitigate these threats.
+in security infrastructure to mitigate these threats. For security incident reports,
+contact our CISO office at security-incidents@example.com or call (555) 012-3457.
 
 CLIMATE CHANGE
 Climate change poses risks to our global supply chain and manufacturing operations.
@@ -86,13 +91,22 @@ to enhance our products and services including Siri and computational photograph
 
 SUPPLY CHAIN
 Our products are manufactured by outsourcing partners primarily in Asia. Supply chain
-disruptions from logistics issues or geopolitical tensions could impact production.""",
-        "0000789019_2024-10-15_10-K.txt": """MICROSOFT CORPORATION FORM 10-K ANNUAL REPORT
+disruptions from logistics issues or geopolitical tensions could impact production.
+
+For additional information, contact Apple Investor Relations at (555) 012-3458
+or visit investor.apple.com. Transfer agent: Equiniti Trust Company,
+shareowner@example.com, (555) 012-3459.""",
+        "0000789019_2025-10-15_10-K.txt": """MICROSOFT CORPORATION FORM 10-K ANNUAL REPORT
+Filed with the Securities and Exchange Commission
+Registrant's telephone number, including area code: (555) 021-6543
+Investor Relations: ir-contact@example.com
+
 ITEM 1A. RISK FACTORS
 
 CLOUD INFRASTRUCTURE
 Our Azure cloud platform faces intense competition from AWS and Google Cloud.
 Cybersecurity threats continue to evolve and require constant vigilance.
+Report vulnerabilities to security-team@example.com or call (555) 021-6544.
 
 AI INTEGRATION
 We are integrating artificial intelligence across our product portfolio.
@@ -100,8 +114,15 @@ Our Copilot AI assistant represents significant investment in machine learning.
 
 REGULATORY COMPLIANCE
 We operate in a complex regulatory environment. Privacy regulations like GDPR
-require continuous compliance investment across all markets.""",
-        "0000019617_2024-03-01_10-K.txt": """JPMORGAN CHASE & CO. FORM 10-K ANNUAL REPORT
+require continuous compliance investment across all markets.
+
+Media inquiries: media-contact@example.com, (555) 021-6545.
+Investor Relations: (555) 021-6546.""",
+        "0000019617_2025-03-01_10-K.txt": """JPMORGAN CHASE & CO. FORM 10-K ANNUAL REPORT
+Filed with the Securities and Exchange Commission
+Registrant's telephone number, including area code: (555) 034-7890
+Investor Relations Contact: ir-contact@example.com
+
 ITEM 1A. RISK FACTORS
 
 CREDIT RISK
@@ -111,10 +132,19 @@ Economic downturns may result in increased loan defaults.
 CYBERSECURITY
 We face constant cybersecurity threats from criminal organizations.
 We invest over $700 million annually in cybersecurity.
+Report suspicious activity to fraud-report@example.com or (555) 034-7891.
 
 CLIMATE RISK
 Climate change poses transition and physical risks to our business.
-We have committed to align financing with Paris Agreement goals.""",
+We have committed to align financing with Paris Agreement goals.
+
+Contact: JPMorgan Chase Investor Relations, investor-info@example.com, (555) 034-7892.
+
+EXHIBIT 10.1 - EMPLOYMENT AGREEMENT (EXCERPT)
+Executive: Jane A. Doe, Managing Director
+SSN: 287-65-4321 [Filed inadvertently - to be redacted per Reg S-T Rule 83]
+Annual Base Salary: $450,000
+Contact: jane.doe@example.com, (555) 034-7893""",
     }
 
     for filename, content in sample_filings.items():
@@ -133,14 +163,14 @@ We have committed to align financing with Paris Agreement goals.""",
                         "units": {
                             "USD": [
                                 {
-                                    "end": "2024-09-28",
+                                    "end": "2025-09-28",
                                     "val": 394328000000,
-                                    "filed": "2024-11-01",
+                                    "filed": "2025-11-01",
                                 },
                                 {
-                                    "end": "2023-09-30",
+                                    "end": "2024-09-30",
                                     "val": 383285000000,
-                                    "filed": "2023-11-03",
+                                    "filed": "2024-11-03",
                                 },
                             ]
                         },
@@ -151,9 +181,9 @@ We have committed to align financing with Paris Agreement goals.""",
                         "units": {
                             "USD": [
                                 {
-                                    "end": "2024-09-28",
+                                    "end": "2025-09-28",
                                     "val": 93736000000,
-                                    "filed": "2024-11-01",
+                                    "filed": "2025-11-01",
                                 },
                             ]
                         },
@@ -172,9 +202,9 @@ We have committed to align financing with Paris Agreement goals.""",
                         "units": {
                             "USD": [
                                 {
-                                    "end": "2024-06-30",
+                                    "end": "2025-06-30",
                                     "val": 245122000000,
-                                    "filed": "2024-10-15",
+                                    "filed": "2025-10-15",
                                 },
                             ]
                         },
@@ -193,9 +223,9 @@ We have committed to align financing with Paris Agreement goals.""",
                         "units": {
                             "USD": [
                                 {
-                                    "end": "2023-12-31",
+                                    "end": "2024-12-31",
                                     "val": 158104000000,
-                                    "filed": "2024-03-01",
+                                    "filed": "2025-03-01",
                                 },
                             ]
                         },
@@ -212,9 +242,9 @@ We have committed to align financing with Paris Agreement goals.""",
 
     # PDF EXHIBITS (minimal valid PDFs)
     sample_pdfs = {
-        "0000320193_2024-ex21.pdf": "APPLE INC - SUBSIDIARIES\n\n1. Apple Sales International\n2. Apple Operations International\n3. Braeburn Capital, Inc.",
-        "0000789019_2024-ex21.pdf": "MICROSOFT CORPORATION - SUBSIDIARIES\n\n1. LinkedIn Corporation\n2. GitHub, Inc.\n3. Nuance Communications",
-        "0000019617_2024-ex21.pdf": "JPMORGAN CHASE & CO - SUBSIDIARIES\n\n1. JPMorgan Chase Bank, N.A.\n2. J.P. Morgan Securities LLC",
+        "0000320193_2025-ex21.pdf": "APPLE INC - SUBSIDIARIES\n\n1. Apple Sales International\n2. Apple Operations International\n3. Braeburn Capital, Inc.\n\nRegistered Agent: Corporation Trust Company\nContact: agent.services@example.com, (555) 045-0001",
+        "0000789019_2025-ex21.pdf": "MICROSOFT CORPORATION - SUBSIDIARIES\n\n1. LinkedIn Corporation\n2. GitHub, Inc.\n3. Nuance Communications\n\nRegistered Agent: Corporation Service Company\nContact: agent.notices@example.com, (555) 045-0002",
+        "0000019617_2025-ex21.pdf": "JPMORGAN CHASE & CO - SUBSIDIARIES\n\n1. JPMorgan Chase Bank, N.A.\n2. J.P. Morgan Securities LLC\n\nNotices to:\nGeneral Counsel\nEmail: legal.notices@example.com\nPhone: (555) 045-0003\n\nEmployee referenced: SSN 000-12-3456 [REDACTION REQUIRED]",
     }
 
     for filename, text_content in sample_pdfs.items():

--- a/examples/sec_edgar_analytics/pyproject.toml
+++ b/examples/sec_edgar_analytics/pyproject.toml
@@ -13,13 +13,8 @@ dependencies = [
     "sentence-transformers>=2.2.0",
     # PDF processing (optional - for full PDF support)
     # "marker-pdf>=1.0.0",
-    # LLM summary (optional)
-    "anthropic>=0.18.0",
-    # Data handling
-    "httpx>=0.27.0",
     # Utilities
     "python-dotenv>=1.0.0",
-    "jinja2>=3.1.0",
     "jupyter>=1.1.1",
     "nest-asyncio>=1.6.0",
 ]

--- a/examples/sec_edgar_analytics/tutorial.ipynb
+++ b/examples/sec_edgar_analytics/tutorial.ipynb
@@ -45,9 +45,9 @@
     "│  Filters: time_gate=365 days, topics=[RISK:CYBER], source=filing        │\n",
     "│                                                                         │\n",
     "│  Results:                                                               │\n",
-    "│  [0.032] Apple 10-K 2024 → \"We face significant cybersecurity...\"       │\n",
-    "│  [0.029] Microsoft 10-K 2024 → \"Cyber threats continue to evolve...\"    │\n",
-    "│  [0.025] JPMorgan 10-K 2024 → \"We invest $700M in cybersecurity...\"     │\n",
+    "│  [0.032] Apple 10-K 2025 → \"We face significant cybersecurity...\"       │\n",
+    "│  [0.029] Microsoft 10-K 2025 → \"Cyber threats continue to evolve...\"    │\n",
+    "│  [0.025] JPMorgan 10-K 2025 → \"We invest $700M in cybersecurity...\"     │\n",
     "└─────────────────────────────────────────────────────────────────────────┘\n",
     "                                    ▲\n",
     "                                    │ Hybrid Search\n",
@@ -234,7 +234,7 @@
     "- **Item 8: Financial Statements** — The numbers\n",
     "\n",
     "```\n",
-    "data/filings/0000320193_2024-11-01_10-K.txt\n",
+    "data/filings/0000320193_2025-11-01_10-K.txt\n",
     "             │          │          │\n",
     "             │          │          └── Form type\n",
     "             │          └───────────── Filing date\n",
@@ -260,7 +260,7 @@
     "- Technical specifications\n",
     "\n",
     "```\n",
-    "data/exhibits_pdf/0000320193_2024-ex21.pdf\n",
+    "data/exhibits_pdf/0000320193_2025-ex21.pdf\n",
     "```\n",
     "\n",
     "**This tutorial shows how to ingest ALL THREE formats into a single searchable index.**"
@@ -268,9 +268,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created sample SEC data\n",
+      "\n",
+      "data/filings/ (TXT):\n",
+      "  0000019617_2025-02-14_10-K.txt\n",
+      "  0000019617_2025-03-01_10-K.txt\n",
+      "  0000320193_2025-10-31_10-K.txt\n",
+      "  0000320193_2025-11-01_10-K.txt\n",
+      "  0000789019_2025-07-30_10-K.txt\n",
+      "  0000789019_2025-10-15_10-K.txt\n",
+      "\n",
+      "data/company_facts/ (JSON):\n",
+      "  0000019617.json\n",
+      "  0000320193.json\n",
+      "  0000789019.json\n",
+      "\n",
+      "data/exhibits_pdf/ (PDF):\n",
+      "  0000019617_2025-04-07_DEF 14A_jpmc2025proxycourtesy.pdf\n",
+      "  0000019617_2025-ex21.pdf\n",
+      "  0000320193_2025-ex21.pdf\n",
+      "  0000320193_2026-01-08_DEF 14A_aapl_courtesy-pdf.pdf\n",
+      "  0000789019_2025-10-21_DEF 14A_d908201ddef14a1.pdf\n",
+      "  0000789019_2025-ex21.pdf\n"
+     ]
+    }
+   ],
    "source": [
     "# Create sample SEC data\n",
     "from download import create_sample_data\n",
@@ -357,14 +386,14 @@
     "Each data source encodes metadata in its filename. We extract this into structured fields for filtering:\n",
     "\n",
     "```\n",
-    "0000320193_2024-11-01_10-K.txt\n",
+    "0000320193_2025-11-01_10-K.txt\n",
     "│          │          │\n",
     "│          │          └── form_type: \"10-K\" (annual report)\n",
-    "│          └───────────── filing_date: \"2024-11-01\"\n",
+    "│          └───────────── filing_date: \"2025-11-01\"\n",
     "└──────────────────────── cik: \"0000320193\" (Apple's SEC ID)\n",
     "```\n",
     "\n",
-    "**Why this matters**: Enables queries like \"show 10-K filings from 2024\" without scanning content."
+    "**Why this matters**: Enables queries like \"show 10-K filings from 2025\" without scanning content."
    ]
   },
   {
@@ -377,15 +406,15 @@
      "output_type": "stream",
      "text": [
       "CIK:         0000320193 (Apple Inc.)\n",
-      "Filing Date: 2024-11-01\n",
+      "Filing Date: 2025-11-01\n",
       "Form Type:   10-K\n",
-      "Fiscal Year: 2024\n"
+      "Fiscal Year: 2025\n"
      ]
     }
    ],
    "source": [
     "# Test it\n",
-    "result = extract_filing_metadata(\"0000320193_2024-11-01_10-K.txt\")\n",
+    "result = extract_filing_metadata(\"0000320193_2025-11-01_10-K.txt\")\n",
     "print(f\"CIK:         {result.cik} (Apple Inc.)\")\n",
     "print(f\"Filing Date: {result.filing_date}\")\n",
     "print(f\"Form Type:   {result.form_type}\")\n",
@@ -405,8 +434,8 @@
     "**The solution**: `parse_company_facts()` converts JSON into natural language:\n",
     "\n",
     "```\n",
-    "Input:  {\"facts\": {\"us-gaap\": {\"Revenues\": {\"val\": 394328000000, \"end\": \"2024-09-28\"}}}}\n",
-    "Output: \"### Revenues\\nRecent values: 2024-09-28: $394.3B\"\n",
+    "Input:  {\"facts\": {\"us-gaap\": {\"Revenues\": {\"val\": 394328000000, \"end\": \"2025-09-28\"}}}}\n",
+    "Output: \"### Revenues\\nRecent values: 2025-09-28: $394.3B\"\n",
     "```\n",
     "\n",
     "Now the content can be chunked, embedded, and searched like any text document."
@@ -414,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -424,7 +453,7 @@
       "Metadata:\n",
       "  Entity: APPLE INC\n",
       "  CIK: 0000320193\n",
-      "  Latest Date: 2024-11-01\n",
+      "  Latest Date: 2025-11-01\n",
       "\n",
       "Parsed Content (first 800 chars):\n",
       "--------------------------------------------------\n",
@@ -435,19 +464,11 @@
       "\n",
       "### Revenues\n",
       "Amount of revenue recognized from goods sold, services rendered.\n",
-      "Recent values: 2024-09-28: $394.3B, 2023-09-30: $383.3B, 2022-09-24: $394.3B\n",
+      "Recent values: 2025-09-28: $394.3B, 2024-09-30: $383.3B\n",
       "\n",
       "### Net Income (Loss)\n",
       "The portion of profit or loss for the period.\n",
-      "Recent values: 2024-09-28: $93.7B, 2023-09-30: $97.0B\n",
-      "\n",
-      "### Assets\n",
-      "Sum of the carrying amounts as of the balance sheet date.\n",
-      "Recent values: 2024-09-28: $365.0B\n",
-      "\n",
-      "### Research and Development Expense\n",
-      "The aggregate costs incurred for research and development.\n",
-      "Recent values: 2024-09-28: $29.9B\n",
+      "Recent values: 2025-09-28: $93.7B\n",
       "...\n"
      ]
     }
@@ -490,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -498,7 +519,7 @@
      "output_type": "stream",
      "text": [
       "CIK:          0000320193\n",
-      "Filing Date:  2024-ex21\n",
+      "Filing Date:  2025-ex21\n",
       "Exhibit Type: EXHIBIT\n",
       "Form Type:    EXHIBIT\n"
      ]
@@ -506,7 +527,7 @@
    ],
    "source": [
     "# Test PDF metadata extraction\n",
-    "result = extract_pdf_metadata(\"0000320193_2024-ex21.pdf\")\n",
+    "result = extract_pdf_metadata(\"0000320193_2025-ex21.pdf\")\n",
     "print(f\"CIK:          {result.cik}\")\n",
     "print(f\"Filing Date:  {result.filing_date}\")\n",
     "print(f\"Exhibit Type: {result.exhibit_type}\")\n",
@@ -533,23 +554,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Before: Contact IR at ir@apple.com or 408-996-1010\n",
-      "After:  Contact IR at [EMAIL REDACTED] or [PHONE REDACTED]\n"
+      "BEFORE scrubbing (from JPMorgan 10-K sample):\n",
+      "-------------------------------------------------------\n",
+      "EXHIBIT 10.1 - EMPLOYMENT AGREEMENT (EXCERPT)\n",
+      "Executive: Jane A. Doe, Managing Director\n",
+      "SSN: 287-65-4321 [Filed inadvertently - to be redacted per Reg S-T Rule 83]\n",
+      "Annual Base Salary: $450,000\n",
+      "Contact: jane.doe@example.com, (555) 034-7893\n",
+      "\n",
+      "AFTER scrubbing:\n",
+      "-------------------------------------------------------\n",
+      "EXHIBIT 10.1 - EMPLOYMENT AGREEMENT (EXCERPT)\n",
+      "Executive: Jane A. Doe, Managing Director\n",
+      "SSN: [SSN REDACTED] [Filed inadvertently - to be redacted per Reg S-T Rule 83]\n",
+      "Annual Base Salary: $450,000\n",
+      "Contact: [EMAIL REDACTED], [PHONE REDACTED]\n"
      ]
     }
    ],
    "source": [
-    "# Test it\n",
-    "test = \"Contact IR at ir@apple.com or 408-996-1010\"\n",
-    "print(f\"Before: {test}\")\n",
-    "print(f\"After:  {scrub_pii(test)}\")"
+    "# Test PII scrubbing on actual sample data\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sample_file = Path(\"data/filings/0000019617_2025-03-01_10-K.txt\")\n",
+    "if sample_file.exists():\n",
+    "    original = sample_file.read_text()\n",
+    "    # Show a PII-rich excerpt (the employment agreement section at the end)\n",
+    "    excerpt = original[original.find(\"EXHIBIT 10.1\"):]\n",
+    "    if excerpt:\n",
+    "        print(\"BEFORE scrubbing (from JPMorgan 10-K sample):\")\n",
+    "        print(\"-\" * 55)\n",
+    "        print(excerpt)\n",
+    "        print()\n",
+    "        print(\"AFTER scrubbing:\")\n",
+    "        print(\"-\" * 55)\n",
+    "        print(scrub_pii(excerpt))\n",
+    "    else:\n",
+    "        # Fallback: show cover page area\n",
+    "        excerpt = original[:300]\n",
+    "        print(\"BEFORE scrubbing:\")\n",
+    "        print(\"-\" * 55)\n",
+    "        print(excerpt)\n",
+    "        print()\n",
+    "        print(\"AFTER scrubbing:\")\n",
+    "        print(\"-\" * 55)\n",
+    "        print(scrub_pii(excerpt))\n",
+    "else:\n",
+    "    # Fallback demo\n",
+    "    test = \"Contact IR at ir@example.com or 555-012-3456. SSN on file: 287-65-4321\"\n",
+    "    print(f\"Before: {test}\")\n",
+    "    print(f\"After:  {scrub_pii(test)}\")"
    ]
   },
   {
@@ -586,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -689,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -755,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -875,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -894,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -902,9 +963,6 @@
      "output_type": "stream",
      "text": [
       "Setting up database tables...\n",
-      "\u001b[2m2026-02-04T20:05:03.908582Z\u001b[0m \u001b[32m INFO\u001b[0m \u001b[1msetup.apply_changes_for_flow_ctx\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m\u001b[1msetup.apply_changes_for_flow\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m \u001b[2mcocoindex_engine::execution::db_tracking_setup\u001b[0m\u001b[2m:\u001b[0m Cleaning up tracking metadata and target data for 1 stale source(s): [6]\n",
-      "\u001b[2m2026-02-04T20:05:03.916399Z\u001b[0m \u001b[32m INFO\u001b[0m \u001b[1msetup.apply_changes_for_flow_ctx\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m\u001b[1msetup.apply_changes_for_flow\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m \u001b[2mcocoindex_engine::execution::db_tracking_setup\u001b[0m\u001b[2m:\u001b[0m Processed 0 tracking entries, deleted 0 target rows\n",
-      "\u001b[2m2026-02-04T20:05:03.917932Z\u001b[0m \u001b[32m INFO\u001b[0m \u001b[1msetup.apply_changes_for_flow_ctx\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m\u001b[1msetup.apply_changes_for_flow\u001b[0m\u001b[1m{\u001b[0m\u001b[3mflow_name\u001b[0m\u001b[2m=\u001b[0mSECFilingAnalytics\u001b[1m}\u001b[0m\u001b[2m:\u001b[0m \u001b[2mcocoindex_engine::execution::db_tracking_setup\u001b[0m\u001b[2m:\u001b[0m Deleted 0 tracking entries for stale sources\n",
       "\n",
       "Processing SEC data from all sources...\n",
       "  - TXT filings (10-K/10-Q)\n",
@@ -978,7 +1036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1047,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1132,30 +1190,30 @@
     "**When to use**: Exact terms, acronyms, regulatory codes, or when you need precise keyword matching.\n",
     "\n",
     "```python\n",
-    "# Find exact mentions of \"supply chain\" as a phrase\n",
-    "await search_lexical(\"supply chain\", match_type=\"phrase\")\n",
+    "# Find exact mentions of \"cybersecurity risks\" as a phrase\n",
+    "await search_lexical(\"cybersecurity risks\", match_type=\"phrase\")\n",
     "\n",
     "# Find chunks with ANY of these terms (OR)\n",
-    "await search_lexical(\"supply chain\", match_type=\"any\")\n",
+    "await search_lexical(\"cybersecurity risks\", match_type=\"any\")\n",
     "\n",
     "# Find chunks with ALL of these terms (AND)\n",
-    "await search_lexical(\"supply chain\", match_type=\"all\")\n",
+    "await search_lexical(\"cybersecurity risks\", match_type=\"all\")\n",
     "```\n",
     "\n",
     "**Doris Inverted Index Operators**:\n",
     "\n",
     "| Operator | SQL | Behavior | Strictness |\n",
     "|----------|-----|----------|------------|\n",
-    "| `MATCH_ANY` | `text MATCH_ANY 'supply chain'` | supply OR chain | Broadest |\n",
-    "| `MATCH_ALL` | `text MATCH_ALL 'supply chain'` | supply AND chain | Stricter |\n",
-    "| `MATCH_PHRASE` | `text MATCH_PHRASE 'supply chain'` | Exact phrase | Strictest |\n",
+    "| `MATCH_ANY` | `text MATCH_ANY 'cybersecurity risks'` | cybersecurity OR risks | Broadest |\n",
+    "| `MATCH_ALL` | `text MATCH_ALL 'cybersecurity risks'` | cybersecurity AND risks | Stricter |\n",
+    "| `MATCH_PHRASE` | `text MATCH_PHRASE 'cybersecurity risks'` | Exact phrase | Strictest |\n",
     "\n",
     "**Relevance Ranking**: Doris provides `SCORE()` — a BM25-based relevance score computed during full-text matching. We use `ORDER BY SCORE() DESC` to return the most relevant results first."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1217,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1225,37 +1283,31 @@
      "output_type": "stream",
      "text": [
       "======================================================================\n",
-      "MATCH_ANY (OR): Finds chunks with 'supply' OR 'chain'\n",
+      "MATCH_ANY (OR): Finds chunks with 'cybersecurity' OR 'risks'\n",
       "----------------------------------------------------------------------\n",
-      "1. [score=8.7] APPLE INC. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CYBERSECURITY RISKS\n",
-      "Th...\n",
-      "2. [score=8.3] The Company has a large, global business with sales outside the U.S. representin...\n",
-      "3. [score=7.9] Major public health issues, including pandemics such as the COVID-19 pandemic, h...\n",
+      "  → 5 results (showing top 3)\n",
+      "  1. [score=1.5] APPLE INC. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commis...\n",
+      "  2. [score=0.8] We face constant cybersecurity threats from criminal organizations.\n",
+      "We invest ov...\n",
+      "  3. [score=0.5] JPMORGAN CHASE & CO. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Excha...\n",
       "\n",
       "======================================================================\n",
-      "MATCH_ALL (AND): Finds chunks with BOTH 'supply' AND 'chain'\n",
+      "MATCH_ALL (AND): Finds chunks with BOTH 'cybersecurity' AND 'risks'\n",
       "----------------------------------------------------------------------\n",
-      "1. [score=8.7] APPLE INC. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CYBERSECURITY RISKS\n",
-      "Th...\n",
-      "2. [score=8.3] The Company has a large, global business with sales outside the U.S. representin...\n",
-      "3. [score=7.9] Major public health issues, including pandemics such as the COVID-19 pandemic, h...\n",
+      "  → 2 results\n",
+      "  1. [score=1.5] APPLE INC. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commis...\n",
+      "  2. [score=0.8] We face constant cybersecurity threats from criminal organizations.\n",
+      "We invest ov...\n",
       "\n",
       "======================================================================\n",
-      "MATCH_PHRASE (exact): Finds chunks with exact phrase 'supply chain'\n",
+      "MATCH_PHRASE (exact): Finds chunks with exact phrase 'cybersecurity risks'\n",
       "----------------------------------------------------------------------\n",
-      "1. [score=8.7] APPLE INC. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CYBERSECURITY RISKS\n",
-      "Th...\n",
-      "2. [score=8.3] The Company has a large, global business with sales outside the U.S. representin...\n",
-      "3. [score=7.9] Major public health issues, including pandemics such as the COVID-19 pandemic, h...\n",
+      "  → 1 results\n",
+      "  1. [score=1.5] APPLE INC. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commis...\n",
       "\n",
       "Results ranked by BM25 score via Doris SCORE().\n",
       "Notice: ANY (broadest) → ALL (stricter) → PHRASE (strictest).\n"
@@ -1264,28 +1316,32 @@
    ],
    "source": [
     "# Compare MATCH_ANY (OR) vs MATCH_ALL (AND) vs MATCH_PHRASE (exact)\n",
-    "# Using \"supply chain\" — a phrase that demonstrates all three operators well.\n",
+    "# Using \"cybersecurity risks\" — \"cybersecurity\" and \"risks\" appear widely but\n",
+    "# the exact phrase \"cybersecurity risks\" is rarer, showing clear operator differences.\n",
     "\n",
     "print(\"=\" * 70)\n",
-    "print(\"MATCH_ANY (OR): Finds chunks with 'supply' OR 'chain'\")\n",
+    "print(\"MATCH_ANY (OR): Finds chunks with 'cybersecurity' OR 'risks'\")\n",
     "print(\"-\" * 70)\n",
-    "results = await search_lexical(\"supply chain\", match_type=\"any\", limit=3)\n",
-    "for i, r in enumerate(results, 1):\n",
-    "    print(f\"{i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
+    "results = await search_lexical(\"cybersecurity risks\", match_type=\"any\", limit=5)\n",
+    "print(f\"  → {len(results)} results (showing top 3)\")\n",
+    "for i, r in enumerate(results[:3], 1):\n",
+    "    print(f\"  {i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
     "\n",
     "print(\"\\n\" + \"=\" * 70)\n",
-    "print(\"MATCH_ALL (AND): Finds chunks with BOTH 'supply' AND 'chain'\")\n",
+    "print(\"MATCH_ALL (AND): Finds chunks with BOTH 'cybersecurity' AND 'risks'\")\n",
     "print(\"-\" * 70)\n",
-    "results = await search_lexical(\"supply chain\", match_type=\"all\", limit=3)\n",
-    "for i, r in enumerate(results, 1):\n",
-    "    print(f\"{i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
+    "results = await search_lexical(\"cybersecurity risks\", match_type=\"all\", limit=5)\n",
+    "print(f\"  → {len(results)} results\")\n",
+    "for i, r in enumerate(results[:3], 1):\n",
+    "    print(f\"  {i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
     "\n",
     "print(\"\\n\" + \"=\" * 70)\n",
-    "print(\"MATCH_PHRASE (exact): Finds chunks with exact phrase 'supply chain'\")\n",
+    "print(\"MATCH_PHRASE (exact): Finds chunks with exact phrase 'cybersecurity risks'\")\n",
     "print(\"-\" * 70)\n",
-    "results = await search_lexical(\"supply chain\", match_type=\"phrase\", limit=3)\n",
-    "for i, r in enumerate(results, 1):\n",
-    "    print(f\"{i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
+    "results = await search_lexical(\"cybersecurity risks\", match_type=\"phrase\", limit=5)\n",
+    "print(f\"  → {len(results)} results\")\n",
+    "for i, r in enumerate(results[:3], 1):\n",
+    "    print(f\"  {i}. [score={r['score']:.1f}] {r['text'][:80]}...\")\n",
     "\n",
     "print(\"\\nResults ranked by BM25 score via Doris SCORE().\")\n",
     "print(\"Notice: ANY (broadest) → ALL (stricter) → PHRASE (strictest).\")"
@@ -1302,7 +1358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1313,37 +1369,23 @@
       "===========================================================================\n",
       "#   RRF Score    Sem Rank   Lex Rank   Source     File\n",
       "---------------------------------------------------------------------------\n",
-      "1   0.0328       #1        #1        filing     0000789019_2025-07-30_10-K.txt\n",
-      "2   0.0313       #6        #2        filing     0000320193_2025-10-31_10-K.txt\n",
-      "3   0.0310       #4        #5        filing     0000320193_2025-10-31_10-K.txt\n",
-      "4   0.0298       #2        #13       filing     0000320193_2025-10-31_10-K.txt\n",
-      "5   0.0295       #5        #11       filing     0000789019_2025-07-30_10-K.txt\n",
+      "1   0.0325       #2        #1        filing     0000320193_2025-11-01_10-K.txt\n",
+      "2   0.0325       #1        #2        filing     0000019617_2025-03-01_10-K.txt\n",
+      "3   0.0315       #4        #3        filing     0000019617_2025-03-01_10-K.txt\n",
+      "4   0.0312       #3        #5        filing     0000789019_2025-10-15_10-K.txt\n",
+      "5   0.0310       #5        #4        filing     0000320193_2025-11-01_10-K.txt\n",
       "\n",
       "===========================================================================\n",
       "How to read: Lower rank = better. RRF boosts docs that rank well on BOTH signals.\n",
       "\n",
       "Top result preview:\n",
       "  Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\"]\n",
-      "  Text: Business\n",
-      "3\n",
-      "Information about our Executive Officers\n",
-      "14\n",
-      "Item 1A.\n",
-      "Risk Factors\n",
-      "16\n",
-      "Item 1B.\n",
-      "Unresolved Staff Comments\n",
-      "30\n",
-      "Item 1C.\n",
-      "Cybersecurity\n",
-      "30\n",
-      "Item 2.\n",
-      "Properties\n",
-      "32\n",
-      "Item 3.\n",
-      "Legal Proceedings\n",
-      "32\n",
-      "Item ...\n"
+      "  Text: APPLE INC. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commission\n",
+      "Registrant's telephone number, including area code: [PHONE REDACTED]\n",
+      "Investor Relations Contact: [EMAIL REDACTED]\n",
+      "\n",
+      "...\n"
      ]
     }
    ],
@@ -1387,7 +1429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1396,15 +1438,19 @@
      "text": [
       "Source filter: filing only\n",
       "============================================================\n",
-      "1. [filing] 0000320193_2025-10-31_10-K.txt\n",
-      "   The Company has historically experienced higher net sales in its first quarter compared to other qua...\n",
+      "1. [filing] 0000019617_2025-03-01_10-K.txt\n",
+      "   We face constant cybersecurity threats from criminal organizations.\n",
+      "We invest over $700 million annu...\n",
       "\n",
-      "2. [filing] 0000320193_2025-10-31_10-K.txt\n",
-      "   Markets and Distribution\n",
-      "The Company’s customers are primarily in the consumer, small and mid-sized ...\n",
+      "2. [filing] 0000320193_2025-11-01_10-K.txt\n",
+      "   APPLE INC. FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commission\n",
+      "Registrant's te...\n",
       "\n",
-      "3. [filing] 0000789019_2025-07-30_10-K.txt\n",
-      "   Indicate by check mark whether the registrant has filed a report on and attestation to its managemen...\n",
+      "3. [filing] 0000789019_2025-10-15_10-K.txt\n",
+      "   MICROSOFT CORPORATION FORM 10-K ANNUAL REPORT\n",
+      "Filed with the Securities and Exchange Commission\n",
+      "Regi...\n",
       "\n"
      ]
     }
@@ -1421,7 +1467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1430,14 +1476,14 @@
      "text": [
       "Source filter: filing, exhibit (skip JSON)\n",
       "============================================================\n",
-      "1. [filing] 0000789019_2025-07-30_10-K.txt\n",
+      "1. [filing] 0000320193_2025-11-01_10-K.txt\n",
       "   Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\"]\n",
       "\n",
-      "2. [filing] 0000789019_2025-07-30_10-K.txt\n",
-      "   Topics: [\"RISK:REGULATORY\"]\n",
+      "2. [filing] 0000019617_2025-03-01_10-K.txt\n",
+      "   Topics: [\"RISK:CYBER\",\"RISK:CLIMATE\",\"RISK:REGULATORY\"]\n",
       "\n",
-      "3. [filing] 0000789019_2025-07-30_10-K.txt\n",
-      "   Topics: [\"RISK:REGULATORY\"]\n",
+      "3. [filing] 0000789019_2025-10-15_10-K.txt\n",
+      "   Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
       "\n"
      ]
     }
@@ -1490,7 +1536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1559,7 +1605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1568,29 +1614,15 @@
      "text": [
       "Topic filter: TOPIC:AI\n",
       "============================================================\n",
-      "1. [filing] 0000320193_2024-11-01_10-K.txt\n",
-      "   Score: 1.217 | Topics: [\"RISK:CYBER\",\"RISK:CLIMATE\",\"RISK:SUPPLY\",\"RISK:REGULATORY\",\"TOPIC:AI\"]\n",
-      "   APPLE INC. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
+      "1. [filing] 0000320193_2025-11-01_10-K.txt\n",
+      "   Score: 1.219 | Topics: [\"RISK:CLIMATE\",\"RISK:SUPPLY\",\"TOPIC:AI\"]\n",
+      "   CLIMATE CHANGE\n",
+      "Climate change poses risks to our global supply chain and manufac...\n",
       "\n",
-      "CYBERSECURITY RISKS\n",
-      "Th...\n",
-      "\n",
-      "2. [filing] 0000789019_2025-07-30_10-K.txt\n",
-      "   Score: 1.232 | Topics: [\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
-      "   PART\n",
-      "I\n",
-      "ITEM 1. B\n",
-      "USINESS\n",
-      "GENERAL\n",
-      "Microsoft is a technology company committed to ...\n",
-      "\n",
-      "3. [filing] 0000789019_2024-10-15_10-K.txt\n",
-      "   Score: 1.289 | Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
+      "2. [filing] 0000789019_2025-10-15_10-K.txt\n",
+      "   Score: 1.290 | Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
       "   MICROSOFT CORPORATION FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CLOUD INFRA...\n",
+      "Filed with the Securities and Exch...\n",
       "\n"
      ]
     }
@@ -1655,7 +1687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1715,7 +1747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1726,28 +1758,21 @@
       "=================================================================\n",
       "\n",
       "JPMorgan (0000019617) [filing]\n",
-      "  Score: 1.072 | Topics: [\"RISK:CYBER\",\"RISK:CLIMATE\",\"RISK:REGULATORY\"]\n",
-      "  JPMORGAN CHASE & CO. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CREDIT RISK\n",
-      "The Company faces significant credit ris...\n",
+      "  Score: 1.032 | Topics: [\"RISK:CYBER\",\"RISK:CLIMATE\",\"RISK:REGULATORY\"]\n",
+      "  We face constant cybersecurity threats from criminal organizations.\n",
+      "We invest over $700 million annually in cybersecurit...\n",
       "\n",
       "Apple (0000320193) [filing]\n",
-      "  Score: 1.018 | Topics: [\"RISK:CYBER\",\"RISK:CLIMATE\",\"RISK:SUPPLY\",\"RISK:REGULATORY\",\"TOPIC:AI\"]\n",
+      "  Score: 1.078 | Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\"]\n",
       "  APPLE INC. FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CYBERSECURITY RISKS\n",
-      "The Company faces significant cybersecurit...\n",
+      "Filed with the Securities and Exchange Commission\n",
+      "Registrant's telephone number, incl...\n",
       "\n",
       "Microsoft (0000789019) [filing]\n",
-      "  Score: 1.060 | Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
+      "  Score: 1.042 | Topics: [\"RISK:CYBER\",\"RISK:REGULATORY\",\"TOPIC:AI\",\"TOPIC:CLOUD\"]\n",
       "  MICROSOFT CORPORATION FORM 10-K ANNUAL REPORT\n",
-      "ITEM 1A. RISK FACTORS\n",
-      "\n",
-      "CLOUD INFRASTRUCTURE\n",
-      "Our Azure cloud platform faces...\n"
+      "Filed with the Securities and Exchange Commission\n",
+      "Registrant's telephone n...\n"
      ]
     }
    ],
@@ -1828,7 +1853,61 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n## Summary\n\nYou've built a production-ready SEC filing search system with:\n\n| Feature | Implementation |\n|---------|----------------|\n| **Multi-format ingestion** | TXT (filings) + JSON (API) + PDF (exhibits) |\n| **Unified search** | Single collector, `source_type` field for filtering |\n| **Semantic search** | SentenceTransformer embeddings + HNSW index |\n| **Keyword search** | Doris inverted index (MATCH_ANY/ALL/PHRASE) |\n| **Hybrid ranking** | RRF fusion (no weight tuning needed) |\n| **Temporal awareness** | Time gating via WHERE clause |\n| **Category filtering** | topics[] JSON array with `json_contains()` |\n| **Portfolio analysis** | `PARTITION BY` for per-company results |\n| **Access control** | Row/column-level security via `CREATE ROW POLICY` |\n| **Incremental updates** | CocoIndex caching |\n| **Audit trail** | doc_filename + location + source_type lineage |\n\n### Search API\n\n```python\n# Hybrid search (semantic + keyword)\nawait search(\"cybersecurity risks\", time_gate_days=365)\n\n# Lexical search (keyword only)\nawait search_lexical(\"GDPR\", match_type=\"phrase\")\n\n# Topic-filtered search\nawait search_by_topics(\"risks\", topics=[\"RISK:CYBER\"])\n\n# Portfolio comparison (top-k per company)\nawait search_portfolio(\"cybersecurity\", ciks=[\"0000320193\", \"0000789019\"])\n```\n\n### Project Files\n\n| File | Purpose |\n|------|---------|\n| `functions.py` | CocoIndex transformation functions (ETL) |\n| `search.py` | Low-level Doris SQL helpers |\n| `download.py` | Sample data creation |\n\n### Next Steps\n\n1. **View lineage**: `cocoindex server -ci main.py`\n2. **Add more data**: Extend `download.py` with additional companies\n\n### Resources\n\n- [CocoIndex Documentation](https://cocoindex.io/docs)\n- [Apache Doris Vector Search](https://doris.apache.org/docs)\n- [SEC EDGAR API](https://www.sec.gov/developer)"
+   "source": [
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "You've built a production-ready SEC filing search system with:\n",
+    "\n",
+    "| Feature | Implementation |\n",
+    "|---------|----------------|\n",
+    "| **Multi-format ingestion** | TXT (filings) + JSON (API) + PDF (exhibits) |\n",
+    "| **Unified search** | Single collector, `source_type` field for filtering |\n",
+    "| **Semantic search** | SentenceTransformer embeddings + HNSW index |\n",
+    "| **Keyword search** | Doris inverted index (MATCH_ANY/ALL/PHRASE) |\n",
+    "| **Hybrid ranking** | RRF fusion (no weight tuning needed) |\n",
+    "| **Temporal awareness** | Time gating via WHERE clause |\n",
+    "| **Category filtering** | topics[] JSON array with `json_contains()` |\n",
+    "| **Portfolio analysis** | `PARTITION BY` for per-company results |\n",
+    "| **Access control** | Row/column-level security via `CREATE ROW POLICY` |\n",
+    "| **Incremental updates** | CocoIndex caching |\n",
+    "| **Audit trail** | doc_filename + location + source_type lineage |\n",
+    "\n",
+    "### Search API\n",
+    "\n",
+    "```python\n",
+    "# Hybrid search (semantic + keyword)\n",
+    "await search(\"cybersecurity risks\", time_gate_days=365)\n",
+    "\n",
+    "# Lexical search (keyword only)\n",
+    "await search_lexical(\"GDPR\", match_type=\"phrase\")\n",
+    "\n",
+    "# Topic-filtered search\n",
+    "await search_by_topics(\"risks\", topics=[\"RISK:CYBER\"])\n",
+    "\n",
+    "# Portfolio comparison (top-k per company)\n",
+    "await search_portfolio(\"cybersecurity\", ciks=[\"0000320193\", \"0000789019\"])\n",
+    "```\n",
+    "\n",
+    "### Project Files\n",
+    "\n",
+    "| File | Purpose |\n",
+    "|------|---------|\n",
+    "| `functions.py` | CocoIndex transformation functions (ETL) |\n",
+    "| `search.py` | Low-level Doris SQL helpers |\n",
+    "| `download.py` | Sample data creation |\n",
+    "\n",
+    "### Next Steps\n",
+    "\n",
+    "1. **View lineage**: `cocoindex server -ci main.py`\n",
+    "2. **Add more data**: Extend `download.py` with additional companies\n",
+    "\n",
+    "### Resources\n",
+    "\n",
+    "- [CocoIndex Documentation](https://cocoindex.io/docs)\n",
+    "- [Apache Doris Vector Search](https://doris.apache.org/docs)\n",
+    "- [SEC EDGAR API](https://www.sec.gov/developer)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Remove unused dependencies (`anthropic`, `httpx`, `jinja2`) from pyproject.toml
- Bump all sample data dates from 2024 → 2025 so `time_gate_days=365` works (today is 2026)
- Add safe PII patterns (555 phones, `@example.com` emails, fake SSNs) to sample data so the PII scrubbing cell shows real before/after redaction
- Change lexical search demo query to "cybersecurity risks" which shows clear operator differentiation: `MATCH_ANY`=5, `MATCH_ALL`=2, `MATCH_PHRASE`=1
- Update all markdown cells to match 2025 dates and new query
- Add "About the Sample Data" section to README with links to real SEC EDGAR APIs and filings
- Re-execute notebook to refresh all cached outputs

## Test plan

- [x] `docker compose up -d` to start Doris + PostgreSQL
- [x] Open `tutorial.ipynb` and Run All — verify all cells execute without errors
- [x] Verify cell-17 (PII scrubbing) shows SSN/phone/email redaction
- [x] Verify cell-32 (lexical comparison) shows ANY > ALL > PHRASE result counts
- [x] Verify cell-34 (hybrid search with time_gate_days=365) returns results (not empty)