### PR TITLE
fix: suppress noisy CancelledError log on Ctrl+C in live mode

### DIFF
--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -501,8 +501,13 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
             match result {
                 Ok(()) => state.ensure_mark_ready(),
                 Err(e) => {
-                    if !state.is_ready() {
-                        // Error before mark_ready — drop the guard to signal error.
+                    // Check if this is a cancellation — either the token was
+                    // cancelled (normal shutdown) or the error itself is a
+                    // cancellation (e.g. Python CancelledError, which can race
+                    // ahead of token cancellation on KeyboardInterrupt).
+                    if token.is_cancelled() || e.is_cancelled() {
+                        state.ensure_mark_ready();
+                    } else if !state.is_ready() {
                         state.resolve_ready_with_error(e);
                     } else {
                         error!("process_live failed after mark_ready: {e:?}");

--- a/rust/py_utils/src/error.rs
+++ b/rust/py_utils/src/error.rs
@@ -61,6 +61,20 @@ impl std::error::Error for HostedPyErr {
     }
 }
 
+impl cocoindex_utils::error::HostError for HostedPyErr {
+    fn is_cancelled(&self) -> bool {
+        Python::attach(|py| {
+            let Ok(asyncio) = PyModule::import(py, "asyncio") else {
+                return false;
+            };
+            let Ok(cancelled_cls) = asyncio.getattr("CancelledError") else {
+                return false;
+            };
+            self.0.is_instance(py, &cancelled_cls)
+        })
+    }
+}
+
 fn cerror_to_pyerr(err: CError) -> PyErr {
     match err.without_contexts() {
         CError::HostLang(host_err) => {

--- a/rust/utils/src/error.rs
+++ b/rust/utils/src/error.rs
@@ -12,8 +12,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub trait HostError: Any + StdError + Send + Sync + 'static {}
-impl<T: Any + StdError + Send + Sync + 'static> HostError for T {}
+pub trait HostError: Any + StdError + Send + Sync + 'static {
+    /// Whether this error represents a cancellation (e.g. Python `CancelledError`).
+    /// Default: `false`. Override in host-language error wrappers.
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+}
 
 pub enum Error {
     Context { msg: String, source: Box<SError> },
@@ -85,6 +90,15 @@ impl Error {
             Error::Context { source, .. } => source.0.without_contexts(),
             other => other,
         }
+    }
+
+    /// Check if this error represents a cancellation (e.g. Python `CancelledError`).
+    pub fn is_cancelled(&self) -> bool {
+        let inner = self.without_contexts();
+        if let Error::HostLang(host_err) = inner {
+            return host_err.is_cancelled();
+        }
+        false
     }
 
     pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -470,6 +484,7 @@ mod tests {
     }
 
     impl StdError for MockHostError {}
+    impl HostError for MockHostError {}
 
     #[test]
     fn test_client_error_creation() {


### PR DESCRIPTION
## Summary
- Add `is_cancelled()` method to `HostError` trait (default `false`), with `HostedPyErr` overriding to check `asyncio.CancelledError`
- Live component error handler now treats cancellation errors as normal shutdown, suppressing the noisy ERROR-level traceback on Ctrl+C
- Fixes a race where Python `CancelledError` propagates through `process_live_fut` before the cancellation token is cancelled

## Test plan
- CI
- Manual: run a live-mode example, press Ctrl+C — no error traceback should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
