### PR TITLE
fix(progress): refresh elapsed timer independently of stats changes

### DIFF
--- a/rust/core/src/engine/progress_display.rs
+++ b/rust/core/src/engine/progress_display.rs
@@ -378,14 +378,24 @@ async fn show_progress_pty<T: Send + 'static>(
     // Display loop
     let mut spinner_idx: usize = 0;
     let mut ready_time: Option<Instant> = None;
+    let mut sleep_fut = std::pin::pin!(tokio::time::sleep(options.refresh_interval));
 
     loop {
-        let version = handle.changed().await?;
-        if version >= TERMINATED_VERSION {
-            break;
+        // Wake on stats change OR refresh interval, whichever comes first.
+        // This ensures the elapsed timer and spinner update regularly even when
+        // no stats changes occur (e.g. slow components with no progress for a while).
+        tokio::select! {
+            result = handle.changed() => {
+                let version = result?;
+                if version >= TERMINATED_VERSION {
+                    break;
+                }
+            }
+            () = &mut sleep_fut => {}
         }
 
-        tokio::time::sleep(options.refresh_interval).await;
+        // Reset the sleep future for the next iteration.
+        sleep_fut.set(tokio::time::sleep(options.refresh_interval));
 
         let snapshot = handle.stats_snapshot();
         if snapshot.ready && ready_time.is_none() {
@@ -459,17 +469,23 @@ async fn show_progress_plain<T: Send + 'static>(
     start_time: Instant,
 ) -> Result<T> {
     let mut ready_time: Option<Instant> = None;
+    let mut sleep_fut = std::pin::pin!(tokio::time::sleep(options.refresh_interval));
 
     loop {
-        let version = match handle.changed().await {
-            Ok(v) => v,
-            Err(_) => break,
-        };
-        if version >= TERMINATED_VERSION {
-            break;
+        tokio::select! {
+            result = handle.changed() => {
+                let version = match result {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                if version >= TERMINATED_VERSION {
+                    break;
+                }
+            }
+            () = &mut sleep_fut => {}
         }
 
-        tokio::time::sleep(options.refresh_interval).await;
+        sleep_fut.set(tokio::time::sleep(options.refresh_interval));
 
         let snapshot = handle.stats_snapshot();
         if snapshot.ready && ready_time.is_none() {


### PR DESCRIPTION
## Summary
- The progress display loop previously blocked on `handle.changed().await` before refreshing, causing the elapsed timer and spinner to freeze when slow components produced no stats updates for extended periods.
- Use `tokio::select!` to wake on either a stats change or the refresh interval timeout, whichever comes first, ensuring the timer updates every ~1 second regardless of stats activity.
- Applied to both PTY and plain-text display paths.

## Test plan
- CI (existing `progress_display` unit tests pass)
- Manual: run an app with slow components and verify the elapsed timer updates smoothly every second even when no stats changes occur.
