### PR TITLE
chore: assorted fix and improvements

### DIFF
--- a/docs/docs/connectors/localfs.md
+++ b/docs/docs/connectors/localfs.md
@@ -14,55 +14,52 @@ from cocoindex.connectors import localfs
 
 ## Stable memoization with FilePath
 
-A key feature of the `localfs` connector is **stable memoization** through `FilePath`. When you move your entire project directory, memoization keys remain stable as long as you use the same registered base directory key.
+A key feature of the `localfs` connector is **stable memoization** through `FilePath`. When you move your entire project directory, memoization keys remain stable as long as you use the same `ContextKey` key string for the base directory.
 
-### register_base_dir
+### Using ContextKey for stable base directories
 
-Register a base directory with a stable key. This enables stable memoization even when the actual filesystem path changes.
-
-```python
-def register_base_dir(key: str, path: Path) -> FilePath
-```
-
-**Parameters:**
-
-- `key` — A stable identifier for this base directory (e.g., `"source"`, `"output"`). Must be unique.
-- `path` — The filesystem path of the base directory.
-
-**Returns:** A `FilePath` representing the base directory itself.
-
-**Example:**
+Define a `ContextKey[pathlib.Path]` with a stable string identifier. Provide the actual path in your app's lifespan, then pass the key directly to `walk_dir()`, `declare_dir_target()`, and related functions.
 
 ```python
-from pathlib import Path
+import pathlib
+import cocoindex as coco
 from cocoindex.connectors import localfs
 
-# Register base directories with stable keys
-source_dir = localfs.register_base_dir("source", Path("./data"))
-output_dir = localfs.register_base_dir("output", Path("./out"))
+# Define a stable key (the string "source_dir" is the stable memo identifier)
+SOURCE_DIR = coco.ContextKey[pathlib.Path]("source_dir", tracked=False)
 
-# Use FilePath for stable memoization
-for file in localfs.walk_dir(source_dir, recursive=True):
-    # file.file_path has stable memo key based on "source" key
-    process(file)
+@coco.function
+async def app_main() -> None:
+    async for file in localfs.walk_dir(SOURCE_DIR, recursive=True):
+        # file.file_path has a stable memo key based on "source_dir"
+        await process(file)
+
+# In your lifespan, provide the actual path:
+async def lifespan(builder: coco.EnvBuilder) -> None:
+    builder.provide(SOURCE_DIR, pathlib.Path("./data"))
 ```
 
-When you move your project to a different location, just update the paths in `register_base_dir()` — the memoization keys stay the same because they're based on the stable key (`"source"`), not the filesystem path.
+When you move your project to a different location, just update the path in `builder.provide()` — memoization keys remain the same because they're based on the stable key string (`"source_dir"`), not the filesystem path.
 
 ### FilePath
 
-`FilePath` combines a base directory (with a stable key) and a relative path. It supports all `pathlib.PurePath` operations:
+`FilePath` combines an optional base directory key and a relative path. Passing a `ContextKey[Path]` directly to any localfs function is equivalent to constructing `FilePath(base_dir=key)`.
+
+`FilePath` supports all `pathlib.PurePath` operations:
 
 ```python
+SOURCE_DIR = coco.ContextKey[pathlib.Path]("source_dir", tracked=False)
+source = localfs.FilePath(base_dir=SOURCE_DIR)
+
 # Create paths using the / operator
-config_path = source_dir / "config" / "settings.json"
+config_path = source / "config" / "settings.json"
 
 # Access path properties
 print(config_path.name)      # "settings.json"
 print(config_path.suffix)    # ".json"
 print(config_path.parent)    # FilePath pointing to "config/"
 
-# Resolve to absolute path
+# Resolve to absolute path (requires active component context)
 abs_path = config_path.resolve()  # pathlib.Path
 ```
 
