### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/python/cocoindex/llm.py
+++ b/python/cocoindex/llm.py
@@ -18,6 +18,7 @@ class LlmApiType(Enum):
     VLLM = "Vllm"
     BEDROCK = "Bedrock"
     AZURE_OPENAI = "AzureOpenAi"
+    NOVITA = "Novita"
 
 
 @dataclass

--- a/rust/cocoindex/src/llm/mod.rs
+++ b/rust/cocoindex/src/llm/mod.rs
@@ -20,6 +20,7 @@ pub enum LlmApiType {
     VertexAi,
     Bedrock,
     AzureOpenAi,
+    Novita,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,6 +126,7 @@ mod anthropic;
 mod bedrock;
 mod gemini;
 mod litellm;
+mod novita;
 mod ollama;
 mod openai;
 mod openrouter;
@@ -170,6 +172,8 @@ pub async fn new_llm_generation_client(
         }
         LlmApiType::Vllm => Box::new(vllm::Client::new_vllm(address, api_key).await?)
             as Box<dyn LlmGenerationClient>,
+        LlmApiType::Novita => Box::new(novita::Client::new_novita(address, api_key).await?)
+            as Box<dyn LlmGenerationClient>,
     };
     Ok(client)
 }
@@ -207,6 +211,8 @@ pub async fn new_llm_embedding_client(
         LlmApiType::LiteLlm | LlmApiType::Vllm | LlmApiType::Anthropic | LlmApiType::Bedrock => {
             api_bail!("Embedding is not supported for API type {:?}", api_type)
         }
+        LlmApiType::Novita => Box::new(novita::Client::new_novita(address, api_key).await?)
+            as Box<dyn LlmEmbeddingClient>,
     };
     Ok(client)
 }

--- a/rust/cocoindex/src/llm/novita.rs
+++ b/rust/cocoindex/src/llm/novita.rs
@@ -1,0 +1,21 @@
+use async_openai::Client as OpenAIClient;
+use async_openai::config::OpenAIConfig;
+
+pub use super::openai::Client;
+
+impl Client {
+    pub async fn new_novita(
+        address: Option<String>,
+        api_key: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let address = address.unwrap_or_else(|| "https://api.novita.ai/openai/v1".to_string());
+
+        let api_key = api_key.or_else(|| std::env::var("NOVITA_API_KEY").ok());
+
+        let mut config = OpenAIConfig::new().with_api_base(address);
+        if let Some(api_key) = api_key {
+            config = config.with_api_key(api_key);
+        }
+        Ok(Client::from_parts(OpenAIClient::with_config(config)))
+    }
+}


### PR DESCRIPTION
## Summary
- Add Novita AI as a new LLM provider supporting both text generation and embedding
- Uses OpenAI-compatible API at `https://api.novita.ai/openai/v1`
- API key via `NOVITA_API_KEY` environment variable or constructor parameter

## Changes
- Added `Novita` variant to `LlmApiType` enum in both Rust and Python
- Created `novita.rs` client module using OpenAI-compatible endpoint
- Wired Novita into generation and embedding client factories

## Usage
```python
import cocoindex

llm_spec = cocoindex.LlmSpec(
    api_type=cocoindex.LlmApiType.NOVITA,
    model="moonshotai/kimi-k2.5"
)
```

## Test Plan
- Rust code compiles successfully (`cargo check`)
- Follows the same pattern as existing OpenAI-compatible providers (LiteLLM, vLLM)