### PR TITLE
fix: ChromaDB collection not created on first run

### DIFF
--- a/python/cocoindex/targets/chromadb.py
+++ b/python/cocoindex/targets/chromadb.py
@@ -283,7 +283,7 @@ class _Connector:
         setup_state: _State,
     ) -> _MutateContext:
         client = _get_client(spec)
-        collection = client.get_collection(spec.collection_name)
+        collection = client.get_or_create_collection(spec.collection_name)
 
         return _MutateContext(
             client=client,


### PR DESCRIPTION
Fixes #1660

[`prepare()`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/targets/chromadb.py#L281) was using `get_collection()` which throws if the collection doesn't exist yet. Switched to [`get_or_create_collection()`](https://docs.trychroma.com/docs/collections/manage-collections#getting-collections); idempotent, returns existing or creates new.

Thanks @RodTol for flagging this!