### PR TITLE
feat: support LiveComponent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "storekey",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/docs/docs/advanced_topics/live_component.md
+++ b/docs/docs/advanced_topics/live_component.md
@@ -1,0 +1,232 @@
+---
+title: Live Components
+description: Build components that process continuously and react to changes incrementally, instead of only processing in full sweeps.
+---
+
+# Live Components
+
+By default, a processing component runs a **full scan** each time — it declares all target states and mounts all sub-components from scratch. CocoIndex handles incremental updates by skipping memoized sub-components and reconciling target states at the end. This works well when the dataset is small enough to scan fully each cycle.
+
+When the dataset is large or you need to react to changes continuously (e.g., watching a file system), you want the component itself to be incremental. A **live component** does an initial full scan, then reacts to individual changes without rescanning everything.
+
+## The LiveComponent protocol
+
+A live component is a class with three methods:
+
+```python
+class MyLiveComponent:
+    def __init__(self, folder: pathlib.Path, target: localfs.DirTarget) -> None:
+        """Receive arguments from the mount() call."""
+        self.folder = folder
+        self.target = target
+
+    async def process(self) -> None:
+        """Full processing — mount all children, declare all target states."""
+        ...
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        """Continuous processing — orchestrate full and incremental updates."""
+        ...
+```
+
+- **`__init__`** receives arguments passed to `coco.mount()`.
+- **`process()`** does a full scan — mounts children via `coco.mount()` and declares target states, just like a traditional component function. Called indirectly via `operator.update_full()`.
+- **`process_live(operator)`** is the long-running entry point. It orchestrates full and incremental updates using the operator.
+
+CocoIndex detects a live component by checking if the class has both `process` and `process_live` methods.
+
+## LiveComponentOperator
+
+The `operator` passed to `process_live()` provides four methods:
+
+| Method | Description |
+|--------|-------------|
+| `await operator.update_full()` | Run `process()` with a full submission phase (GCs removed children). Blocks until fully ready. |
+| `await operator.update(subpath, fn, *args, **kwargs)` | Mount a child component incrementally. |
+| `await operator.delete(subpath)` | Delete a child component. |
+| `await operator.mark_ready()` | Signal that processing has caught up to the time `process_live()` was called. |
+
+### `update_full()`
+
+Triggers a full processing cycle: calls `process()`, submits target states, waits for all children to be ready, and garbage-collects children that are no longer mounted. This is the same mechanism as a traditional component's update cycle.
+
+### `update()` and `delete()`
+
+Mount or delete individual child components without a full scan. These are concurrent with each other but serialized with `update_full()` — if `update_full()` is running, incremental operations wait until it finishes.
+
+When multiple operations target the same subpath, only the latest one (by invocation order) takes effect.
+
+### `mark_ready()`
+
+Signals to the parent that the live component has caught up. The parent's `await handle.ready()` returns when `mark_ready()` is called. If `process_live()` returns without calling `mark_ready()`, it is called automatically.
+
+## Example: file system watcher
+
+A component that watches a local folder and processes each file:
+
+```python
+import pathlib
+import cocoindex as coco
+
+class FolderWatcher:
+    def __init__(self, folder: pathlib.Path, target) -> None:
+        self.folder = folder
+        self.target = target
+
+    async def process(self) -> None:
+        """Full scan — mount a child for every file in the folder."""
+        for path in self.folder.iterdir():
+            if path.is_file():
+                await coco.mount(
+                    coco.component_subpath(path.name),
+                    process_file,
+                    path,
+                    self.target,
+                )
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        # 1. Set up the file watcher before the full scan so no events are missed.
+        watcher = setup_watchdog(self.folder)
+
+        # 2. Full scan.
+        await operator.update_full()
+
+        # 3. Signal readiness — parent can proceed.
+        await operator.mark_ready()
+
+        # 4. React to changes.
+        async for event in watcher.events():
+            subpath = coco.component_subpath(event.filename)
+            if event.is_update:
+                await operator.update(subpath, process_file, event.path, self.target)
+            elif event.is_delete:
+                await operator.delete(subpath)
+```
+
+The parent mounts it like any other component:
+
+```python
+@coco.fn
+async def app_main(folder: pathlib.Path, outdir: pathlib.Path) -> None:
+    # Set up the target in the parent (use_mount is not allowed inside process()).
+    target = await coco.use_mount(
+        coco.component_subpath("setup"),
+        localfs.declare_dir_target,
+        outdir,
+    )
+    # Mount the live component.
+    await coco.mount(coco.component_subpath("watch"), FolderWatcher, folder, target)
+```
+
+## Example: traditional component equivalent
+
+A traditional single-function component:
+
+```python
+@coco.fn
+async def process_all(data) -> None:
+    for key, value in data.items():
+        coco.declare_target_state(target.target_state(key, value))
+```
+
+is equivalent to this LiveComponent:
+
+```python
+class ProcessAll:
+    def __init__(self, data):
+        self.data = data
+
+    async def process(self) -> None:
+        for key, value in self.data.items():
+            coco.declare_target_state(target.target_state(key, value))
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        # mark_ready() is called automatically on return.
+```
+
+The key difference: the LiveComponent version can later be extended to handle incremental changes in `process_live()` without changing `process()`.
+
+## Live mode
+
+Live mode controls whether `process_live()` continues running after `mark_ready()`.
+
+### Enabling live mode
+
+```python
+# Programmatic
+app.update_blocking(live=True)
+
+# Or async
+handle = app.update(live=True)
+await handle.result()
+```
+
+```bash
+# CLI
+cocoindex update --live my_app.py
+# or
+cocoindex update -L my_app.py
+```
+
+### Propagation
+
+- `coco.mount()` and `operator.update()` inherit `live` from the parent.
+- `coco.use_mount()` always sets children as non-live.
+
+### Non-live mode behavior
+
+When `live=False` (the default), `process_live()` is still called, but it terminates as soon as `mark_ready()` is awaited. No code after `await operator.mark_ready()` executes. This means a live component in non-live mode behaves like a traditional component: it does a full update, signals ready, and stops.
+
+This design lets you use the same LiveComponent class in both modes without code changes.
+
+## Restrictions
+
+### No `use_mount()` inside `process()`
+
+`process()` may only call `coco.mount()` (background child mounts). Any setup that requires `use_mount()` — such as declaring target tables — must be done in the **parent** component before mounting the LiveComponent. This keeps the controller's provider set stable across full and incremental updates.
+
+### Not allowed in `use_mount()` or `mount_each()`
+
+LiveComponent classes can only be used with `coco.mount()` and `operator.update()`. Passing a LiveComponent class to `coco.use_mount()` or `coco.mount_each()` raises a `TypeError`.
+
+## Readiness
+
+The parent's `await handle.ready()` returns when `mark_ready()` is called inside `process_live()`, regardless of whether `process_live()` is still running.
+
+```mermaid
+sequenceDiagram
+    participant Parent
+    participant LC as LiveComponent
+    participant Op as Operator
+    participant Children
+
+    Parent->>LC: mount()
+    activate LC
+    Note over LC: process_live(operator)
+
+    LC->>Op: update_full()
+    activate Op
+    Op->>LC: process()
+    activate LC
+    LC->>Children: mount(A), mount(B), ...
+    deactivate LC
+    Note over Op: submit + GC<br/>wait children ready
+    Op-->>LC: done
+    deactivate Op
+
+    LC->>Op: mark_ready()
+    Op-->>Parent: readiness resolved
+
+    rect rgb(240, 248, 255)
+        Note over LC,Children: Live mode only
+        LC->>Op: update(A)
+        Op->>Children: run A
+        LC->>Op: delete(B)
+        Op->>Children: delete B
+        Note over LC: continues...
+    end
+    deactivate LC
+```
+
+If `process_live()` returns without calling `mark_ready()`, it is called automatically — the parent will not hang.

--- a/docs/docs/cli_commands.md
+++ b/docs/docs/cli_commands.md
@@ -129,6 +129,7 @@ cocoindex update [OPTIONS] APP_TARGET
 | `-q, --quiet` | Avoid printing anything to the standard output, e.g. statistics. |
 | `--reset` | Drop existing setup before updating (equivalent to running 'cocoindex drop' first). |
 | `--full-reprocess` | Reprocess everything and invalidate existing caches. |
+| `-L, --live` | Run in live mode (live components continue processing after initial update). |
 | `--help` | Show this message and exit. |
 
 ---

--- a/docs/docs/programming_guide/processing_component.md
+++ b/docs/docs/programming_guide/processing_component.md
@@ -67,6 +67,8 @@ await handle.ready()
 
 You usually only need to call `ready()` when you have logic that depends on the processing component's target states being applied — for example, querying the latest data from a target table after syncing it.
 
