### PR TITLE
refactor: rename NotMemoizable to NotMemoKeyable

### DIFF
--- a/docs/docs/advanced_topics/memoization_keys.md
+++ b/docs/docs/advanced_topics/memoization_keys.md
@@ -224,12 +224,12 @@ class S3Object:
 
 Some types maintain internal state that makes memoization semantically incorrect. For example, a generator that tracks call counts would produce wrong results if memoized.
 
-### Inherit from `NotMemoizable` (when you control the type)
+### Inherit from `NotMemoKeyable` (when you control the type)
 
 ```python
 import cocoindex as coco
 
-class MyStatefulGenerator(coco.NotMemoizable):
+class MyStatefulGenerator(coco.NotMemoKeyable):
     def __init__(self) -> None:
         self._counter = 0
 
@@ -238,13 +238,13 @@ class MyStatefulGenerator(coco.NotMemoizable):
         return self._counter
 ```
 
-### Register as not memoizable (when you don't control the type)
+### Register as not memo-keyable (when you don't control the type)
 
 ```python
 import cocoindex as coco
 from some_library import StatefulGenerator
 
-coco.register_not_memoizable(StatefulGenerator)
+coco.register_not_memo_keyable(StatefulGenerator)
 ```
 
 In either case, attempting to use the type as a memo key raises a clear error.
@@ -255,4 +255,4 @@ In either case, attempting to use the type as a memo key raises a clear error.
 - **Separate identity from freshness**: put stable identifiers (file path, URL, primary key) in the key. Put freshness checks (mtime, ETag, version) in the state.
 - **Use state validation for expensive checks**: if freshness validation is costly (content hashing, network calls), a state function lets you do it only when the fingerprint matches, and only when a cheap pre-check (mtime) fails.
 - **Use `MemoStateOutcome(state=new_state, memo_valid=True)` for cheap state updates**: when a cheap property changes (mtime) but the expensive check (content hash) confirms nothing meaningful changed, return `memo_valid=True` while updating the state. This avoids re-executing the function and avoids re-checking the expensive property next time.
-- **Mark stateful types as `NotMemoizable`**: prevent subtle bugs from incorrect memoization of types with side effects.
+- **Mark stateful types as `NotMemoKeyable`**: prevent subtle bugs from incorrect memoization of types with side effects.

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -129,7 +129,7 @@ from .environment import lifespan
 
 from .runner import GPU, Runner
 
-from .memo_fingerprint import register_memo_key_function, NotMemoizable
+from .memo_fingerprint import register_memo_key_function, NotMemoKeyable
 
 from .serde import unpickle_safe, serialize_by_pickle
 
@@ -704,7 +704,7 @@ __all__ = [
     "serialize_by_pickle",
     # .memo_fingerprint
     "register_memo_key_function",
-    "NotMemoizable",
+    "NotMemoKeyable",
     # .pending_marker
     "MaybePendingS",
     "PendingS",

--- a/python/cocoindex/_internal/memo_fingerprint.py
+++ b/python/cocoindex/_internal/memo_fingerprint.py
@@ -133,14 +133,14 @@ def _canonicalize_pydantic(obj: object, _seen: dict[int, int]) -> Fingerprintabl
     )
 
 
-class NotMemoizable:
+class NotMemoKeyable:
     """
     Base class for objects that must not be used as memoization keys.
 
     Inherit from this class when an object maintains internal state that would
     make memoization semantically incorrect (e.g., generators that track call counts).
 
-    Attempting to use a `NotMemoizable` instance as a memo key will raise TypeError.
+    Attempting to use a `NotMemoKeyable` instance as a memo key will raise TypeError.
     """
 
     __slots__ = ()
@@ -166,26 +166,26 @@ def register_memo_key_function(
     _memo_fns[typ] = _MemoFns(key_fn, state_fn)
 
 
-def register_not_memoizable(typ: type) -> None:
-    """Register a type as not memoizable.
+def register_not_memo_keyable(typ: type) -> None:
+    """Register a type as not memo-keyable.
 
     Use this for third-party types that maintain internal state incompatible
-    with memoization, but which you cannot modify to inherit from `NotMemoizable`.
+    with memoization, but which you cannot modify to inherit from `NotMemoKeyable`.
 
     Example:
         import cocoindex as coco
         from some_library import StatefulGenerator
 
-        coco.register_not_memoizable(StatefulGenerator)
+        coco.register_not_memo_keyable(StatefulGenerator)
     """
 
-    def _raise_not_memoizable(obj: object) -> typing.NoReturn:
+    def _raise_not_memo_keyable(obj: object) -> typing.NoReturn:
         raise TypeError(
             f"{type(obj).__name__} cannot be used as a memoization key. "
             "This type maintains internal state that is incompatible with memoization."
         )
 
-    _memo_fns[typ] = _MemoFns(_raise_not_memoizable)
+    _memo_fns[typ] = _MemoFns(_raise_not_memo_keyable)
 
 
 def unregister_memo_key_function(typ: type) -> None:
@@ -399,9 +399,9 @@ register_memo_key_function(
 
 
 __all__ = [
-    "NotMemoizable",
+    "NotMemoKeyable",
     "register_memo_key_function",
-    "register_not_memoizable",
+    "register_not_memo_keyable",
     "unregister_memo_key_function",
     "fingerprint_call",
 ]

--- a/python/cocoindex/resources/id.py
+++ b/python/cocoindex/resources/id.py
@@ -86,7 +86,7 @@ def generate_uuid(_dep: _typing.Any = None) -> _uuid.UUID:
     return _uuid.uuid4()
 
 
-class IdGenerator(_coco.NotMemoizable):
+class IdGenerator(_coco.NotMemoKeyable):
     """
     Generator for stable unique IDs that produces distinct IDs on each call.
 
@@ -149,7 +149,7 @@ class IdGenerator(_coco.NotMemoizable):
         return await _generate_next_id(self._deps_fp, dep_fp, ordinal)
 
 
-class UuidGenerator(_coco.NotMemoizable):
+class UuidGenerator(_coco.NotMemoKeyable):
     """
     Generator for stable unique UUIDs that produces distinct UUIDs on each call.
 


### PR DESCRIPTION
## Summary
- Rename `NotMemoizable` → `NotMemoKeyable` and `register_not_memoizable()` → `register_not_memo_keyable()`
- Old name had category confusion: "memoizable" describes a function property, but the class applies to objects used as memoization inputs
- New name aligns with user-facing `memo_key` vocabulary (`__coco_memo_key__`, `register_memo_key_function`) and correctly scopes the property to the object

## Test plan
- `uv run pytest python/` — 513 passed, 70 skipped
- CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
