### PR TITLE
feat: LiveItemsView helpers for mount_each and localfs live watching

### DIFF
--- a/docs/docs/advanced_topics/live_component.md
+++ b/docs/docs/advanced_topics/live_component.md
@@ -147,38 +147,57 @@ class ProcessAll:
 
 The key difference: the LiveComponent version can later be extended to handle incremental changes in `process_live()` without changing `process()`.
 
-## Live mode
+## LiveItemsView {#liveitems-view}
 
-Live mode controls whether `process_live()` continues running after `mark_ready()`.
+:::tip
+For a user-facing introduction to live mode and when to use it, see [Live Mode](../programming_guide/live_mode.md). This section covers the protocol details for connector authors and advanced use cases.
+:::
 
-### Enabling live mode
+`LiveItemsView` is a protocol for keyed collections that support both iteration and live change watching. When `mount_each()` receives a `LiveItemsView` as its `items` argument, it automatically creates an internal `LiveComponent`.
 
 ```python
-# Programmatic
-app.update_blocking(live=True)
-
-# Or async
-handle = app.update(live=True)
-await handle.result()
+class LiveItemsView(Protocol[K, V]):
+    def __aiter__(self) -> AsyncIterator[tuple[K, V]]: ...
+    async def watch(self, subscriber: LiveItemsSubscriber[K, V]) -> None: ...
 ```
 
-```bash
-# CLI
-cocoindex update --live my_app.py
-# or
-cocoindex update -L my_app.py
+- **`__aiter__`** yields all `(key, value)` pairs — used for full scans (called inside the internal `process()`).
+- **`watch(subscriber)`** is the long-running entry point — analogous to `process_live(operator)`. It controls the full lifecycle: initial scan, readiness, and incremental updates.
+
+### LiveItemsSubscriber
+
+The `subscriber` passed to `watch()` mirrors `LiveComponentOperator`:
+
+| LiveItemsSubscriber | LiveComponentOperator | Description |
+|---|---|---|
+| `await subscriber.update_all()` | `await operator.update_full()` | Full re-scan of all items |
+| `await subscriber.mark_ready()` | `await operator.mark_ready()` | Signal readiness |
+| `await subscriber.update(key, value)` | `await operator.update(subpath, fn, ...)` | Incremental update; returns `ComponentMountHandle` |
+| `await subscriber.delete(key)` | `await operator.delete(subpath)` | Incremental delete; returns `ComponentMountHandle` |
+
+A typical `watch()` implementation:
+
+```python
+async def watch(self, subscriber: LiveItemsSubscriber[K, V]) -> None:
+    await subscriber.update_all()     # initial full scan
+    await subscriber.mark_ready()     # signal readiness
+    # ... watch for changes and call subscriber.update()/delete() ...
 ```
 
-### Propagation
+### Implementing LiveItemsView for a connector
 
-- `coco.mount()` and `operator.update()` inherit `live` from the parent.
-- `coco.use_mount()` always sets children as non-live.
+To add live support to a source connector, make its `items()` method return an object that implements `LiveItemsView` when live mode is requested. See the `localfs` connector's `DirWalker` for a reference implementation — `walk_dir(..., live=True).items()` returns a `LiveItemsView` backed by `watchfiles`.
 
-### Non-live mode behavior
+## Live mode
 
-When `live=False` (the default), `process_live()` is still called, but it terminates as soon as `mark_ready()` is awaited. No code after `await operator.mark_ready()` executes. This means a live component in non-live mode behaves like a traditional component: it does a full update, signals ready, and stops.
+See [Live Mode](../programming_guide/live_mode.md) for enabling live mode and an overview of how it works.
 
-This design lets you use the same LiveComponent class in both modes without code changes.
+In the context of a manual `LiveComponent`, live mode controls whether `process_live()` continues running after `mark_ready()`:
+
+- **Live mode** (`live=True`): `process_live()` continues after `mark_ready()` — the component keeps watching for changes.
+- **Non-live mode** (`live=False`, default): `process_live()` terminates as soon as `mark_ready()` is awaited. No code after `await operator.mark_ready()` executes.
+
+This lets you use the same `LiveComponent` class in both modes without code changes.
 
 ## Restrictions
 
@@ -186,9 +205,13 @@ This design lets you use the same LiveComponent class in both modes without code
 
 `process()` may only call `coco.mount()` (background child mounts). Any setup that requires `use_mount()` — such as declaring target tables — must be done in the **parent** component before mounting the LiveComponent. This keeps the controller's provider set stable across full and incremental updates.
 
-### Not allowed in `use_mount()` or `mount_each()`
+### Not allowed in `use_mount()`
 
-LiveComponent classes can only be used with `coco.mount()` and `operator.update()`. Passing a LiveComponent class to `coco.use_mount()` or `coco.mount_each()` raises a `TypeError`.
+LiveComponent classes can only be used with `coco.mount()` and `operator.update()`. Passing a LiveComponent class to `coco.use_mount()` raises a `TypeError`.
+
+:::tip
+While LiveComponent classes cannot be passed to `mount_each()`, you can get live watching behavior more easily using a [`LiveItemsView`](#liveitems-view) — `mount_each()` automatically creates an internal LiveComponent when it detects one.
+:::
 
 ## Readiness
 

--- a/docs/docs/connectors/localfs.md
+++ b/docs/docs/connectors/localfs.md
@@ -73,6 +73,7 @@ Use `walk_dir()` to iterate over files in a directory. It returns a `DirWalker` 
 def walk_dir(
     path: FilePath | Path | ContextKey[Path],
     *,
+    live: bool = False,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
 ) -> DirWalker
@@ -81,6 +82,7 @@ def walk_dir(
 **Parameters:**
 
 - `path` — The root directory path to walk through. Can be a `FilePath`, a `pathlib.Path`, or a `ContextKey[Path]` (equivalent to `FilePath(base_dir=path)`).
+- `live` — If `True`, `items()` returns a [`LiveItemsView`](../advanced_topics/live_component.md#liveitems-view) that supports live file watching via `mount_each()`.
 - `recursive` — If `True`, recursively walk subdirectories.
 - `path_matcher` — Optional filter for files and directories. See [PatternFilePathMatcher](../resource_types.md#patternfilepathmatcher).
 
@@ -124,6 +126,21 @@ matcher = PatternFilePathMatcher(
 async for file in localfs.walk_dir("/path/to/project", recursive=True, path_matcher=matcher):
     await process(file)
 ```
