### PR TITLE
fix(lmdb): retry read transactions on MDB_READERS_FULL with backoff

### DIFF
--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -4,13 +4,29 @@ use crate::{
 };
 
 use cocoindex_utils::fingerprint::Fingerprint;
+use cocoindex_utils::retryable;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::time::Duration;
 
 const DEFAULT_MAX_DBS: u32 = 1024;
 const DEFAULT_LMDB_MAP_SIZE: usize = 0x1_0000_0000; // 4GiB
+
+/// Phase 1: short timeout to handle transient concurrency.
+static LMDB_READ_TXN_RETRY_PHASE1: retryable::RetryOptions = retryable::RetryOptions {
+    retry_timeout: Some(Duration::from_secs(3)),
+    initial_backoff: Duration::from_millis(10),
+    max_backoff: Duration::from_secs(1),
+};
+
+/// Phase 2: after clearing stale readers, retry indefinitely.
+static LMDB_READ_TXN_RETRY_PHASE2: retryable::RetryOptions = retryable::RetryOptions {
+    retry_timeout: None,
+    initial_backoff: Duration::from_millis(10),
+    max_backoff: Duration::from_secs(1),
+};
 
 fn default_max_dbs() -> u32 {
     DEFAULT_MAX_DBS
@@ -29,7 +45,7 @@ pub struct EnvironmentSettings {
 }
 
 struct EnvironmentInner<Prof: EngineProfile> {
-    db_env: heed::Env,
+    db_env: heed::Env<heed::WithoutTls>,
     txn_batcher: TxnBatcher,
     app_names: Mutex<BTreeSet<String>>,
     target_states_providers: Arc<Mutex<TargetStateProviderRegistry<Prof>>>,
@@ -67,6 +83,7 @@ impl<Prof: EngineProfile> Environment<Prof> {
         }
         let db_env = unsafe {
             heed::EnvOpenOptions::new()
+                .read_txn_without_tls()
                 .max_dbs(settings.lmdb_max_dbs)
                 .map_size(settings.lmdb_map_size)
                 .open(db_path)
@@ -112,8 +129,46 @@ impl<Prof: EngineProfile> Environment<Prof> {
         Ok(())
     }
 
-    pub fn db_env(&self) -> &heed::Env {
+    pub fn db_env(&self) -> &heed::Env<heed::WithoutTls> {
         &self.inner.db_env
+    }
+
+    /// Open an LMDB read transaction with automatic retry on `MDB_READERS_FULL`.
+    ///
+    /// Two-phase strategy:
+    /// 1. Retry with a short timeout — handles transient reader slot contention.
+    /// 2. If phase 1 times out, call `clear_stale_readers()` to reclaim slots
+    ///    from dead processes, then retry indefinitely.
+    pub async fn read_txn(&self) -> Result<heed::RoTxn<'_, heed::WithoutTls>> {
+        let db_env = self.db_env();
+        let try_read_txn = || async {
+            match db_env.read_txn() {
+                Ok(txn) => retryable::Ok(txn),
+                Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
+                    warn!("LMDB readers full, retrying");
+                    Err(retryable::Error::retryable(internal_error!(
+                        "LMDB readers full"
+                    )))
+                }
+                Err(e) => Err(retryable::Error::not_retryable(e)),
+            }
+        };
+
+        // Phase 1: short timeout for transient concurrency.
+        match retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE1).await {
+            Ok(txn) => return Ok(txn),
+            Err(e) if !e.is_retryable => return Err(e.into()),
+            Err(_) => {}
+        }
+
+        // Phase 2: clear stale readers, then retry indefinitely.
+        let cleared = db_env.clear_stale_readers()?;
+        if cleared > 0 {
+            warn!("Cleared {cleared} stale LMDB readers");
+        }
+        retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE2)
+            .await
+            .map_err(Into::into)
     }
 
     pub fn txn_batcher(&self) -> &TxnBatcher {

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -92,10 +92,9 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
     )
     .encode()?;
 
-    let db_env = comp_ctx.app_ctx().env().db_env();
     let db = comp_ctx.app_ctx().db();
     {
-        let rtxn = db_env.read_txn()?;
+        let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
         let Some(data) = db.get(&rtxn, key.as_slice())? else {
             return Ok(None);
         };
@@ -274,7 +273,7 @@ fn read_fn_call_memo_with_txn<Prof: EngineProfile>(
     }))
 }
 
-pub(crate) fn read_fn_call_memo<Prof: EngineProfile>(
+pub(crate) async fn read_fn_call_memo<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
 ) -> Result<Option<FnCallMemo<Prof>>> {
@@ -282,11 +281,8 @@ pub(crate) fn read_fn_call_memo<Prof: EngineProfile>(
     if comp_ctx.full_reprocess() {
         return Ok(None);
     }
-    let db_env = comp_ctx.app_ctx().env().db_env();
-    {
-        let rtxn = db_env.read_txn()?;
-        read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().db(), comp_ctx, memo_fp)
-    }
+    let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
+    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().db(), comp_ctx, memo_fp)
 }
 
 pub fn declare_target_state<Prof: EngineProfile>(
@@ -572,7 +568,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
             })
             .await?;
         // Transaction committed — open a read txn so GC sees the committed tombstones.
