### PR TITLE
fix: clean up stale GC tombstone after live component incremental delete

### DIFF
--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -262,6 +262,64 @@ def test_live_component_incremental_delete_direct() -> None:
     assert "b" not in GlobalDictTarget.store.data
 
 
+class _IncrementalDeleteNoStaleComponent:
+    """LiveComponent for testing that incremental delete doesn't leave stale tombstones.
+
+    First run: process() mounts "a" and "b", process_live() deletes "b".
+    Second run: process() mounts only "a", process_live() does nothing extra.
+    The second run should NOT produce an "<unknown>" deletion for "b".
+    """
+
+    async def process(self) -> None:
+        for key, value in _source_data.items():
+            await coco.mount(coco.component_subpath(key), _declare_item, key, value)
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        # Delete "b" only if it's in the current source data
+        if "b" in _source_data:
+            handle = await operator.delete(coco.component_subpath("b"))
+            await handle.ready()
+        await operator.mark_ready()
+
+
+@pytest.mark.asyncio
+async def test_live_component_incremental_delete_no_stale_tombstone() -> None:
+    """After incremental delete, a second run should not produce '<unknown>' deletions."""
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+
+    async def _main() -> None:
+        await coco.mount(
+            coco.component_subpath("live"), _IncrementalDeleteNoStaleComponent
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_incr_delete_no_stale", environment=coco_env),
+        _main,
+    )
+
+    # First run: deletes "b" incrementally
+    app.update_blocking(live=True)
+    assert "a" in GlobalDictTarget.store.data
+    assert "b" not in GlobalDictTarget.store.data
+
+    # Second run: "b" no longer in source, should be a clean run
+    _source_data.pop("b", None)
+    handle = app.update(live=True)
+    await handle.result()
+    stats = handle.stats()
+    assert stats is not None
+
+    # There should be no "<unknown>" component in the stats
+    assert "<unknown>" not in stats.by_component, (
+        f"Stale tombstone caused '<unknown>' deletion: {stats.by_component}"
+    )
+
+
 class _IncrementalDeleteViaGCLiveComponent:
     """LiveComponent that tests deletion via update_full GC.
 

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -6,7 +6,10 @@ use std::sync::Weak;
 use std::sync::atomic::AtomicU64;
 
 use crate::engine::context::FnCallContext;
-use crate::engine::context::{AppContext, ComponentProcessingMode, ComponentProcessorContext};
+use crate::engine::context::{
+    AppContext, ComponentDeleteContext, ComponentProcessingAction, ComponentProcessingMode,
+    ComponentProcessorContext,
+};
 use crate::engine::execution::{
     cleanup_tombstone, post_submit_for_build, submit, update_component_memo_states,
     use_or_invalidate_component_memoization,
@@ -433,14 +436,15 @@ impl<Prof: EngineProfile> Component<Prof> {
         }
     }
 
-    pub(crate) fn relative_path(
-        &self,
-        context: &ComponentProcessorContext<Prof>,
-    ) -> Result<StablePathRef<'_>> {
-        if let Some(parent_ctx) = context.parent_context() {
+    pub fn parent(&self) -> Option<&Component<Prof>> {
+        self.inner.parent.as_ref()
+    }
+
+    pub(crate) fn relative_path(&self) -> Result<StablePathRef<'_>> {
+        if let Some(parent) = self.parent() {
             self.stable_path()
                 .as_ref()
-                .strip_parent(parent_ctx.stable_path().as_ref())
+                .strip_parent(parent.stable_path().as_ref())
         } else {
             Ok(self.stable_path().as_ref())
         }
@@ -468,7 +472,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             context.set_inflight_permit(permit);
         }
 
-        let relative_path = self.relative_path(&context)?;
+        let relative_path = self.relative_path()?;
         let child_readiness_guard = context
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
@@ -885,13 +889,10 @@ impl<Prof: EngineProfile> Component<Prof> {
         };
         Ok(ComponentProcessorContext::new(
             self.clone(),
-            providers,
             parent_ctx.cloned(),
             processing_stats,
-            ComponentProcessingMode::Build,
-            full_reprocess,
-            live,
             host_ctx,
+            ComponentProcessingAction::new_build(providers, full_reprocess, live),
         ))
     }
 
@@ -902,16 +903,12 @@ impl<Prof: EngineProfile> Component<Prof> {
         processing_stats: ProcessingStats,
         host_ctx: Arc<Prof::HostCtx>,
     ) -> ComponentProcessorContext<Prof> {
-        let full_reprocess = parent_ctx.map(|ctx| ctx.full_reprocess()).unwrap_or(false);
         ComponentProcessorContext::new(
             self.clone(),
-            providers,
             parent_ctx.cloned(),
             processing_stats,
-            ComponentProcessingMode::Delete,
-            full_reprocess,
-            false,
             host_ctx,
+            ComponentProcessingAction::Delete(ComponentDeleteContext { providers }),
         )
     }
 }

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -149,6 +149,27 @@ pub(crate) enum ComponentProcessingAction<Prof: EngineProfile> {
     Delete(ComponentDeleteContext<Prof>),
 }
 
+impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
+    pub fn new_build(
+        providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+        full_reprocess: bool,
+        live: bool,
+    ) -> Self {
+        Self::Build(ComponentBuildContext {
+            state: Mutex::new(Some(ComponentBuildingState {
+                target_states: ComponentTargetStatesContext {
+                    declared_target_states: Default::default(),
+                    provider_registry: TargetStateProviderRegistry::new(providers),
+                },
+                child_path_set: Default::default(),
+                fn_call_memos: Default::default(),
+            })),
+            full_reprocess,
+            live,
+        })
+    }
+}
+
 struct ComponentProcessorContextInner<Prof: EngineProfile> {
     component: Component<Prof>,
     parent_context: Option<ComponentProcessorContext<Prof>>,
@@ -173,35 +194,16 @@ pub struct ComponentProcessorContext<Prof: EngineProfile> {
 impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
     pub(crate) fn new(
         component: Component<Prof>,
-        providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
         parent_context: Option<ComponentProcessorContext<Prof>>,
         processing_stats: ProcessingStats,
-        mode: ComponentProcessingMode,
-        full_reprocess: bool,
-        live: bool,
         host_ctx: Arc<Prof::HostCtx>,
+        processing_action: ComponentProcessingAction<Prof>,
     ) -> Self {
-        let processing_state = if mode == ComponentProcessingMode::Build {
-            ComponentProcessingAction::Build(ComponentBuildContext {
-                state: Mutex::new(Some(ComponentBuildingState {
-                    target_states: ComponentTargetStatesContext {
-                        declared_target_states: Default::default(),
-                        provider_registry: TargetStateProviderRegistry::new(providers),
-                    },
-                    child_path_set: Default::default(),
-                    fn_call_memos: Default::default(),
-                })),
-                full_reprocess,
-                live,
-            })
-        } else {
-            ComponentProcessingAction::Delete(ComponentDeleteContext { providers })
-        };
         Self {
             inner: Arc::new(ComponentProcessorContextInner {
                 component,
                 parent_context,
-                processing_action: processing_state,
+                processing_action,
                 components_readiness: Default::default(),
                 processing_stats,
                 inflight_permit: Mutex::new(None),

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -1428,16 +1428,16 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
 pub(crate) async fn cleanup_tombstone<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
 ) -> Result<()> {
-    let Some(parent_ctx) = comp_ctx.parent_context() else {
+    let Some(parent) = comp_ctx.component().parent() else {
         return Ok(());
     };
-    let parent_path = parent_ctx.stable_path();
+    let owner_path = parent.stable_path();
     let relative_path = comp_ctx
         .stable_path()
         .as_ref()
-        .strip_parent(parent_path.as_ref())?;
+        .strip_parent(owner_path.as_ref())?;
     let tombstone_key = db_schema::DbEntryKey::StablePath(
-        parent_path.clone(),
+        owner_path.clone(),
         db_schema::StablePathEntryKey::ChildComponentTombstone(relative_path.into()),
     );
     let encoded_tombstone_key = tombstone_key.encode()?;

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::engine::component::{
     Component, ComponentBgChildReadinessChildGuard, ComponentExecutionHandle,
 };
-use crate::engine::context::{ComponentProcessingMode, ComponentProcessorContext, FnCallContext};
+use crate::engine::context::{ComponentProcessingAction, ComponentProcessorContext, FnCallContext};
 use crate::engine::profile::EngineProfile;
 use crate::engine::stats::ProcessingStats;
 use crate::engine::target_state::TargetStateProvider;
@@ -303,13 +303,14 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // Create fresh context with no parent.
         let context = ComponentProcessorContext::new(
             self.component.clone(),
-            self.providers.clone(),
             None,
             self.processing_stats.clone(),
-            ComponentProcessingMode::Build,
-            self.full_reprocess,
-            self.live,
             self.host_ctx.clone(),
+            ComponentProcessingAction::new_build(
+                self.providers.clone(),
+                self.full_reprocess,
+                self.live,
+            ),
         );
 
         // Run via run_in_background (no parent context → no readiness guard to grandparent).
@@ -345,13 +346,14 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
 
         let context = ComponentProcessorContext::new(
             child.clone(),
-            self.providers.clone(),
             None,
             self.processing_stats.clone(),
-            ComponentProcessingMode::Build,
-            self.full_reprocess,
-            self.live,
             self.host_ctx.clone(),
+            ComponentProcessingAction::new_build(
+                self.providers.clone(),
+                self.full_reprocess,
+                self.live,
+            ),
         );
 
         let child_for_check = child.clone();
@@ -424,14 +426,10 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .await?;
         }
 
-        let context = ComponentProcessorContext::new(
-            child.clone(),
+        let context = child.new_processor_context_for_delete(
             self.providers.clone(),
             None,
             self.processing_stats.clone(),
-            ComponentProcessingMode::Delete,
-            false,
-            self.live,
             self.host_ctx.clone(),
         );
 


### PR DESCRIPTION
## Summary
- Fix stale GC tombstone after `LiveComponentController::delete()` — the tombstone was never cleaned up because `cleanup_tombstone()` relied on a parent `ComponentProcessorContext` that didn't exist in the live component path, causing a spurious `<unknown>` deletion on the next `update_full()`
- `cleanup_tombstone()` now derives the tombstone owner from `Component::parent()` instead of the processing context, working uniformly for both GC-launched and live-component deletions
- Refactors `ComponentProcessorContext::new()` to accept `ComponentProcessingAction` directly, eliminating mixed build-only/delete-only parameters; adds `Component::parent()` getter and simplifies `relative_path()`

## Test plan
- Added `test_live_component_incremental_delete_no_stale_tombstone` that does two runs: first with an incremental delete, second verifying no `<unknown>` stats appear
- All existing tests pass (496 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