+
+### Live file watching
+
+When `live=True`, `items()` returns a [`LiveItemsView`](../advanced_topics/live_component.md#liveitems-view) instead of a plain `AsyncIterable`. Combined with [`mount_each()`](../programming_guide/processing_component.md#mount-each), this enables automatic incremental file watching — new, modified, and deleted files are processed without a full rescan:
+
+```python
+files = localfs.walk_dir(
+    sourcedir, recursive=True,
+    path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+    live=True,
+)
+await coco.mount_each(process_file, files.items(), target)
+```
+
+See [Live Mode](../programming_guide/live_mode.md) for how this works and how to enable it on the app.
 
 ### Example
 

--- a/docs/docs/programming_guide/app.md
+++ b/docs/docs/programming_guide/app.md
@@ -56,6 +56,7 @@ result = app.update_blocking()
 
 **Parameters:**
 
+- `live` option keeps the app running after the initial scan so live components can continue watching for changes. See [Live Mode](./live_mode.md).
 - `report_to_stdout` option prints periodic progress updates during execution.
 - `full_reprocess` option reprocesses everything and invalidates existing caches. This forces all components to re-execute and all target states to be re-applied, even if they haven't changed.
 
@@ -257,7 +258,7 @@ Run your app once to sync all target states:
 cocoindex update main.py
 ```
 
-This executes your pipeline and applies all declared target states to external systems.
+This executes your pipeline and applies all declared target states to external systems. Add `--live` (or `-L`) to keep the app running and react to source changes continuously — see [Live Mode](./live_mode.md).
 
 ### Drop an app
 

--- a/docs/docs/programming_guide/live_mode.md
+++ b/docs/docs/programming_guide/live_mode.md
@@ -96,7 +96,7 @@ app = coco.App(coco.AppConfig(name="FilesTransform"), app_main, sourcedir=..., o
 app.update_blocking(live=True)
 ```
 
-For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/main/examples/files_transform).
+For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/files_transform).
 
 ## Going deeper
 