-        let rtxn = app_ctx.env().db_env().read_txn()?;
+        let rtxn = app_ctx.env().read_txn().await?;
         committer.launch_child_component_gc(&rtxn)
     }
 
@@ -1279,17 +1275,21 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         mut finalized_fn_call_memos,
     ) = match comp_ctx.processing_state() {
         ComponentProcessingAction::Build(build_ctx) => {
-            let mut building_state = build_ctx.state.lock().unwrap();
-            let Some(building_state) = building_state.take() else {
-                internal_bail!(
-                    "Processing for the component at {} is already finished",
-                    comp_ctx.stable_path()
-                );
+            // Extract from MutexGuard in a block so the guard is dropped before `.await`.
+            let building_state = {
+                let mut guard = build_ctx.state.lock().unwrap();
+                let Some(state) = guard.take() else {
+                    internal_bail!(
+                        "Processing for the component at {} is already finished",
+                        comp_ctx.stable_path()
+                    );
+                };
+                state
             };
 
             let child_path_set = building_state.child_path_set;
             let finalized_fn_call_memos =
-                finalize_fn_call_memoization(comp_ctx, building_state.fn_call_memos)?;
+                finalize_fn_call_memoization(comp_ctx, building_state.fn_call_memos).await?;
             (
                 &built_target_states_providers
                     .get_or_insert(building_state.target_states.provider_registry)
@@ -1568,7 +1568,7 @@ struct FinalizedFnCallMemoization<Prof: EngineProfile> {
     contained_target_state_paths: HashSet<TargetStatePath>,
 }
 
-fn finalize_fn_call_memoization<Prof: EngineProfile>(
+async fn finalize_fn_call_memoization<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     fn_call_memos: HashMap<Fingerprint, Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>>,
 ) -> Result<FinalizedFnCallMemoization<Prof>> {
@@ -1603,8 +1603,7 @@ fn finalize_fn_call_memoization<Prof: EngineProfile>(
     // Collect their target_state_paths so those target states are not GC'd.
     // Use a single read transaction for all DB reads.
     if !deps_to_process.is_empty() {
-        let db_env = comp_ctx.app_ctx().env().db_env();
-        let rtxn = db_env.read_txn()?;
+        let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
         let db = comp_ctx.app_ctx().db();
         while let Some(fp) = deps_to_process.pop_front() {
             if !result.all_memos_fps.insert(fp) {

--- a/rust/core/src/engine/function.rs
+++ b/rust/core/src/engine/function.rs
@@ -127,7 +127,7 @@ pub async fn reserve_memoization<Prof: EngineProfile>(
     // try loading from the database.
     if let FnCallMemoEntry::Pending = &*guard {
         if !comp_exec_ctx.full_reprocess() {
-            if let Some(fn_call_memo) = read_fn_call_memo(comp_exec_ctx, memo_fp)? {
+            if let Some(fn_call_memo) = read_fn_call_memo(comp_exec_ctx, memo_fp).await? {
                 *guard = FnCallMemoEntry::Ready(Some(fn_call_memo));
             }
         }

--- a/rust/core/src/engine/txn_batcher.rs
+++ b/rust/core/src/engine/txn_batcher.rs
@@ -11,7 +11,7 @@ type TxnBody =
     Box<dyn for<'txn> FnOnce(&mut heed::RwTxn<'txn>) -> Result<Box<dyn Any + Send>> + Send>;
 
 struct TxnRunner {
-    db_env: heed::Env,
+    db_env: heed::Env<heed::WithoutTls>,
 }
 
 #[async_trait]
@@ -48,7 +48,7 @@ pub struct TxnBatcher {
 }
 
 impl TxnBatcher {
-    pub fn new(db_env: heed::Env) -> Self {
+    pub fn new(db_env: heed::Env<heed::WithoutTls>) -> Self {
         let queue = Arc::new(BatchQueue::new());
         Self {
             inner: Batcher::new(TxnRunner { db_env }, queue, BatchingOptions::default()),


### PR DESCRIPTION
## Summary
- Add `Environment::read_txn()` async method that retries on `MDB_READERS_FULL` with exponential backoff in two phases: first a short timeout for transient concurrency, then clearing stale readers and retrying indefinitely
- Switch LMDB env to `WithoutTls` so `RoTxn` is `Send`, enabling clean async retry via `retryable::run`
- Convert all 4 `read_txn()` call sites in the engine to use the new retry-aware method

Related: cocoindex-io/cocoindex-code#129

## Test plan
- CI (cargo test, mypy, pytest all pass)
