### PR TITLE
feat: make LMDB max_dbs and map_size configurable

### DIFF
--- a/python/cocoindex/_internal/setting.py
+++ b/python/cocoindex/_internal/setting.py
@@ -58,8 +58,8 @@ class Settings:
 
     db_path: os.PathLike[str] | None = None
     global_execution_options: GlobalExecutionOptions | None = None
-    lmdb_max_dbs: int | None = None
-    lmdb_map_size: int | None = None
+    lmdb_max_dbs: int = 1024
+    lmdb_map_size: int = 0x1_0000_0000  # 4 GiB
 
     @classmethod
     def from_env(cls, db_path: os.PathLike[str] | None = None) -> Self:

--- a/python/cocoindex/setting.py
+++ b/python/cocoindex/setting.py
@@ -46,8 +46,8 @@ class Settings:
 
     db_path: os.PathLike[str] | None = None
     global_execution_options: GlobalExecutionOptions | None = None
-    lmdb_max_dbs: int | None = None
-    lmdb_map_size: int | None = None
+    lmdb_max_dbs: int = 1024
+    lmdb_map_size: int = 0x1_0000_0000  # 4 GiB
 
     @classmethod
     def from_env(cls, db_path: os.PathLike[str] | None = None) -> Self:

--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -3,18 +3,25 @@ use crate::{
 };
 
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, path::PathBuf, u32};
+use std::{collections::BTreeSet, path::PathBuf};
 
 const DEFAULT_MAX_DBS: u32 = 1024;
 const DEFAULT_LMDB_MAP_SIZE: usize = 0x1_0000_0000; // 4GiB
 
+fn default_max_dbs() -> u32 {
+    DEFAULT_MAX_DBS
+}
+fn default_lmdb_map_size() -> usize {
+    DEFAULT_LMDB_MAP_SIZE
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EnvironmentSettings {
     pub db_path: PathBuf,
-    #[serde(default)]
-    pub lmdb_max_dbs: Option<u32>,
-    #[serde(default)]
-    pub lmdb_map_size: Option<usize>,
+    #[serde(default = "default_max_dbs")]
+    pub lmdb_max_dbs: u32,
+    #[serde(default = "default_lmdb_map_size")]
+    pub lmdb_map_size: usize,
 }
 
 struct EnvironmentInner<Prof: EngineProfile> {
@@ -40,12 +47,16 @@ impl<Prof: EngineProfile> Environment<Prof> {
         std::fs::create_dir_all(&db_path)?;
         // Backward compatibility: migrate LMDB files from old layout into mdb/.
         Self::migrate_legacy_db_files(&settings.db_path, &db_path)?;
-        let max_dbs = settings.lmdb_max_dbs.unwrap_or(DEFAULT_MAX_DBS);
-        let map_size = settings.lmdb_map_size.unwrap_or(DEFAULT_LMDB_MAP_SIZE);
+        if settings.lmdb_max_dbs < 1 {
+            client_bail!("lmdb_max_dbs must be >= 1, got {}", settings.lmdb_max_dbs);
+        }
+        if settings.lmdb_map_size == 0 {
+            client_bail!("lmdb_map_size must be > 0, got {}", settings.lmdb_map_size);
+        }
         let db_env = unsafe {
             heed::EnvOpenOptions::new()
-                .max_dbs(max_dbs)
-                .map_size(map_size)
+                .max_dbs(settings.lmdb_max_dbs)
+                .map_size(settings.lmdb_map_size)
                 .open(db_path)
         }?;
         let cleared_count = db_env.clear_stale_readers()?;


### PR DESCRIPTION
## Summary

- Exposes the hardcoded LMDB `max_dbs` (1024) and `map_size` (4 GiB) as configurable settings
- Configurable via Python `Settings(lmdb_max_dbs=..., lmdb_map_size=...)` or environment variables `COCOINDEX_LMDB_MAX_DBS` / `COCOINDEX_LMDB_MAP_SIZE`
- Defaults are set on the Python side (matching the `source_max_inflight_rows` pattern), so fields are always concrete values
- Invalid values are validated on the Rust side with `client_bail!`

**Fixes** #1703

## Changes

- `rust/core/src/engine/environment.rs` — Added `lmdb_max_dbs: u32` and `lmdb_map_size: usize` to `EnvironmentSettings` with `#[serde(default = "...")]` for backward compatibility. Validates `max_dbs >= 1` and `map_size > 0` via `client_bail!`. Removed unused `u32` import and the `// TODO: Expose these as settings` comment.
- `python/cocoindex/_internal/setting.py` — Added `lmdb_max_dbs: int = 1024` and `lmdb_map_size: int = 0x1_0000_0000` to `Settings`, loaded from env vars in `from_env()`
- `python/cocoindex/setting.py` — Same changes (public API mirror, noted as deprecated in v1)

## Usage

```python
import cocoindex

settings = cocoindex.Settings(
    db_path="/tmp/cocoindex_db",
    lmdb_max_dbs=2048,
    lmdb_map_size=0x2_0000_0000,  # 8 GiB
)
```

Or via environment variables:
```bash
export COCOINDEX_LMDB_MAX_DBS=2048
export COCOINDEX_LMDB_MAP_SIZE=8589934592
```