### PR TITLE
feat(fn): add deps= to @coco.fn for external logic dependencies

### DIFF
--- a/docs/docs/programming_guide/function.md
+++ b/docs/docs/programming_guide/function.md
@@ -78,10 +78,11 @@ Add a **return type annotation** to memoized functions so CocoIndex can properly
 
 ### Controlling change detection scope
 
-Two parameters on `@coco.fn` let you customize how code changes are detected:
+Three parameters on `@coco.fn` let you customize how code changes are detected:
 
 - **`logic_tracking`** — controls the *scope* of automatic code change detection
 - **`version`** — provides explicit manual control over when dependent memos are invalidated
+- **`deps`** — declares external values (e.g. a module-level prompt string) as part of the function's logic, so changing them invalidates dependent memos
 
 These parameters control the **code** side of change detection. The **data** side is controlled by [`detect_change`](./context.md#change-detection) on context keys, and by the fingerprinting behavior of the objects themselves (see [Memoization Keys & States](../advanced_topics/memoization_keys.md)).
 
@@ -103,6 +104,39 @@ def process_chunk(chunk: Chunk) -> Embedding:
     # Bumping version invalidates all memoized callers, even if code looks the same
     return embed(chunk.text)
 ```
+
+#### `deps`
+
+The `deps` parameter declares external value(s) the function logic depends on but that aren't visible in its body — for example a prompt string or a model identifier defined at module scope. When the value changes, the function's logic fingerprint changes and dependent memos are invalidated, exactly as if the function body had been edited.
+
+```python
+SYSTEM_PROMPT = "You are a helpful assistant. Be concise."
+
+@coco.fn(memo=True, deps=SYSTEM_PROMPT)
+def summarize(text: str) -> str:
+    # Editing SYSTEM_PROMPT invalidates this function's memo
+    # (and propagates to memoized callers) just like a code change would.
+    return call_llm(SYSTEM_PROMPT, text)
+```
+
+For multiple dependencies, pass a tuple or dict:
+
+```python
+SYSTEM_PROMPT = "..."
+MODEL = "claude-haiku-4-5"
+
+@coco.fn(memo=True, deps={"prompt": SYSTEM_PROMPT, "model": MODEL})
+def summarize(text: str) -> str:
+    return call_llm(SYSTEM_PROMPT, text, model=MODEL)
+```
+
+The value is canonicalized through the [memoization-key pipeline](../advanced_topics/memoization_keys.md), which honors `__coco_memo_key__()`, registered memo key functions, and the standard handling for primitives, dataclasses, and Pydantic models.
+
+:::caution Snapshotted at decoration time
+`deps` is evaluated **once** when the decorator is applied (typically at module import), not re-evaluated per call. For per-call or per-instance values — instance attributes in a bound method, request-scoped config, anything that changes at runtime — pass them as regular function arguments instead, so the memoization layer observes each new value.
+:::
+
+`deps` requires `logic_tracking` to be enabled; combining `deps=<value>` with `logic_tracking=None` raises `ValueError`.
 
 #### Common patterns
 

--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -37,7 +37,7 @@ from .component_ctx import (
     get_context_from_ctx,
 )
 from .context_keys import resolve_awaitables_sync
-from .memo_fingerprint import StateFnEntry, fingerprint_call
+from .memo_fingerprint import StateFnEntry, fingerprint_call, memo_fingerprint
 from .runner import Runner
 from .runner import in_subprocess as _in_subprocess
 from .serde import (
@@ -443,7 +443,10 @@ def _strip_docstring(body: list[ast.stmt]) -> None:
 
 
 def _compute_logic_fingerprint(
-    fn: Callable[..., Any], *, version: int | None = None
+    fn: Callable[..., Any],
+    *,
+    version: int | None = None,
+    deps: Any = None,
 ) -> core.Fingerprint:
     """Compute a fingerprint from the function's canonical AST.
 
@@ -456,6 +459,10 @@ def _compute_logic_fingerprint(
 
     The fully-qualified module + qualname is always included so that
     identical function bodies in different modules don't collide.
+
+    When *deps* is not ``None``, it is canonicalized via the memoization-key
+    pipeline and its fingerprint is folded into the payload, so changing the
+    value invalidates the result just like a code change does.
     """
     if version is not None:
         canonical = f"<version>({version})"
@@ -471,6 +478,14 @@ def _compute_logic_fingerprint(
         except (OSError, SyntaxError):
             canonical = f"<bytecode>{hashlib.sha256(fn.__code__.co_code).hexdigest()}"
     payload = f"{fn.__module__}.{fn.__qualname__}\n{canonical}"
+    if deps is not None:
+        # Use an explicit stable encoding (hex of the 16-byte digest) rather
+        # than Fingerprint.__str__ — the deps fingerprint ends up embedded in
+        # the logic fingerprint that's persisted in memo entries, and we don't
+        # want any future change to the Fingerprint Display impl to silently
+        # reshape every cached entry that uses deps=. Hex matches the
+        # `<bytecode>` fallback above (`hashlib.sha256(...).hexdigest()`).
+        payload += f"\n<deps>{memo_fingerprint(deps).as_bytes().hex()}"
     return core.fingerprint_str(payload)
 
 
@@ -506,7 +521,14 @@ class SyncFunction(Function[P, R_co]):
         memo: bool,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ):
+        if logic_tracking is None and deps is not None:
+            raise ValueError(
+                "deps= requires logic_tracking to be enabled; with "
+                "logic_tracking=None the function's logic is not tracked at "
+                "all, so the deps value would be silently ignored."
+            )
         self._fn = fn
         self._memo = memo
         self._processor_info = core.ComponentProcessorInfo(fn.__qualname__)
@@ -515,7 +537,7 @@ class SyncFunction(Function[P, R_co]):
         self._return_deserializer_lock = threading.Lock()
 
         if logic_tracking is not None:
-            self._logic_fp = _compute_logic_fingerprint(fn, version=version)
+            self._logic_fp = _compute_logic_fingerprint(fn, version=version, deps=deps)
             core.register_logic_fingerprint(self._logic_fp)
         else:
             self._logic_fp = None
@@ -929,10 +951,17 @@ class AsyncFunction(Function[P, R_co]):
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> None:
         fn = async_fn or sync_fn
         if fn is None:
             raise ValueError("Either async_fn or sync_fn must be provided")
+        if logic_tracking is None and deps is not None:
+            raise ValueError(
+                "deps= requires logic_tracking to be enabled; with "
+                "logic_tracking=None the function's logic is not tracked at "
+                "all, so the deps value would be silently ignored."
+            )
         self._orig_async_fn = async_fn
         self._orig_sync_fn = sync_fn
         self._memo = memo
@@ -942,7 +971,7 @@ class AsyncFunction(Function[P, R_co]):
         self._return_deserializer_lock = threading.Lock()
 
         if logic_tracking is not None:
-            self._logic_fp = _compute_logic_fingerprint(fn, version=version)
+            self._logic_fp = _compute_logic_fingerprint(fn, version=version, deps=deps)
             core.register_logic_fingerprint(self._logic_fp)
         else:
             self._logic_fp = None
@@ -1437,6 +1466,7 @@ class _GenericFunctionBuilder:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> None:
         self._memo = memo
         self._batching = batching
@@ -1444,6 +1474,7 @@ class _GenericFunctionBuilder:
         self._runner = runner
         self._version = version
         self._logic_tracking = logic_tracking
+        self._deps = deps
 
     def _build_sync(self, fn: Callable[P, R_co]) -> SyncFunction[P, R_co]:
         if self._batching or self._runner is not None:
@@ -1456,6 +1487,7 @@ class _GenericFunctionBuilder:
             memo=self._memo,
             version=self._version,
             logic_tracking=self._logic_tracking,
+            deps=self._deps,
         )
         functools.update_wrapper(wrapper, fn)
         return wrapper
@@ -1476,6 +1508,7 @@ class _GenericFunctionBuilder:
             runner=self._runner,
             version=self._version,
             logic_tracking=self._logic_tracking,
+            deps=self._deps,
         )
         functools.update_wrapper(wrapper, fn)
         return wrapper
@@ -1501,8 +1534,14 @@ class _AutoFunctionBuilder(_GenericFunctionBuilder):
         memo: bool = False,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> None:
-        super().__init__(memo=memo, version=version, logic_tracking=logic_tracking)
+        super().__init__(
+            memo=memo,
+            version=version,
+            logic_tracking=logic_tracking,
+            deps=deps,
+        )
 
     @overload
     def __call__(  # type: ignore[overload-overlap]
@@ -1550,6 +1589,7 @@ class _FunctionDecorator:
         memo: bool = False,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> _AutoFunctionBuilder: ...
     # Overload for batching=True
     @overload
@@ -1562,6 +1602,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> _AsyncBatchedDecorator: ...
     # With batching / runner, only supports sync functions
     @overload
@@ -1574,6 +1615,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> _SyncFunctionBuilder: ...
     # Overloads for direct function decoration
     @overload
@@ -1593,6 +1635,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> Any:
         """Decorator for CocoIndex functions (exposed as @coco.fn).
 
@@ -1612,7 +1655,29 @@ class _FunctionDecorator:
             logic_tracking: Controls logic change tracking granularity.
                 "full" (default): Track own code + transitive children.
                 "self": Track own code only, not children.
-                None: No function logic tracking.
+                None: No function logic tracking (incompatible with ``deps``).
+            deps: External value(s) the function logic depends on but which
+                aren't visible in its body — for example a module-level prompt
+                string or model identifier. The value is canonicalized via the
+                memoization-key pipeline (see
+                :doc:`/advanced_topics/memoization_keys` for the full contract,
+                including ``__coco_memo_key__()`` and registered key functions)
+                and folded into the function's logic fingerprint; when the
+                canonical form changes, memoized results are invalidated and
+                the change propagates to callers according to ``logic_tracking``
+                (transitively under ``"full"``, only to the function itself
+                under ``"self"``). For multiple dependencies, pass a tuple or
+                dict, e.g. ``deps={"prompt": SYSTEM_PROMPT, "model": MODEL_NAME}``.
+                ``None`` (the default) means no external dependency.
+
+                **Snapshotted once at decoration time** (typically module
+                import), not re-evaluated per call. For per-call or per-instance
+                values — instance attributes in a bound method, request-scoped
+                config, anything that changes at runtime — pass them as regular
+                function arguments instead.
+
+                Requires ``logic_tracking`` to be enabled; raises ``ValueError`` if
+                combined with ``logic_tracking=None``.
 
         Batching and runner require an async interface. With this decorator, only
         async underlying functions are accepted when batching/runner is specified.
@@ -1631,10 +1696,14 @@ class _FunctionDecorator:
                 runner=runner,
                 version=version,
                 logic_tracking=logic_tracking,
+                deps=deps,
             )
             if batching or runner or max_batch_size is not None
             else _AutoFunctionBuilder(
-                memo=memo, version=version, logic_tracking=logic_tracking
+                memo=memo,
+                version=version,
+                logic_tracking=logic_tracking,
+                deps=deps,
             )
         )
         if fn is not None:
@@ -1655,6 +1724,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> _BatchedDecorator: ...
     # Overload for keyword-only args without batching
     @overload
@@ -1667,6 +1737,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> _AsyncFunctionBuilder: ...
     # Overloads for direct function decoration
     @overload
@@ -1692,6 +1763,7 @@ class _FunctionDecorator:
         runner: Runner | None = None,
         version: int | None = None,
         logic_tracking: LogicTracking = "full",
+        deps: Any = None,
     ) -> Any:
         """Decorator for CocoIndex functions (exposed as @coco.fn.as_async).
 
@@ -1710,7 +1782,11 @@ class _FunctionDecorator:
             logic_tracking: Controls logic change tracking granularity.
                 "full" (default): Track own code + transitive children.
                 "self": Track own code only, not children.
-                None: No function logic tracking.
+                None: No function logic tracking (incompatible with ``deps``).
+            deps: Additional value(s) the function logic depends on but that
+                aren't visible in its body. See :func:`fn` for the full
+                contract — the value is canonicalized through the memoization
+                key pipeline and folded into the function's logic fingerprint.
 
         Batching and runner are fully supported since the result is always async.
 
@@ -1725,6 +1801,7 @@ class _FunctionDecorator:
             runner=runner,
             version=version,
             logic_tracking=logic_tracking,
+            deps=deps,
         )
         if fn is not None:
             return builder(fn)

--- a/python/cocoindex/_internal/memo_fingerprint.py
+++ b/python/cocoindex/_internal/memo_fingerprint.py
@@ -404,4 +404,5 @@ __all__ = [
     "register_not_memo_keyable",
     "unregister_memo_key_function",
     "fingerprint_call",
+    "memo_fingerprint",
 ]

--- a/python/tests/core/mod_logic_deps_chain_v1.py
+++ b/python/tests/core/mod_logic_deps_chain_v1.py
@@ -1,0 +1,39 @@
+"""Module v1 for transitive deps-change propagation tests.
+
+bar (memo, deps='v1') is called by both foo_full (memo, "full") and
+foo_self (memo, "self"). Function bodies are IDENTICAL in v1 and v2 — the
+only difference is the value passed to ``deps=`` on bar.
+"""
+
+import cocoindex as coco
+from tests.common.target_states import Metrics
+
+_metrics: Metrics | None = None
+
+_BAR_PROMPT = "deps_chain_v1_prompt"
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+@coco.fn(memo=True, deps=_BAR_PROMPT)
+def bar(s: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("bar")
+    return "bar: " + s
+
+
+@coco.fn(memo=True, logic_tracking="full")
+def foo_full(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("foo_full")
+    return bar(value)
+
+
+@coco.fn(memo=True, logic_tracking="self")
+def foo_self(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("foo_self")
+    return bar(value)

--- a/python/tests/core/mod_logic_deps_chain_v2.py
+++ b/python/tests/core/mod_logic_deps_chain_v2.py
@@ -1,0 +1,39 @@
+"""Module v2 for transitive deps-change propagation tests.
+
+Identical to v1 except bar's ``deps=`` value differs. Function bodies for
+bar, foo_full, and foo_self are byte-for-byte the same as v1 — the goal is
+to isolate the effect of a deps-only change on memo invalidation.
+"""
+
+import cocoindex as coco
+from tests.common.target_states import Metrics
+
+_metrics: Metrics | None = None
+
+_BAR_PROMPT = "deps_chain_v2_prompt"
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+@coco.fn(memo=True, deps=_BAR_PROMPT)
+def bar(s: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("bar")
+    return "bar: " + s
+
+
+@coco.fn(memo=True, logic_tracking="full")
+def foo_full(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("foo_full")
+    return bar(value)
+
+
+@coco.fn(memo=True, logic_tracking="self")
+def foo_self(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("foo_self")
+    return bar(value)

--- a/python/tests/core/mod_logic_deps_v1.py
+++ b/python/tests/core/mod_logic_deps_v1.py
@@ -1,0 +1,24 @@
+"""Module with deps='v1' for external-dependency change detection testing.
+
+The function body is IDENTICAL in deps_v1 and deps_v2 — only the value
+declared via the ``deps=`` parameter on ``@coco.fn`` differs.
+"""
+
+import cocoindex as coco
+from tests.common.target_states import Metrics
+
+_metrics: Metrics | None = None
+
+_PROMPT = "deps_v1_prompt"
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+@coco.fn(memo=True, deps=_PROMPT)
+def transform_memo_deps(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("transform_memo_deps")
+    return f"deps: {value}"

--- a/python/tests/core/mod_logic_deps_v2.py
+++ b/python/tests/core/mod_logic_deps_v2.py
@@ -1,0 +1,24 @@
+"""Module with deps='v2' for external-dependency change detection testing.
+
+The function body is IDENTICAL in deps_v1 and deps_v2 — only the value
+declared via the ``deps=`` parameter on ``@coco.fn`` differs.
+"""
+
+import cocoindex as coco
+from tests.common.target_states import Metrics
+
+_metrics: Metrics | None = None
+
+_PROMPT = "deps_v2_prompt"
+
+
+def set_metrics(metrics: Metrics) -> None:
+    global _metrics
+    _metrics = metrics
+
+
+@coco.fn(memo=True, deps=_PROMPT)
+def transform_memo_deps(key: str, value: str) -> str:
+    assert _metrics is not None
+    _metrics.increment("transform_memo_deps")
+    return f"deps: {value}"

--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -25,6 +25,10 @@ _V1_PATH = str(_TEST_DIR / "mod_logic_v1.py")
 _V2_PATH = str(_TEST_DIR / "mod_logic_v2.py")
 _VER1_PATH = str(_TEST_DIR / "mod_logic_ver1.py")
 _VER2_PATH = str(_TEST_DIR / "mod_logic_ver2.py")
+_DEPS_V1_PATH = str(_TEST_DIR / "mod_logic_deps_v1.py")
+_DEPS_V2_PATH = str(_TEST_DIR / "mod_logic_deps_v2.py")
+_DEPS_CHAIN_V1_PATH = str(_TEST_DIR / "mod_logic_deps_chain_v1.py")
+_DEPS_CHAIN_V2_PATH = str(_TEST_DIR / "mod_logic_deps_chain_v2.py")
 _SELF_V1_PATH = str(_TEST_DIR / "mod_logic_self_v1.py")
 _SELF_V2_PATH = str(_TEST_DIR / "mod_logic_self_v2.py")
 _SELF_V3_PATH = str(_TEST_DIR / "mod_logic_self_v3.py")
@@ -808,3 +812,270 @@ def test_bound_method_component_memo_invalidated_on_logic_change() -> None:
     # v2: second run — component memo hit again
     app.update_blocking()
     assert metrics.collect() == {}
+
+
+# ============================================================================
+# `deps=` parameter — external value declared as a logic dependency
+# ============================================================================
+
+
+def test_fn_memo_invalidated_on_deps_change() -> None:
+    """Changing the value passed to ``deps=`` invalidates the memo even when
+    the function body is identical, mirroring how ``version=`` behaves."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+
+    @coco.fn
+    def app_main() -> None:
+        mod = current_module[0]
+        result = mod.transform_memo_deps("A", "value1")
+        coco.declare_target_state(GlobalDictTarget.target_state("A", result))
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_fn_memo_invalidated_on_deps_change", environment=coco_env
+        ),
+        app_main,
+    )
+
+    # deps_v1: first run — function executes
+    mod = _load_module(_DEPS_V1_PATH, metrics, current_module)
+    app.update_blocking()
+    assert metrics.collect() == {"transform_memo_deps": 1}
+    assert GlobalDictTarget.store.data["A"].data == "deps: value1"
+
+    # deps_v1: second run — memo hit
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # deps_v2: identical body but deps value changed — memo invalidated
+    mod = _load_module(_DEPS_V2_PATH, metrics, current_module, old_module=mod)
+    app.update_blocking()
+    assert metrics.collect() == {"transform_memo_deps": 1}
+    assert GlobalDictTarget.store.data["A"].data == "deps: value1"
+
+    # deps_v2: second run — memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+def test_transitive_deps_change_propagates_through_full() -> None:
+    """A child function whose only change is its ``deps=`` value should
+    invalidate a memoized ``logic_tracking="full"`` parent the same way a
+    child code change does."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+
+    @coco.fn
+    def app_main() -> None:
+        mod = current_module[0]
+        result = mod.foo_full("A", "value1")
+        coco.declare_target_state(GlobalDictTarget.target_state("A", result))
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_transitive_deps_change_propagates_through_full",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    # v1: first run — both foo_full and bar execute
+    mod = _load_module(_DEPS_CHAIN_V1_PATH, metrics, current_module)
+    app.update_blocking()
+    assert metrics.collect() == {"foo_full": 1, "bar": 1}
+    assert GlobalDictTarget.store.data["A"].data == "bar: value1"
+
+    # v1: second run — memo hit at foo_full, bar not called
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # v2: bar's deps changed (body identical) — full propagation invalidates foo_full
+    mod = _load_module(_DEPS_CHAIN_V2_PATH, metrics, current_module, old_module=mod)
+    app.update_blocking()
+    assert metrics.collect() == {"foo_full": 1, "bar": 1}
+    assert GlobalDictTarget.store.data["A"].data == "bar: value1"
+
+    # v2: second run — memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+def test_transitive_deps_change_blocked_by_self() -> None:
+    """A ``logic_tracking="self"`` parent should NOT be invalidated when a
+    child function's ``deps=`` changes — ``"self"`` blocks transitive logic
+    propagation, deps changes included."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+
+    @coco.fn
+    def app_main() -> None:
+        mod = current_module[0]
+        result = mod.foo_self("A", "value1")
+        coco.declare_target_state(GlobalDictTarget.target_state("A", result))
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_transitive_deps_change_blocked_by_self",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    # v1: first run — both foo_self and bar execute
+    mod = _load_module(_DEPS_CHAIN_V1_PATH, metrics, current_module)
+    app.update_blocking()
+    assert metrics.collect() == {"foo_self": 1, "bar": 1}
+    assert GlobalDictTarget.store.data["A"].data == "bar: value1"
+
+    # v1: second run — memo hit at foo_self
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # v2: bar's deps changed but foo_self is in "self" mode — memo NOT invalidated.
+    # foo_self keeps returning the cached value, so bar is never called either.
+    mod = _load_module(_DEPS_CHAIN_V2_PATH, metrics, current_module, old_module=mod)
+    app.update_blocking()
+    assert metrics.collect() == {}
+    assert GlobalDictTarget.store.data["A"].data == "bar: value1"
+
+
+def test_deps_fingerprint_contract() -> None:
+    """Focused unit-level checks on the deps fingerprint contract.
+
+    Probes the per-function ``_logic_fp`` directly (bypassing the full
+    end-to-end app path) to verify that equal deps produce equal fingerprints,
+    different deps differ, ``__coco_memo_key__()`` is honored, and ``deps``
+    composes correctly with ``version``.
+    """
+    from cocoindex._internal.function import SyncFunction
+
+    def my_fn(x: str) -> str:
+        return x + " done"
+
+    # Build several SyncFunction wrappers around the same callable so the
+    # only varying input is the deps value.
+    no_deps = SyncFunction(my_fn, memo=True)
+    deps_a1 = SyncFunction(my_fn, memo=True, deps="prompt-A")
+    deps_a2 = SyncFunction(my_fn, memo=True, deps="prompt-A")
+    deps_b = SyncFunction(my_fn, memo=True, deps="prompt-B")
+    deps_explicit_none = SyncFunction(my_fn, memo=True, deps=None)
+
+    try:
+        assert deps_a1._logic_fp == deps_a2._logic_fp, (
+            "equal deps must produce equal logic fingerprints"
+        )
+        assert deps_a1._logic_fp != deps_b._logic_fp, (
+            "different deps must produce different logic fingerprints"
+        )
+        assert no_deps._logic_fp != deps_a1._logic_fp, (
+            "absence of deps must differ from a deps value"
+        )
+        assert no_deps._logic_fp == deps_explicit_none._logic_fp, (
+            "deps=None is equivalent to no deps"
+        )
+
+        # Multi-value deps via dict.
+        deps_dict_1 = SyncFunction(
+            my_fn,
+            memo=True,
+            deps={"prompt": "P", "model": "M"},
+        )
+        deps_dict_2 = SyncFunction(
+            my_fn,
+            memo=True,
+            deps={"model": "M", "prompt": "P"},  # same content, different order
+        )
+        deps_dict_3 = SyncFunction(
+            my_fn,
+            memo=True,
+            deps={"prompt": "P", "model": "M2"},
+        )
+        try:
+            assert deps_dict_1._logic_fp == deps_dict_2._logic_fp, (
+                "dict deps must be order-independent"
+            )
+            assert deps_dict_1._logic_fp != deps_dict_3._logic_fp, (
+                "changing any value in dict deps must invalidate the fingerprint"
+            )
+        finally:
+            del deps_dict_1, deps_dict_2, deps_dict_3
+            gc.collect()
+
+        # __coco_memo_key__ contract: the transient field must not affect the fp.
+        class WithKey:
+            def __init__(self, n: int, transient: str) -> None:
+                self.n = n
+                self.transient = transient
+
+            def __coco_memo_key__(self) -> object:
+                return ("with_key", self.n)
+
+        same_a = SyncFunction(my_fn, memo=True, deps=WithKey(42, "noise-a"))
+        same_b = SyncFunction(my_fn, memo=True, deps=WithKey(42, "noise-b"))
+        diff = SyncFunction(my_fn, memo=True, deps=WithKey(43, "noise-a"))
+        try:
+            assert same_a._logic_fp == same_b._logic_fp, (
+                "__coco_memo_key__ should ignore transient fields"
+            )
+            assert same_a._logic_fp != diff._logic_fp, (
+                "changing the keyed field must invalidate the fingerprint"
+            )
+        finally:
+            del same_a, same_b, diff
+            gc.collect()
+
+        # version= and deps= are independent contributors: both feed into the
+        # same _logic_fp, and changing either should change it while holding
+        # the other fixed.
+        v1_dA = SyncFunction(my_fn, memo=True, version=1, deps="A")
+        v1_dA_b = SyncFunction(my_fn, memo=True, version=1, deps="A")
+        v1_dB = SyncFunction(my_fn, memo=True, version=1, deps="B")
+        v2_dA = SyncFunction(my_fn, memo=True, version=2, deps="A")
+        v2_dB = SyncFunction(my_fn, memo=True, version=2, deps="B")
+        try:
+            assert v1_dA._logic_fp == v1_dA_b._logic_fp, (
+                "same version + same deps must produce the same fingerprint"
+            )
+            assert v1_dA._logic_fp != v1_dB._logic_fp, (
+                "same version + different deps must differ"
+            )
+            assert v1_dA._logic_fp != v2_dA._logic_fp, (
+                "different version + same deps must differ"
+            )
+            assert v1_dA._logic_fp != v2_dB._logic_fp, (
+                "different version + different deps must differ"
+            )
+            # No collisions across the four distinct cells of the 2x2 matrix.
+            assert (
+                len(
+                    {v1_dA._logic_fp, v1_dB._logic_fp, v2_dA._logic_fp, v2_dB._logic_fp}
+                )
+                == 4
+            )
+        finally:
+            del v1_dA, v1_dA_b, v1_dB, v2_dA, v2_dB
+            gc.collect()
+    finally:
+        del no_deps, deps_a1, deps_a2, deps_b, deps_explicit_none
+        gc.collect()
+
+
+def test_deps_rejected_with_logic_tracking_none() -> None:
+    """Passing ``deps=`` with ``logic_tracking=None`` is contradictory — the
+    function opts out of logic tracking entirely, so deps would be silently
+    dropped. Catch it at decoration time instead."""
+    with pytest.raises(ValueError, match="deps="):
+
+        @coco.fn(memo=True, deps="ignored", logic_tracking=None)
+        def _f(x: str) -> str:
+            return x
+
+    with pytest.raises(ValueError, match="deps="):
+
+        @coco.fn.as_async(memo=True, deps="ignored", logic_tracking=None)
+        async def _g(x: str) -> str:
+            return x


### PR DESCRIPTION
## Summary

Adds `deps=` to `@coco.fn` / `@coco.fn.as_async` so users can declare external values — typically module-level strings (prompts, model names) or tuples/dicts of such — as *logic dependencies* for memoization. When `deps` changes, the function's logic fingerprint changes and memoized results are invalidated, propagating to callers according to `logic_tracking` the same way a code change does.

```python
SYSTEM_PROMPT = "You are a helpful assistant."

@coco.fn(memo=True, deps=SYSTEM_PROMPT)
def generate(text: str) -> str:
    return call_llm(SYSTEM_PROMPT, text)
```

Closes #1832.

## Design choices

### Fold into `_logic_fp`, don't register a separate logic dep

`add_fn_logic_dep` takes a single `Fingerprint` and logic-dep propagation is set-based, so two options were equivalent behaviorally:

1. Compute `deps_fp = memo_fingerprint(deps)` separately and call `add_fn_logic_dep(deps_fp)` alongside `add_fn_logic_dep(self._logic_fp)` at every call site.
2. Fold the deps fingerprint into `_logic_fp` itself at decoration time.

Went with (2). Smaller diff (no second registry entry to manage, no new `add_fn_logic_dep` call site to wire up across the sync/async/batching/bound-method paths), same propagation semantics, same invalidation contract.

### Explicit hex encoding for the deps payload

`_compute_logic_fingerprint` assembles a string payload. The deps fingerprint is embedded via `.as_bytes().hex()` rather than `str(...)` because the resulting logic fingerprint ends up persisted in memo entries — any future change to Rust's `Fingerprint::Display` would silently reshape every cached entry that uses `deps=`. Hex matches the encoding of the `<bytecode>` fallback above (`hashlib.sha256(...).hexdigest()`).

### `deps=None` means "no deps"

The default is `deps=None`, and `None` is treated as "no external dependency" — nothing is folded into the fingerprint. We don't distinguish "not provided" from "explicitly `None`" because `None` as an actual dependency value carries no meaningful invalidation signal (its fingerprint would be a trivial constant), so the two cases are indistinguishable by intent.

### Loud failure on `deps=<value>` + `logic_tracking=None`

With `logic_tracking=None` there's no `_logic_fp` at all, so a `deps=` value would be silently ignored. We raise `ValueError` at decoration time instead — caught at import, not at runtime. `version=` has the same silent-drop behavior, but we opted for the stricter contract for this new parameter.

## Documentation

`docs/docs/programming_guide/function.md` is updated under "Controlling change detection scope" with a new `#### deps` subsection covering the single- and multi-value forms, the decoration-time snapshot caveat, the link to the memoization-keys page, and the `logic_tracking=None` incompatibility.

## Test coverage

- `test_fn_memo_invalidated_on_deps_change` — end-to-end v1/v2 module swap (mirrors `test_fn_memo_invalidated_on_version_bump`).
- `test_transitive_deps_change_propagates_through_full` — full-mode parent re-executes when child's deps change.
- `test_transitive_deps_change_blocked_by_self` — self-mode parent stays cached.
- `test_deps_fingerprint_contract` — equal/different deps, dict order-independence, `__coco_memo_key__` honored (transient fields ignored), `version + deps` 2×2 matrix.
- `test_deps_rejected_with_logic_tracking_none` — `ValueError` on both `@coco.fn` and `@coco.fn.as_async`.

## Validation

- `uv run mypy` — clean (190 source files)
- `uv run ruff format --check` / `ruff check` — clean
- `uv run pytest python/` — all passing (one pre-existing WSL2 localfs flake unrelated to this change)
- `cargo test` — clean
