### PR TITLE
fix: make module name consistent when loading user app via CLI (#1834)

### DIFF
--- a/python/cocoindex/user_app_loader.py
+++ b/python/cocoindex/user_app_loader.py
@@ -24,7 +24,11 @@ def load_user_app(app_target: str) -> types.ModuleType:
             raise Error(f"Application file path not found: {app_target}")
         app_path = os.path.abspath(app_target)
         app_dir = os.path.dirname(app_path)
-        module_name = os.path.splitext(os.path.basename(app_path))[0]
+        # Use "__main__" as the module name so that functions defined in the loaded
+        # module have __module__ == "__main__", matching the behavior when running
+        # the script directly (python main.py). This keeps memoization cache keys
+        # consistent between direct execution and CLI-loaded execution.
+        module_name = "__main__"
 
         if app_dir not in sys.path:
             sys.path.insert(0, app_dir)


### PR DESCRIPTION
## Problem

Fixes #1834

When a user app is loaded via CLI (), the module name is set to the file basename (e.g., ), but when running directly (), Python sets  to . This causes functions defined in the module to have different  attributes, which invalidates memoization cache keys (since they use  for identification).

## Solution

Changed  in  to use  as the module name when loading a file path, matching the behavior of direct script execution.

### Before


### After
python main.py

## Impact

- Functions defined in user apps loaded via CLI now have , same as direct execution
- Memoization cache keys remain consistent regardless of how the app is started
- No behavior change for module imports (non-file-path targets)

## Testing

Verified with standalone tests that:
1.  is  after loading
2. Functions defined in the module have  
3.  points to the loaded module