### PR TITLE
refactor: rename prev_possible_states to prev_possible_records

### DIFF
--- a/.claude/skills/target-connector/SKILL.md
+++ b/.claude/skills/target-connector/SKILL.md
@@ -98,7 +98,7 @@ class TargetHandler(Protocol[KeyT, ValueT, TrackingRecordT, OptChildHandlerT]):
         self,
         key: KeyT,
         desired_state: ValueT | NonExistenceType,
-        prev_possible_states: Collection[TrackingRecordT],
+        prev_possible_records: Collection[TrackingRecordT],
         prev_may_be_missing: bool,
         /,
     ) -> TargetReconcileOutput[ActionT, TrackingRecordT, OptChildHandlerT] | None:
@@ -113,7 +113,7 @@ class TargetHandler(Protocol[KeyT, ValueT, TrackingRecordT, OptChildHandlerT]):
 
 - `key`: Unique identifier for the target state
 - `desired_state`: What the user declared, or `NON_EXISTENCE` if no longer declared
-- `prev_possible_states`: Tracking records from previous runs (may have multiple)
+- `prev_possible_records`: Tracking records from previous runs (may have multiple)
 - `prev_may_be_missing`: If `True`, the target state might not exist in the external system
 
 **Returns:**
@@ -144,11 +144,11 @@ await conn.execute("INSERT ...")  # Fails on duplicate key
 
 ### Handle Multiple Previous States
 
-Due to interrupted updates, `prev_possible_states` may contain multiple records:
+Due to interrupted updates, `prev_possible_records` may contain multiple records:
 
 ```python
 if not prev_may_be_missing and all(
-    prev.fingerprint == target_fp for prev in prev_possible_states
+    prev.fingerprint == target_fp for prev in prev_possible_records
 ):
     return None  # Safe to skip
 ```

--- a/.claude/skills/target-connector/attachments.md
+++ b/.claude/skills/target-connector/attachments.md
@@ -68,7 +68,7 @@ class _VectorIndexHandler:
         self,
         key: coco.StableKey,
         desired_state: _VectorIndexSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_VectorIndexFingerprint],
+        prev_possible_records: Collection[_VectorIndexFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_VectorIndexAction, _VectorIndexFingerprint] | None:
@@ -122,7 +122,7 @@ Choose the tracking record type based on whether teardown recovery is needed:
 tracking_record = fingerprint_object(desired_state)  # bytes
 ```
 
-**Full spec example** (SQL command): On change or delete, the previous `teardown_sql` must be executed before the new `setup_sql`. The full spec is stored so `prev_possible_states` contains recoverable teardown information.
+**Full spec example** (SQL command): On change or delete, the previous `teardown_sql` must be executed before the new `setup_sql`. The full spec is stored so `prev_possible_records` contains recoverable teardown information.
 
 ```python
 tracking_record = desired_state  # _SqlCommandSpec (the spec itself)

--- a/docs/docs/advanced_topics/custom_target_connector.md
+++ b/docs/docs/advanced_topics/custom_target_connector.md
@@ -35,7 +35,7 @@ class TargetHandler(Protocol[KeyT, ValueT, TrackingRecordT, OptChildHandlerT]):
         self,
         key: KeyT,
         desired_state: ValueT | NonExistenceType,
-        prev_possible_states: Collection[TrackingRecordT],
+        prev_possible_records: Collection[TrackingRecordT],
         prev_may_be_missing: bool,
         /,
     ) -> TargetReconcileOutput[ActionT, TrackingRecordT, OptChildHandlerT] | None:
@@ -57,7 +57,7 @@ class TargetHandler(Protocol[KeyT, ValueT, TrackingRecordT, OptChildHandlerT]):
 
 - `key`: Unique identifier for this target state
 - `desired_state`: What the user declared, or `NON_EXISTENCE` if no longer declared
-- `prev_possible_states`: Tracking records from previous runs (may have multiple due to interrupted updates)
+- `prev_possible_records`: Tracking records from previous runs (may have multiple due to interrupted updates)
 - `prev_may_be_missing`: If `True`, the target state might not exist in the external system
 
 **Returns:**
@@ -204,10 +204,10 @@ Understanding what happens at runtime:
 
 4. **Action Execution**: CocoIndex batches actions by their `TargetActionSink` and executes them. The sink applies changes to the external system (database writes, file operations, API calls, etc.).
 
