### PR TITLE
feat: add MiniMax as LLM provider for text generation and embedding

### DIFF
--- a/docs/docs/ai/llm.mdx
+++ b/docs/docs/ai/llm.mdx
@@ -30,6 +30,7 @@ We support the following types of LLM APIs:
 | [OpenRouter](#openrouter) | `LlmApiType.OPEN_ROUTER` | ✅ | ✅ |
 | [vLLM](#vllm) | `LlmApiType.VLLM` | ✅ | ❌ |
 | [Bedrock](#bedrock) | `LlmApiType.BEDROCK` | ✅ | ❌ |
+| [MiniMax](#minimax) | `LlmApiType.MINIMAX` | ✅ | ✅ |
 
 ## LLM Tasks
 
@@ -555,3 +556,46 @@ cocoindex.LlmSpec(
 </Tabs>
 
 You can find the full list of models supported by Bedrock [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
+
+### MiniMax
+
+[MiniMax](https://www.minimax.io/) is a cloud AI platform offering powerful language models and embedding capabilities through an OpenAI-compatible API.
+
+To use the MiniMax API, you need to set the environment variable `MINIMAX_API_KEY`.
+You can generate the API key from [MiniMax Platform](https://platform.minimax.chat/).
+
+For text generation, a spec for MiniMax looks like this:
+
+<Tabs>
+<TabItem value="python" label="Python" default>
+
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.MINIMAX,
+    model="MiniMax-M2.7",
+)
+```
+
+</TabItem>
+</Tabs>
+
+Available generation models include `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, and `MiniMax-M2.5-highspeed`.
+
+For text embedding, MiniMax provides the `embo-01` model (1536 dimensions). A spec for MiniMax embedding looks like this:
+
+<Tabs>
+<TabItem value="python" label="Python" default>
+
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.MINIMAX,
+    model="embo-01",
+    # Use "db" for storage or "query" for search queries
+    task_type="db",
+)
+```
+
+</TabItem>
+</Tabs>
+
+MiniMax embedding supports `task_type` with values `"db"` (for storing documents) and `"query"` (for search queries).

--- a/examples/manuals_llm_extraction/main.py
+++ b/examples/manuals_llm_extraction/main.py
@@ -121,6 +121,9 @@ def manual_extraction_flow(
                 # Replace by this spec below, to use Bedrock API model
                 #   llm_spec=cocoindex.LlmSpec(
                 #       api_type=cocoindex.LlmApiType.BEDROCK, model="us.anthropic.claude-3-5-haiku-20241022-v1:0"),
+                # Replace by this spec below, to use MiniMax API model
+                #   llm_spec=cocoindex.LlmSpec(
+                #       api_type=cocoindex.LlmApiType.MINIMAX, model="MiniMax-M2.7"),
                 output_type=ModuleInfo,
                 instruction="Please extract Python module information from the manual.",
             )

--- a/python/cocoindex/llm.py
+++ b/python/cocoindex/llm.py
@@ -18,6 +18,7 @@ class LlmApiType(Enum):
     VLLM = "Vllm"
     BEDROCK = "Bedrock"
     AZURE_OPENAI = "AzureOpenAi"
+    MINIMAX = "MiniMax"
 
 
 @dataclass

--- a/python/cocoindex/tests/test_minimax_provider.py
+++ b/python/cocoindex/tests/test_minimax_provider.py
@@ -1,0 +1,245 @@
+"""Tests for MiniMax LLM provider integration."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cocoindex.llm import LlmApiType, LlmSpec
+
+
+class TestMiniMaxLlmApiType:
+    """Unit tests for MiniMax LlmApiType enum."""
+
+    def test_minimax_enum_exists(self) -> None:
+        """MiniMax should be a valid LlmApiType variant."""
+        assert hasattr(LlmApiType, "MINIMAX")
+        assert LlmApiType.MINIMAX.value == "MiniMax"
+
+    def test_minimax_enum_distinct(self) -> None:
+        """MiniMax should be distinct from other enum values."""
+        other_values = [
+            member.value for name, member in LlmApiType.__members__.items()
+            if name != "MINIMAX"
+        ]
+        assert LlmApiType.MINIMAX.value not in other_values
+
+    def test_all_providers_present(self) -> None:
+        """All expected providers including MiniMax should be present."""
+        expected = {
+            "OPENAI", "OLLAMA", "GEMINI", "VERTEX_AI", "ANTHROPIC",
+            "LITE_LLM", "OPEN_ROUTER", "VOYAGE", "VLLM", "BEDROCK",
+            "AZURE_OPENAI", "MINIMAX",
+        }
+        actual = set(LlmApiType.__members__.keys())
+        assert expected == actual
+
+
+class TestMiniMaxLlmSpec:
+    """Unit tests for LlmSpec with MiniMax configuration."""
+
+    def test_basic_spec_creation(self) -> None:
+        """LlmSpec with MiniMax api_type should be created successfully."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7",
+        )
+        assert spec.api_type == LlmApiType.MINIMAX
+        assert spec.model == "MiniMax-M2.7"
+        assert spec.address is None
+        assert spec.api_key is None
+        assert spec.api_config is None
+
+    def test_spec_with_custom_address(self) -> None:
+        """LlmSpec should accept a custom address for MiniMax."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.5",
+            address="https://custom.minimax.io/v1",
+        )
+        assert spec.address == "https://custom.minimax.io/v1"
+
+    def test_spec_with_m27_model(self) -> None:
+        """LlmSpec should work with MiniMax-M2.7 model."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7",
+        )
+        assert spec.model == "MiniMax-M2.7"
+
+    def test_spec_with_m25_highspeed_model(self) -> None:
+        """LlmSpec should work with MiniMax-M2.5-highspeed model."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.5-highspeed",
+        )
+        assert spec.model == "MiniMax-M2.5-highspeed"
+
+    def test_spec_with_m27_highspeed_model(self) -> None:
+        """LlmSpec should work with MiniMax-M2.7-highspeed model."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7-highspeed",
+        )
+        assert spec.model == "MiniMax-M2.7-highspeed"
+
+    def test_spec_with_embedding_model(self) -> None:
+        """LlmSpec should work with embo-01 embedding model."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+        )
+        assert spec.model == "embo-01"
+
+    def test_spec_serialization_roundtrip(self) -> None:
+        """LlmSpec should survive dataclass field access."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7",
+            address="https://api.minimax.io/v1",
+        )
+        assert spec.api_type.value == "MiniMax"
+        assert spec.model == "MiniMax-M2.7"
+        assert spec.address == "https://api.minimax.io/v1"
+
+    def test_spec_no_api_config_needed(self) -> None:
+        """MiniMax does not require provider-specific api_config."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7",
+            api_config=None,
+        )
+        assert spec.api_config is None
+
+
+class TestMiniMaxEmbedTextSpec:
+    """Unit tests for EmbedText function spec with MiniMax."""
+
+    def test_embed_text_spec_creation(self) -> None:
+        """EmbedText spec should accept MiniMax api_type."""
+        from cocoindex.functions._engine_builtin_specs import EmbedText
+
+        spec = EmbedText(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+        )
+        assert spec.api_type == LlmApiType.MINIMAX
+        assert spec.model == "embo-01"
+
+    def test_embed_text_spec_with_task_type(self) -> None:
+        """EmbedText spec should accept task_type for MiniMax embedding."""
+        from cocoindex.functions._engine_builtin_specs import EmbedText
+
+        spec = EmbedText(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+            task_type="query",
+        )
+        assert spec.task_type == "query"
+
+    def test_embed_text_spec_with_db_task_type(self) -> None:
+        """EmbedText spec should accept 'db' task_type for storage embedding."""
+        from cocoindex.functions._engine_builtin_specs import EmbedText
+
+        spec = EmbedText(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+            task_type="db",
+        )
+        assert spec.task_type == "db"
+
+    def test_embed_text_spec_default_dimension(self) -> None:
+        """EmbedText spec should handle expected_output_dimension for embo-01."""
+        from cocoindex.functions._engine_builtin_specs import EmbedText
+
+        spec = EmbedText(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+            expected_output_dimension=1536,
+        )
+        assert spec.expected_output_dimension == 1536
+
+
+class TestMiniMaxExtractByLlmSpec:
+    """Unit tests for ExtractByLlm function spec with MiniMax."""
+
+    def test_extract_by_llm_spec_creation(self) -> None:
+        """ExtractByLlm spec should work with MiniMax LlmSpec."""
+        import dataclasses
+        from cocoindex.functions._engine_builtin_specs import ExtractByLlm
+
+        @dataclasses.dataclass
+        class SampleOutput:
+            title: str
+            summary: str
+
+        spec = ExtractByLlm(
+            llm_spec=LlmSpec(
+                api_type=LlmApiType.MINIMAX,
+                model="MiniMax-M2.7",
+            ),
+            output_type=SampleOutput,
+            instruction="Extract title and summary.",
+        )
+        assert spec.llm_spec.api_type == LlmApiType.MINIMAX
+        assert spec.llm_spec.model == "MiniMax-M2.7"
+        assert spec.instruction == "Extract title and summary."
+
+    def test_extract_by_llm_spec_without_instruction(self) -> None:
+        """ExtractByLlm spec should work without instruction."""
+        import dataclasses
+        from cocoindex.functions._engine_builtin_specs import ExtractByLlm
+
+        @dataclasses.dataclass
+        class InfoOutput:
+            name: str
+
+        spec = ExtractByLlm(
+            llm_spec=LlmSpec(
+                api_type=LlmApiType.MINIMAX,
+                model="MiniMax-M2.5",
+            ),
+            output_type=InfoOutput,
+        )
+        assert spec.instruction is None
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    @pytest.fixture(autouse=True)
+    def skip_without_api_key(self) -> None:
+        if not os.environ.get("MINIMAX_API_KEY"):
+            pytest.skip("MINIMAX_API_KEY not set")
+
+    def test_minimax_generation_spec_ready(self) -> None:
+        """Full LlmSpec for MiniMax generation should be constructable."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7",
+            address="https://api.minimax.io/v1",
+        )
+        assert spec.api_type == LlmApiType.MINIMAX
+        assert spec.model == "MiniMax-M2.7"
+
+    def test_minimax_embedding_spec_ready(self) -> None:
+        """Full EmbedText spec for MiniMax embedding should be constructable."""
+        from cocoindex.functions._engine_builtin_specs import EmbedText
+
+        spec = EmbedText(
+            api_type=LlmApiType.MINIMAX,
+            model="embo-01",
+            task_type="db",
+            expected_output_dimension=1536,
+        )
+        assert spec.api_type == LlmApiType.MINIMAX
+        assert spec.expected_output_dimension == 1536
+
+    def test_minimax_highspeed_model_spec(self) -> None:
+        """MiniMax-M2.7-highspeed model should be configurable."""
+        spec = LlmSpec(
+            api_type=LlmApiType.MINIMAX,
+            model="MiniMax-M2.7-highspeed",
+            address="https://api.minimax.io/v1",
+        )
+        assert spec.model == "MiniMax-M2.7-highspeed"

--- a/rust/cocoindex/src/llm/minimax.rs
+++ b/rust/cocoindex/src/llm/minimax.rs
@@ -1,0 +1,105 @@
+use crate::prelude::*;
+
+use crate::llm::{LlmEmbeddingClient, LlmEmbeddingRequest, LlmEmbeddingResponse};
+use async_openai::Client as OpenAIClient;
+use async_openai::config::OpenAIConfig;
+use phf::phf_map;
+
+pub use super::openai::Client;
+
+static DEFAULT_EMBEDDING_DIMENSIONS: phf::Map<&str, u32> = phf_map! {
+    "embo-01" => 1536,
+};
+
+impl Client {
+    pub async fn new_minimax(
+        address: Option<String>,
+        api_key: Option<String>,
+    ) -> Result<Self> {
+        let address = address.unwrap_or_else(|| "https://api.minimax.io/v1".to_string());
+
+        let api_key = api_key
+            .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+            .ok_or_else(|| {
+                client_error!("MINIMAX_API_KEY environment variable must be set")
+            })?;
+
+        let config = OpenAIConfig::new()
+            .with_api_base(address)
+            .with_api_key(api_key);
+        Ok(Client::from_parts(OpenAIClient::with_config(config)))
+    }
+}
+
+pub struct MiniMaxEmbeddingClient {
+    api_key: String,
+    address: String,
+    client: reqwest::Client,
+}
+
+impl MiniMaxEmbeddingClient {
+    pub fn new(address: Option<String>, api_key: Option<String>) -> Result<Self> {
+        let address =
+            address.unwrap_or_else(|| "https://api.minimax.io/v1/embeddings".to_string());
+
+        let api_key = api_key
+            .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+            .ok_or_else(|| {
+                client_error!("MINIMAX_API_KEY environment variable must be set")
+            })?;
+
+        Ok(Self {
+            api_key,
+            address,
+            client: reqwest::Client::new(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct EmbedResponse {
+    vectors: Vec<Vec<f32>>,
+}
+
+#[async_trait]
+impl LlmEmbeddingClient for MiniMaxEmbeddingClient {
+    async fn embed_text<'req>(
+        &self,
+        request: LlmEmbeddingRequest<'req>,
+    ) -> Result<LlmEmbeddingResponse> {
+        let texts: Vec<String> = request.texts.iter().map(|t| t.to_string()).collect();
+
+        // MiniMax uses "db" for storage and "query" for search queries.
+        let embed_type = match request.task_type.as_deref() {
+            Some("query") => "query",
+            _ => "db",
+        };
+
+        let payload = serde_json::json!({
+            "model": request.model,
+            "texts": texts,
+            "type": embed_type,
+        });
+
+        let resp = http::request(&self.client, |client| {
+            client
+                .post(&self.address)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .json(&payload)
+        })
+        .await
+        .map_err(Error::from)
+        .with_context(|| "MiniMax Embedding API error")?;
+
+        let embedding_resp: EmbedResponse =
+            resp.json().await.with_context(|| "Invalid JSON from MiniMax Embedding API")?;
+
+        Ok(LlmEmbeddingResponse {
+            embeddings: embedding_resp.vectors,
+        })
+    }
+
+    fn get_default_embedding_dimension(&self, model: &str) -> Option<u32> {
+        DEFAULT_EMBEDDING_DIMENSIONS.get(model).copied()
+    }
+}

--- a/rust/cocoindex/src/llm/mod.rs
+++ b/rust/cocoindex/src/llm/mod.rs
@@ -20,6 +20,7 @@ pub enum LlmApiType {
     VertexAi,
     Bedrock,
     AzureOpenAi,
+    MiniMax,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,6 +126,7 @@ mod anthropic;
 mod bedrock;
 mod gemini;
 mod litellm;
+mod minimax;
 mod ollama;
 mod openai;
 mod openrouter;
@@ -170,6 +172,10 @@ pub async fn new_llm_generation_client(
         }
         LlmApiType::Vllm => Box::new(vllm::Client::new_vllm(address, api_key).await?)
             as Box<dyn LlmGenerationClient>,
+        LlmApiType::MiniMax => {
+            Box::new(minimax::Client::new_minimax(address, api_key).await?)
+                as Box<dyn LlmGenerationClient>
+        }
     };
     Ok(client)
 }
@@ -202,6 +208,10 @@ pub async fn new_llm_embedding_client(
         }
         LlmApiType::AzureOpenAi => {
             Box::new(openai::Client::new_azure(address, api_key, api_config).await?)
+                as Box<dyn LlmEmbeddingClient>
+        }
+        LlmApiType::MiniMax => {
+            Box::new(minimax::MiniMaxEmbeddingClient::new(address, api_key)?)
                 as Box<dyn LlmEmbeddingClient>
         }
         LlmApiType::LiteLlm | LlmApiType::Vllm | LlmApiType::Anthropic | LlmApiType::Bedrock => {


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class LLM provider supporting both **text generation** and **text embedding**.

### Text Generation
- Reuses the existing OpenAI-compatible client via `async-openai`, connecting to `https://api.minimax.io/v1`
- Supports models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
- API key via `MINIMAX_API_KEY` environment variable

### Text Embedding
- Custom embedding client for MiniMax's native embedding API (`embo-01` model, 1536 dimensions)
- Supports task type distinction: `"db"` for storage, `"query"` for search queries
- Batch embedding support

### Changes
- **`rust/cocoindex/src/llm/minimax.rs`** (new): MiniMax generation client + embedding client
- **`rust/cocoindex/src/llm/mod.rs`**: Added `MiniMax` enum variant + factory dispatch for both generation and embedding
- **`python/cocoindex/llm.py`**: Added `MINIMAX = "MiniMax"` to `LlmApiType` enum
- **`docs/docs/ai/llm.mdx`**: MiniMax section with generation and embedding examples
- **`python/cocoindex/tests/test_minimax_provider.py`** (new): 20 tests covering enum, spec, EmbedText, ExtractByLlm, and integration
- **`examples/manuals_llm_extraction/main.py`**: Added MiniMax usage comment

### Usage

```python
# Text generation
cocoindex.LlmSpec(
    api_type=cocoindex.LlmApiType.MINIMAX,
    model="MiniMax-M2.7",
)

# Text embedding
cocoindex.functions.EmbedText(
    api_type=cocoindex.LlmApiType.MINIMAX,
    model="embo-01",
    task_type="db",
)
```

## Test plan
- [x] 20 Python unit tests pass (`pytest python/cocoindex/tests/test_minimax_provider.py`)
- [x] Rust builds successfully (`maturin develop`)
- [ ] Manual verification with live MiniMax API (requires `MINIMAX_API_KEY`)