--- a/docs/docs/programming_guide/live_mode.md
+++ b/docs/docs/programming_guide/live_mode.md
@@ -1,0 +1,109 @@
+---
+title: Live Mode
+description: Make your app react to source changes continuously, instead of only processing in full sweeps.
+---
+
+# Live Mode
+
+By default, calling `app.update()` runs a full processing cycle — it scans all sources, processes everything, syncs target states, and returns. To process again, you call `update()` again.
+
+**Live mode** keeps the app running after the initial scan, so components can watch for changes and process them incrementally — without rescanning everything. This is useful when:
+
+- You have a large dataset and only a few items change at a time
+- You want near-real-time reactions to source changes (e.g., file system watcher, database change feed)
+
+Two things are needed for live mode to work: the app must be **enabled** to stay running, and somewhere in the component tree a component must **react** to changes.
+
+## Enabling live mode
+
+Pass `live=True` when updating the app:
+
+```python
+app.update_blocking(live=True)
+
+# Or async
+handle = app.update(live=True)
+await handle.result()
+```
+
+From the CLI:
+
+```bash
+cocoindex update --live my_app.py
+# or
+cocoindex update -L my_app.py
+```
+
+The `live` flag propagates top-down through the component tree:
+
+- **`coco.mount()`** inherits `live` from the parent — children are live when the app is live.
+- **`coco.use_mount()`** always sets children as non-live. Since the parent waits for the return value, the child must complete and can't keep running independently.
+
+Without `live=True` on the app, everything completes after the initial scan — even if a source supports live watching.
+
+## Reacting to changes
+
+Enabling live mode keeps the app running, but something in the component tree needs to actually watch for changes. That something is a [**LiveComponent**](../advanced_topics/live_component.md) — a component with a long-running `process_live()` method that delivers incremental updates.
+
+You rarely need to write a `LiveComponent` manually. The most common pattern is:
+
+### Sources with `LiveItemsView`
+
+Some source connectors can provide a [`LiveItemsView`](../advanced_topics/live_component.md#liveitems-view) — a collection that can be iterated for a full scan *and* watched for changes. When `mount_each()` receives a `LiveItemsView`, it automatically creates a `LiveComponent` internally:
+
+```python
+@coco.fn
+async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
+    files = localfs.walk_dir(
+        sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,  # source provides LiveItemsView when live
+    )
+    await coco.mount_each(process_file, files.items(), outdir)  # outdir passed to process_file
+```
+
+The internally created `LiveComponent`:
+
+1. **Full scan** — iterates all items and mounts a processing component for each
+2. **Signals readiness** — the initial scan is complete, target states are synced
+3. **Watches for changes** — the source delivers incremental updates:
+   - New or modified items → re-mount the affected component
+   - Deleted items → remove the component and its target states
+
+CocoIndex handles change detection, memoization, and target state reconciliation the same way as in batch mode.
+
+Without live support on the source, `mount_each()` does a one-time iteration — items are processed in batch and that's it.
+
+**Non-live compatibility:** Live-capable sources work in non-live mode too — they do the initial full scan and exit cleanly, no watching occurs. This means you can write your pipeline once and choose batch or live at run time.
+
+How live mode is activated varies by connector — some use a flag, others may require external configuration (e.g., subscribing to a change notification service). Check each connector's documentation for details.
+
+## Example: `localfs` with live file watching
+
+The [`localfs`](../connectors/localfs.md) connector supports live mode via `walk_dir(..., live=True)`, which watches for file system changes using `watchfiles`. Here's a pipeline that transforms Markdown files to HTML and reacts to file changes:
+
+```python
+@coco.fn
+async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
+    files = localfs.walk_dir(
+        sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,
+    )
+    await coco.mount_each(process_file, files.items(), outdir)
+
+app = coco.App(coco.AppConfig(name="FilesTransform"), app_main, sourcedir=..., outdir=...)
+app.update_blocking(live=True)
+```
+
+For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/main/examples/files_transform).
+
+## Going deeper
+
+The abstractions behind live mode, from most general to most specific:
+
+- **[LiveComponent](../advanced_topics/live_component.md)** — the underlying protocol for components that react to changes incrementally. Most flexible — full control over the lifecycle.
+- **[LiveItemsView](../advanced_topics/live_component.md#liveitems-view)** — represents a changing collection of keyed items. `mount_each()` uses it to construct a `LiveComponent` automatically. Connector authors implement this to add live support.
+- **Source connectors** (e.g., `localfs.walk_dir(live=True)`) — provide `LiveItemsView` from their `items()` method. Users just flip a flag.
+
+For custom change feeds, fine-grained lifecycle control, or implementing `LiveItemsView` on your own connector, see [Live Components](../advanced_topics/live_component.md).

--- a/docs/docs/programming_guide/processing_component.md
+++ b/docs/docs/programming_guide/processing_component.md
@@ -92,16 +92,17 @@ files = localfs.walk_dir(sourcedir, path_matcher=PatternFilePathMatcher(included
 await coco.mount_each(process_file, files.items(), target)
 ```
 
-Each item in the iterable is a `(key, value)` tuple. The key becomes the component subpath, and the value is passed as the first argument to the function. Any additional arguments are passed through.
+Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an auto-derived subpath (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
 
-This is equivalent to:
+You can provide an explicit subpath as the first argument:
 
 ```python
-for key, file in files.items():
-    await coco.mount(coco.component_subpath(key), process_file, file, target)
+await coco.mount_each(coco.component_subpath("files"), process_file, files.items(), target)
 ```
 
 Source connectors provide an `items()` method that returns `(StableKey, T)` pairs. For example, `localfs.walk_dir(...).items()` yields `(relative_path, File)` tuples.
+
+When a source connector supports live watching, its `items()` returns a `LiveItemsView` instead of a plain iterable. `mount_each()` detects this and automatically handles incremental updates — no changes to `mount_each()` itself are needed. See [Live Mode](./live_mode.md).
 
 ### `mount_target()` {#mount-target}
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         'programming_guide/function',
         'programming_guide/processing_helpers',
         'programming_guide/app',
+        'programming_guide/live_mode',
         'programming_guide/context',
       ],
     },

--- a/examples/files_transform/main.py
+++ b/examples/files_transform/main.py
@@ -18,7 +18,9 @@ async def process_file(file: FileLike, outdir: pathlib.Path) -> None:
 @coco.fn
 async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
     files = localfs.walk_dir(
-        sourcedir, path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"])
+        sourcedir,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,
     )
     await coco.mount_each(process_file, files.items(), outdir)
 

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -102,6 +102,9 @@ from .target_state import (
 from .live_component import (
     LiveComponent,
     LiveComponentOperator,
+    LiveItemsView,
+    LiveItemsSubscriber,
+    _MountEachLiveComponent,
     is_live_component_class,
 )
 
@@ -263,15 +266,9 @@ async def use_mount(
 async def _mount_live_component(
     parent_ctx: ComponentContext,
     child_path: core.StablePath,
-    cls: Any,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
+    instance: Any,
 ) -> ComponentMountHandle:
-    """Mount a LiveComponent class."""
-    instance = cls(*args, **kwargs)
-
-    # Create controller via Rust.
-    # mount_live_async returns (LiveComponentController, ComponentMountHandle).
+    """Mount a pre-constructed LiveComponent instance."""
     controller, readiness_handle = await core.mount_live_async(
         child_path,
         parent_ctx._core_processor_ctx,
@@ -281,8 +278,6 @@ async def _mount_live_component(
 
     operator = LiveComponentOperator(controller, instance, parent_ctx._env, child_path)
 
-    # Start process_live via Rust (handles cancellation, error handling,
-    # ensure_mark_ready).
     process_live_coro = instance.process_live(operator)
     controller.start(process_live_coro)
 
@@ -317,9 +312,8 @@ async def mount(
     child_path = build_child_path(parent_ctx, subpath)
 
     if is_live_component_class(processor_fn):
-        return await _mount_live_component(
-            parent_ctx, child_path, processor_fn, args, kwargs
-        )
+        instance = processor_fn(*args, **kwargs)
+        return await _mount_live_component(parent_ctx, child_path, instance)
 
     processor = create_core_component_processor(
         processor_fn, parent_ctx._env, child_path, args, kwargs
@@ -346,35 +340,69 @@ async def mount(
     return ComponentMountHandle([core_handle])
 
 
+_ItemsType = (
+    Iterable[tuple[StableKey, T]]
+    | AsyncIterable[tuple[StableKey, T]]
+    | LiveItemsView[StableKey, T]
+)
+
+
+@overload
 async def mount_each(
+    subpath: ComponentSubpath,
     fn: AnyCallable[Concatenate[T, P], Any],
-    items: Iterable[tuple[StableKey, T]] | AsyncIterable[tuple[StableKey, T]],
+    items: _ItemsType[T],
     *args: P.args,
     **kwargs: P.kwargs,
-) -> ComponentMountHandle:
+) -> ComponentMountHandle: ...
+
+
+@overload
+async def mount_each(
+    fn: AnyCallable[Concatenate[T, P], Any],
+    items: _ItemsType[T],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> ComponentMountHandle: ...
+
+
+async def mount_each(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
     """
     Mount one independent component per item in a keyed iterable.
 
-    Sugar over a loop of mount() calls. Each item's key is used as the component subpath.
-    Accepts both sync and async iterables; prefers async iteration when available.
+    Accepts an optional ``ComponentSubpath`` as the first argument. When omitted,
+    the subpath is auto-derived from ``Symbol(fn.__name__)``.
+
+    When *items* is a ``LiveItemsView``, an internal ``LiveComponent`` is created
+    to handle live watching automatically.
 
     Args:
+        subpath: Optional component subpath. Auto-derived from fn.__name__ when omitted.
         fn: The function to run for each item. The item value is passed as the first argument.
-        items: A keyed iterable of (key, value) pairs (sync or async). The key becomes the
-            component subpath.
+        items: A keyed iterable of (key, value) pairs, or a LiveItemsView for live mode.
         *args: Additional arguments passed to fn after the item value.
         **kwargs: Additional keyword arguments passed to fn.
 
     Returns:
         A handle that can be used to wait until all processing units are ready.
-
-    Example:
-        await coco.mount_each(process_file, files.items(), target_table)
-
-        # Equivalent to:
-        # for key, item in files.items():
-        #     coco.mount(coco.component_subpath(key), process_file, item, target_table)
     """
+    if pos_args and isinstance(pos_args[0], ComponentSubpath):
+        subpath = pos_args[0]
+        fn = pos_args[1]
+        items = pos_args[2]
+        extra_args = pos_args[3:]
+    else:
+        fn = pos_args[0]
+        items = pos_args[1]
+        extra_args = pos_args[2:]
+        name = getattr(fn, "__name__", None)
+        if name is None:
+            raise TypeError(
+                "mount_each() requires a ComponentSubpath when the function has no "
+                "__name__. Provide an explicit subpath as the first argument."
+            )
+        subpath = ComponentSubpath(Symbol(name))
+
     if is_live_component_class(fn):
         raise TypeError(
             "LiveComponent classes cannot be used with mount_each(). "
@@ -382,18 +410,24 @@ async def mount_each(
         )
 
     parent_ctx = get_context_from_ctx()
+    child_path = build_child_path(parent_ctx, subpath)
+
+    if isinstance(items, LiveItemsView):
+        instance = _MountEachLiveComponent(items, fn, extra_args, kwargs)
+        return await _mount_live_component(parent_ctx, child_path, instance)
+
     core_handles: list[core.ComponentMountHandle] = []
 
     async def _mount_one(key: StableKey, item: Any) -> None:
-        child_path = build_child_path(parent_ctx, ComponentSubpath(key))
+        item_path = child_path.concat(key)
         processor = create_core_component_processor(
-            fn, parent_ctx._env, child_path, (item, *args), kwargs
+            fn, parent_ctx._env, item_path, (item, *extra_args), kwargs
         )
         resolved = (
             _resolve_handler(
                 parent_ctx._exception_handler_chain,
                 env_name=parent_ctx._env.name,
-                stable_path=child_path.to_string(),
+                stable_path=item_path.to_string(),
                 processor_name=getattr(fn, "__qualname__", None),
                 mount_kind="mount_each",
                 parent_stable_path=parent_ctx._core_path.to_string(),
@@ -403,7 +437,7 @@ async def mount_each(
         )
         core_handle = await core.mount_async(
             processor,
-            child_path,
+            item_path,
             parent_ctx._core_processor_ctx,
             parent_ctx._core_fn_call_ctx,
             resolved,
@@ -626,6 +660,8 @@ __all__ = [
     # .live_component
     "LiveComponent",
     "LiveComponentOperator",
+    "LiveItemsView",
+    "LiveItemsSubscriber",
     # Mount APIs
     "ComponentMountHandle",
     "mount",

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
-from typing import Any, ParamSpec, runtime_checkable, Protocol
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import (
+    Any,
+    Generic,
+    ParamSpec,
+    TypeVar,
+    runtime_checkable,
+    Protocol,
+    TYPE_CHECKING,
+)
 
 from . import core
 from .component_ctx import ComponentSubpath
 from .function import AnyCallable, create_core_component_processor
 from .environment import Environment
 
+if TYPE_CHECKING:
+    from .api import ComponentMountHandle
+
 _P = ParamSpec("_P")
+_K = TypeVar("_K")
+_V = TypeVar("_V")
 
 
 @runtime_checkable
@@ -88,3 +102,88 @@ class LiveComponentOperator:
     async def mark_ready(self) -> None:
         """Signal readiness. In non-live mode, this never returns (terminates process_live)."""
         await self._controller.mark_ready_async()
+
+
+@runtime_checkable
+class LiveItemsView(Protocol[_K, _V]):
+    """A keyed items view that can be iterated and watched for live changes.
+
+    Returned by sources like ``LiveDirWalker.items()`` and consumed by ``mount_each()``.
+    """
+
+    def __aiter__(self) -> AsyncIterator[tuple[_K, _V]]: ...
+    async def watch(self, subscriber: LiveItemsSubscriber[_K, _V]) -> None: ...
+
+
+class LiveItemsSubscriber(Generic[_K, _V]):
+    """Callback interface for ``LiveItemsView.watch()`` to deliver changes.
+
+    Wraps a ``LiveComponentOperator`` at a higher level of abstraction — callers
+    provide keys and values instead of component subpaths and processor functions.
+    """
+
+    __slots__ = ("_operator", "_fn", "_args", "_kwargs")
+
+    def __init__(
+        self,
+        operator: LiveComponentOperator,
+        fn: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        self._operator = operator
+        self._fn = fn
+        self._args = args
+        self._kwargs = kwargs
+
+    async def update_all(self) -> None:
+        """Trigger a full re-iteration of all items."""
+        await self._operator.update_full()
+
+    async def mark_ready(self) -> None:
+        """Signal readiness. In non-live mode, this terminates ``watch()``."""
+        await self._operator.mark_ready()
+
+    async def update(self, key: _K, value: _V) -> ComponentMountHandle:
+        """Incrementally update a single entry."""
+        return await self._operator.update(  # type: ignore[no-any-return]
+            ComponentSubpath(key),  # type: ignore[arg-type]
+            self._fn,
+            value,
+            *self._args,
+            **self._kwargs,
+        )
+
+    async def delete(self, key: _K) -> ComponentMountHandle:
+        """Incrementally delete a single entry."""
+        return await self._operator.delete(ComponentSubpath(key))  # type: ignore[no-any-return,arg-type]
+
+
+class _MountEachLiveComponent:
+    """Internal LiveComponent created by mount_each() for LiveItemsView items."""
+
+    def __init__(
+        self,
+        items: LiveItemsView[Any, Any],
+        fn: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        self._items = items
+        self._fn = fn
+        self._args = args
+        self._kwargs = kwargs
+
+    async def process(self) -> None:
+        from .api import mount
+
+        async for key, value in self._items:
+            await mount(
+                ComponentSubpath(key), self._fn, value, *self._args, **self._kwargs
+            )  # type: ignore[arg-type]
+
+    async def process_live(self, operator: LiveComponentOperator) -> None:
+        subscriber: LiveItemsSubscriber[Any, Any] = LiveItemsSubscriber(
+            operator, self._fn, self._args, self._kwargs
+        )
+        await self._items.watch(subscriber)

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
+from collections.abc import AsyncIterable as _AsyncIterable
 from typing import AsyncIterator, Iterator
 
 import pathlib
@@ -18,6 +19,7 @@ from cocoindex.resources.file import (
 )
 
 from cocoindex._internal.context_keys import ContextKey
+from cocoindex._internal.live_component import LiveItemsSubscriber
 
 from ._common import FilePath, to_file_path
 
@@ -66,24 +68,30 @@ class File(_file.FileLike[pathlib.Path]):
 class DirWalker:
     """An async directory walker.
 
-    Use as an async iterator to get `File` objects::
+    Use as an async iterator to get ``File`` objects::
 
         async for file in walk_dir(path):
             content = await file.read()
+
+    When ``live=True``, ``items()`` returns a ``LiveItemsView`` that supports
+    live file watching via ``mount_each()``.
     """
 
     _root_path: FilePath
     _recursive: bool
     _path_matcher: FilePathMatcher
+    _live: bool
 
     def __init__(
         self,
         path: FilePath | Path | ContextKey[Path],
         *,
+        live: bool = False,
         recursive: bool = False,
         path_matcher: FilePathMatcher | None = None,
     ) -> None:
         self._root_path = to_file_path(path)
+        self._live = live
         self._recursive = recursive
         self._path_matcher = path_matcher or MatchAllFilePathMatcher()
 
@@ -136,16 +144,18 @@ class DirWalker:
             # Add subdirectories in reverse order to maintain consistent traversal
             dirs_to_process.extend(reversed(subdirs))
 
-    async def items(self) -> AsyncIterator[tuple[str, File]]:
-        """Async iterate over (key, file) pairs for use with mount_each().
+    def items(self) -> _AsyncIterable[tuple[str, File]]:
+        """Return keyed ``(relative_path, File)`` pairs for use with ``mount_each()``.
 
-        The key is the file's relative path within the walked directory.
-
-        Example::
-
-            async for key, file in walker.items():
-                content = await file.read()
+        When ``live=True``, returns a ``LiveItemsView`` that supports live watching.
+        Otherwise returns a plain ``AsyncIterable``.
         """
+        if self._live:
+            return _LiveDirItems(self)
+        return self._items_iter()
+
+    async def _items_iter(self) -> AsyncIterator[tuple[str, File]]:
+        """Async iterate over (key, file) pairs (non-live path)."""
         root_path = self._root_path.path
         async for file in self:
             yield (file.file_path.path.relative_to(root_path).as_posix(), file)
@@ -158,21 +168,87 @@ class DirWalker:
             yield file
 
 
+class _LiveDirItems:
+    """``LiveItemsView`` returned by ``DirWalker.items()`` when ``live=True``."""
+
+    def __init__(self, walker: DirWalker) -> None:
+        self._walker = walker
+        self._resolved_root = walker._root_path.resolve()
+
+    def __aiter__(self) -> AsyncIterator[tuple[str, File]]:
+        return self._aiter_impl()
+
+    async def _aiter_impl(self) -> AsyncIterator[tuple[str, File]]:
+        async for pair in self._walker._items_iter():
+            yield pair
+
+    async def watch(self, subscriber: LiveItemsSubscriber[str, File]) -> None:
+        import watchfiles
+
+        # Initial full scan and readiness signal
+        await subscriber.update_all()
+        await subscriber.mark_ready()
+
+        # Incremental changes
+        root_resolved = self._resolved_root
+
+        async for changes in watchfiles.awatch(
+            root_resolved,
+            recursive=self._walker._recursive,
+            watch_filter=None,
+        ):
+            for change_type, changed_path_str in changes:
+                changed_path = Path(changed_path_str)
+                try:
+                    relative = changed_path.relative_to(root_resolved)
+                except ValueError:
+                    continue
+
+                key = relative.as_posix()
+
+                if change_type == watchfiles.Change.deleted:
+                    if self._walker._path_matcher.is_file_included(relative):
+                        handle = await subscriber.delete(key)
+                        await handle.ready()
+                    # Directory move: watchfiles may not decompose into
+                    # individual file events, so trigger a full rescan.
+                    elif not changed_path.exists():
+                        await subscriber.update_all()
+                    continue
+
+                if changed_path.is_dir():
+                    continue
+                if not self._walker._path_matcher.is_file_included(relative):
+                    continue
+
+                file_path = self._walker._root_path / relative
+                try:
+                    stat = changed_path.stat()
+                except OSError:
+                    continue
+                file = File(file_path, _stat=stat)
+                handle = await subscriber.update(key, file)
+                await handle.ready()
+
+
 def walk_dir(
     path: FilePath | Path | ContextKey[Path],
     *,
+    live: bool = False,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
 ) -> DirWalker:
     """
     Walk through a directory and yield file entries.
 
-    Returns a DirWalker that supports async iteration, yielding `File` objects
-    with async read methods.
+    Returns a ``DirWalker`` that supports async iteration, yielding ``File``
+    objects with async read methods.
 
     Args:
         path: The root directory path to walk through. Can be a FilePath (with stable
             base directory key) or a pathlib.Path (uses CWD as base directory).
+        live: If True, ``items()`` returns a ``LiveItemsView`` that supports
+            live file watching via ``mount_each()``.
         recursive: If True, recursively walk subdirectories. If False, only list files
             in the immediate directory.
         path_matcher: Optional file path matcher to filter files and directories.
@@ -180,21 +256,8 @@ def walk_dir(
 
     Returns:
         A DirWalker that can be used with ``async for`` loops.
-
-    Examples:
-        Async iteration::
-
-            async for file in walk_dir("/path/to/dir"):
-                content = await file.read()
-
-        With stable base directory::
-
-            source_dir = register_base_dir("source", Path("./data"))
-            async for file in walk_dir(source_dir):
-                # file.file_path has stable memo key based on "source" key
-                content = await file.read()
     """
-    return DirWalker(path, recursive=recursive, path_matcher=path_matcher)
+    return DirWalker(path, live=live, recursive=recursive, path_matcher=path_matcher)
 
 
 __all__ = ["walk_dir", "File", "DirWalker"]

--- a/python/tests/connectors/test_localfs_live.py
+++ b/python/tests/connectors/test_localfs_live.py
@@ -1,0 +1,127 @@
+"""End-to-end tests for localfs source connector in live mode."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import cocoindex as coco
+from cocoindex.connectors import localfs
+
+from tests import common
+from tests.common.target_states import GlobalDictTarget
+
+coco_env = common.create_test_env(__file__)
+
+
+@coco.fn
+async def process_file(file: localfs.File) -> None:
+    content = await file.read_text()
+    # Use the filename as the target state key
+    key = file.file_path.path.name
+    coco.declare_target_state(GlobalDictTarget.target_state(key, content))
+
+
+async def _wait_for_target_keys(
+    expected_keys: set[str],
+    *,
+    timeout: float = 15.0,
+    poll_interval: float = 0.2,
+) -> None:
+    """Poll until GlobalDictTarget.store.data has exactly the expected keys."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if set(GlobalDictTarget.store.data.keys()) == expected_keys:
+            return
+        await asyncio.sleep(poll_interval)
+    actual = set(GlobalDictTarget.store.data.keys())
+    raise AssertionError(
+        f"Timed out waiting for target keys.\n"
+        f"  Expected: {expected_keys}\n"
+        f"  Actual:   {actual}"
+    )
+
+
+async def _wait_for_value(
+    key: str,
+    expected_value: str,
+    *,
+    timeout: float = 10.0,
+    poll_interval: float = 0.1,
+) -> None:
+    """Poll until GlobalDictTarget.store.data[key].data == expected_value."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        entry = GlobalDictTarget.store.data.get(key)
+        if entry is not None and entry.data == expected_value:
+            return
+        await asyncio.sleep(poll_interval)
+    actual = GlobalDictTarget.store.data.get(key)
+    raise AssertionError(
+        f"Timed out waiting for {key!r} to have value {expected_value!r}.\n"
+        f"  Actual entry: {actual}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_localfs_live_add_edit_delete(tmp_path: Path) -> None:
+    """Full lifecycle: initial scan, add file, edit file, delete file."""
+    GlobalDictTarget.store.clear()
+
+    # --- Initial files ---
+    (tmp_path / "file1.txt").write_text("content1")
+    (tmp_path / "file2.txt").write_text("content2")
+
+    @coco.fn
+    async def app_main() -> None:
+        files = localfs.walk_dir(tmp_path, live=True)
+        await coco.mount_each(process_file, files.items())
+
+    app = coco.App(
+        coco.AppConfig(name="test_localfs_live", environment=coco_env),
+        app_main,
+    )
+
+    handle = app.update(live=True)
+    # Drive the update in the background
+    update_task = asyncio.create_task(handle.result())
+    # Give the task a chance to start
+    await asyncio.sleep(0.5)
+
+    try:
+        # Keys are relative paths (what DirWalker.items() yields as keys)
+        file1_key = "file1.txt"
+        file2_key = "file2.txt"
+
+        # Wait for initial state: 2 files
+        await _wait_for_target_keys({file1_key, file2_key})
+        assert GlobalDictTarget.store.data[file1_key].data == "content1"
+        assert GlobalDictTarget.store.data[file2_key].data == "content2"
+
+        # --- Add a new file ---
+        (tmp_path / "file3.txt").write_text("content3")
+        file3_key = "file3.txt"
+        await _wait_for_target_keys({file1_key, file2_key, file3_key})
+        assert GlobalDictTarget.store.data[file3_key].data == "content3"
+
+        # --- Edit an existing file ---
+        (tmp_path / "file1.txt").write_text("content1_edited")
+        await _wait_for_value(file1_key, "content1_edited")
+        assert GlobalDictTarget.store.data[file1_key].data == "content1_edited"
+
+        # --- Delete a file ---
+        (tmp_path / "file2.txt").unlink()
+        await _wait_for_target_keys({file1_key, file3_key})
+        assert file2_key not in GlobalDictTarget.store.data
+
+        # Final state verification
+        assert GlobalDictTarget.store.data[file1_key].data == "content1_edited"
+        assert GlobalDictTarget.store.data[file3_key].data == "content3"
+    finally:
+        update_task.cancel()
+        try:
+            await update_task
+        except asyncio.CancelledError:
+            pass

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -836,14 +836,16 @@ async def test_mount_each_insert() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
     assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    _me = coco.Symbol("_declare_one_dict")
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
-        coco.ROOT_PATH / "D1",
-        coco.ROOT_PATH / "D1" / "setup",
-        coco.ROOT_PATH / "D2",
-        coco.ROOT_PATH / "D2" / "setup",
-        coco.ROOT_PATH / "D3",
-        coco.ROOT_PATH / "D3" / "setup",
+        coco.ROOT_PATH / _me,
+        coco.ROOT_PATH / _me / "D1",
+        coco.ROOT_PATH / _me / "D1" / "setup",
+        coco.ROOT_PATH / _me / "D2",
+        coco.ROOT_PATH / _me / "D2" / "setup",
+        coco.ROOT_PATH / _me / "D3",
+        coco.ROOT_PATH / _me / "D3" / "setup",
     ]
 
 
@@ -875,12 +877,14 @@ async def test_mount_each_delete() -> None:
         },
     }
     assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1, "delete": 1}
+    _me = coco.Symbol("_declare_one_dict")
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
-        coco.ROOT_PATH / "D2",
-        coco.ROOT_PATH / "D2" / "setup",
-        coco.ROOT_PATH / "D3",
-        coco.ROOT_PATH / "D3" / "setup",
+        coco.ROOT_PATH / _me,
+        coco.ROOT_PATH / _me / "D2",
+        coco.ROOT_PATH / _me / "D2" / "setup",
+        coco.ROOT_PATH / _me / "D3",
+        coco.ROOT_PATH / _me / "D3" / "setup",
     ]
 
     # Re-insert after deletion
@@ -901,12 +905,13 @@ async def test_mount_each_delete() -> None:
     assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
-        coco.ROOT_PATH / "D1",
-        coco.ROOT_PATH / "D1" / "setup",
-        coco.ROOT_PATH / "D2",
-        coco.ROOT_PATH / "D2" / "setup",
-        coco.ROOT_PATH / "D3",
-        coco.ROOT_PATH / "D3" / "setup",
+        coco.ROOT_PATH / _me,
+        coco.ROOT_PATH / _me / "D1",
+        coco.ROOT_PATH / _me / "D1" / "setup",
+        coco.ROOT_PATH / _me / "D2",
+        coco.ROOT_PATH / _me / "D2" / "setup",
+        coco.ROOT_PATH / _me / "D3",
+        coco.ROOT_PATH / _me / "D3" / "setup",
     ]
 
 

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
 
 import pytest
 
@@ -41,7 +43,11 @@ def test_live_component_rejected_in_use_mount() -> None:
 
 def test_live_component_rejected_in_mount_each() -> None:
     async def _main() -> None:
-        await coco.mount_each(_MinimalLiveComponent, [("a",), ("b",)])  # type: ignore[arg-type]
+        await coco.mount_each(  # type: ignore[call-overload]
+            coco.component_subpath("x"),
+            _MinimalLiveComponent,
+            [("a",), ("b",)],
+        )
 
     app = coco.App(
         coco.AppConfig(name="test_rejected_mount_each", environment=coco_env),
@@ -211,6 +217,51 @@ def test_live_component_incremental_update() -> None:
     assert GlobalDictTarget.store.data["new_key"].data == 99
 
 
+class _IncrementalDeleteDirectLiveComponent:
+    """LiveComponent that tests direct deletion via operator.delete().
+
+    process() mounts child components for each key in _source_data.
+    process_live() does a full update, then directly deletes one child.
+    """
+
+    async def process(self) -> None:
+        for key, value in _source_data.items():
+            await coco.mount(coco.component_subpath(key), _declare_item, key, value)
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        # Directly delete the child that was mounted by process() for key "b"
+        handle = await operator.delete(coco.component_subpath("b"))
+        await handle.ready()
+        await operator.mark_ready()
+
+
+def test_live_component_incremental_delete_direct() -> None:
+    """operator.delete() removes a child originally created by update_full()."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+
+    async def _main() -> None:
+        await coco.mount(
+            coco.component_subpath("live"), _IncrementalDeleteDirectLiveComponent
+        )
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_live_incremental_delete_direct", environment=coco_env
+        ),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    # "a" should remain, "b" should be deleted
+    assert "a" in GlobalDictTarget.store.data
+    assert "b" not in GlobalDictTarget.store.data
+
+
 class _IncrementalDeleteViaGCLiveComponent:
     """LiveComponent that tests deletion via update_full GC.
 
@@ -322,3 +373,192 @@ def test_live_component_update_full_gc() -> None:
     assert "gc_b" in GlobalDictTarget.store.data
     assert "gc_c" not in GlobalDictTarget.store.data
     assert "gc_d" not in GlobalDictTarget.store.data
+
+
+# ============================================================================
+# LiveItemsView + mount_each tests
+# ============================================================================
+
+
+class _TestLiveItemsView:
+    """A simple LiveItemsView for testing.
+
+    Yields (key, key) pairs — the value is the same as the key string.
+    The per-item function receives the value (a str) as first arg.
+    """
+
+    def __init__(self, data: dict[str, int]) -> None:
+        self._data = data
+        self._watch_fn: (
+            Callable[[coco.LiveItemsSubscriber[str, str]], Awaitable[None]] | None
+        ) = None
+
+    def set_watch_fn(
+        self,
+        fn: Callable[[coco.LiveItemsSubscriber[str, str]], Awaitable[None]],
+    ) -> None:
+        self._watch_fn = fn
+
+    def __aiter__(self) -> AsyncIterator[tuple[str, str]]:
+        return self._aiter_impl()
+
+    async def _aiter_impl(self) -> AsyncIterator[tuple[str, str]]:
+        for k in self._data:
+            yield (k, k)
+
+    async def watch(self, subscriber: coco.LiveItemsSubscriber[str, str]) -> None:
+        await subscriber.update_all()
+        if self._watch_fn is not None:
+            await self._watch_fn(subscriber)
+        await subscriber.mark_ready()
+
+
+_live_source: dict[str, int] = {}
+
+
+def _declare_live_item(key: str) -> None:
+    """Per-item function for LiveItemsView tests. Looks up value from _live_source."""
+    value = _live_source[key]
+    coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+
+def test_mount_each_live_items_view_basic() -> None:
+    GlobalDictTarget.store.clear()
+    _live_source.clear()
+    _live_source.update({"a": 1, "b": 2, "c": 3})
+
+    items = _TestLiveItemsView(_live_source)
+
+    async def _main() -> None:
+        await coco.mount_each(_declare_live_item, items)  # type: ignore[call-overload]
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_items_basic", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    assert GlobalDictTarget.store.data == {
+        "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+        "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+        "c": DictDataWithPrev(data=3, prev=[], prev_may_be_missing=True),
+    }
+
+
+def test_mount_each_live_items_view_non_live_mode() -> None:
+    GlobalDictTarget.store.clear()
+    _live_source.clear()
+    _live_source["x"] = 10
+
+    items = _TestLiveItemsView(_live_source)
+
+    async def _main() -> None:
+        await coco.mount_each(_declare_live_item, items)  # type: ignore[call-overload]
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_items_non_live", environment=coco_env),
+        _main,
+    )
+    # Non-live mode: mark_ready terminates watch(), app completes
+    app.update_blocking()
+
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=10, prev=[], prev_may_be_missing=True),
+    }
+
+
+def test_mount_each_live_items_view_incremental_update() -> None:
+    GlobalDictTarget.store.clear()
+    _live_source.clear()
+    _live_source["a"] = 1
+
+    items = _TestLiveItemsView(_live_source)
+
+    async def _after_ready(subscriber: coco.LiveItemsSubscriber[str, str]) -> None:
+        _live_source["new_key"] = 99
+        handle = await subscriber.update("new_key", "new_key")
+        await handle.ready()
+
+    items.set_watch_fn(_after_ready)
+
+    async def _main() -> None:
+        await coco.mount_each(_declare_live_item, items)  # type: ignore[call-overload]
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_items_incr_update", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    assert "a" in GlobalDictTarget.store.data
+    assert "new_key" in GlobalDictTarget.store.data
+    assert GlobalDictTarget.store.data["new_key"].data == 99
+
+
+def test_mount_each_live_items_view_update_all_rescan() -> None:
+    GlobalDictTarget.store.clear()
+    _live_source.clear()
+    _live_source.update({"a": 1, "b": 2, "c": 3})
+
+    items = _TestLiveItemsView(_live_source)
+
+    async def _after_ready(subscriber: coco.LiveItemsSubscriber[str, str]) -> None:
+        # Mutate backing data, then trigger rescan
+        _live_source.clear()
+        _live_source.update({"a": 1, "d": 4})
+        items._data = _live_source
+        await subscriber.update_all()
+
+    items.set_watch_fn(_after_ready)
+
+    async def _main() -> None:
+        await coco.mount_each(_declare_live_item, items)  # type: ignore[call-overload]
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_items_rescan", environment=coco_env),
+        _main,
+    )
+    app.update_blocking(live=True)
+
+    # After rescan: a and d should exist, b and c should be GC'd
+    assert "a" in GlobalDictTarget.store.data
+    assert "d" in GlobalDictTarget.store.data
+    assert "b" not in GlobalDictTarget.store.data
+    assert "c" not in GlobalDictTarget.store.data
+
+
+def test_mount_each_auto_subpath() -> None:
+    GlobalDictTarget.store.clear()
+    _live_source.clear()
+    _live_source["k1"] = 1
+
+    async def _main() -> None:
+        await coco.mount_each(_declare_live_item, [("k1", "k1")])  # type: ignore[call-overload]
+
+    app = coco.App(
+        coco.AppConfig(name="test_mount_each_auto_subpath", environment=coco_env),
+        _main,
+    )
+    app.update_blocking()
+
+    assert "k1" in GlobalDictTarget.store.data
+
+
+def test_mount_each_no_name_raises() -> None:
+    """Callables without __name__ require an explicit ComponentSubpath."""
+
+    class _NoName:
+        def __call__(self, x: Any) -> None:
+            pass
+
+    fn = _NoName()  # callable instance without __name__
+
+    async def _main() -> None:
+        await coco.mount_each(fn, [("a", 1)])  # type: ignore[arg-type]
+
+    app = coco.App(
+        coco.AppConfig(name="test_mount_each_no_name", environment=coco_env),
+        _main,
+    )
+    with pytest.raises(TypeError, match="requires a ComponentSubpath"):
+        app.update_blocking()

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -9,6 +9,7 @@ use crate::engine::profile::EngineProfile;
 use crate::engine::stats::ProcessingStats;
 use crate::engine::target_state::TargetStateProvider;
 use crate::prelude::*;
+use crate::state::db_schema;
 use crate::state::stable_path::StablePath;
 use crate::state::target_state_path::TargetStatePath;
 use cocoindex_utils::error::SharedError;
@@ -386,6 +387,42 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         let child = self.component.get_child(subpath.clone());
         let seq = self.state.next_seq.fetch_add(1, Ordering::Relaxed);
         child.latest_seq().store(seq, Ordering::Release);
+
+        // Remove the child existence entry and write a GC tombstone atomically.
+        // The existence removal lets pre_commit proceed with target state cleanup.
+        // The tombstone ensures that if the process crashes between here and GC
+        // completion, the child will be cleaned up on restart.
+        if let Some((parent_ref, child_key)) = subpath.as_ref().split_parent() {
+            let db = self.component.app_ctx().db().clone();
+            let parent_path: StablePath = parent_ref.into();
+            let child_key = child_key.clone();
+            let component_path = self.component.stable_path().clone();
+            let relative_child = subpath.as_ref().strip_parent(component_path.as_ref())?;
+            let relative_child: StablePath = relative_child.into();
+            self.component
+                .app_ctx()
+                .env()
+                .txn_batcher()
+                .run(move |wtxn| {
+                    // Remove child existence entry from parent
+                    let existence_key = db_schema::DbEntryKey::StablePath(
+                        parent_path,
+                        db_schema::StablePathEntryKey::ChildExistence(child_key),
+                    )
+                    .encode()?;
+                    db.delete(wtxn, &existence_key)?;
+
+                    // Write tombstone for GC (relative path from component root)
+                    let tombstone_key = db_schema::DbEntryKey::StablePath(
+                        component_path,
+                        db_schema::StablePathEntryKey::ChildComponentTombstone(relative_child),
+                    )
+                    .encode()?;
+                    db.put(wtxn, &tombstone_key, &[])?;
+                    Ok(())
+                })
+                .await?;
+        }
 
         let context = ComponentProcessorContext::new(
             child.clone(),


### PR DESCRIPTION
## Summary
- Add `LiveItemsView` protocol and `LiveItemsSubscriber` so `mount_each()` can automatically create internal `LiveComponent`s when given a live-capable data source
- Update `DirWalker` with `live=True` mode — `items()` returns a `LiveItemsView` that watches for file changes via `watchfiles`
- Update `mount_each()` to accept optional `ComponentSubpath` (auto-derived from `Symbol(fn.__name__)` when omitted)
- Add new "Live Mode" programming guide doc and update existing docs (live_component, processing_component, localfs, app)

## Test plan
- [x] `uv run mypy` passes (0 errors)
- [x] `uv run pytest python/` passes (476 tests, 0 failures)
- [x] `cargo test` passes
- [x] Pre-commit hooks pass (cargo fmt, ruff format, mypy, maturin develop, cargo test, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
