### PR TITLE
docs: clarify that collect() accepts plain Python values

### DIFF
--- a/python/cocoindex/flow.py
+++ b/python/cocoindex/flow.py
@@ -381,6 +381,20 @@ class DataCollector:
     def collect(self, **kwargs: Any) -> None:
         """
         Collect data into the collector.
+
+        Values can be ``DataSlice`` objects or plain Python values
+        (``str``, ``int``, ``float``, etc.). Plain values are automatically
+        wrapped as constant ``DataSlice`` instances, which is useful for
+        tagging rows with static metadata like source labels.
+
+        Example::
+
+            collector.collect(
+                source="my_label",          # plain str -> constant DataSlice
+                filename=doc["filename"],   # DataSlice from the pipeline
+                text=chunk["text"],         # DataSlice from the pipeline
+                embedding=chunk["embedding"],
+            )
         """
         regular_kwargs = []
         auto_uuid_field = None


### PR DESCRIPTION
## Summary

The `collect()` docstring says "Collect data into the collector" with no parameter documentation. This makes it unclear that plain Python values (`str`, `int`, `float`) are accepted alongside `DataSlice` objects.

Under the hood, `get_data_slice()` auto-wraps plain values as constant `DataSlice` instances via `engine_flow_builder.constant()` — but without documentation, users (and LLMs generating code) assume they need a special wrapper for literal values.

## What changed

Added a docstring to `DataCollector.collect()` explaining:
- Both `DataSlice` objects and plain Python values are accepted
- Plain values are auto-wrapped as constants
- Example showing a mix of plain strings and `DataSlice` pipeline values

## Context

We hit this while building a multi-source indexing pipeline that sends data from several directories into a single collector. We needed to tag chunks with a source label (e.g., `"docs"`, `"notes"`) and incorrectly assumed we needed a `LiteralStr` wrapper that doesn't exist. The fix was just passing the plain string directly — but nothing in the docs or examples shows this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)