### PR TITLE
docs: rename "non-live" to "catch-up mode"

### DIFF
--- a/docs/docs/advanced_topics/live_component.md
+++ b/docs/docs/advanced_topics/live_component.md
@@ -5,9 +5,9 @@ description: Build components that process continuously and react to changes inc
 
 # Live Components
 
-By default, a processing component runs a **full scan** each time — it declares all target states and mounts all sub-components from scratch. CocoIndex handles incremental updates by skipping memoized sub-components and reconciling target states at the end. This works well when the dataset is small enough to scan fully each cycle.
+By default, a processing component runs in **catch-up mode** — on each `app.update()`, it declares all target states and mounts all sub-components from scratch. CocoIndex handles incremental updates by skipping memoized sub-components and reconciling target states at the end, then the component exits. This works well when the dataset is small enough to scan fully each cycle.
 
-When the dataset is large or you need to react to changes continuously (e.g., watching a file system), you want the component itself to be incremental. A **live component** does an initial full scan, then reacts to individual changes without rescanning everything.
+When the dataset is large or you need to react to changes continuously (e.g., watching a file system), you want the component itself to stay running and react incrementally. A **live component** does an initial full scan (same as catch-up mode), then keeps running and reacts to individual changes without rescanning everything.
 
 ## The LiveComponent protocol
 
@@ -198,14 +198,14 @@ To add live support to a source connector, make your source return an object tha
 - **`LiveMapView` example**: The [`localfs`](../connectors/localfs.md) connector's `DirWalker` — `walk_dir(..., live=True).items()` returns a `LiveMapView` backed by `watchfiles`.
 - **`LiveMapFeed` example**: The [`kafka`](../connectors/kafka.md) connector — `topic_as_map()` returns a `LiveMapFeed` that consumes messages from Kafka topics.
 
-## Live mode
+## Live mode vs catch-up mode
 
-See [Live Mode](../programming_guide/live_mode.md) for enabling live mode and an overview of how it works.
+See [Live Mode](../programming_guide/live_mode.md) for how the two modes are enabled at the app level and an overview of how they work.
 
-In the context of a manual `LiveComponent`, live mode controls whether `process_live()` continues running after `mark_ready()`:
+For a manual `LiveComponent`, the mode controls whether `process_live()` continues running after `mark_ready()`:
 
 - **Live mode** (`live=True`): `process_live()` continues after `mark_ready()` — the component keeps watching for changes.
-- **Non-live mode** (`live=False`, default): `process_live()` terminates as soon as `mark_ready()` is awaited. No code after `await operator.mark_ready()` executes.
+- **Catch-up mode** (`live=False`, default): `process_live()` terminates as soon as `mark_ready()` is awaited. No code after `await operator.mark_ready()` executes, so the component behaves like a traditional one-shot processor.
 
 This lets you use the same `LiveComponent` class in both modes without code changes.
 

--- a/docs/docs/programming_guide/live_mode.md
+++ b/docs/docs/programming_guide/live_mode.md
@@ -5,11 +5,11 @@ description: Make your app react to source changes continuously, instead of only
 
 # Live Mode
 
-By default, calling `app.update()` runs one processing cycle — it scans all sources, processes what changed since the last run (memoized components are skipped, so unchanged work is not redone), syncs target states, and returns. To pick up further changes, you call `update()` again.
+By default, calling `app.update()` runs in **catch-up mode**: it scans all sources, processes what changed since the last run (memoized components are skipped, so unchanged work is not redone), syncs target states, and returns. Targets are caught up to the moment the run started, and that's it — to pick up further changes, you call `update()` again.
 
-So updates are already incremental — but each call still has to scan sources to discover what changed, and changes are only picked up when you trigger a new run.
+So catch-up mode is already incremental — but each call still has to scan sources to discover what changed, and changes are only picked up when you trigger a new run.
 
-**Live mode** keeps the app running after that initial scan and lets components stream changes continuously from their sources (e.g. a file system watcher or a database change feed), applying them to target states with very low latency. This is useful when:
+**Live mode** keeps the app running after catch-up finishes and lets components stream changes continuously from their sources (e.g. a file system watcher or a database change feed), applying them to target states with very low latency. This is useful when:
 
 - You want near-real-time reactions to source changes, instead of waiting for the next `update()` call
 - Your sources can push changes more efficiently than a full rescan can discover them
@@ -38,7 +38,7 @@ cocoindex update -L my_app.py
 
 The `live` flag propagates top-down through the component tree — both `coco.mount()` and `coco.use_mount()` inherit `live` from the parent, so children are live when the app is live.
 
-Without `live=True` on the app, everything completes after the initial scan — even if a source supports live watching.
+Without `live=True` on the app, the app runs in catch-up mode — everything completes after the initial scan, even if a source supports live watching.
 
 ## Reacting to changes
 
@@ -61,9 +61,9 @@ When `mount_each()` receives either, it automatically creates a `LiveComponent` 
    - New or modified items → re-mount the affected component
    - Deleted items → remove the component and its target states
 
-CocoIndex handles change detection, memoization, and target state reconciliation the same way as in batch mode.
+CocoIndex handles change detection, memoization, and target state reconciliation the same way as in catch-up mode.
 
-Without live support on the source, `mount_each()` does a one-time iteration — items are processed in batch and that's it.
+Without live support on the source, `mount_each()` falls back to catch-up behavior — a one-time iteration over items and that's it.
 
 ## Examples
 