+`mount()` also accepts **LiveComponent classes** — components that process continuously and react to changes incrementally instead of rescanning everything. See [Live Components](../advanced_topics/live_component.md) for details.
+
 ### `use_mount()`
 
 Use `use_mount()` when you need the processing component's return value. It mounts the component, waits until it's ready, and returns the value directly:

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
       label: 'Advanced Topics',
       collapsed: false,
       items: [
+        'advanced_topics/live_component',
         'advanced_topics/exception_handlers',
         'advanced_topics/internal_storage',
         'advanced_topics/memoization_keys',

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -99,6 +99,11 @@ from .target_state import (
     TargetHandler,
     declare_target_state_with_child,
 )
+from .live_component import (
+    LiveComponent,
+    LiveComponentOperator,
+    is_live_component_class,
+)
 
 # ============================================================================
 # Re-exports from internal modules (shared types)
@@ -233,6 +238,12 @@ async def use_mount(
             coco.component_subpath("setup"), declare_table_target, table_name
         )
     """
+    if is_live_component_class(processor_fn):
+        raise TypeError(
+            "LiveComponent classes cannot be used with use_mount(). "
+            "Use mount() instead."
+        )
+
     parent_ctx = get_context_from_ctx()
     child_path = build_child_path(parent_ctx, subpath)
 
@@ -249,6 +260,35 @@ async def use_mount(
     return pyvalue.get(fn_ret_deserializer(processor_fn))
 
 
+async def _mount_live_component(
+    parent_ctx: ComponentContext,
+    child_path: core.StablePath,
+    cls: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> ComponentMountHandle:
+    """Mount a LiveComponent class."""
+    instance = cls(*args, **kwargs)
+
+    # Create controller via Rust.
+    # mount_live_async returns (LiveComponentController, ComponentMountHandle).
+    controller, readiness_handle = await core.mount_live_async(
+        child_path,
+        parent_ctx._core_processor_ctx,
+        parent_ctx._core_fn_call_ctx,
+        parent_ctx._core_processor_ctx.live,
+    )
+
+    operator = LiveComponentOperator(controller, instance, parent_ctx._env, child_path)
+
+    # Start process_live via Rust (handles cancellation, error handling,
+    # ensure_mark_ready).
+    process_live_coro = instance.process_live(operator)
+    controller.start(process_live_coro)
+
+    return ComponentMountHandle([readiness_handle])
+
+
 async def mount(
     subpath: ComponentSubpath,
     processor_fn: AnyCallable[P, Any],
@@ -261,8 +301,9 @@ async def mount(
     Args:
         subpath: The component subpath (from component_subpath()).
         processor_fn: The function to run as the processing unit processor.
-        *args: Arguments to pass to the function.
-        **kwargs: Keyword arguments to pass to the function.
+            Can also be a LiveComponent class.
+        *args: Arguments to pass to the function (or LiveComponent constructor).
+        **kwargs: Keyword arguments to pass to the function (or LiveComponent constructor).
 
     Returns:
         A handle that can be used to wait until the processing unit is ready.
@@ -274,6 +315,11 @@ async def mount(
     """
     parent_ctx = get_context_from_ctx()
     child_path = build_child_path(parent_ctx, subpath)
+
+    if is_live_component_class(processor_fn):
+        return await _mount_live_component(
+            parent_ctx, child_path, processor_fn, args, kwargs
+        )
 
     processor = create_core_component_processor(
         processor_fn, parent_ctx._env, child_path, args, kwargs
@@ -329,6 +375,12 @@ async def mount_each(
         # for key, item in files.items():
         #     coco.mount(coco.component_subpath(key), process_file, item, target_table)
     """
+    if is_live_component_class(fn):
+        raise TypeError(
+            "LiveComponent classes cannot be used with mount_each(). "
+            "Use mount() instead."
+        )
+
     parent_ctx = get_context_from_ctx()
     core_handles: list[core.ComponentMountHandle] = []
 
@@ -571,6 +623,9 @@ __all__ = [
     "NonExistenceType",
     "is_non_existence",
     "MemoStateOutcome",
+    # .live_component
+    "LiveComponent",
+    "LiveComponentOperator",
     # Mount APIs
     "ComponentMountHandle",
     "mount",

--- a/python/cocoindex/_internal/app.py
+++ b/python/cocoindex/_internal/app.py
@@ -224,7 +224,11 @@ class App(Generic[P, R]):
             return self._core_env_app
 
     def update(
-        self, *, report_to_stdout: bool = False, full_reprocess: bool = False
+        self,
+        *,
+        report_to_stdout: bool = False,
+        full_reprocess: bool = False,
+        live: bool = False,
     ) -> UpdateHandle[R]:
         """
         Start an update and return a handle for tracking progress and awaiting the result.
@@ -235,6 +239,8 @@ class App(Generic[P, R]):
         Args:
             report_to_stdout: If True, periodically report processing stats to stdout.
             full_reprocess: If True, reprocess everything and invalidate existing caches.
+            live: If True, run in live mode (live components continue processing
+                after mark_ready).
 
         Returns:
             An UpdateHandle that provides access to stats(), watch(), and result().
@@ -250,13 +256,18 @@ class App(Generic[P, R]):
                 processor,
                 report_to_stdout=report_to_stdout,
                 full_reprocess=full_reprocess,
+                live=live,
                 host_ctx=env._context_provider,
             )
 
         return UpdateHandle(_init(), main_fn=self._main_fn)
 
     def update_blocking(
-        self, *, report_to_stdout: bool = False, full_reprocess: bool = False
+        self,
+        *,
+        report_to_stdout: bool = False,
+        full_reprocess: bool = False,
+        live: bool = False,
     ) -> R:
         """
         Update the app synchronously (run the app once to process all pending changes).
@@ -264,6 +275,8 @@ class App(Generic[P, R]):
         Args:
             report_to_stdout: If True, periodically report processing stats to stdout.
             full_reprocess: If True, reprocess everything and invalidate existing caches.
+            live: If True, run in live mode (live components continue processing
+                after mark_ready).
 
         Returns:
             The result of the main function.
@@ -277,6 +290,7 @@ class App(Generic[P, R]):
             processor,
             report_to_stdout=report_to_stdout,
             full_reprocess=full_reprocess,
+            live=live,
             host_ctx=env._context_provider,
         )
         return pyvalue.get(fn_ret_deserializer(self._main_fn))  # type: ignore[no-any-return]

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -85,6 +85,8 @@ class ComponentProcessorContext:
     def environment(self) -> "Environment": ...
     @property
     def stable_path(self) -> StablePath: ...
+    @property
+    def live(self) -> bool: ...
     def join_fn_call(self, child_fn_ctx: FnCallContext) -> None: ...
     async def next_id(self, key: StableKey | None = None) -> int: ...
 
@@ -169,19 +171,44 @@ class App:
     def update(
         self,
         root_processor: ComponentProcessor[T_co],
-        report_to_stdout: bool,
-        full_reprocess: bool,
-        host_ctx: Any,
+        report_to_stdout: bool = False,
+        full_reprocess: bool = False,
+        live: bool = False,
+        host_ctx: Any = None,
     ) -> StoredValue: ...
     def update_async(
         self,
         root_processor: ComponentProcessor[T_co],
-        report_to_stdout: bool,
-        full_reprocess: bool,
-        host_ctx: Any,
+        report_to_stdout: bool = False,
+        full_reprocess: bool = False,
+        live: bool = False,
+        host_ctx: Any = None,
     ) -> UpdateHandle: ...
     def drop(self, report_to_stdout: bool, host_ctx: Any) -> None: ...
     def drop_async(self, report_to_stdout: bool, host_ctx: Any) -> Coroutine[Any, Any, None]: ...
+
+# --- LiveComponentController ---
+class LiveComponentController:
+    def update_full_async(
+        self, processor: ComponentProcessor[Any]
+    ) -> Coroutine[Any, Any, None]: ...
+    def update_async(
+        self, stable_path: StablePath, processor: ComponentProcessor[Any]
+    ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
+    def delete_async(
+        self, stable_path: StablePath
+    ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
+    def mark_ready_async(self) -> Coroutine[Any, Any, None]: ...
+    def start(self, process_live_fut: Any) -> None: ...
+    @property
+    def is_live(self) -> bool: ...
+
+def mount_live_async(
+    stable_path: StablePath,
+    comp_ctx: ComponentProcessorContext,
+    fn_ctx: FnCallContext,
+    live: bool,
+) -> Coroutine[Any, Any, tuple[LiveComponentController, ComponentMountHandle]]: ...
 
 # --- TargetActionSink ---
 class TargetActionSink:

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, ParamSpec, runtime_checkable, Protocol
+
+from . import core
+from .component_ctx import ComponentSubpath
+from .function import AnyCallable, create_core_component_processor
+from .environment import Environment
+
+_P = ParamSpec("_P")
+
+
+@runtime_checkable
+class LiveComponent(Protocol):
+    """Protocol for live components that process continuously."""
+
+    async def process(self) -> None: ...
+    async def process_live(self, operator: LiveComponentOperator) -> None: ...
+
+
+def is_live_component_class(cls: Any) -> bool:
+    """Check if cls is a class with process and process_live methods."""
+    return (
+        isinstance(cls, type)
+        and hasattr(cls, "process")
+        and hasattr(cls, "process_live")
+        and callable(getattr(cls, "process"))
+        and callable(getattr(cls, "process_live"))
+    )
+
+
+class LiveComponentOperator:
+    """Passed to process_live(). Wraps the Rust LiveComponentController."""
+
+    __slots__ = ("_controller", "_instance", "_env", "_path")
+
+    def __init__(
+        self,
+        controller: core.LiveComponentController,
+        instance: Any,  # The LiveComponent instance
+        env: Environment,
+        path: core.StablePath,
+    ) -> None:
+        self._controller = controller
+        self._instance = instance
+        self._env = env
+        self._path = path
+
+    async def update_full(self) -> None:
+        """Trigger a full update via instance.process(). Blocks until fully ready."""
+        processor = create_core_component_processor(
+            self._instance.process, self._env, self._path, (), {}
+        )
+        await self._controller.update_full_async(processor)
+
+    async def update(
+        self,
+        subpath: ComponentSubpath,
+        processor_fn: AnyCallable[_P, Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Any:  # Returns ComponentMountHandle
+        from .api import ComponentMountHandle
+
+        if is_live_component_class(processor_fn):
+            raise TypeError(
+                "Nested LiveComponent classes in operator.update() are not yet supported. "
+                f"Got: {processor_fn}"
+            )
+        child_path = self._path
+        for part in subpath.parts:
+            child_path = child_path.concat(part)
+        processor = create_core_component_processor(
+            processor_fn, self._env, child_path, args, kwargs
+        )
+        core_handle = await self._controller.update_async(child_path, processor)
+        return ComponentMountHandle([core_handle])
+
+    async def delete(self, subpath: ComponentSubpath) -> Any:
+        from .api import ComponentMountHandle
+
+        child_path = self._path
+        for part in subpath.parts:
+            child_path = child_path.concat(part)
+        core_handle = await self._controller.delete_async(child_path)
+        return ComponentMountHandle([core_handle])
+
+    async def mark_ready(self) -> None:
+        """Signal readiness. In non-live mode, this never returns (terminates process_live)."""
+        await self._controller.mark_ready_async()

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -587,8 +587,21 @@ async def _stop_all_environments() -> None:
     default=False,
     help="Reprocess everything and invalidate existing caches.",
 )
+@click.option(
+    "--live",
+    "-L",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Run in live mode (live components continue processing after initial update).",
+)
 def update(
-    app_target: str, force: bool, quiet: bool, reset: bool, full_reprocess: bool
+    app_target: str,
+    force: bool,
+    quiet: bool,
+    reset: bool,
+    full_reprocess: bool,
+    live: bool,
 ) -> None:
     """
     Run a v1 app once (one-time update).
@@ -619,11 +632,30 @@ def update(
                 if app._name in persisted_names:
                     await app.drop(report_to_stdout=not quiet)
 
-            await app.update(report_to_stdout=not quiet, full_reprocess=full_reprocess)
+            handle = app.update(
+                report_to_stdout=not quiet,
+                full_reprocess=full_reprocess,
+                live=live,
+            )
+            await handle.result()
+
+            if live:
+                if not quiet:
+                    print("Live mode active. Press Ctrl+C to stop.")
+                # Block until interrupted — live components continue in background.
+                stop_event = asyncio.Event()
+                try:
+                    await stop_event.wait()
+                except asyncio.CancelledError:
+                    pass
         finally:
             await _stop_all_environments()
 
-    asyncio.run(_do())
+    try:
+        asyncio.run(_do())
+    except KeyboardInterrupt:
+        if not quiet:
+            print("\nStopping...")
 
 
 @cli.command()

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import cocoindex as coco
+
+from tests import common
+from tests.common.target_states import GlobalDictTarget, DictDataWithPrev
+
+coco_env = common.create_test_env(__file__)
+
+_source_data: dict[str, int] = {}
+
+
+# ============================================================================
+# Rejection tests
+# ============================================================================
+
+
+class _MinimalLiveComponent:
+    async def process(self) -> None:
+        pass
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        pass
+
+
+def test_live_component_rejected_in_use_mount() -> None:
+    async def _main() -> None:
+        await coco.use_mount(coco.component_subpath("x"), _MinimalLiveComponent)
+
+    app = coco.App(
+        coco.AppConfig(name="test_rejected_use_mount", environment=coco_env),
+        _main,
+    )
+    with pytest.raises(TypeError, match="cannot be used with use_mount"):
+        app.update_blocking()
+
+
+def test_live_component_rejected_in_mount_each() -> None:
+    async def _main() -> None:
+        await coco.mount_each(_MinimalLiveComponent, [("a",), ("b",)])  # type: ignore[arg-type]
+
+    app = coco.App(
+        coco.AppConfig(name="test_rejected_mount_each", environment=coco_env),
+        _main,
+    )
+    with pytest.raises(TypeError, match="cannot be used with mount_each"):
+        app.update_blocking()
+
+
+# ============================================================================
+# Basic lifecycle tests
+# ============================================================================
+
+
+def _declare_source_entries() -> None:
+    for key, value in _source_data.items():
+        coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+
+class _BasicLiveComponent:
+    """LiveComponent that processes _source_data into GlobalDictTarget."""
+
+    async def process(self) -> None:
+        _declare_source_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+
+
+def test_live_component_basic_full_update() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("live"), _BasicLiveComponent)
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_basic_full_update", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    assert GlobalDictTarget.store.data == {
+        "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+        "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+    }
+
+
+class _NonLiveLiveComponent:
+    """LiveComponent that loops forever after mark_ready (tests non-live termination)."""
+
+    async def process(self) -> None:
+        _declare_source_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+        # In non-live mode, mark_ready should terminate process_live.
+        # This infinite loop should never execute.
+        while True:
+            await asyncio.sleep(1)
+
+
+def test_live_component_non_live_mode() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["x"] = 10
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("live"), _NonLiveLiveComponent)
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_non_live_mode", environment=coco_env),
+        _main,
+    )
+    # Non-live mode (default): should complete without hanging
+    app.update_blocking()
+
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=10, prev=[], prev_may_be_missing=True),
+    }
+
+
+class _AutoReadyLiveComponent:
+    """LiveComponent where process_live returns without calling mark_ready."""
+
+    async def process(self) -> None:
+        _declare_source_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        # Deliberately NOT calling mark_ready — ensure_mark_ready should auto-call it
+
+
+def test_live_component_mark_ready_auto_on_return() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["auto"] = 42
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("live"), _AutoReadyLiveComponent)
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_mark_ready_auto", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    assert GlobalDictTarget.store.data == {
+        "auto": DictDataWithPrev(data=42, prev=[], prev_may_be_missing=True),
+    }
+
+
+# ============================================================================
+# Incremental operations
+# ============================================================================
+
+
+def _declare_item(key: str, value: int) -> None:
+    coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+
+class _IncrementalUpdateLiveComponent:
+    """LiveComponent that does a full update then an incremental update."""
+
+    async def process(self) -> None:
+        _declare_source_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        # Incremental: add a new item not in _source_data
+        handle = await operator.update(
+            coco.component_subpath("new_item"), _declare_item, "new_key", 99
+        )
+        await handle.ready()
+        # mark_ready called AFTER incremental operations so update_blocking waits
+        await operator.mark_ready()
+
+
+def test_live_component_incremental_update() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+
+    async def _main() -> None:
+        await coco.mount(
+            coco.component_subpath("live"), _IncrementalUpdateLiveComponent
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_incremental_update", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    assert "a" in GlobalDictTarget.store.data
+    assert "b" in GlobalDictTarget.store.data
+    assert "new_key" in GlobalDictTarget.store.data
+    assert GlobalDictTarget.store.data["new_key"].data == 99
+
+
+class _IncrementalDeleteViaGCLiveComponent:
+    """LiveComponent that tests deletion via update_full GC.
+
+    The update_full GC mechanism is the primary way children get cleaned up:
+    any children mounted by the previous update_full but NOT mounted by the
+    current update_full are garbage collected.
+    """
+
+    async def process(self) -> None:
+        _declare_source_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        # First full update: adds "a" and "b" from _source_data
+        await operator.update_full()
+        # Incrementally add "extra"
+        handle = await operator.update(
+            coco.component_subpath("extra"), _declare_item, "extra_key", 42
+        )
+        await handle.ready()
+        # Second full update: process() still only declares "a" and "b".
+        # The incremental "extra" child was not mounted by process(), so it
+        # gets GC'd by the second update_full.
+        await operator.update_full()
+        # mark_ready auto-called on return
+
+
+def test_live_component_incremental_delete() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+
+    async def _main() -> None:
+        await coco.mount(
+            coco.component_subpath("live"), _IncrementalDeleteViaGCLiveComponent
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_incremental_delete", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    # a and b should remain from both full updates
+    assert "a" in GlobalDictTarget.store.data
+    assert "b" in GlobalDictTarget.store.data
+    # extra_key should have been GC'd by the second update_full
+    assert "extra_key" not in GlobalDictTarget.store.data
+
+
+# State for GC test — controlled by a flag to change behavior between update_full calls
+_gc_phase: int = 0
+
+
+def _declare_gc_entries() -> None:
+    """Declares entries based on _gc_phase:
+    Phase 0: A, B, C
+    Phase 1+: A, B only
+    """
+    if _gc_phase == 0:
+        coco.declare_target_state(GlobalDictTarget.target_state("gc_a", 1))
+        coco.declare_target_state(GlobalDictTarget.target_state("gc_b", 2))
+        coco.declare_target_state(GlobalDictTarget.target_state("gc_c", 3))
+    else:
+        coco.declare_target_state(GlobalDictTarget.target_state("gc_a", 1))
+        coco.declare_target_state(GlobalDictTarget.target_state("gc_b", 2))
+
+
+class _GCLiveComponent:
+    """LiveComponent that tests GC via two update_full calls."""
+
+    async def process(self) -> None:
+        _declare_gc_entries()
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        global _gc_phase
+        # First full update: A, B, C
+        _gc_phase = 0
+        await operator.update_full()
+
+        # Incremental add D
+        handle = await operator.update(
+            coco.component_subpath("d_item"), _declare_item, "gc_d", 4
+        )
+        await handle.ready()
+
+        # Second full update: only A, B (C removed from process, D was incremental)
+        _gc_phase = 1
+        await operator.update_full()
+        # mark_ready auto-called on return
+
+
+def test_live_component_update_full_gc() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("live"), _GCLiveComponent)
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_update_full_gc", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    # After second update_full: only A and B should exist. C and D should be GC'd.
+    assert "gc_a" in GlobalDictTarget.store.data
+    assert "gc_b" in GlobalDictTarget.store.data
+    assert "gc_c" not in GlobalDictTarget.store.data
+    assert "gc_d" not in GlobalDictTarget.store.data

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -1,0 +1,227 @@
+"""Tests for target state ownership transfer between components."""
+
+from __future__ import annotations
+
+import cocoindex as coco
+
+from tests import common
+from tests.common.target_states import GlobalDictTarget, DictDataWithPrev
+
+coco_env = common.create_test_env(__file__)
+
+# Controls which component paths declare which target state keys+values.
+# Outer key = component name (becomes component subpath), inner key = target state key.
+_source_data: dict[str, dict[str, object]] = {}
+
+
+@coco.fn
+async def _process_component(name: str) -> None:
+    for key, value in _source_data.get(name, {}).items():
+        coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+
+@coco.fn
+async def _app_main() -> None:
+    for name in sorted(_source_data):
+        await coco.mount(coco.component_subpath(name), _process_component, name)
+
+
+def test_ownership_transfer_basic() -> None:
+    """Target state moves from C1 to C2 with update semantics."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_ownership_transfer_basic", environment=coco_env),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+
+    # Run 2: Ownership transfers from C1 to C2
+    _source_data.clear()
+    _source_data["C2"] = {"x": 2}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=2, prev=[1], prev_may_be_missing=False),
+    }
+    # Should be 1 upsert (update), NOT a delete + insert
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+
+
+def test_ownership_transfer_same_value() -> None:
+    """Transfer with same value triggers no-change detection."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_ownership_transfer_same_value", environment=coco_env),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x" with value 1
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C2 takes over with same value
+    _source_data.clear()
+    _source_data["C2"] = {"x": 1}
+    app.update_blocking()
+    # No-change: prev == desired and prev_may_be_missing=False → reconcile returns None
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {}
+
+
+def test_ownership_transfer_then_delete() -> None:
+    """After transfer, new owner can delete the target state."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_ownership_transfer_then_delete", environment=coco_env
+        ),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C2 takes over
+    _source_data.clear()
+    _source_data["C2"] = {"x": 2}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 3: C2 stops declaring "x"
+    _source_data.clear()
+    _source_data["C2"] = {}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "delete": 1}
+
+
+def test_ownership_transfer_ordering_independence() -> None:
+    """Regardless of submission order, the target state survives transfer."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_ownership_transfer_ordering", environment=coco_env),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C1 drops "x", C2 picks it up
+    _source_data.clear()
+    _source_data["C1"] = {}
+    _source_data["C2"] = {"x": 2}
+    app.update_blocking()
+    # The target state must exist (this is the bug fix)
+    assert "x" in GlobalDictTarget.store.data
+    assert GlobalDictTarget.store.data["x"].data == 2
+
+
+def test_ownership_transfer_multiple_keys() -> None:
+    """Only transferred keys move; others stay with original owner."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_ownership_transfer_multiple_keys", environment=coco_env
+        ),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "a" and "b"
+    _source_data["C1"] = {"a": 1, "b": 2}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C2 takes "a", C1 keeps "b"
+    _source_data.clear()
+    _source_data["C1"] = {"b": 2}
+    _source_data["C2"] = {"a": 3}
+    app.update_blocking()
+    # Only check final target state values — reconciliation details (prev,
+    # prev_may_be_missing) are nondeterministic due to concurrent processing order.
+    assert GlobalDictTarget.store.data["a"].data == 3
+    assert GlobalDictTarget.store.data["b"].data == 2
+
+
+def test_ownership_transfer_chain() -> None:
+    """Target state can be transferred multiple times: C1→C2→C3."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_ownership_transfer_chain", environment=coco_env),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data["x"].data == 1
+
+    # Run 2: C1 gone, C2 takes over
+    _source_data.clear()
+    _source_data["C2"] = {"x": 2}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data["x"].data == 2
+
+    # Run 3: C2 gone, C3 takes over
+    _source_data.clear()
+    _source_data["C3"] = {"x": 3}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data["x"].data == 3
+
+
+def test_component_delete_cleans_inverted_tracking() -> None:
+    """After component deletion, re-declaration is a fresh insert."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_component_delete_cleans_inverted", environment=coco_env
+        ),
+        _app_main,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C1 is gone entirely
+    _source_data.clear()
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 3: C2 declares "x" fresh (no previous owner)
+    _source_data["C2"] = {"x": 2}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+    }

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -24,6 +24,7 @@ serde_with = { workspace = true }
 uuid = { workspace = true }
 indexmap = { workspace = true }
 
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 futures = { workspace = true }

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -17,6 +17,8 @@ pub struct AppUpdateOptions {
     pub report_to_stdout: bool,
     /// If true, reprocess everything and invalidate existing caches.
     pub full_reprocess: bool,
+    /// If true, enable live component mode for this update.
+    pub live: bool,
 }
 
 /// Options for dropping an app.
@@ -108,6 +110,7 @@ impl<Prof: EngineProfile> App<Prof> {
             None,
             processing_stats.clone(),
             options.full_reprocess,
+            options.live,
             host_ctx,
         )?;
 
@@ -154,6 +157,8 @@ impl<Prof: EngineProfile> App<Prof> {
         options: AppDropOptions,
         host_ctx: Arc<Prof::HostCtx>,
     ) -> Result<()> {
+        self.app_ctx().cancellation_token().cancel();
+
         let processing_stats = ProcessingStats::default();
         let providers = self
             .app_ctx()
@@ -173,7 +178,7 @@ impl<Prof: EngineProfile> App<Prof> {
 
         let drop_fut = async {
             // Delete the root component
-            let handle = self.root_component.clone().delete(context.clone())?;
+            let handle = self.root_component.clone().delete(context.clone(), None)?;
 
             // Wait for the drop operation to complete
             handle.ready().await?;

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -1,7 +1,8 @@
 use crate::engine::runtime::get_runtime;
 use crate::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
 
 use crate::engine::context::FnCallContext;
 use crate::engine::context::{AppContext, ComponentProcessingMode, ComponentProcessorContext};
@@ -74,11 +75,18 @@ struct ComponentInner<Prof: EngineProfile> {
     app_ctx: AppContext<Prof>,
     stable_path: StablePath,
 
-    // For check existence / dedup
-    //   live_sub_components: HashMap<StablePath, std::rc::Weak<ComponentInner<Prof>>>,
     /// Semaphore to ensure `process()` and `commit_effects()` calls cannot happen in parallel.
     build_semaphore: tokio::sync::Semaphore,
     last_memo_fp: Mutex<Option<Fingerprint>>,
+
+    /// Latest invocation sequence number for "latest wins" ordering.
+    latest_seq: AtomicU64,
+
+    /// Active child components, keyed by their full StablePath.
+    active_children: Mutex<HashMap<StablePath, Component<Prof>>>,
+
+    /// Shared state for a live component running at this path.
+    live_state: Mutex<Option<Arc<crate::engine::live_component::LiveComponentState>>>,
 }
 
 #[derive(Clone)]
@@ -121,7 +129,7 @@ impl ComponentBgChildReadinessState {
 }
 
 #[derive(Debug, Default, Clone)]
-struct ComponentRunOutcome {
+pub(crate) struct ComponentRunOutcome {
     has_exception: bool,
     logic_deps: HashSet<Fingerprint>,
 }
@@ -146,11 +154,11 @@ struct ComponentBgChildReadinessInner {
 }
 
 #[derive(Clone)]
-pub(crate) struct ComponentBgChildReadiness {
+pub struct ComponentBgChildReadiness {
     inner: Arc<ComponentBgChildReadinessInner>,
 }
 
-struct ComponentBgChildReadinessChildGuard {
+pub struct ComponentBgChildReadinessChildGuard {
     readiness: ComponentBgChildReadiness,
     resolved: bool,
 }
@@ -172,7 +180,7 @@ impl Drop for ComponentBgChildReadinessChildGuard {
 }
 
 impl ComponentBgChildReadinessChildGuard {
-    fn resolve(mut self, outcome: ComponentRunOutcome) {
+    pub(crate) fn resolve(mut self, outcome: ComponentRunOutcome) {
         {
             let mut state = self.readiness.state().lock().unwrap();
             state.remaining_count -= 1;
@@ -207,7 +215,7 @@ impl ComponentBgChildReadiness {
         &self.inner.readiness
     }
 
-    fn add_child(self) -> ComponentBgChildReadinessChildGuard {
+    pub fn add_child(self) -> ComponentBgChildReadinessChildGuard {
         self.state().lock().unwrap().remaining_count += 1;
         ComponentBgChildReadinessChildGuard {
             readiness: self,
@@ -263,12 +271,16 @@ impl<Prof: EngineProfile> ComponentMountRunHandle<Prof> {
 }
 
 pub struct ComponentExecutionHandle {
-    join_handle: tokio::task::JoinHandle<SharedResult<()>>,
+    fut: Pin<Box<dyn Future<Output = SharedResult<()>> + Send + Sync>>,
 }
 
 impl ComponentExecutionHandle {
+    pub fn new(fut: impl Future<Output = SharedResult<()>> + Send + Sync + 'static) -> Self {
+        Self { fut: Box::pin(fut) }
+    }
+
     pub async fn ready(self) -> Result<()> {
-        self.join_handle.await?.into_result()
+        self.fut.await.into_result()
     }
 }
 
@@ -285,6 +297,9 @@ impl<Prof: EngineProfile> Component<Prof> {
                 stable_path,
                 build_semaphore: tokio::sync::Semaphore::const_new(1),
                 last_memo_fp: Mutex::new(None),
+                latest_seq: AtomicU64::new(0),
+                active_children: Mutex::new(HashMap::new()),
+                live_state: Mutex::new(None),
             }),
         }
     }
@@ -295,8 +310,11 @@ impl<Prof: EngineProfile> Component<Prof> {
     }
 
     pub fn get_child(&self, stable_path: StablePath) -> Self {
-        // TODO: Get the child component directly if it already exists.
-        Self::new(self.app_ctx().clone(), stable_path)
+        let mut children = self.inner.active_children.lock().unwrap();
+        children
+            .entry(stable_path.clone())
+            .or_insert_with(|| Self::new(self.app_ctx().clone(), stable_path))
+            .clone()
     }
 
     pub fn app_ctx(&self) -> &AppContext<Prof> {
@@ -305,6 +323,23 @@ impl<Prof: EngineProfile> Component<Prof> {
 
     pub fn stable_path(&self) -> &StablePath {
         &self.inner.stable_path
+    }
+
+    pub fn set_live_state(&self, state: Arc<crate::engine::live_component::LiveComponentState>) {
+        *self.inner.live_state.lock().unwrap() = Some(state);
+    }
+
+    pub fn live_state(&self) -> Option<Arc<crate::engine::live_component::LiveComponentState>> {
+        self.inner.live_state.lock().unwrap().clone()
+    }
+
+    pub fn latest_seq(&self) -> &AtomicU64 {
+        &self.inner.latest_seq
+    }
+
+    /// Remove a child from active_children. Called after a delete task completes.
+    pub fn remove_active_child(&self, path: &StablePath) {
+        self.inner.active_children.lock().unwrap().remove(path);
     }
 
     pub(crate) fn relative_path(
@@ -379,6 +414,7 @@ impl<Prof: EngineProfile> Component<Prof> {
                     + 'static,
             >,
         >,
+        pre_execute_check: Option<Box<dyn FnOnce() -> bool + Send>>,
     ) -> Result<ComponentExecutionHandle> {
         // TODO: Skip building and reuse cached result if the component is already built and up to date.
 
@@ -401,6 +437,20 @@ impl<Prof: EngineProfile> Component<Prof> {
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
         let join_handle = get_runtime().spawn(async move {
+            // Check if this task has been superseded before executing.
+            if let Some(check) = pre_execute_check {
+                if !check() {
+                    // Superseded — skip execution, resolve as success.
+                    context.release_inflight_permit();
+                    drop(processor);
+                    drop(context);
+                    drop(self);
+                    if let Some(guard) = child_readiness_guard {
+                        guard.resolve(ComponentRunOutcome::default());
+                    }
+                    return Ok(());
+                }
+            }
             let result = self.execute_once(&context, Some(&processor)).await;
             // For background child component, never propagate the error back to the parent.
             // If an error handler is registered, run it; otherwise log.
@@ -424,37 +474,57 @@ impl<Prof: EngineProfile> Component<Prof> {
             }
             Ok(())
         });
-        Ok(ComponentExecutionHandle { join_handle })
+        Ok(ComponentExecutionHandle::new(async move {
+            join_handle
+                .await
+                .map_err(|e| SharedError::new(internal_error!("task panicked: {e}")))?
+        }))
     }
 
     pub fn delete(
         self,
         context: ComponentProcessorContext<Prof>,
+        pre_execute_check: Option<Box<dyn FnOnce() -> bool + Send>>,
     ) -> Result<ComponentExecutionHandle> {
         let child_readiness_guard = context
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
-        let join_handle = get_runtime().spawn(async move {
-            trace!("deleting component at {}", self.stable_path());
-            let result = self.execute_once(&context, None).await;
-            let outcome = match &result {
-                Ok((outcome, _)) => outcome.clone(),
-                Err(err) => {
-                    error!("component delete failed:\n{err}");
-                    ComponentRunOutcome::exception()
+        let join_handle: tokio::task::JoinHandle<SharedResult<()>> =
+            get_runtime().spawn(async move {
+                if let Some(check) = pre_execute_check {
+                    if !check() {
+                        drop(context);
+                        drop(self);
+                        if let Some(guard) = child_readiness_guard {
+                            guard.resolve(ComponentRunOutcome::default());
+                        }
+                        return Ok(());
+                    }
                 }
-            };
-            let task_result = result.map(|_| ()).map_err(Into::into);
-            // Drop profile-specific objects BEFORE resolving child readiness.
-            // See run_in_background for the rationale (PyGILState finalization fix).
-            drop(context);
-            drop(self);
-            if let Some(guard) = child_readiness_guard {
-                guard.resolve(outcome);
-            }
-            task_result
-        });
-        Ok(ComponentExecutionHandle { join_handle })
+                trace!("deleting component at {}", self.stable_path());
+                let result = self.execute_once(&context, None).await;
+                let outcome = match &result {
+                    Ok((outcome, _)) => outcome.clone(),
+                    Err(err) => {
+                        error!("component delete failed:\n{err}");
+                        ComponentRunOutcome::exception()
+                    }
+                };
+                let task_result = result.map(|_| ()).map_err(SharedError::from);
+                // Drop profile-specific objects BEFORE resolving child readiness.
+                // See run_in_background for the rationale (PyGILState finalization fix).
+                drop(context);
+                drop(self);
+                if let Some(guard) = child_readiness_guard {
+                    guard.resolve(outcome);
+                }
+                task_result
+            });
+        Ok(ComponentExecutionHandle::new(async move {
+            join_handle
+                .await
+                .map_err(|e| SharedError::new(internal_error!("task panicked: {e}")))?
+        }))
     }
 
     async fn execute_once(
@@ -695,6 +765,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         parent_ctx: Option<&ComponentProcessorContext<Prof>>,
         processing_stats: ProcessingStats,
         full_reprocess: bool,
+        live: bool,
         host_ctx: Arc<Prof::HostCtx>,
     ) -> Result<ComponentProcessorContext<Prof>> {
         let providers = if let Some(parent_ctx) = parent_ctx {
@@ -728,6 +799,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             processing_stats,
             ComponentProcessingMode::Build,
             full_reprocess,
+            live,
             host_ctx,
         ))
     }
@@ -747,6 +819,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             processing_stats,
             ComponentProcessingMode::Delete,
             full_reprocess,
+            false,
             host_ctx,
         )
     }

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -26,6 +26,7 @@ struct AppContextInner<Prof: EngineProfile> {
     app_reg: AppRegistration<Prof>,
     id_sequencer_manager: IdSequencerManager,
     inflight_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    cancellation_token: tokio_util::sync::CancellationToken,
 }
 
 #[derive(Clone)]
@@ -49,6 +50,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
                 app_reg,
                 id_sequencer_manager: IdSequencerManager::new(),
                 inflight_semaphore,
+                cancellation_token: tokio_util::sync::CancellationToken::new(),
             }),
         }
     }
@@ -67,6 +69,10 @@ impl<Prof: EngineProfile> AppContext<Prof> {
 
     pub fn inflight_semaphore(&self) -> Option<&Arc<tokio::sync::Semaphore>> {
         self.inner.inflight_semaphore.as_ref()
+    }
+
+    pub fn cancellation_token(&self) -> &tokio_util::sync::CancellationToken {
+        &self.inner.cancellation_token
     }
 
     /// Get the next ID for the given key.
@@ -125,6 +131,7 @@ pub(crate) struct ComponentBuildingState<Prof: EngineProfile> {
 pub(crate) struct ComponentBuildContext<Prof: EngineProfile> {
     pub state: Mutex<Option<ComponentBuildingState<Prof>>>,
     pub full_reprocess: bool,
+    pub live: bool,
 }
 
 pub(crate) struct ComponentDeleteContext<Prof: EngineProfile> {
@@ -171,6 +178,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         processing_stats: ProcessingStats,
         mode: ComponentProcessingMode,
         full_reprocess: bool,
+        live: bool,
         host_ctx: Arc<Prof::HostCtx>,
     ) -> Self {
         let processing_state = if mode == ComponentProcessingMode::Build {
@@ -184,6 +192,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
                     fn_call_memos: Default::default(),
                 })),
                 full_reprocess,
+                live,
             })
         } else {
             ComponentProcessingAction::Delete(ComponentDeleteContext { providers })
@@ -222,6 +231,9 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         self.inner.parent_context.as_ref()
     }
 
+    /// Access the building state under a single lock acquisition.
+    /// Callers should access all needed fields within `f` rather than wrapping
+    /// this in convenience methods — the caller decides the lock granularity.
     pub(crate) fn update_building_state<T>(
         &self,
         f: impl FnOnce(&mut ComponentBuildingState<Prof>) -> Result<T>,
@@ -250,7 +262,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         &self.inner.processing_action
     }
 
-    pub(crate) fn components_readiness(&self) -> &ComponentBgChildReadiness {
+    pub fn components_readiness(&self) -> &ComponentBgChildReadiness {
         &self.inner.components_readiness
     }
 
@@ -302,6 +314,13 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
     pub fn full_reprocess(&self) -> bool {
         match &self.inner.processing_action {
             ComponentProcessingAction::Build(build_ctx) => build_ctx.full_reprocess,
+            ComponentProcessingAction::Delete { .. } => false,
+        }
+    }
+
+    pub fn live(&self) -> bool {
+        match &self.inner.processing_action {
+            ComponentProcessingAction::Build(build_ctx) => build_ctx.live,
             ComponentProcessingAction::Delete { .. } => false,
         }
     }

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -82,7 +82,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
     }
 }
 
-pub(crate) struct DeclaredEffect<Prof: EngineProfile> {
+pub(crate) struct DeclaredTargetState<Prof: EngineProfile> {
     pub provider: TargetStateProvider<Prof>,
     pub item_key: StableKey,
     pub value: Prof::TargetStateValue,
@@ -90,7 +90,7 @@ pub(crate) struct DeclaredEffect<Prof: EngineProfile> {
 }
 
 pub(crate) struct ComponentTargetStatesContext<Prof: EngineProfile> {
-    pub declared_effects: BTreeMap<TargetStatePath, DeclaredEffect<Prof>>,
+    pub declared_target_states: BTreeMap<TargetStatePath, DeclaredTargetState<Prof>>,
     pub provider_registry: TargetStateProviderRegistry<Prof>,
 }
 
@@ -177,7 +177,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
             ComponentProcessingAction::Build(ComponentBuildContext {
                 state: Mutex::new(Some(ComponentBuildingState {
                     target_states: ComponentTargetStatesContext {
-                        declared_effects: Default::default(),
+                        declared_target_states: Default::default(),
                         provider_registry: TargetStateProviderRegistry::new(providers),
                     },
                     child_path_set: Default::default(),

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -705,7 +705,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 self.component_ctx.processing_stats().clone(),
                 self.component_ctx.host_ctx().clone(),
             );
-            let _ = component.delete(delete_ctx)?;
+            let _ = component.delete(delete_ctx, None)?;
         }
         Ok(())
     }

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -8,8 +8,8 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque, btree_map};
 use heed::{RoTxn, RwTxn};
 
 use crate::engine::context::{
-    ComponentProcessingAction, ComponentProcessingMode, ComponentProcessorContext, DeclaredEffect,
-    FnCallMemo, TARGET_ID_KEY,
+    ComponentProcessingAction, ComponentProcessingMode, ComponentProcessorContext,
+    DeclaredTargetState, FnCallMemo, TARGET_ID_KEY,
 };
 use crate::engine::context::{FnCallContext, FnCallMemoEntry};
 use crate::engine::id_sequencer::IdReservation;
@@ -260,7 +260,7 @@ pub fn declare_target_state<Prof: EngineProfile>(
     value: Prof::TargetStateValue,
 ) -> Result<()> {
     let target_state_path = provider.target_state_path().concat(&key);
-    let declared_effect = DeclaredEffect {
+    let declared_target_state = DeclaredTargetState {
         provider,
         item_key: key,
         value,
@@ -269,7 +269,7 @@ pub fn declare_target_state<Prof: EngineProfile>(
     comp_ctx.update_building_state(|building_state| {
         match building_state
             .target_states
-            .declared_effects
+            .declared_target_states
             .entry(target_state_path.clone())
         {
             btree_map::Entry::Occupied(entry) => {
@@ -279,7 +279,7 @@ pub fn declare_target_state<Prof: EngineProfile>(
                 );
             }
             btree_map::Entry::Vacant(entry) => {
-                entry.insert(declared_effect);
+                entry.insert(declared_target_state);
             }
         }
         Ok(())
@@ -300,7 +300,7 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
             .target_states
             .provider_registry
             .register_lazy(&provider, key.clone())?;
-        let declared_effect = DeclaredEffect {
+        let declared_target_state = DeclaredTargetState {
             provider,
             item_key: key,
             value,
@@ -308,7 +308,7 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
         };
         match building_state
             .target_states
-            .declared_effects
+            .declared_target_states
             .entry(child_provider.target_state_path().clone())
         {
             btree_map::Entry::Occupied(entry) => {
@@ -318,7 +318,7 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
                 );
             }
             btree_map::Entry::Vacant(entry) => {
-                entry.insert(declared_effect);
+                entry.insert(declared_target_state);
             }
         }
         Ok(child_provider)
@@ -403,19 +403,37 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 let mut tracking_info: db_schema::StablePathEntryTrackingInfo = self
                     .db
                     .get(&*wtxn, encoded_target_state_info_key.as_ref())?
-                    .map(|data| from_msgpack_slice(&data))
+                    .map(|data| from_msgpack_slice(data))
                     .transpose()?
                     .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
 
-                for item in tracking_info.effect_items.values_mut() {
+                for item in tracking_info.target_state_items.values_mut() {
                     item.states.retain(|(version, state)| {
                         *version > curr_version || *version == curr_version && !state.is_deleted()
                     });
                 }
+                // Prune entries with empty states and collect their paths for
+                // inverted tracking cleanup (deferred until tracking_info is dropped).
+                let mut pruned_paths: HashSet<TargetStatePath> = HashSet::new();
                 tracking_info
-                    .effect_items
-                    .retain(|_, item| !item.states.is_empty());
-                for (path_with_pid, item) in tracking_info.effect_items.iter_mut() {
+                    .target_state_items
+                    .retain(|path_with_pid, item| {
+                        if item.states.is_empty() {
+                            pruned_paths.insert(path_with_pid.target_state_path.clone());
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                // Don't delete inverted tracking if a surviving entry shares the same
+                // target_state_path (can happen when provider_id changed — old entry
+                // pruned, new entry survives under different provider_id).
+                if !pruned_paths.is_empty() {
+                    for path_with_pid in tracking_info.target_state_items.keys() {
+                        pruned_paths.remove(&path_with_pid.target_state_path);
+                    }
+                }
+                for (path_with_pid, item) in tracking_info.target_state_items.iter_mut() {
                     if let Some(parent_provider) = self
                         .target_states_providers
                         .get(path_with_pid.target_state_path.provider_path())
@@ -426,14 +444,15 @@ impl<Prof: EngineProfile> Committer<Prof> {
                     }
                 }
 
-                let is_version_converged = tracking_info.effect_items.iter().all(|(_, item)| {
-                    item.states
-                        .iter()
-                        .all(|(version, _)| *version == curr_version)
-                });
+                let is_version_converged =
+                    tracking_info.target_state_items.iter().all(|(_, item)| {
+                        item.states
+                            .iter()
+                            .all(|(version, _)| *version == curr_version)
+                    });
                 if is_version_converged {
                     tracking_info.version = 1;
-                    for item in tracking_info.effect_items.values_mut() {
+                    for item in tracking_info.target_state_items.values_mut() {
                         for (version, _) in item.states.iter_mut() {
                             *version = 1;
                         }
@@ -441,11 +460,17 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 }
 
                 let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
+                drop(tracking_info); // Release borrow before mutable operations.
                 self.db.put(
                     &mut *wtxn,
                     encoded_target_state_info_key.as_ref(),
                     data_bytes.as_slice(),
                 )?;
+
+                // Clean up inverted tracking for pruned entries.
+                for path in &pruned_paths {
+                    delete_target_state_owner(&mut *wtxn, &self.db, path)?;
+                }
             }
 
             // Write memos.
@@ -782,6 +807,42 @@ struct PreCommitOutput<Prof: EngineProfile> {
     processor_name_for_del: Option<String>,
 }
 
+// --- Inverted tracking (TargetStatePath → owning component) helpers ---
+
+fn read_target_state_owner(
+    wtxn: &heed::RwTxn<'_>,
+    db: &db_schema::Database,
+    target_state_path: &TargetStatePath,
+) -> Result<Option<db_schema::TargetStateOwnerInfo>> {
+    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
+    Ok(db
+        .get(wtxn, key.as_slice())?
+        .map(|data| from_msgpack_slice(data))
+        .transpose()?)
+}
+
+/// Encode an inverted tracking upsert as a deferred write (key, Some(value)).
+fn encode_owner_upsert(
+    target_state_path: &TargetStatePath,
+    component_path: &StablePath,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
+    let value = rmp_serde::to_vec_named(&db_schema::TargetStateOwnerInfo {
+        component_path: component_path.clone(),
+    })?;
+    Ok((key, value))
+}
+
+fn delete_target_state_owner(
+    wtxn: &mut heed::RwTxn<'_>,
+    db: &db_schema::Database,
+    target_state_path: &TargetStatePath,
+) -> Result<()> {
+    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
+    db.delete(wtxn, key.as_slice())?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn pre_commit<Prof: EngineProfile>(
     wtxn: &mut heed::RwTxn<'_>,
@@ -794,7 +855,7 @@ fn pre_commit<Prof: EngineProfile>(
     memo_del_key: &[u8],
     contained_target_state_paths: &HashSet<TargetStatePath>,
     target_states_providers: &rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
-    declared_effects: BTreeMap<TargetStatePath, DeclaredEffect<Prof>>,
+    declared_target_states: BTreeMap<TargetStatePath, DeclaredTargetState<Prof>>,
 ) -> Result<Option<PreCommitOutput<Prof>>> {
     let mut actions_by_sinks = HashMap::<Prof::TargetActionSink, SinkInput<Prof>>::new();
     let mut demote_component_only = false;
@@ -835,6 +896,10 @@ fn pre_commit<Prof: EngineProfile>(
         .get(wtxn, encoded_target_state_info_key)?
         .map(|data| from_msgpack_slice(data))
         .transpose()?;
+    // Deferred DB writes that will be flushed after tracking_info is dropped,
+    // since tracking_info borrows from wtxn and prevents mutable DB operations.
+    // Each entry is (encoded_key, optional_encoded_value); None value means delete.
+    let mut deferred_writes: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
     let previously_exists = tracking_info.is_some();
     if let Some(tracking_info) = &mut tracking_info {
         if let Some(processor_name) = processor_name {
@@ -850,13 +915,194 @@ fn pre_commit<Prof: EngineProfile>(
     let curr_version = if let Some(mut tracking_info) = tracking_info {
         let curr_version = tracking_info.version + 1;
         tracking_info.version = curr_version;
-        let mut declared_target_states_to_process = declared_effects;
 
-        // Deal with existing target states
-        for (target_state_path_with_pid, item) in tracking_info.effect_items.iter_mut() {
-            // Check if this child entry is stale (provider_id doesn't match parent's current generation).
-            // Stale entries arise from a parent's destructive change, which already cleaned up
-            // the external state. Skip them — commit() will prune them via version retention.
+        // Entries to insert/re-insert into target_state_items after both phases.
+        // Collected separately so Phase 2 doesn't see items added by Phase 1.
+        let mut items_to_insert: Vec<(
+            TargetStatePathWithProviderId,
+            db_schema::TargetStateInfoItem,
+        )> = Vec::new();
+
+        // Phase 1: Insert + Update — iterate declared target states.
+        // For each declared target state, find and remove any existing tracked entry,
+        // then reconcile. This unifies the insert and update code paths.
+        for (target_state_path, declared_target_state) in declared_target_states {
+            // Look up existing tracked entry using exact key (provider_id from current providers).
+            let parent_provider_gen = target_states_providers
+                .get(target_state_path.provider_path())
+                .and_then(|p| p.provider_generation());
+            let parent_provider_id = parent_provider_gen.map(|g| g.provider_id);
+            let lookup_key = TargetStatePathWithProviderId {
+                target_state_path: target_state_path.clone(),
+                provider_id: parent_provider_id,
+            };
+            let existing_item = tracking_info.target_state_items.remove(&lookup_key);
+
+            // Whether this target state path is new to this component's forward tracking
+            // (either fresh insert or preempted from another component).
+            // When provider_id changed, the old entry (under old_pid) stays for Phase 2
+            // to skip (stale) and commit to prune.
+            let is_new_to_component = existing_item.is_none();
+
+            // Obtain prev_item: either from this component's existing entry or via preempt.
+            let mut prev_item = if let Some(existing_item) = existing_item {
+                Some(existing_item)
+            } else {
+                // Insert path: check inverted tracking for ownership preempt.
+                match read_target_state_owner(wtxn, db, &target_state_path)? {
+                    Some(owner_info) if owner_info.component_path != *stable_path => {
+                        let old_owner_key = db_schema::DbEntryKey::StablePath(
+                            owner_info.component_path.clone(),
+                            db_schema::StablePathEntryKey::TrackingInfo,
+                        )
+                        .encode()?;
+                        if let Some(data) = db.get(wtxn, old_owner_key.as_slice())? {
+                            let mut old_tracking: db_schema::StablePathEntryTrackingInfo =
+                                from_msgpack_slice(data)?;
+                            let len_before = old_tracking.target_state_items.len();
+                            // Look up the entry matching current provider_id.
+                            let prev_item = old_tracking.target_state_items.remove(&lookup_key);
+                            // Also remove any stale entries (different provider_ids)
+                            // to prevent them from clobbering inverted tracking on prune.
+                            old_tracking
+                                .target_state_items
+                                .retain(|k, _| k.target_state_path != target_state_path);
+                            if old_tracking.target_state_items.len() < len_before {
+                                // Write back old owner's modified tracking info — deferred.
+                                let old_data = rmp_serde::to_vec_named(&old_tracking)?;
+                                deferred_writes.push((old_owner_key, old_data));
+                            }
+                            prev_item
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            };
+
+            // Compute prev_states and prev_may_be_missing uniformly from prev_item.
+            let (prev_states, prev_may_be_missing) = if let Some(ref prev_item) = prev_item {
+                let schema_version_mismatch = match parent_provider_gen {
+                    Some(pg) => prev_item.provider_schema_version != pg.provider_schema_version,
+                    None => false,
+                };
+                let prev_may_be_missing = full_reprocess
+                    || schema_version_mismatch
+                    || prev_item.states.iter().any(|(_, s)| s.is_deleted());
+                let prev_states = prev_item
+                    .states
+                    .iter()
+                    .filter_map(|(_, s)| s.as_ref())
+                    .map(|s_bytes| Prof::TargetStateTrackingRecord::from_bytes(s_bytes))
+                    .collect::<Result<Vec<_>>>()?;
+                (prev_states, prev_may_be_missing)
+            } else {
+                (vec![], true)
+            };
+
+            let target_state_key_bytes = storekey::encode_vec(&declared_target_state.item_key)
+                .map_err(|e| internal_error!("Failed to encode StableKey: {e}"))?;
+            let recon_output = declared_target_state
+                .provider
+                .handler()
+                .ok_or_else(|| {
+                    internal_error!(
+                        "provider not ready for target state with key {:?}",
+                        declared_target_state.item_key
+                    )
+                })?
+                .reconcile(
+                    declared_target_state.item_key,
+                    Some(declared_target_state.value),
+                    &prev_states,
+                    prev_may_be_missing,
+                )?;
+
+            if let Some(recon_output) = recon_output {
+                let mut provider_generation = prev_item
+                    .as_ref()
+                    .and_then(|item| item.provider_generation.clone());
+
+                if let Some(child_provider) = &declared_target_state.child_provider {
+                    let existing_gen = provider_generation.clone().unwrap_or_default();
+                    let new_gen = match recon_output.child_invalidation {
+                        Some(ChildInvalidation::Destructive) => {
+                            let new_id = id_reservation.next_id(wtxn, db)?;
+                            TargetStateProviderGeneration {
+                                provider_id: new_id,
+                                provider_schema_version: 0,
+                            }
+                        }
+                        Some(ChildInvalidation::Lossy) => TargetStateProviderGeneration {
+                            provider_id: existing_gen.provider_id,
+                            provider_schema_version: existing_gen.provider_schema_version + 1,
+                        },
+                        None => existing_gen,
+                    };
+                    provider_generation = Some(new_gen.clone());
+                    child_provider.set_provider_generation(new_gen)?;
+                }
+
+                actions_by_sinks
+                    .entry(recon_output.sink)
+                    .or_default()
+                    .add_action(recon_output.action, declared_target_state.child_provider);
+
+                let new_state_bytes = recon_output
+                    .tracking_record
+                    .map(|s| s.to_bytes())
+                    .transpose()?;
+
+                if let Some(item) = &mut prev_item {
+                    // Update existing item.
+                    item.provider_generation = provider_generation;
+                    item.states.push((
+                        curr_version,
+                        match new_state_bytes {
+                            Some(s) => {
+                                db_schema::TargetStateInfoItemState::Existing(Cow::Owned(s.into()))
+                            }
+                            None => db_schema::TargetStateInfoItemState::Deleted,
+                        },
+                    ));
+                } else if let Some(new_state) = new_state_bytes {
+                    // Insert new item.
+                    prev_item = Some(db_schema::TargetStateInfoItem {
+                        key: Cow::Owned(target_state_key_bytes.into()),
+                        states: vec![
+                            (0, db_schema::TargetStateInfoItemState::Deleted),
+                            (
+                                curr_version,
+                                db_schema::TargetStateInfoItemState::Existing(Cow::Owned(
+                                    new_state.into(),
+                                )),
+                            ),
+                        ],
+                        provider_schema_version: 0,
+                        provider_generation,
+                    });
+                }
+            } else if let Some(item) = &mut prev_item {
+                // No change — bump version on existing item.
+                for (version, _) in item.states.iter_mut() {
+                    *version = curr_version;
+                }
+            }
+
+            // Collect item for re-insertion after Phase 2.
+            if let Some(item) = prev_item {
+                // Write inverted tracking for entries new to this component — deferred.
+                if is_new_to_component {
+                    deferred_writes.push(encode_owner_upsert(&target_state_path, stable_path)?);
+                }
+                items_to_insert.push((lookup_key, item));
+            }
+        }
+
+        // Phase 2: Delete + Contained — iterate remaining tracked entries not matched above.
+        for (target_state_path_with_pid, item) in tracking_info.target_state_items.iter_mut() {
+            // Skip stale entries — commit() will prune them via version retention.
             let parent_provider_gen = target_states_providers
                 .get(target_state_path_with_pid.target_state_path.provider_path())
                 .and_then(|p| p.provider_generation());
@@ -866,6 +1112,26 @@ fn pre_commit<Prof: EngineProfile>(
                 continue;
             }
 
+            // Contained entries: still referenced by a parent, just bump version.
+            if contained_target_state_paths.contains(&target_state_path_with_pid.target_state_path)
+            {
+                for (version, _) in item.states.iter_mut() {
+                    *version = curr_version;
+                }
+                continue;
+            }
+
+            // Delete: target state is no longer declared.
+            let Some(target_states_provider) = target_states_providers
+                .get(target_state_path_with_pid.target_state_path.provider_path())
+            else {
+                trace!(
+                    "skip deleting target states with path {target_state_path_with_pid} in {} because target states provider not found",
+                    stable_path
+                );
+                continue;
+            };
+            let target_state_key: StableKey = storekey::decode(item.key.as_ref())?;
             let schema_version_mismatch = match parent_provider_gen {
                 Some(pg) => item.provider_schema_version != pg.provider_schema_version,
                 None => false,
@@ -882,75 +1148,19 @@ fn pre_commit<Prof: EngineProfile>(
                 .map(|s_bytes| Prof::TargetStateTrackingRecord::from_bytes(s_bytes))
                 .collect::<Result<Vec<_>>>()?;
 
-            let (target_states_provider, effect_key, declared_decl, child_provider) =
-                match declared_target_states_to_process
-                    .remove(&target_state_path_with_pid.target_state_path)
-                {
-                    Some(declared_effect) => (
-                        Cow::Owned(declared_effect.provider),
-                        declared_effect.item_key,
-                        Some(declared_effect.value),
-                        declared_effect.child_provider,
-                    ),
-                    None => {
-                        if contained_target_state_paths
-                            .contains(&target_state_path_with_pid.target_state_path)
-                        {
-                            for (version, _) in item.states.iter_mut() {
-                                *version = curr_version;
-                            }
-                            continue;
-                        }
-                        let Some(target_states_provider) = target_states_providers
-                            .get(target_state_path_with_pid.target_state_path.provider_path())
-                        else {
-                            // TODO: Verify the parent is gone.
-                            trace!(
-                                "skip deleting target states with path {target_state_path_with_pid} in {} because target states provider not found",
-                                stable_path
-                            );
-                            continue;
-                        };
-                        let effect_key: StableKey = storekey::decode(item.key.as_ref())?;
-                        (
-                            Cow::Borrowed(target_states_provider),
-                            effect_key,
-                            None,
-                            None,
-                        )
-                    }
-                };
             let recon_output = target_states_provider
                 .handler()
                 .ok_or_else(|| {
-                    internal_error!("provider not ready for target state with key {effect_key:?}")
+                    internal_error!(
+                        "provider not ready for target state with key {target_state_key:?}"
+                    )
                 })?
-                .reconcile(effect_key, declared_decl, &prev_states, prev_may_be_missing)?;
+                .reconcile(target_state_key, None, &prev_states, prev_may_be_missing)?;
             if let Some(recon_output) = recon_output {
-                if let Some(child_provider) = &child_provider {
-                    let existing = item.provider_generation.clone().unwrap_or_default();
-                    let new_gen = match recon_output.child_invalidation {
-                        Some(ChildInvalidation::Destructive) => {
-                            let new_id = id_reservation.next_id(wtxn, db)?;
-                            TargetStateProviderGeneration {
-                                provider_id: new_id,
-                                provider_schema_version: 0,
-                            }
-                        }
-                        Some(ChildInvalidation::Lossy) => TargetStateProviderGeneration {
-                            provider_id: existing.provider_id,
-                            provider_schema_version: existing.provider_schema_version + 1,
-                        },
-                        None => existing,
-                    };
-                    item.provider_generation = Some(new_gen.clone());
-                    child_provider.set_provider_generation(new_gen)?;
-                }
-
                 actions_by_sinks
                     .entry(recon_output.sink)
                     .or_default()
-                    .add_action(recon_output.action, child_provider);
+                    .add_action(recon_output.action, None);
                 item.states.push((
                     curr_version,
                     match recon_output
@@ -971,76 +1181,9 @@ fn pre_commit<Prof: EngineProfile>(
             }
         }
 
-        // Deal with new target states
-        for (target_state_path, target_state) in declared_target_states_to_process {
-            let effect_key_bytes = storekey::encode_vec(&target_state.item_key)
-                .map_err(|e| internal_error!("Failed to encode StableKey: {e}"))?;
-            let Some(recon_output) = target_state
-                .provider
-                .handler()
-                .ok_or_else(|| {
-                    internal_error!(
-                        "provider not ready for target state with key {:?}",
-                        target_state.item_key
-                    )
-                })?
-                .reconcile(
-                    target_state.item_key,
-                    Some(target_state.value),
-                    /*&prev_states=*/ &[],
-                    /*prev_may_be_missing=*/ true,
-                )?
-            else {
-                continue;
-            };
-
-            let provider_generation = if let Some(child_provider) = &target_state.child_provider {
-                let new_id = id_reservation.next_id(wtxn, db)?;
-                let pg = TargetStateProviderGeneration {
-                    provider_id: new_id,
-                    provider_schema_version: 0,
-                };
-                child_provider.set_provider_generation(pg.clone())?;
-                Some(pg)
-            } else {
-                None
-            };
-
-            actions_by_sinks
-                .entry(recon_output.sink)
-                .or_default()
-                .add_action(recon_output.action, target_state.child_provider);
-            let Some(new_state) = recon_output
-                .tracking_record
-                .map(|s| s.to_bytes())
-                .transpose()?
-                .map(|s| Cow::Owned(s.into()))
-            else {
-                continue;
-            };
-
-            let parent_provider_id = target_states_providers
-                .get(target_state_path.provider_path())
-                .and_then(|p| p.provider_generation())
-                .map(|g| g.provider_id);
-            let path_with_pid = TargetStatePathWithProviderId {
-                target_state_path,
-                provider_id: parent_provider_id,
-            };
-
-            let item = db_schema::TargetStateInfoItem {
-                key: Cow::Owned(effect_key_bytes.into()),
-                states: vec![
-                    (0, db_schema::TargetStateInfoItemState::Deleted),
-                    (
-                        curr_version,
-                        db_schema::TargetStateInfoItemState::Existing(new_state),
-                    ),
-                ],
-                provider_schema_version: 0,
-                provider_generation,
-            };
-            tracking_info.effect_items.insert(path_with_pid, item);
+        // Insert/re-insert items collected during Phase 1.
+        for (path_with_pid, item) in items_to_insert {
+            tracking_info.target_state_items.insert(path_with_pid, item);
         }
 
         let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
@@ -1050,6 +1193,11 @@ fn pre_commit<Prof: EngineProfile>(
     } else {
         None
     };
+
+    // Flush deferred writes now that tracking_info is dropped.
+    for (key, value) in &deferred_writes {
+        db.put(wtxn, key.as_slice(), value.as_slice())?;
+    }
 
     id_reservation.commit(wtxn, db)?;
     Ok(Some(PreCommitOutput {
@@ -1075,36 +1223,40 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     let processor_name = processor.map(|p| p.processor_info().name.as_str());
 
     let mut built_target_states_providers: Option<TargetStateProviderRegistry<Prof>> = None;
-    let (target_states_providers, declared_effects, child_path_set, mut finalized_fn_call_memos) =
-        match comp_ctx.processing_state() {
-            ComponentProcessingAction::Build(build_ctx) => {
-                let mut building_state = build_ctx.state.lock().unwrap();
-                let Some(building_state) = building_state.take() else {
-                    internal_bail!(
-                        "Processing for the component at {} is already finished",
-                        comp_ctx.stable_path()
-                    );
-                };
+    let (
+        target_states_providers,
+        declared_target_states,
+        child_path_set,
+        mut finalized_fn_call_memos,
+    ) = match comp_ctx.processing_state() {
+        ComponentProcessingAction::Build(build_ctx) => {
+            let mut building_state = build_ctx.state.lock().unwrap();
+            let Some(building_state) = building_state.take() else {
+                internal_bail!(
+                    "Processing for the component at {} is already finished",
+                    comp_ctx.stable_path()
+                );
+            };
 
-                let child_path_set = building_state.child_path_set;
-                let finalized_fn_call_memos =
-                    finalize_fn_call_memoization(comp_ctx, building_state.fn_call_memos)?;
-                (
-                    &built_target_states_providers
-                        .get_or_insert(building_state.target_states.provider_registry)
-                        .providers,
-                    building_state.target_states.declared_effects,
-                    Some(child_path_set),
-                    finalized_fn_call_memos,
-                )
-            }
-            ComponentProcessingAction::Delete(delete_context) => (
-                &delete_context.providers,
-                Default::default(),
-                None,
-                Default::default(),
-            ),
-        };
+            let child_path_set = building_state.child_path_set;
+            let finalized_fn_call_memos =
+                finalize_fn_call_memoization(comp_ctx, building_state.fn_call_memos)?;
+            (
+                &built_target_states_providers
+                    .get_or_insert(building_state.target_states.provider_registry)
+                    .providers,
+                building_state.target_states.declared_target_states,
+                Some(child_path_set),
+                finalized_fn_call_memos,
+            )
+        }
+        ComponentProcessingAction::Delete(delete_context) => (
+            &delete_context.providers,
+            Default::default(),
+            None,
+            Default::default(),
+        ),
+    };
 
     let db = comp_ctx.app_ctx().db().clone();
     let comp_mode = comp_ctx.mode();
@@ -1143,7 +1295,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
                 &memo_del_key,
                 &contained_target_state_paths,
                 &target_states_providers_owned,
-                declared_effects,
+                declared_target_states,
             )
         })
         .await?;
@@ -1183,10 +1335,12 @@ pub(crate) async fn submit<Prof: EngineProfile>(
                     handlers.len(),
                 );
             }
-            for (child_effect_def, child_provider) in std::iter::zip(handlers, child_providers) {
+            for (child_target_state_def, child_provider) in
+                std::iter::zip(handlers, child_providers)
+            {
                 if let Some(child_provider) = child_provider {
-                    if let Some(child_effect_def) = child_effect_def {
-                        child_provider.fulfill_handler(child_effect_def.handler)?;
+                    if let Some(child_target_state_def) = child_target_state_def {
+                        child_provider.fulfill_handler(child_target_state_def.handler)?;
                     } else {
                         client_bail!("expect child provider returned by Sink to be fulfilled");
                     }

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -1,0 +1,498 @@
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use crate::engine::component::{
+    Component, ComponentBgChildReadinessChildGuard, ComponentExecutionHandle,
+};
+use crate::engine::context::{ComponentProcessingMode, ComponentProcessorContext, FnCallContext};
+use crate::engine::profile::EngineProfile;
+use crate::engine::stats::ProcessingStats;
+use crate::engine::target_state::TargetStateProvider;
+use crate::prelude::*;
+use crate::state::stable_path::StablePath;
+use crate::state::target_state_path::TargetStatePath;
+use cocoindex_utils::error::SharedError;
+
+/// Result of mounting a live component.
+pub struct MountLiveResult<Prof: EngineProfile> {
+    pub controller: LiveComponentController<Prof>,
+    pub readiness_handle: ComponentExecutionHandle,
+}
+
+/// Intermediate state after sync preparation, before async completion.
+pub struct MountLivePending<Prof: EngineProfile> {
+    child: Component<Prof>,
+    parent_ctx: ComponentProcessorContext<Prof>,
+    providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+    live: bool,
+}
+
+/// Mount a live component. Split into two phases:
+/// - `prepare` (sync): registers the child component, borrows fn_ctx
+/// - `complete` (async): cancels existing live state, creates controller
+pub fn mount_live_prepare<Prof: EngineProfile>(
+    parent_ctx: &ComponentProcessorContext<Prof>,
+    fn_ctx: &FnCallContext,
+    child_stable_path: StablePath,
+    live: bool,
+) -> Result<MountLivePending<Prof>> {
+    // 1. Mount (or get existing) child component.
+    let child = parent_ctx
+        .component()
+        .mount_child(fn_ctx, child_stable_path.clone())?;
+
+    // Register the child in the parent's child_path_set and get providers
+    // in a single lock acquisition.
+    let sub_path = child_stable_path
+        .as_ref()
+        .strip_parent(parent_ctx.stable_path().as_ref())?;
+    let providers = parent_ctx.update_building_state(|building_state| {
+        building_state.child_path_set.add_child(
+            sub_path,
+            crate::state::stable_path_set::StablePathSet::Component,
+        )?;
+        Ok(building_state
+            .target_states
+            .provider_registry
+            .providers
+            .clone())
+    })?;
+
+    Ok(MountLivePending {
+        child,
+        parent_ctx: parent_ctx.clone(),
+        providers,
+        live,
+    })
+}
+
+impl<Prof: EngineProfile> MountLivePending<Prof> {
+    /// Complete the mount: cancel existing, create controller and readiness handle.
+    pub async fn complete(self) -> Result<MountLiveResult<Prof>> {
+        let Self {
+            child,
+            parent_ctx,
+            providers,
+            live,
+        } = self;
+
+        // 2. If existing live state, cancel and drain it.
+        if let Some(existing_state) = child.live_state() {
+            existing_state.cancellation_token().cancel();
+            let handle = existing_state.live_task_handle();
+            if let Some(handle) = handle {
+                let _ = handle.await;
+            }
+            existing_state.drain_inflight().await;
+        }
+
+        // 3. Create readiness guard from parent's components_readiness.
+        let readiness_guard = parent_ctx.components_readiness().clone().add_child();
+
+        // 4. Create cancellation token as child of app's root token.
+        let cancellation_token = parent_ctx.app_ctx().cancellation_token().child_token();
+
+        // 5. Create LiveComponentState.
+        let state = Arc::new(LiveComponentState::new(readiness_guard, cancellation_token));
+
+        // 6. Store the state in the child component.
+        child.set_live_state(state.clone());
+
+        // 7. Create the controller (providers were captured during prepare).
+        let controller = LiveComponentController::new(
+            child,
+            state.clone(),
+            parent_ctx.processing_stats().clone(),
+            parent_ctx.host_ctx().clone(),
+            parent_ctx.full_reprocess(),
+            live,
+            providers,
+        );
+
+        // 9. Create readiness handle that resolves when mark_ready is called.
+        let readiness_handle = ComponentExecutionHandle::new(async move {
+            state.ready_notified().await;
+            Ok(())
+        });
+
+        Ok(MountLiveResult {
+            controller,
+            readiness_handle,
+        })
+    }
+}
+
+/// Readiness state. Under a single Mutex so mark_ready() can atomically
+/// take the guard and set the ready flag.
+pub(crate) struct ReadinessState {
+    guard: Option<ComponentBgChildReadinessChildGuard>,
+    ready: bool,
+}
+
+/// Shared state stored in ComponentInner::live_state.
+/// Does NOT reference Component — breaks the cyclic Arc.
+/// Lock ordering: all locks (ops, readiness, live_task) are held independently.
+pub struct LiveComponentState {
+    /// RwLock for serialization only (guards no data).
+    /// update_full takes write (exclusive), update/delete take read (concurrent).
+    ops: tokio::sync::RwLock<()>,
+
+    /// Readiness state — guard + flag under one lock.
+    readiness: Mutex<ReadinessState>,
+
+    /// Signaled once when mark_ready is called. Python side awaits for handle.ready().
+    ready_notify: tokio::sync::Notify,
+
+    /// Cancellation token — triggered on re-mount or app shutdown.
+    cancellation_token: tokio_util::sync::CancellationToken,
+
+    /// JoinHandle of the tokio task running process_live. Set by start().
+    /// Dropping/aborting this cancels the Python task via CancelOnDropPy.
+    live_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+
+    /// In-flight child task tracking. Each spawned task holds an InflightGuard.
+    /// update_full() waits for the counter to reach zero before proceeding.
+    inflight_counter: AtomicUsize,
+    inflight_drained: tokio::sync::Notify,
+
+    /// Global sequence counter for "latest wins" ordering.
+    /// Incremented on each update()/delete() invocation.
+    /// The per-child latest_seq lives on ComponentInner.
+    next_seq: AtomicU64,
+}
+
+impl LiveComponentState {
+    pub fn new(
+        readiness_guard: ComponentBgChildReadinessChildGuard,
+        cancellation_token: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        Self {
+            ops: tokio::sync::RwLock::new(()),
+            readiness: Mutex::new(ReadinessState {
+                guard: Some(readiness_guard),
+                ready: false,
+            }),
+            ready_notify: tokio::sync::Notify::new(),
+            cancellation_token,
+            live_task: Mutex::new(None),
+            inflight_counter: AtomicUsize::new(0),
+            inflight_drained: tokio::sync::Notify::new(),
+            next_seq: AtomicU64::new(0),
+        }
+    }
+
+    pub fn cancellation_token(&self) -> &tokio_util::sync::CancellationToken {
+        &self.cancellation_token
+    }
+
+    /// Take the JoinHandle for the live task (if any).
+    pub fn live_task_handle(&self) -> Option<tokio::task::JoinHandle<()>> {
+        self.live_task.lock().unwrap().take()
+    }
+
+    /// Wait until ready_notify is signaled.
+    pub async fn ready_notified(&self) {
+        // If already ready, return immediately.
+        if self.readiness.lock().unwrap().ready {
+            return;
+        }
+        self.ready_notify.notified().await;
+    }
+
+    /// Wait for all in-flight tasks to complete.
+    pub async fn drain_inflight(&self) {
+        loop {
+            if self.inflight_counter.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            self.inflight_drained.notified().await;
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        self.readiness.lock().unwrap().ready
+    }
+
+    /// Resolve readiness as success. No-op if already resolved.
+    fn ensure_mark_ready(&self) {
+        let mut state = self.readiness.lock().unwrap();
+        if !state.ready {
+            state.ready = true;
+            if let Some(guard) = state.guard.take() {
+                guard.resolve(Default::default());
+            }
+            self.ready_notify.notify_waiters();
+        }
+    }
+
+    /// Resolve readiness with error. Only effective if not already ready.
+    /// Drops the guard without calling resolve(), which triggers the Drop impl
+    /// that reports a cancellation error to the parent.
+    fn resolve_ready_with_error(&self, _err: Error) {
+        let mut state = self.readiness.lock().unwrap();
+        if !state.ready {
+            state.ready = true;
+            // Drop the guard without calling resolve — triggers Drop impl
+            // which sends a "cancelled" SharedError to the parent.
+            state.guard.take();
+            self.ready_notify.notify_waiters();
+        }
+    }
+}
+
+/// Returned to Python. Holds Component + shared state.
+/// NOT stored in ComponentInner — only Python/PyO3 holds this.
+#[derive(Clone)]
+pub struct LiveComponentController<Prof: EngineProfile> {
+    component: Component<Prof>,
+    state: Arc<LiveComponentState>,
+
+    // --- Immutable config ---
+    processing_stats: ProcessingStats,
+    host_ctx: Arc<Prof::HostCtx>,
+    full_reprocess: bool,
+    live: bool,
+
+    /// Providers inherited from the parent component context at creation time.
+    /// Immutable — process() may not call use_mount(), so no new providers are created.
+    providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+}
+
+impl<Prof: EngineProfile> LiveComponentController<Prof> {
+    pub fn new(
+        component: Component<Prof>,
+        state: Arc<LiveComponentState>,
+        processing_stats: ProcessingStats,
+        host_ctx: Arc<Prof::HostCtx>,
+        full_reprocess: bool,
+        live: bool,
+        providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+    ) -> Self {
+        Self {
+            component,
+            state,
+            processing_stats,
+            host_ctx,
+            full_reprocess,
+            live,
+            providers,
+        }
+    }
+
+    pub fn state(&self) -> &Arc<LiveComponentState> {
+        &self.state
+    }
+
+    pub fn component(&self) -> &Component<Prof> {
+        &self.component
+    }
+
+    pub fn is_live(&self) -> bool {
+        self.live
+    }
+
+    /// Full processing cycle. Exclusive — waits for in-flight update/delete to drain,
+    /// then runs process() through execute_once (memoization, submit, wait-children, post-submit).
+    pub async fn update_full(&self, processor: Prof::ComponentProc) -> Result<()> {
+        // Acquire exclusive lock — waits for all update/delete to release read locks.
+        let _write_guard = self.state.ops.write().await;
+        // Wait for in-flight child tasks to drain.
+        self.state.drain_inflight().await;
+
+        // Create fresh context with no parent.
+        let context = ComponentProcessorContext::new(
+            self.component.clone(),
+            self.providers.clone(),
+            None,
+            self.processing_stats.clone(),
+            ComponentProcessingMode::Build,
+            self.full_reprocess,
+            self.live,
+            self.host_ctx.clone(),
+        );
+
+        // Run via run_in_background (no parent context → no readiness guard to grandparent).
+        let handle = self
+            .component
+            .clone()
+            .run_in_background(processor, context, None, None)
+            .await?;
+
+        // Await full readiness including all children.
+        handle.ready().await?;
+
+        Ok(())
+    }
+
+    /// Mount a child component incrementally. Concurrent with other update/delete calls.
+    /// Waits for any in-flight update_full to complete first.
+    pub async fn update(
+        &self,
+        subpath: StablePath,
+        processor: Prof::ComponentProc,
+    ) -> Result<ComponentExecutionHandle> {
+        let _read_guard = self.state.ops.read().await;
+
+        // Increment inflight counter. It will be decremented when the background
+        // task completes (via the wrapper future on ComponentExecutionHandle).
+        self.state.inflight_counter.fetch_add(1, Ordering::AcqRel);
+        let state_for_drain = self.state.clone();
+
+        let child = self.component.get_child(subpath);
+        let seq = self.state.next_seq.fetch_add(1, Ordering::Relaxed);
+        child.latest_seq().store(seq, Ordering::Release);
+
+        let context = ComponentProcessorContext::new(
+            child.clone(),
+            self.providers.clone(),
+            None,
+            self.processing_stats.clone(),
+            ComponentProcessingMode::Build,
+            self.full_reprocess,
+            self.live,
+            self.host_ctx.clone(),
+        );
+
+        let child_for_check = child.clone();
+        let pre_execute_check: Box<dyn FnOnce() -> bool + Send> =
+            Box::new(move || child_for_check.latest_seq().load(Ordering::Acquire) == seq);
+
+        let inner_handle = child
+            .run_in_background(processor, context, None, Some(pre_execute_check))
+            .await?;
+
+        // Wrap: decrement inflight counter after the inner handle's future completes.
+        Ok(ComponentExecutionHandle::new(async move {
+            let result = inner_handle.ready().await;
+            // Decrement inflight counter.
+            if state_for_drain
+                .inflight_counter
+                .fetch_sub(1, Ordering::AcqRel)
+                == 1
+            {
+                state_for_drain.inflight_drained.notify_waiters();
+            }
+            result.map_err(SharedError::from)
+        }))
+    }
+
+    /// Delete a child component. Same concurrency as update().
+    pub async fn delete(&self, subpath: StablePath) -> Result<ComponentExecutionHandle> {
+        let _read_guard = self.state.ops.read().await;
+
+        self.state.inflight_counter.fetch_add(1, Ordering::AcqRel);
+        let state_for_drain = self.state.clone();
+
+        let child = self.component.get_child(subpath.clone());
+        let seq = self.state.next_seq.fetch_add(1, Ordering::Relaxed);
+        child.latest_seq().store(seq, Ordering::Release);
+
+        let context = ComponentProcessorContext::new(
+            child.clone(),
+            self.providers.clone(),
+            None,
+            self.processing_stats.clone(),
+            ComponentProcessingMode::Delete,
+            false,
+            self.live,
+            self.host_ctx.clone(),
+        );
+
+        let child_for_check = child.clone();
+        let pre_execute_check: Box<dyn FnOnce() -> bool + Send> =
+            Box::new(move || child_for_check.latest_seq().load(Ordering::Acquire) == seq);
+
+        let inner_handle = child.delete(context, Some(pre_execute_check))?;
+
+        // Wrap: decrement inflight + remove from active_children after completion.
+        let component = self.component.clone();
+        Ok(ComponentExecutionHandle::new(async move {
+            let result = inner_handle.ready().await;
+            component.remove_active_child(&subpath);
+            // Decrement inflight counter.
+            if state_for_drain
+                .inflight_counter
+                .fetch_sub(1, Ordering::AcqRel)
+                == 1
+            {
+                state_for_drain.inflight_drained.notify_waiters();
+            }
+            result.map_err(SharedError::from)
+        }))
+    }
+
+    /// Signal readiness to parent component. Idempotent — subsequent calls are no-ops.
+    /// - Live mode: resolves readiness and returns immediately.
+    /// - Non-live mode: resolves readiness, cancels the cancellation_token, then
+    ///   suspends indefinitely (Poll::Pending). select! in start() drops the
+    ///   process_live future, terminating the Python task via CancelOnDropPy.
+    pub async fn mark_ready(&self) {
+        {
+            let mut state = self.state.readiness.lock().unwrap();
+            if state.ready {
+                return; // Idempotent
+            }
+            state.ready = true;
+            if let Some(guard) = state.guard.take() {
+                guard.resolve(Default::default());
+            }
+        }
+        self.state.ready_notify.notify_waiters();
+
+        if !self.live {
+            // Non-live mode: cancel the token so select! in start() drops process_live.
+            self.state.cancellation_token.cancel();
+            // Suspend forever — select! will drop us via CancelOnDropPy.
+            std::future::pending::<()>().await;
+        }
+    }
+
+    /// Start running process_live. Accepts the Python coroutine (as a Rust future
+    /// via from_py_future), spawns a tokio task with cancellation support.
+    /// Stores the JoinHandle for later cancellation.
+    pub fn start<F>(&self, process_live_fut: F)
+    where
+        F: Future<Output = Result<()>> + Send + 'static,
+    {
+        let token = self.state.cancellation_token.clone();
+        let state = self.state.clone();
+        let handle = crate::engine::runtime::get_runtime().spawn(async move {
+            let result = tokio::select! {
+                result = process_live_fut => result,
+                _ = token.cancelled() => Ok(()),
+            };
+            match result {
+                Ok(()) => state.ensure_mark_ready(),
+                Err(e) => {
+                    if !state.is_ready() {
+                        // Error before mark_ready — drop the guard to signal error.
+                        state.resolve_ready_with_error(e);
+                    } else {
+                        error!("process_live failed after mark_ready: {e:?}");
+                    }
+                }
+            }
+        });
+        *self.state.live_task.lock().unwrap() = Some(handle);
+    }
+
+    /// Cancel this controller and wait for full quiescence.
+    /// Called by mount_live_async before creating a replacement controller.
+    /// 1. Cancels the cancellation_token (causes tokio::select! to drop the
+    ///    process_live future → CancelOnDropPy::drop() cancels the Python task).
+    /// 2. Awaits the process_live JoinHandle to ensure the task has terminated.
+    /// 3. Waits for inflight_counter to drain (in-flight child tasks complete).
+    pub async fn cancel_and_drain(&self) {
+        // 1. Cancel the token — causes select! to drop process_live future.
+        self.state.cancellation_token.cancel();
+
+        // 2. Await the JoinHandle to ensure the task has terminated.
+        let handle = self.state.live_task.lock().unwrap().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
+
+        // 3. Wait for in-flight child tasks to drain.
+        self.state.drain_inflight().await;
+    }
+}

--- a/rust/core/src/engine/mod.rs
+++ b/rust/core/src/engine/mod.rs
@@ -5,6 +5,7 @@ pub mod environment;
 pub mod execution;
 pub mod function;
 pub mod id_sequencer;
+pub mod live_component;
 pub mod logic_registry;
 pub mod profile;
 pub mod runtime;

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -256,6 +256,14 @@ pub struct TargetStateInfoItem<'a> {
     pub provider_generation: Option<TargetStateProviderGeneration>,
 }
 
+/// Inverted tracking: maps a `TargetStatePath` to the component that owns it.
+/// Stored under `DbEntryKey::TargetState(target_state_path)`.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TargetStateOwnerInfo {
+    #[serde(rename = "C")]
+    pub component_path: StablePath,
+}
+
 pub const UNKNOWN_PROCESSOR_NAME: &'static str = "<unknown>";
 
 fn unknown_processor_name() -> Cow<'static, str> {
@@ -267,7 +275,7 @@ pub struct StablePathEntryTrackingInfo<'a> {
     #[serde(rename = "V")]
     pub version: u64,
     #[serde(rename = "I", borrow)]
-    pub effect_items: BTreeMap<TargetStatePathWithProviderId, TargetStateInfoItem<'a>>,
+    pub target_state_items: BTreeMap<TargetStatePathWithProviderId, TargetStateInfoItem<'a>>,
     #[serde(rename = "N", borrow, default = "unknown_processor_name")]
     pub processor_name: Cow<'a, str>,
 }
@@ -276,7 +284,7 @@ impl<'a> StablePathEntryTrackingInfo<'a> {
     pub fn new(processor_name: Cow<'a, str>) -> Self {
         Self {
             version: 0,
-            effect_items: BTreeMap::new(),
+            target_state_items: BTreeMap::new(),
             processor_name,
         }
     }

--- a/rust/py/src/app.rs
+++ b/rust/py/src/app.rs
@@ -96,17 +96,20 @@ impl PyApp {
         Ok(Self(Arc::new(app)))
     }
 
+    #[pyo3(signature = (root_processor, report_to_stdout, full_reprocess, host_ctx, live=false))]
     pub fn update_async(
         &self,
         root_processor: PyComponentProcessor,
         report_to_stdout: bool,
         full_reprocess: bool,
         host_ctx: Py<PyAny>,
+        live: bool,
     ) -> PyResult<PyUpdateHandle> {
         let app = self.0.clone();
         let options = AppUpdateOptions {
             report_to_stdout,
             full_reprocess,
+            live,
         };
         let host_ctx = Arc::new(host_ctx);
         let handle = app
@@ -121,6 +124,7 @@ impl PyApp {
         })
     }
 
+    #[pyo3(signature = (root_processor, report_to_stdout, full_reprocess, host_ctx, live=false))]
     pub fn update(
         &self,
         py: Python<'_>,
@@ -128,11 +132,13 @@ impl PyApp {
         report_to_stdout: bool,
         full_reprocess: bool,
         host_ctx: Py<PyAny>,
+        live: bool,
     ) -> PyResult<PyStoredValue> {
         let app = self.0.clone();
         let options = AppUpdateOptions {
             report_to_stdout,
             full_reprocess,
+            live,
         };
         let host_ctx = Arc::new(host_ctx);
         py.detach(|| {

--- a/rust/py/src/component.rs
+++ b/rust/py/src/component.rs
@@ -177,6 +177,7 @@ pub fn mount_run(
             Some(&comp_ctx.0),
             comp_ctx.0.processing_stats().clone(),
             comp_ctx.0.full_reprocess(),
+            comp_ctx.0.live(),
             comp_ctx.0.host_ctx().clone(),
         )
         .into_py_result()?;
@@ -206,13 +207,14 @@ pub fn mount(
             Some(&comp_ctx.0),
             comp_ctx.0.processing_stats().clone(),
             comp_ctx.0.full_reprocess(),
+            comp_ctx.0.live(),
             comp_ctx.0.host_ctx().clone(),
         )
         .into_py_result()?;
     py.detach(|| {
         get_runtime().block_on(async {
             let handle = component
-                .run_in_background(processor, child_ctx, None)
+                .run_in_background(processor, child_ctx, None, None)
                 .await
                 .into_py_result()?;
             Ok(PyComponentMountHandle(Some(handle)))
@@ -238,6 +240,7 @@ pub fn mount_run_async<'py>(
             Some(&comp_ctx.0),
             comp_ctx.0.processing_stats().clone(),
             comp_ctx.0.full_reprocess(),
+            comp_ctx.0.live(),
             comp_ctx.0.host_ctx().clone(),
         )
         .into_py_result()?;
@@ -267,6 +270,7 @@ pub fn mount_async<'py>(
             Some(&comp_ctx.0),
             comp_ctx.0.processing_stats().clone(),
             comp_ctx.0.full_reprocess(),
+            comp_ctx.0.live(),
             comp_ctx.0.host_ctx().clone(),
         )
         .into_py_result()?;
@@ -306,7 +310,7 @@ pub fn mount_async<'py>(
 
     future_into_py(py, async move {
         let handle = component
-            .run_in_background(processor, child_ctx, on_error)
+            .run_in_background(processor, child_ctx, on_error, None)
             .await
             .into_py_result()?;
         Ok(PyComponentMountHandle(Some(handle)))
@@ -354,6 +358,10 @@ impl PyComponentMountRunHandle {
 pub struct PyComponentMountHandle(Option<ComponentExecutionHandle>);
 
 impl PyComponentMountHandle {
+    pub fn from_handle(handle: ComponentExecutionHandle) -> Self {
+        Self(Some(handle))
+    }
+
     fn take_handle(&mut self) -> PyResult<ComponentExecutionHandle> {
         self.0.take().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("Handle has already been consumed")

--- a/rust/py/src/context.rs
+++ b/rust/py/src/context.rs
@@ -22,6 +22,11 @@ impl PyComponentProcessorContext {
         PyStablePath(self.0.stable_path().clone())
     }
 
+    #[getter]
+    fn live(&self) -> bool {
+        self.0.live()
+    }
+
     fn join_fn_call(&self, fn_ctx: &PyFnCallContext) -> PyResult<()> {
         self.0.join_fn_call(&fn_ctx.0);
         Ok(())

--- a/rust/py/src/lib.rs
+++ b/rust/py/src/lib.rs
@@ -6,6 +6,7 @@ mod environment;
 mod fingerprint;
 mod function;
 mod inspect;
+pub mod live_component;
 mod logic_registry;
 mod memo_key;
 mod ops;
@@ -41,6 +42,9 @@ fn core_module(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()>
 
     m.add_class::<context::PyComponentProcessorContext>()?;
     m.add_class::<context::PyFnCallContext>()?;
+
+    m.add_class::<live_component::PyLiveComponentController>()?;
+    m.add_function(wrap_pyfunction!(live_component::mount_live_async, m)?)?;
 
     m.add_class::<target_state::PyTargetActionSink>()?;
     m.add_class::<target_state::PyTargetHandler>()?;

--- a/rust/py/src/live_component.rs
+++ b/rust/py/src/live_component.rs
@@ -1,0 +1,109 @@
+use crate::{
+    component::{PyComponentMountHandle, PyComponentProcessor},
+    context::{PyComponentProcessorContext, PyFnCallContext},
+    prelude::*,
+    stable_path::PyStablePath,
+};
+
+use cocoindex_core::engine::live_component::LiveComponentController;
+use cocoindex_py_utils::from_py_future;
+use pyo3_async_runtimes::tokio::future_into_py;
+
+#[pyclass(name = "LiveComponentController")]
+#[derive(Clone)]
+pub struct PyLiveComponentController(pub Arc<LiveComponentController<PyEngineProfile>>);
+
+#[pymethods]
+impl PyLiveComponentController {
+    pub fn update_full_async<'py>(
+        &self,
+        py: Python<'py>,
+        processor: PyComponentProcessor,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let ctrl = self.0.clone();
+        future_into_py(py, async move {
+            ctrl.update_full(processor).await.into_py_result()?;
+            Ok(())
+        })
+    }
+
+    pub fn update_async<'py>(
+        &self,
+        py: Python<'py>,
+        stable_path: PyStablePath,
+        processor: PyComponentProcessor,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let ctrl = self.0.clone();
+        future_into_py(py, async move {
+            let handle = ctrl
+                .update(stable_path.0, processor)
+                .await
+                .into_py_result()?;
+            Ok(PyComponentMountHandle::from_handle(handle))
+        })
+    }
+
+    pub fn delete_async<'py>(
+        &self,
+        py: Python<'py>,
+        stable_path: PyStablePath,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let ctrl = self.0.clone();
+        future_into_py(py, async move {
+            let handle = ctrl.delete(stable_path.0).await.into_py_result()?;
+            Ok(PyComponentMountHandle::from_handle(handle))
+        })
+    }
+
+    pub fn mark_ready_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let ctrl = self.0.clone();
+        future_into_py(py, async move {
+            ctrl.mark_ready().await;
+            Ok(())
+        })
+    }
+
+    pub fn start(&self, py: Python<'_>, process_live_fut: Py<PyAny>) -> PyResult<()> {
+        // Convert the Python coroutine into a Rust future using from_py_future.
+        let host_runtime_ctx = self.0.component().app_ctx().env().host_runtime_ctx();
+        let fut = from_py_future(py, &host_runtime_ctx.0, process_live_fut.into_bound(py))?;
+        // Wrap to convert PyResult<Py<PyAny>> → Result<()>
+        let rust_fut = async move {
+            fut.await.from_py_result()?;
+            Ok(())
+        };
+        self.0.start(rust_fut);
+        Ok(())
+    }
+
+    #[getter]
+    pub fn is_live(&self) -> bool {
+        self.0.is_live()
+    }
+}
+
+#[pyfunction]
+pub fn mount_live_async<'py>(
+    py: Python<'py>,
+    stable_path: PyStablePath,
+    comp_ctx: PyComponentProcessorContext,
+    fn_ctx: &PyFnCallContext,
+    live: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    // Sync phase: borrows fn_ctx (only valid for this call).
+    let pending = cocoindex_core::engine::live_component::mount_live_prepare(
+        &comp_ctx.0,
+        &fn_ctx.0,
+        stable_path.0,
+        live,
+    )
+    .into_py_result()?;
+
+    // Async phase: no borrows needed, all data is owned.
+    future_into_py(py, async move {
+        let result = pending.complete().await.into_py_result()?;
+        let py_controller = PyLiveComponentController(Arc::new(result.controller));
+        let py_handle = PyComponentMountHandle::from_handle(result.readiness_handle);
+        Ok((py_controller, py_handle))
+    })
+}


### PR DESCRIPTION
## Summary
- Add `LiveComponent` support, enabling processing components that can be dynamically created, updated, and removed at runtime without restarting the app
- Include target state ownership transfer between components, allowing live components to take over target states from the main app seamlessly
- Add CLI support (`live-component` subcommand) and comprehensive documentation

## Test plan
- CI (cargo test, mypy, pytest)
- New tests: `test_live_component.py`, `test_ownership_transfer.py`
