### PR TITLE
fix(kafka): await delivery futures in target producer

### DIFF
--- a/examples/csv_to_kafka/main.py
+++ b/examples/csv_to_kafka/main.py
@@ -42,7 +42,6 @@ async def process_csv(file: FileLike, topic_target: kafka.KafkaTopicTarget) -> N
     text = await file.read_text()
     reader = csv.DictReader(io.StringIO(text))
 
-    filename = file.file_path.path.as_posix()
     headers = reader.fieldnames
     if not headers:
         return
@@ -51,9 +50,8 @@ async def process_csv(file: FileLike, topic_target: kafka.KafkaTopicTarget) -> N
     for row in reader:
         key_value = row.get(first_col, None)
         if key_value is not None:
-            key = f"{filename}/{key_value}"
             value = json.dumps(row)
-            topic_target.declare_target_state(key=key, value=value)
+            topic_target.declare_target_state(key=key_value, value=value)
 
 
 @coco.fn

--- a/python/cocoindex/connectors/kafka/_target.py
+++ b/python/cocoindex/connectors/kafka/_target.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Callable, Collection, Generic, NamedTuple, Sequence
+from typing import Callable, Collection, Generic, NamedTuple, Sequence
 
 try:
     from confluent_kafka.aio import AIOProducer  # type: ignore[import-not-found]
@@ -63,14 +63,14 @@ class _MessageHandler:
 
     __slots__ = ("_producer", "_topic", "_deletion_value_fn", "_sink")
 
-    _producer: Any
+    _producer: AIOProducer
     _topic: str
     _deletion_value_fn: Callable[[bytes | str], bytes | str] | None
     _sink: coco.TargetActionSink[_MessageAction]
 
     def __init__(
         self,
-        producer: Any,
+        producer: AIOProducer,
         topic: str,
         deletion_value_fn: Callable[[bytes | str], bytes | str] | None,
     ) -> None:
@@ -85,14 +85,19 @@ class _MessageHandler:
         actions: Sequence[_MessageAction],
         /,
     ) -> None:
-        futures = []
-        for action in actions:
-            fut = self._producer.produce(
-                self._topic, key=action.key, value=action.value
+        if not actions:
+            return
+        # AIOProducer.produce() is an async method that enqueues the message into
+        # the batch buffer and returns an asyncio.Future resolved by the delivery
+        # report. We must await the produce coroutines to obtain those futures,
+        # then await the futures to ensure messages are actually delivered.
+        delivery_futures = await asyncio.gather(
+            *(
+                self._producer.produce(self._topic, key=action.key, value=action.value)
+                for action in actions
             )
-            futures.append(fut)
-        if futures:
-            await asyncio.gather(*futures)
+        )
+        await asyncio.gather(*delivery_futures)
 
     def reconcile(
         self,
@@ -211,11 +216,15 @@ class KafkaTopicTarget(
     Messages are produced for upserts and deletes of declared target states.
     """
 
-    _provider: coco.TargetStateProvider[Any, None, coco.MaybePendingS]
+    _provider: coco.TargetStateProvider[
+        bytes | str | coco.NonExistenceType, None, coco.MaybePendingS
+    ]
 
     def __init__(
         self,
-        provider: coco.TargetStateProvider[Any, None, coco.MaybePendingS],
+        provider: coco.TargetStateProvider[
+            bytes | str | coco.NonExistenceType, None, coco.MaybePendingS
+        ],
     ) -> None:
         self._provider = provider
 

--- a/python/tests/connectors/test_kafka_target.py
+++ b/python/tests/connectors/test_kafka_target.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,9 +21,11 @@ class MockAIOProducer:
     def __init__(self) -> None:
         self.produced_messages: list[tuple[str, Any, Any]] = []
 
-    def produce(self, topic: str, *, key: Any = None, value: Any = None) -> Any:
+    async def produce(
+        self, topic: str, *, key: Any = None, value: Any = None
+    ) -> asyncio.Future[None]:
         self.produced_messages.append((topic, key, value))
-        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         fut.set_result(None)
         return fut
 
@@ -38,6 +40,7 @@ _mock_module.aio = _mock_aio
 sys.modules.setdefault("confluent_kafka", _mock_module)
 sys.modules.setdefault("confluent_kafka.aio", _mock_aio)
 
+from confluent_kafka.aio import AIOProducer  # noqa: E402
 from cocoindex.connectors.kafka._target import (  # noqa: E402
     _MessageAction,
     _MessageHandler,
@@ -61,17 +64,21 @@ def producer() -> MockAIOProducer:
     return MockAIOProducer()
 
 
+def _as_producer(mock: MockAIOProducer) -> AIOProducer:
+    return cast(AIOProducer, mock)
+
+
 @pytest.fixture
 def message_handler(producer: MockAIOProducer) -> _MessageHandler:
     return _MessageHandler(
-        producer=producer, topic="test-topic", deletion_value_fn=None
+        producer=_as_producer(producer), topic="test-topic", deletion_value_fn=None
     )
 
 
 @pytest.fixture
 def message_handler_with_deletion(producer: MockAIOProducer) -> _MessageHandler:
     return _MessageHandler(
-        producer=producer,
+        producer=_as_producer(producer),
         topic="test-topic",
         deletion_value_fn=lambda k: b"deleted:"
         + (k if isinstance(k, bytes) else k.encode()),
@@ -229,7 +236,7 @@ class TestMessageHandlerSink:
     @pytest.mark.asyncio
     async def test_produce_messages(self, producer: MockAIOProducer) -> None:
         handler = _MessageHandler(
-            producer=producer, topic="test-topic", deletion_value_fn=None
+            producer=_as_producer(producer), topic="test-topic", deletion_value_fn=None
         )
 
         action1 = _MessageAction(key=b"k1", value=b"v1")
@@ -245,7 +252,7 @@ class TestMessageHandlerSink:
     @pytest.mark.asyncio
     async def test_produce_tombstone(self, producer: MockAIOProducer) -> None:
         handler = _MessageHandler(
-            producer=producer, topic="test-topic", deletion_value_fn=None
+            producer=_as_producer(producer), topic="test-topic", deletion_value_fn=None
         )
 
         action = _MessageAction(key=b"k1", value=None)
@@ -259,7 +266,7 @@ class TestMessageHandlerSink:
     @pytest.mark.asyncio
     async def test_produce_deletion_value(self, producer: MockAIOProducer) -> None:
         handler = _MessageHandler(
-            producer=producer,
+            producer=_as_producer(producer),
             topic="test-topic",
             deletion_value_fn=lambda k: b"del:"
             + (k if isinstance(k, bytes) else k.encode()),
@@ -275,10 +282,10 @@ class TestMessageHandlerSink:
     @pytest.mark.asyncio
     async def test_multiple_topics(self, producer: MockAIOProducer) -> None:
         handler1 = _MessageHandler(
-            producer=producer, topic="topic-a", deletion_value_fn=None
+            producer=_as_producer(producer), topic="topic-a", deletion_value_fn=None
         )
         handler2 = _MessageHandler(
-            producer=producer, topic="topic-b", deletion_value_fn=None
+            producer=_as_producer(producer), topic="topic-b", deletion_value_fn=None
         )
 
         context_provider = MagicMock(spec=ContextProvider)

--- a/python/tests/connectors/test_kafka_target.py
+++ b/python/tests/connectors/test_kafka_target.py
@@ -40,7 +40,7 @@ _mock_module.aio = _mock_aio
 sys.modules.setdefault("confluent_kafka", _mock_module)
 sys.modules.setdefault("confluent_kafka.aio", _mock_aio)
 
-from confluent_kafka.aio import AIOProducer  # noqa: E402
+from confluent_kafka.aio import AIOProducer  # type: ignore[import-not-found]  # noqa: E402
 from cocoindex.connectors.kafka._target import (  # noqa: E402
     _MessageAction,
     _MessageHandler,


### PR DESCRIPTION
## Summary
- Fix Kafka target: `AIOProducer.produce()` is async and returns a delivery `asyncio.Future`. The previous code discarded those futures, so `_apply_actions` returned before messages were delivered (and small batches could sit in the buffer indefinitely). Await the produce coroutines and then the delivery futures.
- Tighten types in `kafka/_target.py`: replace `Any` with `AIOProducer` on `_MessageHandler`, and use `bytes | str | NonExistenceType` for `TargetStateProvider`'s value type.
- Update `MockAIOProducer` and the kafka target tests to match the new async `produce` signature and stricter types.
- Minor: drop an unused filename-prefixed key in `examples/csv_to_kafka/main.py`.

## Test plan
- `uv run mypy`
- `uv run pytest python/tests/connectors/test_kafka_target.py`
- CI