-5. **Tracking Persistence**: After successful execution, CocoIndex persists the new tracking records. On the next run, these become the `prev_possible_states` for change detection.
+5. **Tracking Persistence**: After successful execution, CocoIndex persists the new tracking records. On the next run, these become the `prev_possible_records` for change detection.
 
 :::note Multiple Previous States
-Due to interrupted updates, `prev_possible_states` may contain multiple records. CocoIndex tracks all possible states until a successful update confirms the current state. Your reconciliation logic should handle this by generating actions that work correctly regardless of which previous state is actual.
+Due to interrupted updates, `prev_possible_records` may contain multiple records. CocoIndex tracks all possible states until a successful update confirms the current state. Your reconciliation logic should handle this by generating actions that work correctly regardless of which previous state is actual.
 :::
 
 ### Step 1: Define your types
@@ -268,13 +268,13 @@ class _RowHandler(coco.TargetHandler[_RowKey, _RowSpec, _RowTrackingRecord]):
         self,
         key: _RowKey,
         desired_state: _RowSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowTrackingRecord],
+        prev_possible_records: Collection[_RowTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RowAction, _RowTrackingRecord] | None:
         # Handle deletion
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None  # Nothing to delete
             return coco.TargetReconcileOutput(
                 action=_RowAction(key=key, data=None),
@@ -287,7 +287,7 @@ class _RowHandler(coco.TargetHandler[_RowKey, _RowSpec, _RowTrackingRecord]):
 
         # Skip if unchanged
         if not prev_may_be_missing and all(
-            prev.fingerprint == target_fp for prev in prev_possible_states
+            prev.fingerprint == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -356,12 +356,12 @@ Set `child_invalidation` in the **parent handler's** `reconcile()` method when y
 
 ```python
 class _DirHandler(coco.TargetHandler[_DirKey, _DirSpec, _DirTrackingRecord]):
-    def reconcile(self, key, desired_state, prev_possible_states, prev_may_be_missing, /):
+    def reconcile(self, key, desired_state, prev_possible_records, prev_may_be_missing, /):
         # Detect if the container change is destructive or lossy
         invalidation = None
-        if self._is_destructive_change(desired_state, prev_possible_states):
+        if self._is_destructive_change(desired_state, prev_possible_records):
             invalidation = "destructive"
-        elif self._is_lossy_change(desired_state, prev_possible_states):
+        elif self._is_lossy_change(desired_state, prev_possible_records):
             invalidation = "lossy"
 
         return coco.TargetReconcileOutput(
@@ -379,7 +379,7 @@ The parent handler reconciles the container itself. The child handler reconciles
 ```python
 # Parent handler for directory
 class _DirHandler(coco.TargetHandler[_DirKey, _DirSpec, _DirTrackingRecord]):
-    def reconcile(self, key, desired_state, prev_possible_states, prev_may_be_missing, /):
+    def reconcile(self, key, desired_state, prev_possible_records, prev_may_be_missing, /):
         # Reconcile the directory itself
         ...
 
@@ -388,7 +388,7 @@ class _EntryHandler(coco.TargetHandler[str, _EntrySpec, _EntryTrackingRecord]):
     def __init__(self, base_path: pathlib.Path):
         self._base_path = base_path
 
-    def reconcile(self, key, desired_state, prev_possible_states, prev_may_be_missing, /):
+    def reconcile(self, key, desired_state, prev_possible_records, prev_may_be_missing, /):
         # Reconcile files/subdirs within the directory
         path = self._base_path / key
         ...
@@ -510,7 +510,7 @@ class _VectorIndexHandler:
                 else:
                     await conn.execute(f'CREATE INDEX "{action.name}" ...')
 
-    def reconcile(self, key, desired_state, prev_possible_states, prev_may_be_missing, /):
+    def reconcile(self, key, desired_state, prev_possible_records, prev_may_be_missing, /):
         # Standard reconcile pattern — compare fingerprints, return action or None
         ...
 ```
@@ -560,7 +560,7 @@ class TableTarget:
 ```
 
 :::tip Tracking records for teardown
-When an attachment has a teardown step (like `DROP INDEX`), store the full spec as the tracking record instead of a fingerprint. This lets you recover the teardown information from `prev_possible_states` when the attachment is deleted or changed. See the `_SqlCommandHandler` in the PostgreSQL connector for an example.
+When an attachment has a teardown step (like `DROP INDEX`), store the full spec as the tracking record instead of a fingerprint. This lets you recover the teardown information from `prev_possible_records` when the attachment is deleted or changed. See the `_SqlCommandHandler` in the PostgreSQL connector for an example.
 :::
 
 ## Best practices
@@ -582,12 +582,12 @@ await conn.execute("INSERT ...")  # Fails on duplicate key
 
 ### Handle multiple previous states
 
-Due to interrupted updates, `prev_possible_states` may contain multiple records. Design your reconciliation logic to handle this:
+Due to interrupted updates, `prev_possible_records` may contain multiple records. Design your reconciliation logic to handle this:
 
 ```python
 # Check if ALL previous states match (conservative approach)
 if not prev_may_be_missing and all(
-    prev.fingerprint == target_fp for prev in prev_possible_states
+    prev.fingerprint == target_fp for prev in prev_possible_records
 ):
     return None  # Safe to skip
 ```
@@ -682,14 +682,14 @@ class _FileHandler(coco.TargetHandler[_FileName, _FileContent, _FileTrackingReco
         self,
         key: _FileName,
         desired_state: _FileContent | coco.NonExistenceType,
-        prev_possible_states: Collection[_FileTrackingRecord],
+        prev_possible_records: Collection[_FileTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_FileAction, _FileTrackingRecord] | None:
         path = self._base_path / key
 
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_FileAction(path=path, content=None),
@@ -700,7 +700,7 @@ class _FileHandler(coco.TargetHandler[_FileName, _FileContent, _FileTrackingReco
         target_fp = fingerprint_bytes(desired_state)
 
         if not prev_may_be_missing and all(
-            prev.fingerprint == target_fp for prev in prev_possible_states
+            prev.fingerprint == target_fp for prev in prev_possible_records
         ):
             return None
 

--- a/python/cocoindex/_internal/target_state.py
+++ b/python/cocoindex/_internal/target_state.py
@@ -154,7 +154,7 @@ class TargetHandler(Protocol[ValueT_contra, TrackingRecordT, OptChildHandlerT_co
         self,
         key: StableKey,
         desired_target_state: ValueT_contra | NonExistenceType,
-        prev_possible_states: Collection[TrackingRecordT],
+        prev_possible_records: Collection[TrackingRecordT],
         prev_may_be_missing: bool,
         /,
     ) -> TargetReconcileOutput[Any, TrackingRecordT, OptChildHandlerT_co] | None: ...

--- a/python/cocoindex/connectors/doris/_target.py
+++ b/python/cocoindex/connectors/doris/_target.py
@@ -899,13 +899,13 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self,
         key: coco.StableKey,
         desired_state: _RowValue | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowFingerprint],
+        prev_possible_records: Collection[_RowFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RowAction, _RowFingerprint] | None:
         key = _ROW_KEY_CHECKER.check(key)
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_RowAction(key=key, value=None),
@@ -915,7 +915,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
 
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -1116,7 +1116,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         self,
         key: coco.StableKey,
         desired_state: _TableSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_TableTrackingRecord],
+        prev_possible_records: Collection[_TableTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -1139,7 +1139,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         resolved = statediff.resolve_system_transition(
             statediff.TrackingRecordTransition(
                 tracking_record,
-                prev_possible_states,
+                prev_possible_records,
                 prev_may_be_missing,
             )
         )

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -444,14 +444,14 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self,
         key: coco.StableKey,
         desired_state: _RowValue | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowFingerprint],
+        prev_possible_records: Collection[_RowFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RowAction, _RowFingerprint] | None:
         key = _ROW_KEY_CHECKER.check(key)
         if coco.is_non_existence(desired_state):
             # Delete case - only if it might exist
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_RowAction(key=key, value=None),
@@ -462,7 +462,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         # Upsert case
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             # No change needed
             return None
@@ -667,7 +667,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         self,
         key: coco.StableKey,
         desired_state: _TableSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_TableTrackingRecord],
+        prev_possible_records: Collection[_TableTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -690,7 +690,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         resolved = statediff.resolve_system_transition(
             statediff.TrackingRecordTransition(
                 tracking_record,
-                prev_possible_states,
+                prev_possible_records,
                 prev_may_be_missing,
             )
         )

--- a/python/cocoindex/connectors/localfs/_target.py
+++ b/python/cocoindex/connectors/localfs/_target.py
@@ -117,7 +117,7 @@ def _reconcile_entry(
     base_dir_key: str | None,
     path_str: str,
     desired_state: _EntrySpec | coco.NonExistenceType,
-    prev_possible_states: Collection[_EntryTrackingRecord],
+    prev_possible_records: Collection[_EntryTrackingRecord],
     prev_may_be_missing: bool,
 ) -> (
     coco.TargetReconcileOutput[_EntryAction, _EntryTrackingRecord, "_EntryHandler"]
@@ -127,7 +127,7 @@ def _reconcile_entry(
     if coco.is_non_existence(desired_state):
         # Determine entry type from previous state (None fingerprint = dir)
         entry_type: Literal["file", "dir"] = "file"
-        for prev in prev_possible_states:
+        for prev in prev_possible_records:
             if prev.fingerprint is None:
                 entry_type = "dir"
                 break
@@ -154,7 +154,7 @@ def _reconcile_entry(
 
     # Check if update needed
     if not prev_may_be_missing and all(
-        prev.fingerprint == target_fp for prev in prev_possible_states
+        prev.fingerprint == target_fp for prev in prev_possible_records
     ):
         return None
 
@@ -194,7 +194,7 @@ class _EntryHandler(
         self,
         key: coco.StableKey,
         desired_state: _EntrySpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_EntryTrackingRecord],
+        prev_possible_records: Collection[_EntryTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -207,7 +207,7 @@ class _EntryHandler(
             None,
             str(path),
             desired_state,
-            prev_possible_states,
+            prev_possible_records,
             prev_may_be_missing,
         )
 
@@ -245,7 +245,7 @@ class _RootHandler(coco.TargetHandler[_EntrySpec, _EntryTrackingRecord, _EntryHa
         self,
         key: coco.StableKey,
         desired_state: _EntrySpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_EntryTrackingRecord],
+        prev_possible_records: Collection[_EntryTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -261,7 +261,7 @@ class _RootHandler(coco.TargetHandler[_EntrySpec, _EntryTrackingRecord, _EntryHa
             root_key.base_dir_key,
             path_str,
             desired_state,
-            prev_possible_states,
+            prev_possible_records,
             prev_may_be_missing,
         )
 

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -452,13 +452,13 @@ class _VectorIndexHandler:
         self,
         key: coco.StableKey,
         desired_state: _VectorIndexSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_VectorIndexFingerprint],
+        prev_possible_records: Collection[_VectorIndexFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_VectorIndexAction, _VectorIndexFingerprint] | None:
         assert isinstance(key, str)
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_VectorIndexAction(name=key, spec=None),
@@ -468,7 +468,7 @@ class _VectorIndexHandler:
 
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -494,10 +494,10 @@ class _SqlCommandAction(NamedTuple):
 
 
 def _collect_teardown_sql(
-    prev_possible_states: Collection[_SqlCommandSpec],
+    prev_possible_records: Collection[_SqlCommandSpec],
 ) -> str | None:
     """Extract the first non-None teardown_sql from previous states."""
-    for prev in prev_possible_states:
+    for prev in prev_possible_records:
         if prev.teardown_sql is not None:
             return prev.teardown_sql
     return None
@@ -538,15 +538,15 @@ class _SqlCommandHandler:
         self,
         key: coco.StableKey,
         desired_state: _SqlCommandSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_SqlCommandSpec],
+        prev_possible_records: Collection[_SqlCommandSpec],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_SqlCommandAction, _SqlCommandSpec] | None:
         assert isinstance(key, str)
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
-            prev_teardown = _collect_teardown_sql(prev_possible_states)
+            prev_teardown = _collect_teardown_sql(prev_possible_records)
             return coco.TargetReconcileOutput(
                 action=_SqlCommandAction(
                     name=key, spec=None, prev_teardown_sql=prev_teardown
@@ -556,11 +556,11 @@ class _SqlCommandHandler:
             )
 
         if not prev_may_be_missing and all(
-            prev == desired_state for prev in prev_possible_states
+            prev == desired_state for prev in prev_possible_records
         ):
             return None
 
-        prev_teardown = _collect_teardown_sql(prev_possible_states)
+        prev_teardown = _collect_teardown_sql(prev_possible_records)
         return coco.TargetReconcileOutput(
             action=_SqlCommandAction(
                 name=key, spec=desired_state, prev_teardown_sql=prev_teardown
@@ -737,14 +737,14 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self,
         key: coco.StableKey,
         desired_state: _RowValue | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowFingerprint],
+        prev_possible_records: Collection[_RowFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RowAction, _RowFingerprint] | None:
         key = _ROW_KEY_CHECKER.check(key)
         if coco.is_non_existence(desired_state):
             # Delete case - only if it might exist
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_RowAction(key=key, value=None),
@@ -755,7 +755,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         # Upsert case
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             # No change needed
             return None
@@ -1063,7 +1063,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         self,
         key: coco.StableKey,
         desired_state: _TableSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_TableTrackingRecord],
+        prev_possible_records: Collection[_TableTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -1087,7 +1087,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         resolved = statediff.resolve_system_transition(
             statediff.TrackingRecordTransition(
                 tracking_record,
-                prev_possible_states,
+                prev_possible_records,
                 prev_may_be_missing,
             )
         )

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -233,13 +233,13 @@ class _PointHandler(coco.TargetHandler[qdrant_models.PointStruct, _PointFingerpr
         self,
         key: coco.StableKey,
         desired_state: qdrant_models.PointStruct | coco.NonExistenceType,
-        prev_possible_states: Collection[_PointFingerprint],
+        prev_possible_records: Collection[_PointFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_PointAction, _PointFingerprint] | None:
         key = _POINT_ID_CHECKER.check(key)
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_PointAction(point_id=key, point=None),
@@ -249,7 +249,7 @@ class _PointHandler(coco.TargetHandler[qdrant_models.PointStruct, _PointFingerpr
 
         target_fp = fingerprint_object((desired_state.vector, desired_state.payload))
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -397,7 +397,7 @@ class _CollectionHandler(
         self,
         key: coco.StableKey,
         desired_state: _CollectionSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_CollectionTrackingRecord],
+        prev_possible_records: Collection[_CollectionTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -421,7 +421,7 @@ class _CollectionHandler(
 
         transition = statediff.TrackingRecordTransition(
             tracking_record,
-            prev_possible_states,
+            prev_possible_records,
             prev_may_be_missing,
         )
         resolved = statediff.resolve_system_transition(transition)

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -541,14 +541,14 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self,
         key: coco.StableKey,
         desired_state: _RowValue | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowFingerprint],
+        prev_possible_records: Collection[_RowFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RowAction, _RowFingerprint] | None:
         key = _ROW_KEY_CHECKER.check(key)
         if coco.is_non_existence(desired_state):
             # Delete case - only if it might exist
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_RowAction(key=key, value=None),
@@ -559,7 +559,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         # Upsert case
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             # No change needed
             return None
@@ -947,7 +947,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         self,
         key: coco.StableKey,
         desired_state: _TableSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_TableTrackingRecord],
+        prev_possible_records: Collection[_TableTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -970,7 +970,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         resolved = statediff.resolve_system_transition(
             statediff.TrackingRecordTransition(
                 tracking_record,
-                prev_possible_states,
+                prev_possible_records,
                 prev_may_be_missing,
             )
         )

--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -595,7 +595,7 @@ class _VectorIndexHandler:
         self,
         key: coco.StableKey,
         desired_state: _VectorIndexSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_VectorIndexFingerprint],
+        prev_possible_records: Collection[_VectorIndexFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -604,7 +604,7 @@ class _VectorIndexHandler:
     ):
         assert isinstance(key, str)
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_VectorIndexAction(
@@ -616,7 +616,7 @@ class _VectorIndexHandler:
 
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -679,14 +679,14 @@ class _RecordHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self,
         key: coco.StableKey,
         desired_state: _RowValue | coco.NonExistenceType,
-        prev_possible_states: Collection[_RowFingerprint],
+        prev_possible_records: Collection[_RowFingerprint],
         prev_may_be_missing: bool,
         /,
     ) -> coco.TargetReconcileOutput[_RecordAction, _RowFingerprint, None] | None:
         key = _ROW_KEY_CHECKER.check(key)
 
         if coco.is_non_existence(desired_state):
-            if not prev_possible_states and not prev_may_be_missing:
+            if not prev_possible_records and not prev_may_be_missing:
                 return None
             return coco.TargetReconcileOutput(
                 action=_RecordAction(
@@ -703,7 +703,7 @@ class _RecordHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
 
         target_fp = fingerprint_object(desired_state)
         if not prev_may_be_missing and all(
-            prev == target_fp for prev in prev_possible_states
+            prev == target_fp for prev in prev_possible_records
         ):
             return None
 
@@ -849,7 +849,7 @@ class _TableHandler(
         self,
         key: coco.StableKey,
         desired_state: _TableSpec | coco.NonExistenceType,
-        prev_possible_states: Collection[_TableTrackingRecord],
+        prev_possible_records: Collection[_TableTrackingRecord],
         prev_may_be_missing: bool,
         /,
     ) -> (
@@ -874,7 +874,7 @@ class _TableHandler(
 
         resolved = statediff.resolve_system_transition(
             statediff.TrackingRecordTransition(
-                tracking_record, prev_possible_states, prev_may_be_missing
+                tracking_record, prev_possible_records, prev_may_be_missing
             )
         )
         main_action, column_transitions = statediff.diff_composite(resolved)

--- a/python/tests/common/target_states.py
+++ b/python/tests/common/target_states.py
@@ -93,7 +93,7 @@ class DictTargetStateStore:
         self,
         key: coco.StableKey,
         desired_state: Any | coco.NonExistenceType,
-        prev_possible_states: Collection[Any],
+        prev_possible_records: Collection[Any],
         prev_may_be_missing: bool,
     ) -> (
         coco.TargetReconcileOutput[
@@ -104,11 +104,11 @@ class DictTargetStateStore:
         assert isinstance(key, str)
         # Short-circuit no-change case
         if coco.is_non_existence(desired_state):
-            if len(prev_possible_states) == 0:
+            if len(prev_possible_records) == 0:
                 return None
         else:
             if not prev_may_be_missing and all(
-                prev == desired_state for prev in prev_possible_states
+                prev == desired_state for prev in prev_possible_records
             ):
                 return None
 
@@ -117,7 +117,7 @@ class DictTargetStateStore:
             if coco.is_non_existence(desired_state)
             else DictDataWithPrev(
                 data=desired_state,
-                prev=prev_possible_states,
+                prev=prev_possible_records,
                 prev_may_be_missing=prev_may_be_missing,
             )
         )
@@ -219,7 +219,7 @@ class DictsTargetStateStore:
         self,
         key: coco.StableKey,
         desired_state: None | coco.NonExistenceType,
-        prev_possible_states: Collection[None],
+        prev_possible_records: Collection[None],
         prev_may_be_missing: bool,
     ) -> (
         coco.TargetReconcileOutput[
@@ -245,7 +245,7 @@ class DictsTargetStateStore:
                 child_invalidation=self.child_invalidation,
             )
         if not prev_may_be_missing and self.child_invalidation is None:
-            assert len(prev_possible_states) > 0
+            assert len(prev_possible_records) > 0
             return coco.TargetReconcileOutput(
                 action=_DictTargetStateStoreAction(name=key, exists=True, action=None),
                 sink=sink,
@@ -257,7 +257,7 @@ class DictsTargetStateStore:
             action=_DictTargetStateStoreAction(
                 name=key,
                 exists=True,
-                action="insert" if len(prev_possible_states) == 0 else "upsert",
+                action="insert" if len(prev_possible_records) == 0 else "upsert",
                 destructive=is_destructive,
             ),
             sink=sink,
@@ -335,7 +335,7 @@ class _AttachmentChildHandler:
         self,
         key: coco.StableKey,
         desired_state: Any | coco.NonExistenceType,
-        prev_possible_states: Collection[Any],
+        prev_possible_records: Collection[Any],
         prev_may_be_missing: bool,
     ) -> None:
         return None
@@ -400,7 +400,7 @@ class AttachmentDictsTargetStateStore:
         self,
         key: coco.StableKey,
         desired_state: None | coco.NonExistenceType,
-        prev_possible_states: Collection[None],
+        prev_possible_records: Collection[None],
         prev_may_be_missing: bool,
     ) -> (
         coco.TargetReconcileOutput[
@@ -422,7 +422,7 @@ class AttachmentDictsTargetStateStore:
                 child_invalidation=self.child_invalidation,
             )
         if not prev_may_be_missing and self.child_invalidation is None:
-            assert len(prev_possible_states) > 0
+            assert len(prev_possible_records) > 0
             return coco.TargetReconcileOutput(
                 action=_DictTargetStateStoreAction(name=key, exists=True, action=None),
                 sink=sink,
@@ -434,7 +434,7 @@ class AttachmentDictsTargetStateStore:
             action=_DictTargetStateStoreAction(
                 name=key,
                 exists=True,
-                action="insert" if len(prev_possible_states) == 0 else "upsert",
+                action="insert" if len(prev_possible_records) == 0 else "upsert",
                 destructive=is_destructive,
             ),
             sink=sink,

--- a/python/tests/core/test_target_key_types.py
+++ b/python/tests/core/test_target_key_types.py
@@ -53,7 +53,7 @@ class AnyKeyDictTargetStateStore:
         self,
         key: Any,
         desired_state: Any | coco.NonExistenceType,
-        prev_possible_states: Collection[Any],
+        prev_possible_records: Collection[Any],
         prev_may_be_missing: bool,
     ) -> (
         coco.TargetReconcileOutput[
@@ -63,11 +63,11 @@ class AnyKeyDictTargetStateStore:
     ):
         # Short-circuit no-change case
         if coco.is_non_existence(desired_state):
-            if len(prev_possible_states) == 0:
+            if len(prev_possible_records) == 0:
                 return None
         else:
             if not prev_may_be_missing and all(
-                prev == desired_state for prev in prev_possible_states
+                prev == desired_state for prev in prev_possible_records
             ):
                 return None
 
@@ -76,7 +76,7 @@ class AnyKeyDictTargetStateStore:
             if coco.is_non_existence(desired_state)
             else DictDataWithPrev(
                 data=desired_state,
-                prev=prev_possible_states,
+                prev=prev_possible_records,
                 prev_may_be_missing=prev_may_be_missing,
             )
         )

--- a/rust/core/src/engine/target_state.rs
+++ b/rust/core/src/engine/target_state.rs
@@ -47,7 +47,7 @@ pub trait TargetHandler<Prof: EngineProfile>: Send + Sync + Sized + 'static {
         &self,
         key: StableKey,
         desired_target_state: Option<Prof::TargetStateValue>,
-        prev_possible_states: &[Prof::TargetStateTrackingRecord],
+        prev_possible_records: &[Prof::TargetStateTrackingRecord],
         prev_may_be_missing: bool,
     ) -> Result<Option<TargetReconcileOutput<Prof>>>;
 

--- a/rust/py/src/target_state.rs
+++ b/rust/py/src/target_state.rs
@@ -108,12 +108,12 @@ impl TargetHandler<PyEngineProfile> for PyTargetHandler {
         &self,
         key: cocoindex_core::state::stable_path::StableKey,
         desired_effect: Option<Py<PyAny>>,
-        prev_possible_states: &[PyValue],
+        prev_possible_records: &[PyValue],
         prev_may_be_missing: bool,
     ) -> Result<Option<TargetReconcileOutput<PyEngineProfile>>> {
         Python::attach(|py| -> PyResult<_> {
-            let prev_possible_states =
-                PyList::new(py, prev_possible_states.iter().map(|s| s.value().bind(py)))?;
+            let prev_possible_records =
+                PyList::new(py, prev_possible_records.iter().map(|s| s.value().bind(py)))?;
             let non_existence = &python_objects().non_existence;
             let py_output = self.0.call_method(
                 py,
@@ -121,7 +121,7 @@ impl TargetHandler<PyEngineProfile> for PyTargetHandler {
                 (
                     PyStableKey(key),
                     desired_effect.as_ref().unwrap_or(non_existence).bind(py),
-                    prev_possible_states,
+                    prev_possible_records,
                     prev_may_be_missing,
                 ),
                 None,


### PR DESCRIPTION
## Summary
- Rename `prev_possible_states` parameter to `prev_possible_records` in `TargetHandler.reconcile()` across the Rust trait, Python protocol, all connectors (postgres, localfs, qdrant, lancedb, sqlite, doris, surrealdb), tests, and docs
- The parameter holds tracking records, not target states — the new name better reflects its type

## Test plan
- CI (all pre-commit hooks passed locally: cargo test, mypy, pytest)