### PR TITLE
fix: test_cli.py::TestShowTree is flaky

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -640,23 +640,27 @@ def show(app_target: str, tree: bool) -> None:
     """
     app = _load_app(app_target)
 
-    if tree:
-        items = list_stable_paths_info_sync(app)
-        component_node_type = _core.StablePathNodeType.component()
-        paths: list[StablePath] = []
-        component_paths: set[StablePath] = set()
-        for item in items:
-            path = StablePath(item.path)
-            paths.append(path)
-            if item.node_type == component_node_type:
-                component_paths.add(path)
-        output = _render_paths_as_tree(paths, component_paths)
-        click.echo(output)
-    else:
-        paths = list_stable_paths_sync(app)
-        click.echo(f"Found {len(paths)} stable paths:")
-        for path in paths:
-            click.echo(f"  {path}")
+    try:
+        if tree:
+            items = list_stable_paths_info_sync(app)
+            component_node_type = _core.StablePathNodeType.component()
+            paths: list[StablePath] = []
+            component_paths: set[StablePath] = set()
+            for item in items:
+                path = StablePath(item.path)
+                paths.append(path)
+                if item.node_type == component_node_type:
+                    component_paths.add(path)
+            output = _render_paths_as_tree(paths, component_paths)
+            click.echo(output)
+        else:
+            paths = list_stable_paths_sync(app)
+            click.echo(f"Found {len(paths)} stable paths:")
+            for path in paths:
+                click.echo(f"  {path}")
+    finally:
+        env_loop = default_env_loop()
+        asyncio.run_coroutine_threadsafe(_stop_all_environments(), env_loop).result()
 
 
 async def _stop_all_environments() -> None:


### PR DESCRIPTION
Fix for the bug at https://github.com/cocoindex-io/cocoindex/issues/1685 

Add clean up for environments and their background threads before the subprocess exits, which was causing a race condition where threads tried to call PyGILState_Release after CPython had torn down thread state resulting in SIGSEGV (-11) or SIGABRT (-6) crash.