@@ -74,7 +71,7 @@ Use `walk_dir()` to iterate over files in a directory. It returns a `DirWalker` 
 
 ```python
 def walk_dir(
-    path: FilePath | Path,
+    path: FilePath | Path | ContextKey[Path],
     *,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
@@ -83,7 +80,7 @@ def walk_dir(
 
 **Parameters:**
 
-- `path` — The root directory path to walk through. Can be a `FilePath` (with stable memoization) or a `pathlib.Path`.
+- `path` — The root directory path to walk through. Can be a `FilePath`, a `pathlib.Path`, or a `ContextKey[Path]` (equivalent to `FilePath(base_dir=path)`).
 - `recursive` — If `True`, recursively walk subdirectories.
 - `path_matcher` — Optional filter for files and directories. See [PatternFilePathMatcher](../resource_types.md#patternfilepathmatcher).
 
@@ -136,13 +133,13 @@ import cocoindex as coco
 from cocoindex.connectors import localfs
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 
+SOURCE_DIR = coco.ContextKey[pathlib.Path]("source_dir", tracked=False)
+
 @coco.fn
-async def app_main(sourcedir: pathlib.Path) -> None:
-    # Register base directory for stable memoization
-    source = localfs.register_base_dir("source", sourcedir)
+async def app_main() -> None:
     matcher = PatternFilePathMatcher(included_patterns=["**/*.md"])
 
-    async for file in localfs.walk_dir(source, recursive=True, path_matcher=matcher):
+    async for file in localfs.walk_dir(SOURCE_DIR, recursive=True, path_matcher=matcher):
         await coco.mount(
             coco.component_subpath("file", str(file.file_path.path)),
             process_file,
@@ -166,7 +163,7 @@ Declare a single file target. This is the simplest way to write a file.
 ```python
 @coco.fn
 def declare_file(
-    path: FilePath | Path,
+    path: FilePath | Path | ContextKey[Path],
     content: bytes | str,
     *,
     create_parent_dirs: bool = False,
@@ -175,21 +172,21 @@ def declare_file(
 
 **Parameters:**
 
-- `path` — The filesystem path for the file. Can be a `FilePath` or `pathlib.Path`.
+- `path` — The filesystem path for the file. Can be a `FilePath`, a `pathlib.Path`, or a `ContextKey[Path]`.
 - `content` — The file content (bytes or str).
 - `create_parent_dirs` — If `True`, create parent directories if they don't exist.
 
 **Example:**
 
 ```python
+OUTPUT_DIR = coco.ContextKey[pathlib.Path]("output_dir", tracked=False)
+
 @coco.fn
 def app_main() -> None:
-    output = localfs.register_base_dir("output", Path("./out"))
-
     coco.mount(
         coco.component_subpath("readme"),
         localfs.declare_file,
-        output / "readme.txt",
+        localfs.FilePath("readme.txt", base_dir=OUTPUT_DIR),
         content="Hello, world!",
         create_parent_dirs=True,
     )
@@ -202,7 +199,7 @@ Declare a directory target for writing multiple files. Returns a `DirTarget` for
 ```python
 @coco.fn
 def declare_dir_target(
-    path: FilePath | Path,
+    path: FilePath | Path | ContextKey[Path],
     *,
     create_parent_dirs: bool = True,
 ) -> DirTarget[coco.PendingS]
@@ -210,7 +207,7 @@ def declare_dir_target(
 
 **Parameters:**
 
-- `path` — The filesystem path for the directory. Can be a `FilePath` or `pathlib.Path`.
+- `path` — The filesystem path for the directory. Can be a `FilePath`, a `pathlib.Path`, or a `ContextKey[Path]`.
 - `create_parent_dirs` — If `True`, create parent directories if they don't exist. Defaults to `True`.
 
 **Returns:** A pending `DirTarget`. Use `await coco.mount_target(...)` or the convenience wrapper `await localfs.mount_dir_target(path)` to resolve.
@@ -263,17 +260,16 @@ import cocoindex as coco
 from cocoindex.connectors import localfs
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 
-@coco.fn
-async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
-    # Register directories for stable memoization
-    source = localfs.register_base_dir("source", sourcedir)
-    output = localfs.register_base_dir("output", outdir)
+SOURCE_DIR = coco.ContextKey[pathlib.Path]("source_dir", tracked=False)
+OUTPUT_DIR = coco.ContextKey[pathlib.Path]("output_dir", tracked=False)
 
-    # Declare output directory target
-    target = await localfs.mount_dir_target(output)
+@coco.fn
+async def app_main() -> None:
+    # Declare output directory target using context key
+    target = await localfs.mount_dir_target(OUTPUT_DIR)
 
     # Process files and write outputs
-    await coco.mount_each(process_file, localfs.walk_dir(source, recursive=True).items(), target)
+    await coco.mount_each(process_file, localfs.walk_dir(SOURCE_DIR, recursive=True).items(), target)
 
 @coco.fn(memo=True)
 async def process_file(file: FileLike, target: localfs.DirTarget) -> None:

--- a/python/cocoindex/_internal/serde.py
+++ b/python/cocoindex/_internal/serde.py
@@ -61,6 +61,11 @@ def _register_builtin_types() -> None:
         import numpy as np
 
         _UNPICKLE_SAFE_GLOBALS[("numpy", "dtype")] = np.dtype
+        _UNPICKLE_SAFE_GLOBALS[("numpy", "ndarray")] = np.ndarray
+        for _dtype_sub in _all_subclasses(np.dtype):
+            _UNPICKLE_SAFE_GLOBALS[(_dtype_sub.__module__, _dtype_sub.__qualname__)] = (
+                _dtype_sub
+            )
         _core_numeric = getattr(np, "_core", None)
         if _core_numeric is not None:
             _frombuffer = getattr(_core_numeric.numeric, "_frombuffer", None)
@@ -107,11 +112,53 @@ class _RestrictedUnpickler(pickle.Unpickler):
 
 
 # ---------------------------------------------------------------------------
+# Strict serialization (opt-in, for use in tests)
+# ---------------------------------------------------------------------------
+
+_strict_serialize: bool = False
+
+
+def enable_strict_serialize() -> None:
+    """Enable strict serialization type checking (call once in test setup)."""
+    global _strict_serialize
+    _strict_serialize = True
+
+
+class _StrictPickler(pickle.Pickler):
+    """Pickler that validates every object's type is in the unpickle allow-list."""
+
+    def reducer_override(self, obj: object) -> object:
+        # When obj is a class being pickled as a global reference, check it directly.
+        if isinstance(obj, type):
+            if obj.__module__ != "builtins":
+                key = (obj.__module__, obj.__qualname__)
+                if key not in _UNPICKLE_SAFE_GLOBALS:
+                    raise pickle.PicklingError(
+                        f"Type not registered for safe unpickling: {obj.__module__}.{obj.__qualname__}"
+                    )
+            return NotImplemented
+        # For instances, check their type.
+        t = type(obj)
+        if t.__module__ == "builtins":
+            return NotImplemented
+        key = (t.__module__, t.__qualname__)
+        if key not in _UNPICKLE_SAFE_GLOBALS:
+            raise pickle.PicklingError(
+                f"Type not registered for safe unpickling: {t.__module__}.{t.__qualname__}"
+            )
+        return NotImplemented
+
+
+# ---------------------------------------------------------------------------
 # Serialize / Deserialize
 # ---------------------------------------------------------------------------
 
 
 def serialize(value: Any) -> bytes:
+    if _strict_serialize:
+        buf = io.BytesIO()
+        _StrictPickler(buf, 5).dump(value)
+        return buf.getvalue()
     return pickle.dumps(value, 5)
 
 

--- a/python/cocoindex/connectors/localfs/_common.py
+++ b/python/cocoindex/connectors/localfs/_common.py
@@ -27,7 +27,7 @@ class FilePath(file.FilePath[pathlib.Path]):
 
         # Using a context key for a named base directory
         SOURCE_DIR = coco.ContextKey[pathlib.Path]("source_dir", tracked=False)
-        path = FilePath("docs/readme.md", _base_dir=SOURCE_DIR)
+        path = FilePath("docs/readme.md", base_dir=SOURCE_DIR)
         ```
     """
 
@@ -37,18 +37,18 @@ class FilePath(file.FilePath[pathlib.Path]):
         self,
         path: str | pathlib.PurePath = ".",
         *,
-        _base_dir: ContextKey[pathlib.Path] | None = None,
+        base_dir: ContextKey[pathlib.Path] | None = None,
     ) -> None:
         """
         Create a FilePath.
 
         Args:
             path: The path (relative to the base directory, or absolute).
-            _base_dir: Optional context key for the base directory. If None, resolves
-                       relative to the current working directory.
+            base_dir: Optional context key for the base directory. If None, resolves
+                      relative to the current working directory.
         """
         super().__init__(
-            _base_dir,
+            base_dir,
             pathlib.PurePath(path),
         )
 
@@ -63,13 +63,15 @@ class FilePath(file.FilePath[pathlib.Path]):
 
     def _with_path(self, path: pathlib.PurePath) -> Self:
         """Create a new FilePath with the given relative path, keeping the same base directory."""
-        return type(self)(path, _base_dir=self._base_dir)  # type: ignore[return-value]
+        return type(self)(path, base_dir=self._base_dir)  # type: ignore[return-value]
 
 
-def to_file_path(path: FilePath | pathlib.Path) -> FilePath:
-    """Convert a Path or FilePath to a FilePath."""
+def to_file_path(path: FilePath | pathlib.Path | ContextKey[pathlib.Path]) -> FilePath:
+    """Convert a Path, FilePath, or ContextKey to a FilePath."""
     if isinstance(path, FilePath):
         return path
+    if isinstance(path, ContextKey):
+        return FilePath(base_dir=path)
     return FilePath(path)
 
 

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -17,6 +17,8 @@ from cocoindex.resources.file import (
     MatchAllFilePathMatcher,
 )
 
+from cocoindex._internal.context_keys import ContextKey
+
 from ._common import FilePath, to_file_path
 
 
@@ -76,7 +78,7 @@ class DirWalker:
 
     def __init__(
         self,
-        path: FilePath | Path,
+        path: FilePath | Path | ContextKey[Path],
         *,
         recursive: bool = False,
         path_matcher: FilePathMatcher | None = None,
@@ -157,7 +159,7 @@ class DirWalker:
 
 
 def walk_dir(
-    path: FilePath | Path,
+    path: FilePath | Path | ContextKey[Path],
     *,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,

--- a/python/cocoindex/connectors/localfs/_target.py
+++ b/python/cocoindex/connectors/localfs/_target.py
@@ -13,7 +13,7 @@ from cocoindex.connectorkits.fingerprint import fingerprint_bytes
 from cocoindex._internal.datatype import TypeChecker
 
 from cocoindex._internal.serde import unpickle_safe
-from cocoindex._internal.context_keys import ContextProvider
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 from ._common import FilePath, to_file_path
 
@@ -355,7 +355,7 @@ class DirTarget(Generic[coco.MaybePendingS], coco.ResolvesTo["DirTarget"]):
 
 @coco.fn
 def declare_dir_target(
-    path: FilePath | pathlib.Path,
+    path: FilePath | pathlib.Path | ContextKey[pathlib.Path],
     *,
     create_parent_dirs: bool = True,
 ) -> DirTarget[coco.PendingS]:
@@ -363,8 +363,9 @@ def declare_dir_target(
     Declare a directory target for writing files.
 
     Args:
-        path: The filesystem path for the directory. Can be a FilePath (with stable
-            base directory key) or a pathlib.Path (uses CWD as base directory).
+        path: The filesystem path for the directory. Can be a FilePath, a
+            pathlib.Path (uses CWD as base directory), or a ContextKey[Path]
+            (equivalent to FilePath(base_dir=path)).
         create_parent_dirs: If True, create parent directories if they don't exist.
             Defaults to True.
 
@@ -389,7 +390,7 @@ def declare_dir_target(
 
 
 def dir_target(
-    path: FilePath | pathlib.Path,
+    path: FilePath | pathlib.Path | ContextKey[pathlib.Path],
     *,
     create_parent_dirs: bool = True,
 ) -> coco.TargetState[_EntryHandler]:
@@ -400,8 +401,9 @@ def dir_target(
     or with ``mount_dir_target()`` for a convenience wrapper.
 
     Args:
-        path: The filesystem path for the directory. Can be a FilePath (with stable
-            base directory key) or a pathlib.Path (uses CWD as base directory).
+        path: The filesystem path for the directory. Can be a FilePath, a
+            pathlib.Path (uses CWD as base directory), or a ContextKey[Path]
+            (equivalent to FilePath(base_dir=path)).
         create_parent_dirs: If True, create parent directories if they don't exist.
             Defaults to True.
 
@@ -421,7 +423,7 @@ def dir_target(
 
 
 async def mount_dir_target(
-    path: FilePath | pathlib.Path,
+    path: FilePath | pathlib.Path | ContextKey[pathlib.Path],
     *,
     create_parent_dirs: bool = True,
 ) -> DirTarget[coco.ResolvedS]:
@@ -431,8 +433,9 @@ async def mount_dir_target(
     Sugar over ``dir_target()`` + ``coco.mount_target()`` + wrapping.
 
     Args:
-        path: The filesystem path for the directory. Can be a FilePath (with stable
-            base directory key) or a pathlib.Path (uses CWD as base directory).
+        path: The filesystem path for the directory. Can be a FilePath, a
+            pathlib.Path (uses CWD as base directory), or a ContextKey[Path]
+            (equivalent to FilePath(base_dir=path)).
         create_parent_dirs: If True, create parent directories if they don't exist.
             Defaults to True.
 
@@ -447,7 +450,7 @@ async def mount_dir_target(
 
 @coco.fn
 def declare_file(
-    path: FilePath | pathlib.Path,
+    path: FilePath | pathlib.Path | ContextKey[pathlib.Path],
     content: bytes | str,
     *,
     create_parent_dirs: bool = False,
@@ -459,8 +462,9 @@ def declare_file(
     first creating a directory target.
 
     Args:
-        path: The filesystem path for the file. Can be a FilePath (with stable
-            base directory key) or a pathlib.Path (uses CWD as base directory).
+        path: The filesystem path for the file. Can be a FilePath, a
+            pathlib.Path (uses CWD as base directory), or a ContextKey[Path]
+            (equivalent to FilePath(base_dir=path)).
         content: The content of the file (bytes or str).
         create_parent_dirs: If True, create parent directories if they don't exist.
             Defaults to False.

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -117,6 +117,7 @@ class ManagedConnection:
         self._conn.close()
 
 
+@unpickle_safe
 @dataclass
 class Vec0TableDef:
     """

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,3 +1,6 @@
 import os
 
+from cocoindex._internal.serde import enable_strict_serialize
+
 os.environ.setdefault("PYTHONASYNCIODEBUG", "1")
+enable_strict_serialize()

--- a/python/tests/connectors/test_file_path.py
+++ b/python/tests/connectors/test_file_path.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from pathlib import PurePath
 
-import pytest
-
 from cocoindex.resources.file import FilePath
 from cocoindex.connectors.localfs import FilePath as LocalfsFilePath
 
@@ -50,7 +48,7 @@ def test_localfs_filepath_with_base_dir_memo_key() -> None:
     import pathlib
 
     key = ContextKey[pathlib.Path]("test_localfs_source_dir_unique_17", tracked=False)
-    fp = LocalfsFilePath("file.txt", _base_dir=key)
+    fp = LocalfsFilePath("file.txt", base_dir=key)
     assert fp.__coco_memo_key__() == (
         "test_localfs_source_dir_unique_17",
         PurePath("file.txt"),

--- a/python/tests/core/test_safe_unpickle.py
+++ b/python/tests/core/test_safe_unpickle.py
@@ -108,7 +108,9 @@ class TestRegisteredTypes:
 
 class TestRejection:
     def test_unregistered_type_rejected(self) -> None:
-        data = serialize(_Unregistered(42))
+        # Use pickle.dumps directly to bypass strict-serialize checking,
+        # so we can test that deserialize rejects the unregistered type.
+        data = pickle.dumps(_Unregistered(42))
         with pytest.raises(pickle.UnpicklingError, match="Forbidden global"):
             deserialize(data)
 


### PR DESCRIPTION
1. Make sure sqlite Vec0 index def unpicklable.
2. Ergonomic for `walk_dir` etc. when using stable path from context key.