### PR TITLE
feat: make ComponentSubpath optional in mount() and use_mount()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,13 @@ Think of it like:
 ### Key APIs
 
 ```python
-# Mounting processing components (subpath first, then function)
-await coco.mount(coco.component_subpath("name"), fn, *args, **kw)      # child runs independently
-result = await coco.use_mount(coco.component_subpath("name"), fn, *args, **kw)  # returns value directly
+# Mounting processing components (subpath auto-derived from fn.__name__)
+await coco.mount(fn, *args, **kw)                                       # child runs independently
+result = await coco.use_mount(fn, *args, **kw)                          # returns value directly
+
+# Explicit subpath (for multi-part paths or multiple mounts of same function)
+await coco.mount(coco.component_subpath("process", filename), fn, *args, **kw)
+result = await coco.use_mount(coco.component_subpath("name"), fn, *args, **kw)
 
 # Component subpath composition
 subpath = coco.component_subpath("process", filename)  # multiple parts
@@ -154,9 +158,7 @@ async def process_file(file: FileLike, target: localfs.DirTarget) -> None:
 
 @coco.fn
 async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
-    target = await coco.use_mount(
-        coco.component_subpath("setup"), localfs.declare_dir_target, outdir
-    )
+    target = await coco.use_mount(localfs.declare_dir_target, outdir)
 
     files = localfs.walk_dir(
         sourcedir, path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"])

--- a/docs/docs/advanced_topics/live_component.md
+++ b/docs/docs/advanced_topics/live_component.md
@@ -109,13 +109,9 @@ The parent mounts it like any other component:
 @coco.fn
 async def app_main(folder: pathlib.Path, outdir: pathlib.Path) -> None:
     # Set up the target in the parent (use_mount is not allowed inside process()).
-    target = await coco.use_mount(
-        coco.component_subpath("setup"),
-        localfs.declare_dir_target,
-        outdir,
-    )
+    target = await coco.use_mount(localfs.declare_dir_target, outdir)
     # Mount the live component.
-    await coco.mount(coco.component_subpath("watch"), FolderWatcher, folder, target)
+    await coco.mount(FolderWatcher, folder, target)
 ```
 
 ## Example: traditional component equivalent

--- a/docs/docs/connectors/kafka.md
+++ b/docs/docs/connectors/kafka.md
@@ -103,9 +103,7 @@ async def process_message(msg: Message, target: localfs.DirTarget) -> None:
 
 @coco.fn
 async def app_main(outdir: pathlib.Path) -> None:
-    target = await coco.use_mount(
-        coco.component_subpath("setup"), localfs.declare_dir_target, outdir
-    )
+    target = await coco.use_mount(localfs.declare_dir_target, outdir)
 
     consumer = AIOConsumer({
         "bootstrap.servers": "localhost:9092",

--- a/docs/docs/connectors/localfs.md
+++ b/docs/docs/connectors/localfs.md
@@ -201,7 +201,6 @@ OUTPUT_DIR = coco.ContextKey[pathlib.Path]("output_dir")
 @coco.fn
 def app_main() -> None:
     coco.mount(
-        coco.component_subpath("readme"),
         localfs.declare_file,
         localfs.FilePath("readme.txt", base_dir=OUTPUT_DIR),
         content="Hello, world!",

--- a/docs/docs/programming_guide/processing_component.md
+++ b/docs/docs/programming_guide/processing_component.md
@@ -46,9 +46,32 @@ And two sugar APIs that simplify common patterns:
 
 See also [Processing Helpers](./processing_helpers.md) for utility APIs like `map()` that operate within a component without creating new ones.
 
+### Automatic subpath derivation {#auto-subpath}
+
+`mount()`, `use_mount()`, and `mount_each()` all accept an optional `ComponentSubpath` as their first argument. When omitted, the subpath is **auto-derived** from the function name using `Symbol(fn.__name__)`.
+
+```python
+# These are equivalent:
+await coco.mount(process_file, file, target)
+await coco.mount(coco.component_subpath(coco.Symbol("process_file")), process_file, file, target)
+```
+
+This means the component path for a `process_file` function is `parent / Symbol("process_file")`. The function must have a `__name__` attribute; if it doesn't (e.g., a lambda), provide an explicit subpath.
+
+Since sibling component paths must not collide, you need an explicit subpath when:
+- **The same function is mounted more than once** — auto-derived paths would be identical, so each call needs a distinct path (e.g., `coco.component_subpath("session", youtube_id)`)
+- **Different functions happen to share a `__name__`** — rare, but possible with wrappers or closures
+- **You want a specific path name** — different from the function name
+
 ### `mount()`
 
 Use `mount()` when you don't need a return value from the processing component. It schedules the processing component to run and returns a handle:
+
+```python
+handle = await coco.mount(process_file, file, target)
+```
+
+With an explicit subpath, for example when mounting multiple components of the same function:
 
 ```python
 handle = await coco.mount(
@@ -74,6 +97,12 @@ You usually only need to call `ready()` when you have logic that depends on the 
 Use `use_mount()` when you need the processing component's return value. It mounts the component, waits until it's ready, and returns the value directly:
 
 ```python
+table = await coco.use_mount(setup_table, table_name="docs")
+```
+
+With an explicit subpath:
+
+```python
 table = await coco.use_mount(
     coco.component_subpath("setup"),
     setup_table,
@@ -92,7 +121,7 @@ files = localfs.walk_dir(sourcedir, path_matcher=PatternFilePathMatcher(included
 await coco.mount_each(process_file, files.items(), target)
 ```
 
-Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an auto-derived subpath (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
+Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an [auto-derived subpath](#auto-subpath) (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
 
 You can provide an explicit subpath as the first argument:
 

--- a/docs/docs/programming_guide/sdk_overview.md
+++ b/docs/docs/programming_guide/sdk_overview.md
@@ -102,9 +102,7 @@ async def process_file(file: FileLike, target: localfs.DirTarget) -> None:
 @coco.fn
 async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
     # Async — orchestrates the pipeline
-    target = await coco.use_mount(
-        coco.component_subpath("setup"), localfs.declare_dir_target, outdir
-    )
+    target = await coco.use_mount(localfs.declare_dir_target, outdir)
     files = localfs.walk_dir(sourcedir)
     await coco.mount_each(process_file, files.items(), target)
 

--- a/examples/image_search/main.py
+++ b/examples/image_search/main.py
@@ -93,7 +93,7 @@ async def process_file(
 @coco.fn
 async def app_main(sourcedir: pathlib.Path) -> None:
     model, _ = get_clip_model()
-    dim = int(model.config.projection_dim)
+    dim: int = model.config.projection_dim  # type: ignore[assignment]
 
     target_collection = await qdrant.mount_collection_target(
         QDRANT_DB,

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -214,12 +214,31 @@ async def use_mount(
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> ReturnT: ...
+@overload
 async def use_mount(
-    subpath: ComponentSubpath,
-    processor_fn: AnyCallable[P, Any],
+    processor_fn: AsyncCallable[P, ResolvesTo[ReturnT]],
     *args: P.args,
     **kwargs: P.kwargs,
-) -> Any:
+) -> ReturnT: ...
+@overload
+async def use_mount(
+    processor_fn: Callable[P, ResolvesTo[ReturnT]],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> ReturnT: ...
+@overload
+async def use_mount(
+    processor_fn: AsyncCallable[P, ReturnT],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> ReturnT: ...
+@overload
+async def use_mount(
+    processor_fn: Callable[P, ReturnT],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> ReturnT: ...
+async def use_mount(*pos_args: Any, **kwargs: Any) -> Any:
     """
     Mount a dependent processing component and return its result.
 
@@ -228,8 +247,11 @@ async def use_mount(
     ``use_context()``) signals that the caller creates a dependency on the
     child's result.
 
+    Accepts an optional ``ComponentSubpath`` as the first argument. When omitted,
+    the subpath is auto-derived from ``Symbol(fn.__name__)``.
+
     Args:
-        subpath: The component subpath (from component_subpath()).
+        subpath: Optional component subpath. Auto-derived from fn.__name__ when omitted.
         processor_fn: The function to run as the processing unit processor.
         *args: Arguments to pass to the function.
         **kwargs: Keyword arguments to pass to the function.
@@ -238,10 +260,28 @@ async def use_mount(
         The return value of processor_fn.
 
     Example:
+        target = await coco.use_mount(declare_table_target, table_name)
+
+        # With explicit subpath:
         target = await coco.use_mount(
             coco.component_subpath("setup"), declare_table_target, table_name
         )
     """
+    if pos_args and isinstance(pos_args[0], ComponentSubpath):
+        subpath = pos_args[0]
+        processor_fn = pos_args[1]
+        args = pos_args[2:]
+    else:
+        processor_fn = pos_args[0]
+        args = pos_args[1:]
+        name = getattr(processor_fn, "__name__", None)
+        if name is None:
+            raise TypeError(
+                "use_mount() requires a ComponentSubpath when the function has no "
+                "__name__. Provide an explicit subpath as the first argument."
+            )
+        subpath = ComponentSubpath(Symbol(name))
+
     if is_live_component_class(processor_fn):
         raise TypeError(
             "LiveComponent classes cannot be used with use_mount(). "
@@ -285,17 +325,32 @@ async def _mount_live_component(
     return ComponentMountHandle([readiness_handle])
 
 
+@overload
 async def mount(
     subpath: ComponentSubpath,
     processor_fn: AnyCallable[P, Any],
     *args: P.args,
     **kwargs: P.kwargs,
-) -> ComponentMountHandle:
+) -> ComponentMountHandle: ...
+
+
+@overload
+async def mount(
+    processor_fn: AnyCallable[P, Any],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> ComponentMountHandle: ...
+
+
+async def mount(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
     """
     Mount a processing unit in the background and return a handle to wait until ready.
 
+    Accepts an optional ``ComponentSubpath`` as the first argument. When omitted,
+    the subpath is auto-derived from ``Symbol(fn.__name__)``.
+
     Args:
-        subpath: The component subpath (from component_subpath()).
+        subpath: Optional component subpath. Auto-derived from fn.__name__ when omitted.
         processor_fn: The function to run as the processing unit processor.
             Can also be a LiveComponent class.
         *args: Arguments to pass to the function (or LiveComponent constructor).
@@ -305,10 +360,26 @@ async def mount(
         A handle that can be used to wait until the processing unit is ready.
 
     Example:
-        with coco.component_subpath("process"):
-            for f in files:
-                await coco.mount(coco.component_subpath(str(f.relative_path)), process_file, f, target)
+        await coco.mount(process_file, file, target)
+
+        # With explicit subpath:
+        await coco.mount(coco.component_subpath("process", filename), process_file, file, target)
     """
+    if pos_args and isinstance(pos_args[0], ComponentSubpath):
+        subpath = pos_args[0]
+        processor_fn = pos_args[1]
+        args = pos_args[2:]
+    else:
+        processor_fn = pos_args[0]
+        args = pos_args[1:]
+        name = getattr(processor_fn, "__name__", None)
+        if name is None:
+            raise TypeError(
+                "mount() requires a ComponentSubpath when the function has no "
+                "__name__. Provide an explicit subpath as the first argument."
+            )
+        subpath = ComponentSubpath(Symbol(name))
+
     parent_ctx = get_context_from_ctx()
     child_path = build_child_path(parent_ctx, subpath)
 

--- a/python/tests/core/test_component_memo.py
+++ b/python/tests/core/test_component_memo.py
@@ -347,7 +347,7 @@ def test_memo_invalidation_on_decorator_change() -> None:
     @coco.fn
     async def app_main() -> None:
         mod = current_module[0]
-        await coco.mount(coco.component_subpath("A"), mod.process_entry, "A", "value1")  # type: ignore[attr-defined]
+        await coco.mount(coco.component_subpath("A"), mod.process_entry, "A", "value1")  # type: ignore[attr-defined, call-overload]
 
     app = coco.App(
         coco.AppConfig(

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -109,16 +109,19 @@ A **processing component** groups an item's processing with its target states.
 # One component per item (preferred for lists)
 await coco.mount_each(process_file, files.items(), target_table)
 
-# Single component
-await coco.mount(coco.component_subpath("setup"), setup_fn, arg1)
+# Single component (subpath auto-derived from fn.__name__)
+await coco.mount(setup_fn, arg1)
 
 # Dependent component (blocks until result returned)
-result = await coco.use_mount(coco.component_subpath("init"), init_fn)
+result = await coco.use_mount(init_fn)
+
+# Explicit subpath (when you need a specific path, e.g. in loops)
+await coco.mount(coco.component_subpath("item", item_id), process_item, item)
 ```
 
 **Key points:**
 - All mount APIs are `async`
-- `mount_each()` auto-derives subpath from `fn.__name__`; optional explicit subpath as first arg
+- `mount()`, `use_mount()`, and `mount_each()` auto-derive subpath from `fn.__name__`; optional explicit subpath as first arg
 - Use `use_mount()` when you need the return value
 - Use stable component paths for proper memoization and cleanup
 

--- a/skills/cocoindex/references/api_reference.md
+++ b/skills/cocoindex/references/api_reference.md
@@ -40,18 +40,26 @@ def batch_embed(texts: list[str]) -> list[NDArray]: ...
 
 ## Mount APIs (all async)
 
+All mount APIs accept an optional `ComponentSubpath` as their first argument. When omitted, the subpath is auto-derived from `Symbol(fn.__name__)`. Provide an explicit subpath when mounting the same function multiple times, using multi-part paths, or needing a specific path name.
+
 ### `coco.mount()`
 
 Mount a processing component in the background.
 
 ```python
-handle = await coco.mount(
-    coco.component_subpath("name"),
-    processor_fn,
-    *args, **kwargs,
-)
+# Subpath auto-derived from fn.__name__
+handle = await coco.mount(processor_fn, *args, **kwargs)
+
+# Explicit subpath
+handle = await coco.mount(coco.component_subpath("name"), processor_fn, *args, **kwargs)
+
 await handle.ready()  # Optional: wait until component finishes
 ```
+
+**Parameters:**
+- `subpath` (optional) -- Component subpath. Auto-derived from `fn.__name__` when omitted.
+- `processor_fn` -- Function (or LiveComponent class) to run.
+- `*args, **kwargs` -- Arguments passed to the function.
 
 **Returns:** `ComponentMountHandle`
 
@@ -60,12 +68,17 @@ await handle.ready()  # Optional: wait until component finishes
 Mount a dependent component and return its result. Parent depends on the child.
 
 ```python
-result = await coco.use_mount(
-    coco.component_subpath("setup"),
-    init_fn,
-    *args, **kwargs,
-)
+# Subpath auto-derived from fn.__name__
+result = await coco.use_mount(init_fn, *args, **kwargs)
+
+# Explicit subpath
+result = await coco.use_mount(coco.component_subpath("setup"), init_fn, *args, **kwargs)
 ```
+
+**Parameters:**
+- `subpath` (optional) -- Component subpath. Auto-derived from `fn.__name__` when omitted.
+- `processor_fn` -- Function to run.
+- `*args, **kwargs` -- Arguments passed to the function.
 
 **Returns:** The return value of `processor_fn`.
 


### PR DESCRIPTION
## Summary
- Make `ComponentSubpath` optional in `mount()` and `use_mount()`, aligning with the existing `mount_each()` behavior — when omitted, the subpath is auto-derived from `Symbol(fn.__name__)`
- Add new "Automatic subpath derivation" section to processing_component.md explaining the shared behavior and when explicit subpaths are needed
- Update doc examples across sdk_overview, kafka, live_component, localfs, CLAUDE.md, and skill references to use the simpler call form

## Test plan
- CI (mypy + pytest pass, all pre-commit hooks pass)
