### PR TITLE
fix: respect @coco.fn(memo=True) on bound class methods

### DIFF
--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -17,7 +17,6 @@ from typing import (
 )
 
 from . import core, environment
-from .serde import fn_ret_deserializer
 from .app import App, AppConfig, UpdateHandle
 from .update_stats import ComponentStats, UpdateSnapshot, UpdateStats, UpdateStatus
 from .pending_marker import ResolvesTo
@@ -91,6 +90,7 @@ from .function import (
     LogicTracking,
     create_core_component_processor,
     fn,
+    fn_ret_deserializer,
 )
 from .stable_path import Symbol
 from .target_state import (

--- a/python/cocoindex/_internal/app.py
+++ b/python/cocoindex/_internal/app.py
@@ -15,8 +15,12 @@ from typing import (
 
 from . import core
 from .environment import Environment, LazyEnvironment, _default_env
-from .function import AnyCallable, AsyncCallable, create_core_component_processor
-from .serde import fn_ret_deserializer
+from .function import (
+    AnyCallable,
+    AsyncCallable,
+    create_core_component_processor,
+    fn_ret_deserializer,
+)
 from .update_stats import (
     ComponentStats,
     UpdateSnapshot,

--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -578,6 +578,11 @@ class _BoundSyncMethod(Generic[SelfT]):
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self._func(self._instance, *args, **kwargs)
 
+    def _core_processor(
+        self, env: Environment, path: core.StablePath, *args: Any, **kwargs: Any
+    ) -> core.ComponentProcessor[Any]:
+        return self._func._core_processor(env, path, self._instance, *args, **kwargs)
+
     async def as_async(self, *args: Any, **kwargs: Any) -> Any:
         """Call this bound sync method wrapped in async (runs via asyncio.to_thread)."""
         return await asyncio.to_thread(self, *args, **kwargs)
@@ -641,6 +646,11 @@ class _BoundAsyncMethod(Generic[SelfT]):
 
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return await self._func(self._instance, *args, **kwargs)
+
+    def _core_processor(
+        self, env: Environment, path: core.StablePath, *args: Any, **kwargs: Any
+    ) -> core.ComponentProcessor[Any]:
+        return self._func._core_processor(env, path, self._instance, *args, **kwargs)
 
     async def as_async(self, *args: Any, **kwargs: Any) -> Any:
         """Call this bound async method (same as __call__)."""
@@ -1478,3 +1488,32 @@ def create_core_component_processor(
             kwargs,
             processor_info,
         )
+
+
+def fn_ret_deserializer(fn: typing.Any) -> DeserializeFn:
+    """Return a ``DeserializeFn`` that deserializes *fn*'s return type.
+
+    Zero upfront cost — all work is deferred to the first call.
+    For ``@coco.fn``-decorated functions the pre-built ``DeserializeFn`` is reused.
+    For plain functions the return-type annotation is inspected at call time.
+    """
+    # Unwrap bound methods to get the underlying Function object.
+    if isinstance(fn, (_BoundSyncMethod, _BoundAsyncMethod)):
+        fn = fn._func
+    fn_label = qualified_name(fn)
+
+    def _deserialize(data: bytes | memoryview) -> typing.Any:
+        cached: DeserializeFn | None = getattr(
+            fn, "_resolved_return_deserializer", None
+        )
+        if cached is not None:
+            return cached(data)
+        try:
+            hint = typing.get_type_hints(fn).get("return", typing.Any)
+        except Exception:
+            hint = typing.Any
+        return make_deserialize_fn(hint, source_label=f"return type of {fn_label}()")(
+            data
+        )
+
+    return _deserialize

--- a/python/cocoindex/_internal/serde.py
+++ b/python/cocoindex/_internal/serde.py
@@ -400,32 +400,6 @@ def deserialize(data: bytes, type_hint: Any = Any) -> Any:
     return _get_deserialize_fn(type_hint)(data)
 
 
-def fn_ret_deserializer(fn: Any) -> DeserializeFn:
-    """Return a ``DeserializeFn`` that deserializes *fn*'s return type.
-
-    Zero upfront cost — all work is deferred to the first call.
-    For ``@coco.fn``-decorated functions the pre-built ``DeserializeFn`` is reused.
-    For plain functions the return-type annotation is inspected at call time.
-    """
-    fn_label = qualified_name(fn)
-
-    def _deserialize(data: bytes | memoryview) -> Any:
-        cached: DeserializeFn | None = getattr(
-            fn, "_resolved_return_deserializer", None
-        )
-        if cached is not None:
-            return cached(data)
-        try:
-            hint = typing.get_type_hints(fn).get("return", Any)
-        except Exception:
-            hint = Any
-        return make_deserialize_fn(hint, source_label=f"return type of {fn_label}()")(
-            data
-        )
-
-    return _deserialize
-
-
 # ---------------------------------------------------------------------------
 # Type hint extraction helpers
 # ---------------------------------------------------------------------------

--- a/python/tests/core/mod_logic_method_v1.py
+++ b/python/tests/core/mod_logic_method_v1.py
@@ -1,0 +1,34 @@
+"""Module with v1 class method bodies for logic change detection testing.
+
+Tests that @coco.fn on class methods correctly participates in logic change
+detection when the bound method is used via mount() or called directly.
+"""
+
+import cocoindex as coco
+from tests.common.target_states import GlobalDictTarget, Metrics
+
+_metrics: Metrics | None = None
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+class Processor:
+    """A class with @coco.fn decorated methods."""
+
+    @coco.fn(memo=True)
+    def transform_memo(self, key: str, value: str) -> str:
+        assert _metrics is not None
+        _metrics.increment("transform_memo")
+        return "v1: " + value
+
+    @coco.fn(memo=True)
+    def declare_entry_memo(self, key: str, value: str) -> None:
+        assert _metrics is not None
+        _metrics.increment("declare_entry_memo")
+        coco.declare_target_state(GlobalDictTarget.target_state(key, "v1: " + value))
+
+
+processor = Processor()

--- a/python/tests/core/mod_logic_method_v2.py
+++ b/python/tests/core/mod_logic_method_v2.py
@@ -1,0 +1,33 @@
+"""Module with v2 class method bodies for logic change detection testing.
+
+The method bodies differ from v1 (return "v2: " instead of "v1: ").
+"""
+
+import cocoindex as coco
+from tests.common.target_states import GlobalDictTarget, Metrics
+
+_metrics: Metrics | None = None
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+class Processor:
+    """A class with @coco.fn decorated methods — v2 bodies."""
+
+    @coco.fn(memo=True)
+    def transform_memo(self, key: str, value: str) -> str:
+        assert _metrics is not None
+        _metrics.increment("transform_memo")
+        return "v2: " + value
+
+    @coco.fn(memo=True)
+    def declare_entry_memo(self, key: str, value: str) -> None:
+        assert _metrics is not None
+        _metrics.increment("declare_entry_memo")
+        coco.declare_target_state(GlobalDictTarget.target_state(key, "v2: " + value))
+
+
+processor = Processor()

--- a/python/tests/core/test_component_memo.py
+++ b/python/tests/core/test_component_memo.py
@@ -392,3 +392,110 @@ def test_memo_invalidation_on_decorator_change() -> None:
     # Cleanup fake module from sys.modules.
     if fake_module_name in sys.modules:
         del sys.modules[fake_module_name]
+
+
+# ============================================================================
+# Bound method memo tests — verifies that @coco.fn(memo=True) on a class method
+# is respected when the bound method is passed to mount() / use_mount().
+# ============================================================================
+
+
+class _MemoMethodComponent:
+    @coco.fn(memo=True)
+    def declare_entry(self, entry: SourceDataEntry) -> None:
+        _metrics.increment("calls")
+        coco.declare_target_state(
+            GlobalDictTarget.target_state(entry.name, entry.content)
+        )
+
+
+_memo_method_obj = _MemoMethodComponent()
+
+
+@coco.fn
+async def _mount_bound_method() -> None:
+    for entry in _source_data.values():
+        await coco.mount(
+            coco.component_subpath(entry.name), _memo_method_obj.declare_entry, entry
+        )
+
+
+def test_bound_method_memo_with_mount() -> None:
+    """@coco.fn(memo=True) on a bound method should be respected in mount()."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+    _metrics.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_bound_method_memo_mount", environment=coco_env),
+        _mount_bound_method,
+    )
+
+    _source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA1")
+    _source_data["B"] = SourceDataEntry(name="B", version=1, content="contentB1")
+    app.update_blocking()
+    assert _metrics.collect() == {"calls": 2}
+
+    # A unchanged (version=1), B changed (version=2) — A should be memoized.
+    _source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA2")
+    _source_data["B"] = SourceDataEntry(name="B", version=2, content="contentB2")
+    app.update_blocking()
+    assert _metrics.collect() == {"calls": 1}  # Only B re-executes
+
+
+class _MemoMethodReturnComponent:
+    @coco.fn(memo=True)
+    def declare_transform_entry(self, entry: SourceDataEntry) -> SourceDataResult:
+        _metrics.increment("calls")
+        coco.declare_target_state(
+            GlobalDictTarget.target_state(entry.name, entry.content)
+        )
+        return SourceDataResult(name=entry.name, content=entry.content)
+
+
+_memo_method_return_obj = _MemoMethodReturnComponent()
+
+
+@coco.fn
+async def _use_mount_bound_method() -> list[SourceDataResult]:
+    results: list[SourceDataResult] = []
+    for name in sorted(_source_data):
+        entry = _source_data[name]
+        result = await coco.use_mount(
+            coco.component_subpath(entry.name),
+            _memo_method_return_obj.declare_transform_entry,
+            entry,
+        )
+        results.append(result)
+    return results
+
+
+def test_bound_method_memo_with_use_mount() -> None:
+    """@coco.fn(memo=True) on a bound method should be respected in use_mount()."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+    _metrics.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_bound_method_memo_use_mount", environment=coco_env),
+        _use_mount_bound_method,
+    )
+
+    _source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA1")
+    _source_data["B"] = SourceDataEntry(name="B", version=1, content="contentB1")
+    ret1 = app.update_blocking()
+    assert _metrics.collect() == {"calls": 2}
+    assert ret1 == [
+        SourceDataResult(name="A", content="contentA1"),
+        SourceDataResult(name="B", content="contentB1"),
+    ]
+
+    # A unchanged, B changed — A should return cached result.
+    _source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA2")
+    _source_data["B"] = SourceDataEntry(name="B", version=2, content="contentB2")
+    ret2 = app.update_blocking()
+    assert _metrics.collect() == {"calls": 1}  # Only B re-executes
+    assert ret2 == [
+        SourceDataResult(name="A", content="contentA1"),  # Cached
+        SourceDataResult(name="B", content="contentB2"),
+    ]

--- a/python/tests/core/test_function_memo.py
+++ b/python/tests/core/test_function_memo.py
@@ -792,3 +792,53 @@ def test_memo_with_runner_async() -> None:
     # No changes - everything should be memoized
     app.update_blocking()
     assert _metrics.collect() == {}
+
+
+# ============================================================================
+# Bound method memo tests — verifies that @coco.fn(memo=True) on a class method
+# is respected when the bound method is called directly (function-level memo).
+# ============================================================================
+
+
+class _MemoMethodTransformer:
+    @coco.fn(memo=True)
+    def transform(self, entry: SourceDataEntry) -> str:
+        _metrics.increment("call.bound_transform")
+        return f"bound: {entry.content}"
+
+
+_memo_transformer = _MemoMethodTransformer()
+
+
+@coco.fn
+def _process_with_bound_method() -> None:
+    for key, value in _plain_source_data.items():
+        transformed_value = _memo_transformer.transform(value)
+        coco.declare_target_state(GlobalDictTarget.target_state(key, transformed_value))
+
+
+def test_memo_bound_method() -> None:
+    """@coco.fn(memo=True) on a bound method should memoize when called directly."""
+    GlobalDictTarget.store.clear()
+    _plain_source_data.clear()
+    _metrics.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_memo_bound_method", environment=coco_env),
+        _process_with_bound_method,
+    )
+
+    _plain_source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA1")
+    _plain_source_data["B"] = SourceDataEntry(name="B", version=1, content="contentB1")
+    app.update_blocking()
+    assert _metrics.collect() == {"call.bound_transform": 2}
+
+    # A unchanged (version=1), B changed (version=2) — A should be memoized.
+    _plain_source_data["A"] = SourceDataEntry(name="A", version=1, content="contentA2")
+    _plain_source_data["B"] = SourceDataEntry(name="B", version=2, content="contentB2")
+    app.update_blocking()
+    assert _metrics.collect() == {"call.bound_transform": 1}  # Only B re-executes
+
+    # No changes - everything should be memoized.
+    app.update_blocking()
+    assert _metrics.collect() == {}