@@ -85,7 +85,7 @@ app = coco.App(coco.AppConfig(name="FilesTransform"), app_main, sourcedir=..., o
 app.update_blocking(live=True)
 ```
 
-**Non-live compatibility:** `LiveMapView` sources also work without `live=True` — they do the initial full scan and exit cleanly. You can write your pipeline once and choose batch or live at run time.
+**Catch-up compatibility:** `LiveMapView` sources also work without `live=True` — they do the initial full scan and exit cleanly. You can write your pipeline once and choose catch-up or live at run time.
 
 For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/files_transform).
 

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -100,7 +100,7 @@ class LiveComponentOperator:
         return ComponentMountHandle([core_handle])
 
     async def mark_ready(self) -> None:
-        """Signal readiness. In non-live mode, this never returns (terminates process_live)."""
+        """Signal readiness. In catch-up mode, this never returns (terminates process_live)."""
         await self._controller.mark_ready_async()
 
 
@@ -153,7 +153,7 @@ class LiveMapSubscriber(Generic[_K, _V]):
         await self._operator.update_full()
 
     async def mark_ready(self) -> None:
-        """Signal readiness. In non-live mode, this terminates ``watch()``."""
+        """Signal readiness. In catch-up mode, this terminates ``watch()``."""
         await self._operator.mark_ready()
 
     async def update(self, key: _K, value: _V) -> ComponentMountHandle:

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -155,7 +155,7 @@ class DirWalker:
         return self._items_iter()
 
     async def _items_iter(self) -> AsyncIterator[tuple[str, File]]:
-        """Async iterate over (key, file) pairs (non-live path)."""
+        """Async iterate over (key, file) pairs (catch-up path)."""
         root_path = self._root_path.path
         async for file in self:
             yield (file.file_path.path.relative_to(root_path).as_posix(), file)

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -100,8 +100,8 @@ def test_live_component_basic_full_update() -> None:
     }
 
 
-class _NonLiveLiveComponent:
-    """LiveComponent that loops forever after mark_ready (tests non-live termination)."""
+class _CatchUpLiveComponent:
+    """LiveComponent that loops forever after mark_ready (tests catch-up termination)."""
 
     async def process(self) -> None:
         _declare_source_entries()
@@ -109,26 +109,26 @@ class _NonLiveLiveComponent:
     async def process_live(self, operator: coco.LiveComponentOperator) -> None:
         await operator.update_full()
         await operator.mark_ready()
-        # In non-live mode, mark_ready should terminate process_live.
+        # In catch-up mode, mark_ready should terminate process_live.
         # This infinite loop should never execute.
         while True:
             await asyncio.sleep(1)
 
 
-def test_live_component_non_live_mode() -> None:
+def test_live_component_catch_up_mode() -> None:
     GlobalDictTarget.store.clear()
     _source_data.clear()
 
     _source_data["x"] = 10
 
     async def _main() -> None:
-        await coco.mount(coco.component_subpath("live"), _NonLiveLiveComponent)
+        await coco.mount(coco.component_subpath("live"), _CatchUpLiveComponent)
 
     app = coco.App(
-        coco.AppConfig(name="test_live_non_live_mode", environment=coco_env),
+        coco.AppConfig(name="test_live_catch_up_mode", environment=coco_env),
         _main,
     )
-    # Non-live mode (default): should complete without hanging
+    # Catch-up mode (default): should complete without hanging
     app.update_blocking()
 
     assert GlobalDictTarget.store.data == {
@@ -503,7 +503,7 @@ def test_mount_each_live_items_view_basic() -> None:
     }
 
 
-def test_mount_each_live_items_view_non_live_mode() -> None:
+def test_mount_each_live_items_view_catch_up_mode() -> None:
     GlobalDictTarget.store.clear()
     _live_source.clear()
     _live_source["x"] = 10
@@ -514,10 +514,10 @@ def test_mount_each_live_items_view_non_live_mode() -> None:
         await coco.mount_each(_declare_live_item, items)  # type: ignore[call-overload]
 
     app = coco.App(
-        coco.AppConfig(name="test_live_items_non_live", environment=coco_env),
+        coco.AppConfig(name="test_live_items_catch_up", environment=coco_env),
         _main,
     )
-    # Non-live mode: mark_ready terminates watch(), app completes
+    # Catch-up mode: mark_ready terminates watch(), app completes
     app.update_blocking()
 
     assert GlobalDictTarget.store.data == {

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -458,7 +458,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
 
     /// Signal readiness to parent component. Idempotent — subsequent calls are no-ops.
     /// - Live mode: resolves readiness and returns immediately.
-    /// - Non-live mode: resolves readiness, cancels the cancellation_token, then
+    /// - Catch-up mode: resolves readiness, cancels the cancellation_token, then
     ///   suspends indefinitely (Poll::Pending). select! in start() drops the
     ///   process_live future, terminating the Python task via CancelOnDropPy.
     pub async fn mark_ready(&self) {
@@ -475,7 +475,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         self.state.ready_notify.notify_waiters();
 
         if !self.live {
-            // Non-live mode: cancel the token so select! in start() drops process_live.
+            // Catch-up mode: cancel the token so select! in start() drops process_live.
             self.state.cancellation_token.cancel();
             // Suspend forever — select! will drop us via CancelOnDropPy.
             std::future::pending::<()>().await;


### PR DESCRIPTION
## Summary
- Introduce "catch-up mode" as the named term for the default (`live=False`) behavior, replacing the awkward "non-live"
- Clarifies that catch-up mode is still incremental — it catches up to the moment the run starts, then exits
- Updates docs, specs, Rust/Python comments, and test names; no behavior change

## Test plan
- CI
