### PR TITLE
feat: add ManagedBy StrEnum for managed_by parameter

### DIFF
--- a/python/cocoindex/connectorkits/statediff.py
+++ b/python/cocoindex/connectorkits/statediff.py
@@ -92,7 +92,7 @@ class TrackingRecordTransition(_Generic[_TrackingRecordT], _NamedTuple):
     prev_may_be_missing: bool
 
 
-ManagedBy = _Literal["system", "user"]
+from cocoindex.connectorkits.target import ManagedBy as ManagedBy
 
 
 @_unpickle_safe

--- a/python/cocoindex/connectorkits/target.py
+++ b/python/cocoindex/connectorkits/target.py
@@ -1,0 +1,14 @@
+"""Shared types for target connectors."""
+
+from __future__ import annotations
+
+__all__ = ["ManagedBy"]
+
+import enum as _enum
+
+
+class ManagedBy(_enum.StrEnum):
+    """Who manages the lifecycle of the target resource."""
+
+    SYSTEM = "system"
+    USER = "user"

--- a/python/cocoindex/connectors/doris/_target.py
+++ b/python/cocoindex/connectors/doris/_target.py
@@ -46,7 +46,7 @@ import numpy as np
 from typing_extensions import TypeVar
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import (
     AnyType,
@@ -942,7 +942,7 @@ _TABLE_KEY_CHECKER = TypeChecker(tuple[str, str])
 @dataclass
 class _TableSpec:
     table_schema: TableSchema[Any]
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
     vector_indexes: list[VectorIndexDef] | None = None
     inverted_indexes: list[InvertedIndexDef] | None = None
 
@@ -1191,7 +1191,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> coco.TargetState[_RowHandler]:
@@ -1210,7 +1210,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> "DorisTableTarget[RowT, coco.PendingS]":
@@ -1232,7 +1232,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> "DorisTableTarget[RowT]":

--- a/python/cocoindex/connectors/doris/_target.py
+++ b/python/cocoindex/connectors/doris/_target.py
@@ -942,7 +942,7 @@ _TABLE_KEY_CHECKER = TypeChecker(tuple[str, str])
 @dataclass
 class _TableSpec:
     table_schema: TableSchema[Any]
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
     vector_indexes: list[VectorIndexDef] | None = None
     inverted_indexes: list[InvertedIndexDef] | None = None
 
@@ -1191,7 +1191,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> coco.TargetState[_RowHandler]:
@@ -1210,7 +1210,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> "DorisTableTarget[RowT, coco.PendingS]":
@@ -1232,7 +1232,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     vector_indexes: list[VectorIndexDef] | None = None,
     inverted_indexes: list[InvertedIndexDef] | None = None,
 ) -> "DorisTableTarget[RowT]":

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -37,7 +37,7 @@ LanceAsyncConnection = Any
 import numpy as np
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import (
     AnyType,
@@ -489,7 +489,7 @@ class _TableSpec:
     """Specification for a LanceDB table."""
 
     table_schema: TableSchema[Any]
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -793,7 +793,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a LanceDB table target.
@@ -823,7 +823,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a LanceDB table.
@@ -849,7 +849,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -489,7 +489,7 @@ class _TableSpec:
     """Specification for a LanceDB table."""
 
     table_schema: TableSchema[Any]
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -793,7 +793,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a LanceDB table target.
@@ -823,7 +823,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a LanceDB table.
@@ -849,7 +849,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -39,7 +39,7 @@ except ImportError as e:
 import numpy as np
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import (
     AnyType,
@@ -783,7 +783,7 @@ class _TableSpec:
     """Specification for a PostgreSQL table."""
 
     table_schema: TableSchema[Any]
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -1257,7 +1257,7 @@ def table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a PostgreSQL table target.
@@ -1293,7 +1293,7 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a PostgreSQL table.
@@ -1327,7 +1327,7 @@ async def mount_table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -783,7 +783,7 @@ class _TableSpec:
     """Specification for a PostgreSQL table."""
 
     table_schema: TableSchema[Any]
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -1257,7 +1257,7 @@ def table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a PostgreSQL table target.
@@ -1293,7 +1293,7 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a PostgreSQL table.
@@ -1327,7 +1327,7 @@ async def mount_table_target(
     table_schema: TableSchema[RowT],
     *,
     pg_schema_name: str | None = None,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -271,7 +271,7 @@ _COLLECTION_KEY_CHECKER = TypeChecker(tuple[str, str])
 @dataclass
 class _CollectionSpec:
     schema: CollectionSchema
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -511,7 +511,7 @@ def collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> "coco.TargetState[_PointHandler]":
     """
     Create a TargetState for a Qdrant collection target.
@@ -538,7 +538,7 @@ def declare_collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> "CollectionTarget[coco.PendingS]":
     """Declare a Qdrant collection target.
 
@@ -562,7 +562,7 @@ async def mount_collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> "CollectionTarget[coco.ResolvedS]":
     """
     Mount a collection target and return a ready-to-use CollectionTarget.

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -32,7 +32,7 @@ except ImportError as e:
     ) from e
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import TypeChecker
 from cocoindex._internal.serde import unpickle_safe
@@ -271,7 +271,7 @@ _COLLECTION_KEY_CHECKER = TypeChecker(tuple[str, str])
 @dataclass
 class _CollectionSpec:
     schema: CollectionSchema
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
 @unpickle_safe
@@ -511,7 +511,7 @@ def collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> "coco.TargetState[_PointHandler]":
     """
     Create a TargetState for a Qdrant collection target.
@@ -538,7 +538,7 @@ def declare_collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> "CollectionTarget[coco.PendingS]":
     """Declare a Qdrant collection target.
 
@@ -562,7 +562,7 @@ async def mount_collection_target(
     collection_name: str,
     schema: CollectionSchema,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> "CollectionTarget[coco.ResolvedS]":
     """
     Mount a collection target and return a ready-to-use CollectionTarget.

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -34,7 +34,7 @@ from typing_extensions import TypeVar
 import numpy as np
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.rwlock import RWLock
 from cocoindex._internal.serde import unpickle_safe
@@ -586,7 +586,7 @@ class _TableSpec:
     """Specification for a SQLite table."""
 
     table_schema: TableSchema[Any]
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
     virtual_table_def: Vec0TableDef | None = None
 
 
@@ -1114,7 +1114,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "coco.TargetState[_RowHandler]":
     """
@@ -1151,7 +1151,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "TableTarget[RowT, coco.PendingS]":
     """
@@ -1198,7 +1198,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "TableTarget[RowT]":
     """

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -586,7 +586,7 @@ class _TableSpec:
     """Specification for a SQLite table."""
 
     table_schema: TableSchema[Any]
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
     virtual_table_def: Vec0TableDef | None = None
 
 
@@ -1114,7 +1114,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "coco.TargetState[_RowHandler]":
     """
@@ -1151,7 +1151,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "TableTarget[RowT, coco.PendingS]":
     """
@@ -1198,7 +1198,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
     virtual_table_def: Vec0TableDef | None = None,
 ) -> "TableTarget[RowT]":
     """

--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -754,7 +754,7 @@ class _TableSpec:
     is_relation: bool
     from_tables: tuple[str, ...] | None  # sorted table names for FROM clause
     to_tables: tuple[str, ...] | None  # sorted table names for TO clause
-    managed_by: Literal["system", "user"] = "system"
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
 
 
 @dataclass(frozen=True, slots=True)
@@ -1284,7 +1284,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RecordHandler]:
     """Create a TargetState for a SurrealDB table."""
     _validate_identifier(table_name, "table name")
@@ -1304,7 +1304,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """Declare a table target and return a pending TableTarget."""
     provider = coco.declare_target_state_with_child(
@@ -1318,7 +1318,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """Mount a table target and return a ready-to-use TableTarget."""
     provider = await coco.mount_target(
@@ -1334,7 +1334,7 @@ def relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RecordHandler]:
     """Create a TargetState for a SurrealDB relation table."""
     _validate_identifier(table_name, "relation table name")
@@ -1362,7 +1362,7 @@ def declare_relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> RelationTarget[RowT, coco.PendingS]:
     """Declare a relation target and return a pending RelationTarget."""
     from_names = _normalize_table_names(from_table)
@@ -1387,7 +1387,7 @@ async def mount_relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
 ) -> RelationTarget[RowT]:
     """Mount a relation target and return a ready-to-use RelationTarget."""
     from_names = _normalize_table_names(from_table)

--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -47,7 +47,7 @@ else:
 import numpy as np
 
 import cocoindex as coco
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import (
     AnyType,
@@ -754,7 +754,7 @@ class _TableSpec:
     is_relation: bool
     from_tables: tuple[str, ...] | None  # sorted table names for FROM clause
     to_tables: tuple[str, ...] | None  # sorted table names for TO clause
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
 @dataclass(frozen=True, slots=True)
@@ -1284,7 +1284,7 @@ def table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RecordHandler]:
     """Create a TargetState for a SurrealDB table."""
     _validate_identifier(table_name, "table name")
@@ -1304,7 +1304,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]:
     """Declare a table target and return a pending TableTarget."""
     provider = coco.declare_target_state_with_child(
@@ -1318,7 +1318,7 @@ async def mount_table_target(
     table_name: str,
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> TableTarget[RowT]:
     """Mount a table target and return a ready-to-use TableTarget."""
     provider = await coco.mount_target(
@@ -1334,7 +1334,7 @@ def relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> coco.TargetState[_RecordHandler]:
     """Create a TargetState for a SurrealDB relation table."""
     _validate_identifier(table_name, "relation table name")
@@ -1362,7 +1362,7 @@ def declare_relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> RelationTarget[RowT, coco.PendingS]:
     """Declare a relation target and return a pending RelationTarget."""
     from_names = _normalize_table_names(from_table)
@@ -1387,7 +1387,7 @@ async def mount_relation_target(
     to_table: TableTarget[Any] | Collection[TableTarget[Any]],
     table_schema: TableSchema[RowT] | None = None,
     *,
-    managed_by: statediff.ManagedBy = statediff.ManagedBy.SYSTEM,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
 ) -> RelationTarget[RowT]:
     """Mount a relation target and return a ready-to-use RelationTarget."""
     from_names = _normalize_table_names(from_table)

--- a/python/tests/connectors/test_sqlite_target.py
+++ b/python/tests/connectors/test_sqlite_target.py
@@ -15,6 +15,7 @@ from numpy.typing import NDArray
 
 import cocoindex as coco
 from cocoindex._internal.context_keys import ContextProvider
+from cocoindex.connectorkits import statediff
 from cocoindex.connectors import sqlite
 from cocoindex.resources.schema import VectorSchema
 
@@ -528,13 +529,13 @@ def test_user_managed_table(sqlite_db: tuple[sqlite.ManagedConnection, Path]) ->
     test_env = make_test_env(managed_conn, "test_user_managed_table")
 
     async def declare_user_managed_rows() -> None:
-        table = await coco.use_mount(
+        table: sqlite.TableTarget[SimpleRow] = await coco.use_mount(
             coco.component_subpath("setup", "table"),
             sqlite.declare_table_target,
             SQLITE_DB,
             "user_managed",
             await sqlite.TableSchema.from_class(SimpleRow, primary_key=["id"]),
-            managed_by="user",
+            managed_by=statediff.ManagedBy.USER,
         )
 
         for row in user_rows:

--- a/python/tests/connectors/test_sqlite_target.py
+++ b/python/tests/connectors/test_sqlite_target.py
@@ -15,7 +15,7 @@ from numpy.typing import NDArray
 
 import cocoindex as coco
 from cocoindex._internal.context_keys import ContextProvider
-from cocoindex.connectorkits import statediff
+from cocoindex.connectorkits import target
 from cocoindex.connectors import sqlite
 from cocoindex.resources.schema import VectorSchema
 
@@ -535,7 +535,7 @@ def test_user_managed_table(sqlite_db: tuple[sqlite.ManagedConnection, Path]) ->
             SQLITE_DB,
             "user_managed",
             await sqlite.TableSchema.from_class(SimpleRow, primary_key=["id"]),
-            managed_by=statediff.ManagedBy.USER,
+            managed_by=target.ManagedBy.USER,
         )
 
         for row in user_rows:


### PR DESCRIPTION
## Summary
- Introduces a `ManagedBy` StrEnum in `python/cocoindex/connectorkits/target.py` with `SYSTEM` and `USER` members
- Replaces all 27 occurrences of `Literal["system", "user"]` across 6 target connectors (postgres, sqlite, lancedb, doris, qdrant, surrealdb) with `target.ManagedBy`
- `statediff.py` imports `ManagedBy` from `target.py` for its own internal use (`MutualTrackingRecord`, `resolve_system_transition`) and keeps it in `__all__` as a safety net, though no external code currently accesses `ManagedBy` through `statediff`
- Fixes pre-existing mypy type errors in `test_sqlite_target.py`

## Motivation
Scattered `Literal["system", "user"]` annotations made it easy to introduce typos and provided no IDE autocompletion. A single `StrEnum` gives a canonical source of truth and better developer experience. Since `StrEnum` inherits from `str`, this is fully backward compatible — existing string comparisons and serialization continue to work.

Closes #1806

## Test plan
- [x] `uv run mypy` — 0 errors (was 7 on base v1, 2 of which are also fixed here)
- [x] `uv run pytest python/` — 495 passed, 70 skipped
- [x] `prek run --all-files` — all 14 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)