--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -33,6 +33,8 @@ _NONE_V2_PATH = str(_TEST_DIR / "mod_logic_none_v2.py")
 _CHAIN_V1_PATH = str(_TEST_DIR / "mod_logic_chain_v1.py")
 _CHAIN_V2_PATH = str(_TEST_DIR / "mod_logic_chain_v2.py")
 _CHAIN_V3_PATH = str(_TEST_DIR / "mod_logic_chain_v3.py")
+_METHOD_V1_PATH = str(_TEST_DIR / "mod_logic_method_v1.py")
+_METHOD_V2_PATH = str(_TEST_DIR / "mod_logic_method_v2.py")
 _FAKE_MODULE = "tests.core._dynamic_logic_change_module"
 
 
@@ -43,6 +45,13 @@ def _unload_module_functions(mod: ModuleType) -> None:
         fp = getattr(obj, "_logic_fp", None)
         if fp is not None:
             core.unregister_logic_fingerprint(fp)
+        # Also scan class attributes for @coco.fn decorated methods.
+        if isinstance(obj, type):
+            for cls_attr_name in dir(obj):
+                cls_obj = getattr(obj, cls_attr_name, None)
+                cls_fp = getattr(cls_obj, "_logic_fp", None)
+                if cls_fp is not None:
+                    core.unregister_logic_fingerprint(cls_fp)
 
 
 def _load_module(
@@ -706,3 +715,94 @@ def test_transitive_full_self_plain_baz_changes() -> None:
     assert metrics.collect() == {}
     # Still has v1 output since foo memo was reused
     assert GlobalDictTarget.store.data["A"].data == "baz_v1: value1"
+
+
+# ============================================================================
+# Bound method — fn memo invalidated on logic change
+# ============================================================================
+
+
+def test_bound_method_fn_memo_invalidated_on_logic_change() -> None:
+    """A @coco.fn(memo=True) bound method's cached result is invalidated when code changes."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+
+    @coco.fn
+    def app_main() -> None:
+        mod = current_module[0]
+        result = mod.processor.transform_memo("A", "value1")
+        coco.declare_target_state(GlobalDictTarget.target_state("A", result))
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_bound_method_fn_memo_logic_change", environment=coco_env
+        ),
+        app_main,
+    )
+
+    # v1: first run — method executes
+    mod = _load_module(_METHOD_V1_PATH, metrics, current_module)
+    app.update_blocking()
+    assert metrics.collect() == {"transform_memo": 1}
+    assert GlobalDictTarget.store.data["A"].data == "v1: value1"
+
+    # v1: second run — memo hit
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # v2: logic changed — memo invalidated, method re-executes
+    mod = _load_module(_METHOD_V2_PATH, metrics, current_module, old_module=mod)
+    app.update_blocking()
+    assert metrics.collect() == {"transform_memo": 1}
+    assert GlobalDictTarget.store.data["A"].data == "v2: value1"
+
+    # v2: second run — memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+# ============================================================================
+# Bound method — component memo invalidated on logic change
+# ============================================================================
+
+
+def test_bound_method_component_memo_invalidated_on_logic_change() -> None:
+    """A @coco.fn(memo=True) bound method's component memo is invalidated when code changes."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+
+    @coco.fn
+    async def app_main() -> None:
+        mod = current_module[0]
+        await coco.mount(
+            coco.component_subpath("A"), mod.processor.declare_entry_memo, "A", "value1"
+        )
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_bound_method_component_memo_logic_change", environment=coco_env
+        ),
+        app_main,
+    )
+
+    # v1: first run — component executes
+    mod = _load_module(_METHOD_V1_PATH, metrics, current_module)
+    app.update_blocking()
+    assert metrics.collect() == {"declare_entry_memo": 1}
+    assert GlobalDictTarget.store.data["A"].data == "v1: value1"
+
+    # v1: second run — component memo hit
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # v2: logic changed — component memo invalidated
+    mod = _load_module(_METHOD_V2_PATH, metrics, current_module, old_module=mod)
+    app.update_blocking()
+    assert metrics.collect() == {"declare_entry_memo": 1}
+    assert GlobalDictTarget.store.data["A"].data == "v2: value1"
+
+    # v2: second run — component memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}


### PR DESCRIPTION
## Summary
- Fix `@coco.fn(memo=True)` on class methods: add `_core_processor` delegation to `_BoundSyncMethod` and `_BoundAsyncMethod` so memoization and logic change detection work correctly when bound methods are passed to `mount()`/`use_mount()`
- Fix `fn_ret_deserializer` to unwrap bound methods for correct return type deserialization of cached values
- Move `fn_ret_deserializer` from `serde.py` to `function.py` where it belongs (tightly coupled with function internals)

## Test plan
- 5 new tests added covering bound method memo with mount, use_mount, direct call, and logic change detection
- All 469 existing + new tests pass, mypy clean
