### PR TITLE
`docs`: incorrect python installation link

### DIFF
--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -15,7 +15,7 @@ CocoIndex is supported on the following operating systems:
 
 To follow the steps in this guide, you'll need:
 
-1. Install [Python](https://wiki.python.org/moin/BeginnersGuide/Download/). We support Python 3.11 to 3.13.
+1. Install [Python](https://wiki.python.org/moin/BeginnersGuide(2f)Download.html). We support Python 3.11 to 3.13.
 2. Install [pip](https://pip.pypa.io/en/stable/installation/) - a Python package installer
 
 ## 🌴 Install CocoIndex


### PR DESCRIPTION
Updated the installation link for Python to the correct URL format (pointed out from the failed `lychee` CI run [here](https://github.com/Haleshot/cocoindex/actions/runs/22028181651)).

Original link / webpage was retired.

<details>
<summary>More details (as taken from the webpage)</summary>
This is a static archive of the Python wiki, which was retired in February 2026 due to lack of usage and the resources necessary to serve it — predominately to bots, crawlers, and LLM companies.
Pages are preserved as they were at the time of archival. For current information, please visit [python.org](https://www.python.org/).
If a change to this archive is absolutely needed, requests can be made via the [infrastructure@python.org](mailto:infrastructure@python.org) mailing list.
</details>