### PR TITLE
docs: document ContextKey as stable identity for sources/targets

### DIFF
--- a/docs/docs/connectors/kafka.md
+++ b/docs/docs/connectors/kafka.md
@@ -132,6 +132,10 @@ The `kafka` connector provides target state APIs for producing messages to Kafka
 
 Create a `ContextKey[AIOProducer]` (with `tracked=False`) to identify your producer, then provide it in your lifespan:
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track target state for topics produced through this key. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 from confluent_kafka import AIOProducer
 import cocoindex as coco

--- a/docs/docs/connectors/lancedb.md
+++ b/docs/docs/connectors/lancedb.md
@@ -53,6 +53,10 @@ The `lancedb` connector provides target state APIs for writing rows to tables. W
 
 Create a `ContextKey[lancedb.LanceAsyncConnection]` (with `tracked=False`) to identify your LanceDB connection, then provide it in your lifespan:
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed tables. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 import cocoindex as coco
 

--- a/docs/docs/connectors/postgres.md
+++ b/docs/docs/connectors/postgres.md
@@ -170,6 +170,10 @@ The `postgres` connector provides target state APIs for writing rows to tables. 
 
 Create a `ContextKey[asyncpg.Pool]` (with `tracked=False`) to identify your connection pool, then provide the pool directly in your lifespan:
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 import asyncpg
 import cocoindex as coco

--- a/docs/docs/connectors/qdrant.md
+++ b/docs/docs/connectors/qdrant.md
@@ -56,6 +56,10 @@ The `qdrant` connector provides target state APIs for writing points to collecti
 
 Create a `ContextKey[QdrantClient]` (with `tracked=False`) to identify your Qdrant client, then provide it in your lifespan:
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed collections. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 from qdrant_client import QdrantClient
 import cocoindex as coco

--- a/docs/docs/connectors/sqlite.md
+++ b/docs/docs/connectors/sqlite.md
@@ -86,6 +86,10 @@ The `sqlite` connector provides target state APIs for writing rows to tables. Wi
 
 Create a `ContextKey[sqlite.ManagedConnection]` (with `tracked=False`) to identify your SQLite connection, then provide it in your lifespan using `sqlite.managed_connection()`:
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 import cocoindex as coco
 

--- a/docs/docs/connectors/surrealdb.md
+++ b/docs/docs/connectors/surrealdb.md
@@ -25,6 +25,10 @@ pip install cocoindex[surrealdb]
 
 Create a `ConnectionFactory` and provide it via a `ContextKey`. It holds connection parameters and creates authenticated connections on demand.
 
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+:::
+
 ```python
 from cocoindex.connectors import surrealdb
 import cocoindex as coco

--- a/docs/docs/programming_guide/context.md
+++ b/docs/docs/programming_guide/context.md
@@ -40,6 +40,20 @@ Use `tracked=False` for resources that don't affect computation results — logg
 Tracking is transitive: if function `foo` (memoized) calls function `bar`, and `bar` calls `use_context(key)` on a tracked key, then `foo`'s memo is also invalidated when the context value changes.
 :::
 
+## ContextKey as stable identity
+
+Beyond sharing resources, a `ContextKey` also serves as the **stable identity** of the resource it points to. When you anchor sources or targets to a `ContextKey`, CocoIndex treats *the key itself* — not the underlying value — as the identifier across runs.
+
+This has two consequences:
+
+1. **The underlying value can change without losing tracked state.** Rotating credentials, moving a database, or relocating a directory won't invalidate memoization or managed state, as long as the same `ContextKey` is used.
+
+2. **Renaming a `ContextKey` is a breaking change.** Two different keys are two different resources, even if they point to the same physical backend. Existing tracked state will be treated as orphaned. When migrating code, reuse the previous key name to preserve continuity.
+
+:::tip
+Pick a `ContextKey` name that reflects the *logical* role of the resource (e.g., `"text_embedding_db"`, `"docs_root"`), not its current address. The name is what CocoIndex persists.
+:::
+
 ## Providing values
 
 In your [lifespan function](./app.md#defining-a-lifespan), use `builder.provide()` to make resources available:


### PR DESCRIPTION
## Summary
- Add a "ContextKey as stable identity" section in the Context programming guide, explaining that the key (not the underlying value) is the persisted identity for sources/targets, and that renaming a key is a breaking change.
- Add a cross-reference note to each connector page that takes a `ContextKey` (postgres, qdrant, lancedb, sqlite, surrealdb, kafka) so users see the warning where they declare a key.

## Test plan
- CI (docs only)
