### PR TITLE
chore: gitignore .claude/hooks dotfiles

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 settings.local.json
+hooks/.*


### PR DESCRIPTION
## Summary
- Ignore dotfiles under `.claude/hooks/` and remove the stray `.py-changed` marker file.

## Test plan
- CI
