### PR TITLE
refactor: improve msgspec serde robustness and migrate tracking records to Struct

### DIFF
--- a/docs/docs/advanced_topics/serialization.md
+++ b/docs/docs/advanced_topics/serialization.md
@@ -7,57 +7,26 @@ description: How CocoIndex serializes and deserializes Python values, and how to
 
 ## Overview
 
-CocoIndex serializes Python values in several situations:
+CocoIndex serializes and caches the return values of [memoized functions](../programming_guide/function.md#memoization) so that unchanged work can be skipped on subsequent runs. Most Python types work automatically — the key thing to get right is the **return type annotation**, which tells CocoIndex how to reconstruct your objects:
 
-- **Memoized function return values** — cached so unchanged functions can skip re-execution.
-- **Memo states** — stored between runs for freshness validation (see [Memo state validation](./memoization_keys.md#memo-state-validation)).
-- **Tracking records** — stored by target state handlers to detect changes (see [Custom Target Connector](./custom_target_connector.md)).
+```python
+@coco.fn(memo=True)
+async def process_chunk(chunk: Chunk) -> Embedding:  # return type annotation
+    return embed(chunk.text)
+```
 
-CocoIndex uses [msgspec](https://jcristharif.com/msgspec/) (msgpack format) as the default serialization engine. Most Python types — dataclasses, NamedTuples, primitives, collections, and Pydantic models — are handled automatically without any special registration.
+Without annotations, values may deserialize as basic Python types (`dict`, `list`, `str`, etc.) instead of their original types.
 
-## Type annotations
+:::info Advanced: other places where serialization and type annotations matter
+Serialization also applies to [memo states](./memoization_keys.md#memo-state-validation) and [tracking records](./custom_target_connector.md#targethandler-you-implement). If you're implementing these, add type annotations to:
 
-CocoIndex uses type annotations to properly reconstruct typed objects during deserialization. Without annotations, values may deserialize as basic Python types (`dict`, `list`, `str`, etc.) instead of their original types.
+- **`__coco_memo_state__` `prev_state` parameter** — annotate with the state type you return in `MemoStateOutcome(state=...)`. See [Memo state validation](./memoization_keys.md#memo-state-validation).
+- **`reconcile()` `prev_possible_records` parameter** — annotate with `Collection[YourTrackingRecord]`. See [Custom Target Connector](./custom_target_connector.md#targethandler-you-implement).
+:::
 
-**Add type annotations in these three places:**
+## Supported types
 
-1. **Memoized function return types** — annotate the return type of `@coco.fn(memo=True)` functions.
-
-   ```python
-   @coco.fn(memo=True)
-   async def process_chunk(chunk: Chunk) -> Embedding:  # return type annotation
-       return embed(chunk.text)
-   ```
-
-   See [Function — Memoization](../programming_guide/function.md#memoization).
-
-2. **`__coco_memo_state__` `prev_state` parameter** — annotate with the state type you return in `MemoStateOutcome(state=...)`.
-
-   ```python
-   def __coco_memo_state__(self, prev_state: tuple[int, str] | coco.NonExistenceType) -> coco.MemoStateOutcome:
-       ...
-   ```
-
-   See [Memoization Keys & States — Memo state validation](./memoization_keys.md#memo-state-validation).
-
-3. **`reconcile()` `prev_possible_records` parameter** — annotate with `Collection[YourTrackingRecord]`.
-
-   ```python
-   def reconcile(
-       self,
-       key: str,
-       desired_state: MyValue | NonExistenceType,
-       prev_possible_records: Collection[MyTrackingRecord],  # tracking record type
-       prev_may_be_missing: bool,
-       /,
-   ) -> ...:
-   ```
-
-   See [Custom Target Connector — TargetHandler](./custom_target_connector.md#targethandler-you-implement).
-
-## What works automatically
-
-You don't need any special registration for the following types — they are serialized with msgspec by default:
+The following types all work out of the box — no registration needed:
 
 | Category | Types |
 |----------|-------|
@@ -66,51 +35,27 @@ You don't need any special registration for the following types — they are ser
 | **Dataclasses** | Any `@dataclass` (including frozen) |
 | **NamedTuples** | Any `NamedTuple` subclass |
 | **Pydantic models** | Any `pydantic.BaseModel` subclass |
+| **msgspec Structs** | Any `msgspec.Struct` subclass |
 | **Date/time** | `datetime.datetime`, `datetime.date`, `datetime.time`, `datetime.timedelta`, `datetime.timezone` |
-| **Other stdlib** | `uuid.UUID` |
-
-These types also work when nested inside collections or other dataclasses.
-
-## Types requiring pickle
-
-Some types can't be serialized with msgspec. These are handled with pickle automatically:
-
-| Category | Types |
-|----------|-------|
-| **Complex numbers** | `complex` |
-| **Paths** | `pathlib.Path`, `pathlib.PurePath`, and all subclasses |
+| **Other stdlib** | `uuid.UUID`, `complex`, `pathlib.Path`, `pathlib.PurePath` |
 | **NumPy** | `numpy.ndarray`, `numpy.dtype` (when numpy is installed) |
 
-### `@coco.serialize_by_pickle`
+More generally, all types [supported by msgspec](https://jcristharif.com/msgspec/supported-types.html) work automatically. These types also work when nested inside collections or other structured types.
 
-For your own types that need pickle serialization, use the `@coco.serialize_by_pickle` decorator:
+## Custom types
+
+If your type isn't in the list above, register it with `@coco.serialize_by_pickle`:
 
 ```python
 import cocoindex as coco
 
 @coco.serialize_by_pickle
 class MySpecialType:
-    """A type with custom __reduce__ that msgspec can't handle."""
     def __init__(self, data):
         self.data = data
-
-    def __reduce__(self):
-        return (MySpecialType, (self.data,))
 ```
 
-This decorator:
-- Routes serialization through pickle instead of msgspec
-- Automatically registers the type as safe to unpickle (equivalent to also applying `@coco.unpickle_safe`)
-
-### `@coco.unpickle_safe` (backward compatibility)
-
-The `@coco.unpickle_safe` decorator only affects deserialization — it adds a type to the restricted unpickle allow-list without changing how the type is serialized. This is kept for backward compatibility with previously cached data.
-
-Most users won't need this. If you previously used `@coco.unpickle_safe` on dataclasses or NamedTuples, you can remove it — msgspec handles these types natively now.
-
-### Registering third-party types
-
-For types from third-party libraries that need pickle serialization, use `coco.serialize_by_pickle()` as a regular function call:
+For third-party types, call it as a regular function:
 
 ```python
 import cocoindex as coco
@@ -119,18 +64,58 @@ from some_library import SomeType
 coco.serialize_by_pickle(SomeType)
 ```
 
-## Backward compatibility
+:::caution Not for dataclasses, NamedTuples, or `msgspec.Struct`
+Don't apply `@coco.serialize_by_pickle` to dataclasses, NamedTuples, or `msgspec.Struct` — these are already supported natively. Applying it only works at the top level; when nested inside another supported type, the native encoding takes precedence and the decorator has no effect.
 
-Old data serialized with pickle (before this change) is readable indefinitely. Pickle-format data starts with byte `0x80`, which CocoIndex recognizes and routes to the restricted unpickler automatically.
+If serialization fails because of a problematic *field* inside a dataclass, register that field's type with `@coco.serialize_by_pickle` instead.
+:::
+
+## Union types
+
+Unions of a custom type with `None` work fine (`MyDataclass | None`). However, unions involving multiple custom types or a custom type with other non-`None` types require tagged `msgspec.Struct` variants.
+
+For example, this **won't work**:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    value: int
+
+class Settings(NamedTuple):
+    config: Config | str  # fails at deserialization
+```
+
+**Fix** — wrap each variant in a tagged [`msgspec.Struct`](https://jcristharif.com/msgspec/structs.html#tagged-unions). The `tag=True` parameter embeds a type tag in the serialized data so that the correct variant can be identified during deserialization:
+
+```python
+import msgspec
+
+class ConfigValue(msgspec.Struct, tag=True):
+    value: int
+
+class StringValue(msgspec.Struct, tag=True):
+    value: str
+
+class Settings(NamedTuple):
+    config: ConfigValue | StringValue  # works — variants are distinguished by tag
+```
 
 ## Troubleshooting
 
+### `DeserializationError: Cannot build msgspec Decoder`
+
+This typically means an unsupported union type. The error message includes a hint about the cause.
+
+**Fix**: Restructure the union to use tagged `msgspec.Struct` variants. See [Union types](#union-types) above.
+
 ### `DeserializationError: Failed to deserialize msgspec payload`
 
-This usually means the type annotation doesn't match the serialized data. Common causes:
+The type annotation doesn't match the serialized data. Common causes:
 
 - **Missing return type annotation** on a memoized function — add `-> YourType` to the function signature.
-- **Changed type structure** between runs — if you renamed or restructured a dataclass, the cached data won't match. Run with `full_reprocess=True` to rebuild the cache.
+- **Changed type structure** between runs — if you renamed or restructured a dataclass, the cached data won't match. Rebuild the cache by running [`app.update(full_reprocess=True)`](../programming_guide/app.md#updating-an-app) or [`cocoindex update --full-reprocess`](../cli).
 - **Forward reference not resolved** — if your type annotation uses a string forward reference, ensure the type is defined before the function is first called.
 
 ### `UnpicklingError: Forbidden global during unpickling`
@@ -139,20 +124,14 @@ This usually means the type annotation doesn't match the serialized data. Common
 _pickle.UnpicklingError: Forbidden global during unpickling: myapp.models.Summary
 ```
 
-This means CocoIndex tried to deserialize a type via pickle but it's not in the allow-list. Fix by either:
+CocoIndex restricts which types can be deserialized for security. This error means your type isn't in the allow-list. Fix by either:
 
-1. Using `@coco.serialize_by_pickle` (if you want the type to use pickle going forward)
-2. Using `@coco.unpickle_safe` (if you only need to read old cached data)
-3. Converting to a dataclass or NamedTuple (recommended — msgspec handles these automatically)
+1. **Converting to a dataclass or NamedTuple** (recommended — supported natively, no registration needed)
+2. **Using `@coco.serialize_by_pickle`** to register the type
 
-:::note Existing cached data
-If you see this error after upgrading from an older version, it means previously cached data references types that aren't yet in the allow-list. Adding `@coco.unpickle_safe` to the type and re-running will fix it — the stale cache entry is skipped and recomputed.
+:::note Upgrading from older versions
+If you see this error after upgrading, previously cached data may reference types that aren't yet registered. You have two options:
+
+- Add `@coco.serialize_by_pickle` to the type and re-run.
+- If the type is already a dataclass or NamedTuple, add `@coco.unpickle_safe` to allow reading the old cached data. Once the cache is rebuilt, the decorator can be removed.
 :::
-
-### Migration from `@coco.unpickle_safe`
-
-If you previously decorated types with `@coco.unpickle_safe`:
-
-- **Dataclasses and NamedTuples**: Remove `@coco.unpickle_safe` — msgspec handles these natively. Old cached data from before the migration is still readable.
-- **Types needing pickle**: Switch to `@coco.serialize_by_pickle` (which also registers for unpickle safety).
-- **Third-party types**: Use `coco.serialize_by_pickle(SomeType)` for types that need pickle serialization.

--- a/examples/conversation_to_knowledge/conv_knowledge/app.py
+++ b/examples/conversation_to_knowledge/conv_knowledge/app.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import cocoindex as coco
 from cocoindex.connectors import localfs, surrealdb
-from cocoindex.ops.entity_resolution import resolve_entities as _resolve_entities
+from cocoindex.ops.entity_resolution import resolve_entities
 from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
 from cocoindex.resources.file import PatternFilePathMatcher
@@ -46,10 +46,10 @@ EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_chang
 
 
 @coco.fn(memo=True)
-async def resolve_entities(
+async def _resolve_entities(
     all_raw_entities: set[str],
 ) -> dict[str, str | None]:
-    result = await _resolve_entities(
+    result = await resolve_entities(
         entities=all_raw_entities,
         embedder=coco.use_context(EMBEDDER),
         resolve_pair=LlmPairResolver(
@@ -327,7 +327,7 @@ async def app_main() -> None:
                 *(
                     coco.use_mount(
                         coco.component_subpath("resolve", cfg.name),
-                        resolve_entities,
+                        _resolve_entities,
                         _collect_all_raw(all_session_raw, cfg.name),
                     )
                     for cfg in ENTITY_TYPES

--- a/examples/image_search_colpali/pyproject.toml
+++ b/examples/image_search_colpali/pyproject.toml
@@ -5,6 +5,7 @@ description = "CocoIndex v1 example: image search with ColPali embeddings stored
 requires-python = ">=3.11"
 dependencies = [
     "cocoindex[colpali,qdrant]>=1.0.0a30",
+    "transformers>=4.45.0,<5",
     "fastapi>=0.100.0",
     "torch>=2.0.0",
     "pillow>=10.0.0",

--- a/python/cocoindex/_internal/serde.py
+++ b/python/cocoindex/_internal/serde.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import functools
 import inspect
@@ -8,6 +9,7 @@ import threading
 import types
 import typing
 import uuid
+import warnings
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
@@ -34,6 +36,7 @@ _BUILTIN_UNPICKLE_SAFE_TYPES: tuple[type, ...] = (
     set,
     frozenset,
     type(None),
+    type,
 )
 
 
@@ -97,6 +100,7 @@ _SERIALIZE_BY_PICKLE_TYPES: set[type] = set()
 
 def _register_builtin_pickle_types() -> None:
     """Register types that must always use pickle serialization."""
+    _SERIALIZE_BY_PICKLE_TYPES.add(type)
     # complex is not natively supported by msgspec
     _SERIALIZE_BY_PICKLE_TYPES.add(complex)
     # pathlib types
@@ -132,8 +136,29 @@ def _add_unpickle_safe_global(module: str, qualname: str, obj: object) -> None:
     _UNPICKLE_SAFE_GLOBALS[(module, qualname)] = obj
 
 
+def _is_msgspec_native_type(cls: type) -> bool:
+    """Check if a type is natively handled by msgspec (and thus bypasses enc_hook)."""
+    if dataclasses.is_dataclass(cls):
+        return True
+    if isinstance(cls, type) and issubclass(cls, tuple) and hasattr(cls, "_fields"):
+        # NamedTuple
+        return True
+    if isinstance(cls, type) and issubclass(cls, msgspec.Struct):
+        return True
+    return False
+
+
 def serialize_by_pickle(cls: type) -> type:
     """Decorator: serialize this type with pickle. Auto-registers as unpickle-safe."""
+    if _is_msgspec_native_type(cls):
+        warnings.warn(
+            f"@serialize_by_pickle on {cls.__qualname__} (a "
+            f"{'dataclass' if dataclasses.is_dataclass(cls) else 'NamedTuple' if issubclass(cls, tuple) else 'msgspec.Struct'}"
+            f") has no effect when nested inside another msgspec-compatible type, "
+            f"because msgspec encodes these types natively and bypasses the pickle "
+            f"hook. Consider restructuring the type to be fully msgspec-compatible.",
+            stacklevel=2,
+        )
     _SERIALIZE_BY_PICKLE_TYPES.add(cls)
     unpickle_safe(cls)
     return cls
@@ -259,10 +284,19 @@ def _ext_hook(code: int, data: memoryview) -> Any:  # type: ignore[type-arg]
 
 
 def _dec_hook(type_hint: Any, obj: Any) -> Any:
-    """Reconstruct Pydantic models nested inside msgspec payloads."""
+    """Handle custom types during msgspec decoding.
+
+    Called when msgspec encounters a type it doesn't natively support.
+    Only two cases reach here:
+
+    1. Pydantic models — enc_hook serialized via model_dump(mode="json"),
+       so *obj* is a dict that needs model_validate to reconstruct.
+    2. Pickle-quarantined values — ext_hook already reconstructed the
+       correct object; just pass through.
+    """
     if _is_pydantic_model_type(type_hint):
         return type_hint.model_validate(obj)
-    raise TypeError(f"Cannot decode type: {type_hint}")
+    return obj
 
 
 # ---------------------------------------------------------------------------
@@ -300,16 +334,35 @@ def make_deserialize_fn(
     Returns a closure that handles routing-byte dispatch
     (``0x01`` msgspec, ``0x02`` pydantic, ``0x80`` pickle).
 
-    The msgspec Decoder is constructed eagerly; callers are responsible for
-    resolving forward-reference type hints before calling this function.
+    The msgspec Decoder construction is attempted eagerly but is best-effort:
+    if the type hint is not supported by msgspec (e.g. a union containing a
+    custom type alongside non-None types), the error is captured and re-raised
+    only if a ``0x01`` (msgspec) payload is actually encountered during
+    deserialization.  Callers are responsible for resolving forward-reference
+    type hints before calling this function.
     The Pydantic TypeAdapter is still lazy (pydantic is optional).
 
     *source_label* is included in error messages to identify where the type
     hint came from (e.g. ``"return type of process_file()"``).
     """
-    decoder = msgspec.msgpack.Decoder(
-        type=type_hint, ext_hook=_ext_hook, dec_hook=_dec_hook
-    )
+    decoder: msgspec.msgpack.Decoder | None = None  # type: ignore[type-arg]
+    decoder_error: DeserializationError | None = None
+    try:
+        decoder = msgspec.msgpack.Decoder(
+            type=type_hint, ext_hook=_ext_hook, dec_hook=_dec_hook
+        )
+    except Exception as e:
+        hint = ""
+        if isinstance(e, TypeError) and "union" in str(e).lower():
+            hint = (
+                " Hint: msgspec does not support union types mixing custom classes "
+                "with other types (except None). Consider wrapping each variant in "
+                "a tagged msgspec.Struct subclass."
+            )
+        decoder_error = DeserializationError(
+            f"Cannot build msgspec Decoder for {type_hint!r}.{hint}"
+        )
+        decoder_error.__cause__ = e
     pydantic_adapter: Any = None
     pydantic_lock = threading.Lock()
 
@@ -326,6 +379,10 @@ def make_deserialize_fn(
 
         # A: Msgspec (most common)
         if routing_byte == 0x01:
+            if decoder is None:
+                raise DeserializationError(
+                    f"Cannot deserialize msgspec payload ({_error_context()})"
+                ) from decoder_error
             try:
                 return decoder.decode(mv[1:])
             except Exception as e:

--- a/python/cocoindex/connectorkits/statediff.py
+++ b/python/cocoindex/connectorkits/statediff.py
@@ -40,8 +40,9 @@ from typing import (
 )
 from typing_extensions import TypeVar as _TypeVar
 
+import msgspec as _msgspec
+
 import cocoindex as _coco
-from cocoindex._internal.serde import unpickle_safe as _unpickle_safe
 
 _TrackingRecordT = _TypeVar("_TrackingRecordT")
 _MainTrackingRecordT = _TypeVar("_MainTrackingRecordT")
@@ -51,9 +52,11 @@ _SubTrackingRecordT = _TypeVar("_SubTrackingRecordT")
 DiffAction = _Literal["insert", "upsert", "replace", "delete"]
 
 
-@_unpickle_safe
 class CompositeTrackingRecord(
-    _Generic[_MainTrackingRecordT, _SubKeyT, _SubTrackingRecordT], _NamedTuple
+    _msgspec.Struct,
+    _Generic[_MainTrackingRecordT, _SubKeyT, _SubTrackingRecordT],
+    frozen=True,
+    array_like=True,
 ):
     """A state with a main component and a set of keyed sub-states.
 
@@ -95,8 +98,9 @@ class TrackingRecordTransition(_Generic[_TrackingRecordT], _NamedTuple):
 from cocoindex.connectorkits.target import ManagedBy as ManagedBy
 
 
-@_unpickle_safe
-class MutualTrackingRecord(_Generic[_TrackingRecordT], _NamedTuple):
+class MutualTrackingRecord(
+    _msgspec.Struct, _Generic[_TrackingRecordT], frozen=True, array_like=True
+):
     """A tracking record tagged with ownership/management information.
 
     This is useful when a resource can be managed by either the system

--- a/python/cocoindex/connectors/doris/_target.py
+++ b/python/cocoindex/connectors/doris/_target.py
@@ -59,7 +59,8 @@ from cocoindex._internal.datatype import (
     is_record_type,
 )
 from cocoindex.resources import schema as res_schema
-from cocoindex._internal.serde import unpickle_safe
+import msgspec
+
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 if TYPE_CHECKING:
@@ -947,21 +948,18 @@ class _TableSpec:
     inverted_indexes: list[InvertedIndexDef] | None = None
 
 
-@unpickle_safe
-class _PkColumnInfo(NamedTuple):
+class _PkColumnInfo(msgspec.Struct, frozen=True, array_like=True):
     name: str
     type: str
 
 
-@unpickle_safe
-class _TablePrimaryTrackingRecord(NamedTuple):
+class _TablePrimaryTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     primary_key_columns: tuple[_PkColumnInfo, ...]
     vector_indexes: tuple[str, ...] | None = None
     inverted_indexes: tuple[str, ...] | None = None
 
 
-@unpickle_safe
-class _NonPkColumnTrackingRecord(NamedTuple):
+class _NonPkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     type: str
     nullable: bool
 

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -48,7 +48,8 @@ from cocoindex._internal.datatype import (
     is_record_type,
 )
 from cocoindex.resources import schema as res_schema
-from cocoindex._internal.serde import unpickle_safe
+import msgspec
+
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 # Type aliases
@@ -490,8 +491,7 @@ class _TableSpec:
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
-@unpickle_safe
-class _ColumnState(NamedTuple):
+class _ColumnState(msgspec.Struct, frozen=True, array_like=True):
     """Per-column state used for table-level state tracking."""
 
     name: str

--- a/python/cocoindex/connectors/localfs/_target.py
+++ b/python/cocoindex/connectors/localfs/_target.py
@@ -12,7 +12,8 @@ import cocoindex as coco
 from cocoindex.connectorkits.fingerprint import fingerprint_bytes
 from cocoindex._internal.datatype import TypeChecker
 
-from cocoindex._internal.serde import unpickle_safe
+import msgspec
+
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 from ._common import FilePath, to_file_path
@@ -170,9 +171,7 @@ def _reconcile_entry(
 # =============================================================================
 
 
-@unpickle_safe
-@dataclass(frozen=True, slots=True)
-class _EntryTrackingRecord:
+class _EntryTrackingRecord(msgspec.Struct, frozen=True):
     """Tracking record for an entry. If fingerprint is None, it's a directory."""
 
     fingerprint: _FileFingerprint | None

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -51,8 +51,9 @@ from cocoindex._internal.datatype import (
     analyze_type_info,
     is_record_type,
 )
+import msgspec
+
 from cocoindex.resources import schema as res_schema
-from cocoindex._internal.serde import unpickle_safe
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 # Type aliases
@@ -482,7 +483,7 @@ class _VectorIndexHandler:
 # --- SQL Command Attachment ---
 
 
-class _SqlCommandSpec(NamedTuple):
+class _SqlCommandSpec(msgspec.Struct, frozen=True, array_like=True):
     setup_sql: str
     teardown_sql: str | None
 
@@ -786,16 +787,14 @@ class _TableSpec:
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
-@unpickle_safe
-class _PkColumnTrackingRecord(NamedTuple):
+class _PkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     """Primary-key column signature used for table-level main tracking record."""
 
     name: str
     type: str
 
 
-@unpickle_safe
-class _NonPkColumnTrackingRecord(NamedTuple):
+class _NonPkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     """Per-non-PK column tracking record used for incremental ALTER TABLE operations."""
 
     type: str

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import cocoindex as coco
 
 import asyncio
+import msgspec
 from dataclasses import dataclass
 from typing import (
     Any,
     Collection,
     Generic,
     Literal,
-    Mapping,
     NamedTuple,
     Sequence,
     cast,
@@ -35,7 +35,6 @@ import cocoindex as coco
 from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.datatype import TypeChecker
-from cocoindex._internal.serde import unpickle_safe
 from cocoindex.resources import schema as res_schema
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
@@ -69,21 +68,22 @@ class QdrantVectorDef(NamedTuple):
     multivector_comparator: Literal["max_sim"] = "max_sim"
 
 
-class _ResolvedQdrantVectorDef(NamedTuple):
-    """Resolved Qdrant vector specification with concrete schema.
+class _ResolvedQdrantVectorDef(msgspec.Struct, frozen=True, tag=True):
+    """Resolved single (unnamed) vector specification.
 
     This is the internal resolved form after calling __coco_vector_schema__()
     or __coco_multi_vector_schema__() on the providers.
-
-    Args:
-        schema: Resolved VectorSchema or MultiVectorSchema
-        distance: Distance metric to use (cosine, dot, or euclid)
-        multivector_comparator: Comparator to use for multivector
     """
 
     schema: res_schema.VectorSchema | res_schema.MultiVectorSchema
     distance: Literal["cosine", "dot", "euclid"]
     multivector_comparator: Literal["max_sim"]
+
+
+class _ResolvedQdrantNamedVectorsDef(msgspec.Struct, frozen=True, tag=True):
+    """Resolved named vectors specification (multiple named vectors per collection)."""
+
+    vectors: dict[str, _ResolvedQdrantVectorDef]
 
 
 async def _resolve_vector_def(vector_def: QdrantVectorDef) -> _ResolvedQdrantVectorDef:
@@ -132,11 +132,11 @@ class CollectionSchema:
         ```
     """
 
-    _vectors: _ResolvedQdrantVectorDef | dict[str, _ResolvedQdrantVectorDef]
+    _vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
 
     def __init__(
         self,
-        vectors: _ResolvedQdrantVectorDef | dict[str, _ResolvedQdrantVectorDef],
+        vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef,
     ) -> None:
         """
         Create a CollectionSchema from pre-resolved vector definitions.
@@ -158,14 +158,16 @@ class CollectionSchema:
             vectors: Either a single QdrantVectorDef (for unnamed vector) or a dictionary
                      mapping vector field names to QdrantVectorDef.
         """
-        resolved: _ResolvedQdrantVectorDef | dict[str, _ResolvedQdrantVectorDef]
+        resolved: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
         if isinstance(vectors, QdrantVectorDef):
             resolved = await _resolve_vector_def(vectors)
         elif isinstance(vectors, dict):
-            resolved = {
-                name: await _resolve_vector_def(vector_def)
-                for name, vector_def in vectors.items()
-            }
+            resolved = _ResolvedQdrantNamedVectorsDef(
+                vectors={
+                    name: await _resolve_vector_def(vector_def)
+                    for name, vector_def in vectors.items()
+                }
+            )
         else:
             raise ValueError(f"Invalid vector definition: {vectors}")
         return cls(resolved)
@@ -173,7 +175,7 @@ class CollectionSchema:
     @property
     def vectors(
         self,
-    ) -> _ResolvedQdrantVectorDef | Mapping[str, _ResolvedQdrantVectorDef]:
+    ) -> _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef:
         """Get vector definitions (all VectorSchemaProviders resolved)."""
         return self._vectors
 
@@ -274,9 +276,8 @@ class _CollectionSpec:
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
-@unpickle_safe
-class _CollectionTrackingRecordCore(NamedTuple):
-    vectors: _ResolvedQdrantVectorDef | Mapping[str, _ResolvedQdrantVectorDef]
+class _CollectionTrackingRecordCore(msgspec.Struct, frozen=True, array_like=True):
+    vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
 
 
 _CollectionTrackingRecord = statediff.MutualTrackingRecord[
@@ -377,11 +378,11 @@ class _CollectionHandler(
         vectors_config: (
             dict[str, qdrant_models.VectorParams] | qdrant_models.VectorParams
         )
-        if isinstance(schema.vectors, Mapping):
+        if isinstance(schema.vectors, _ResolvedQdrantNamedVectorsDef):
             # Named vectors: use dict
             vectors_config = {
                 name: _vector_params_from_def(vector_def)
-                for name, vector_def in schema.vectors.items()
+                for name, vector_def in schema.vectors.vectors.items()
             }
         else:
             # Unnamed vector: pass VectorParams directly (not in a dict)

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -37,7 +37,8 @@ import cocoindex as coco
 from cocoindex.connectorkits import statediff, target
 from cocoindex.connectorkits.fingerprint import fingerprint_object
 from cocoindex._internal.rwlock import RWLock
-from cocoindex._internal.serde import unpickle_safe
+import msgspec
+
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 from cocoindex._internal.datatype import (
     AnyType,
@@ -117,9 +118,7 @@ class ManagedConnection:
         self._conn.close()
 
 
-@unpickle_safe
-@dataclass
-class Vec0TableDef:
+class Vec0TableDef(msgspec.Struct, frozen=True):
     """
     Configuration for vec0 virtual tables (sqlite-vec).
 
@@ -133,8 +132,8 @@ class Vec0TableDef:
             Auxiliary columns store additional data but cannot be used in KNN WHERE filters.
     """
 
-    partition_key_columns: list[str] = field(default_factory=list)
-    auxiliary_columns: list[str] = field(default_factory=list)
+    partition_key_columns: list[str] = []
+    auxiliary_columns: list[str] = []
 
     @property
     def module_name(self) -> str:
@@ -590,24 +589,21 @@ class _TableSpec:
     virtual_table_def: Vec0TableDef | None = None
 
 
-@unpickle_safe
-class _PkColumnInfo(NamedTuple):
+class _PkColumnInfo(msgspec.Struct, frozen=True, array_like=True):
     """Information for a single primary key column."""
 
     name: str
     type: str
 
 
-@unpickle_safe
-class _TablePrimaryTrackingRecord(NamedTuple):
+class _TablePrimaryTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     """Primary tracking information for a table (PK columns + virtual table config)."""
 
     primary_key_columns: tuple[_PkColumnInfo, ...]
     virtual_table_def: Vec0TableDef | None = None
 
 
-@unpickle_safe
-class _NonPkColumnTrackingRecord(NamedTuple):
+class _NonPkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
     """Per-non-PK column tracking record used for incremental ALTER TABLE operations."""
 
     type: str

--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -59,8 +59,9 @@ from cocoindex._internal.datatype import (
     analyze_type_info,
     is_record_type,
 )
+import msgspec
+
 from cocoindex.resources import schema as res_schema
-from cocoindex._internal.serde import unpickle_safe
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 # ---------------------------------------------------------------------------
@@ -757,8 +758,7 @@ class _TableSpec:
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
 
 
-@dataclass(frozen=True, slots=True)
-class _TableMainRecord:
+class _TableMainRecord(msgspec.Struct, frozen=True):
     """Main tracking record for table-level properties requiring DROP+CREATE if changed."""
 
     has_schema: bool
@@ -768,8 +768,7 @@ class _TableMainRecord:
     to_tables: tuple[str, ...] | None
 
 
-@dataclass(frozen=True, slots=True)
-class _FieldTrackingRecord:
+class _FieldTrackingRecord(msgspec.Struct, frozen=True):
     """Per-field tracking record for incremental DEFINE FIELD / REMOVE FIELD."""
 
     surreal_type: str

--- a/python/cocoindex/resources/schema.py
+++ b/python/cocoindex/resources/schema.py
@@ -8,13 +8,9 @@ out-of-band information beyond Python type annotations.
 from __future__ import annotations
 
 import typing as _typing
-import dataclasses as _dataclasses
 import cocoindex as coco
-from cocoindex._internal.context_keys import ContextKey
-from cocoindex._internal.serde import unpickle_safe as _unpickle_safe
-
-if _typing.TYPE_CHECKING:
-    import numpy as _np
+import msgspec as _msgspec
+import numpy as _np
 
 
 @_typing.runtime_checkable
@@ -24,9 +20,7 @@ class VectorSchemaProvider(_typing.Protocol):
     def __coco_vector_schema__(self) -> _typing.Awaitable[VectorSchema]: ...
 
 
-@_unpickle_safe
-@_dataclasses.dataclass(slots=True, frozen=True)
-class VectorSchema:
+class VectorSchema(_msgspec.Struct, frozen=True, tag=True):
     """Additional information for a vector column."""
 
     dtype: _np.dtype
@@ -52,9 +46,7 @@ class MultiVectorSchemaProvider(_typing.Protocol):
     def __coco_multi_vector_schema__(self) -> _typing.Awaitable[MultiVectorSchema]: ...
 
 
-@_unpickle_safe
-@_dataclasses.dataclass(slots=True, frozen=True)
-class MultiVectorSchema:
+class MultiVectorSchema(_msgspec.Struct, frozen=True, tag=True):
     """Additional information for a vector column."""
 
     vector_schema: VectorSchema

--- a/python/tests/core/test_serde.py
+++ b/python/tests/core/test_serde.py
@@ -4,6 +4,7 @@ import datetime
 import pathlib
 import pickle
 import uuid
+import warnings
 from dataclasses import dataclass
 from typing import Any, NamedTuple
 
@@ -47,11 +48,14 @@ class _MyTuple(NamedTuple):
     z: float
 
 
-@serialize_by_pickle
-@dataclass
-class _PickledDC:
-    a: int
-    b: str
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", UserWarning)
+
+    @serialize_by_pickle
+    @dataclass
+    class _PickledDC:
+        a: int
+        b: str
 
 
 @unpickle_safe
@@ -76,6 +80,17 @@ class _NotRegistered:
 
     def __init__(self, v: int) -> None:
         self.v = v
+
+
+@serialize_by_pickle
+class _MsgspecUnsupported:
+    """A custom class not supported by msgspec natively, serialized via pickle."""
+
+    def __init__(self, val: int) -> None:
+        self.val = val
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _MsgspecUnsupported) and self.val == other.val
 
 
 # Module-level pydantic model decorated with @serialize_by_pickle for test 9.
@@ -448,3 +463,44 @@ class TestDeserializeFn:
         result2 = fn(pydantic_data)
         assert isinstance(result2, M)
         assert result2.x == 20
+
+    def test_pickle_type_deserialize_fn(self) -> None:
+        """Test 21: make_deserialize_fn works for a @serialize_by_pickle type
+        that msgspec cannot build a Decoder for natively."""
+        fn: DeserializeFn = make_deserialize_fn(_MsgspecUnsupported)
+        value = _MsgspecUnsupported(val=7)
+        data = serialize(value)
+        assert _routing_byte(data) == 0x80
+        result = fn(data)
+        assert result == value
+
+    def test_union_with_pickle_type_deserialize_fn(self) -> None:
+        """Test 22: make_deserialize_fn works for a union type containing a
+        @serialize_by_pickle class alongside other types (e.g. int).
+
+        msgspec cannot build a Decoder for such unions, but the function should
+        still succeed because the decoder creation is best-effort.  The
+        original decoder error is surfaced only if a 0x01 payload arrives."""
+        from cocoindex._internal.serde import DeserializationError
+
+        fn: DeserializeFn = make_deserialize_fn(_MsgspecUnsupported | int)
+
+        # Pickle path: _MsgspecUnsupported serialized via pickle -- round-trips
+        pickle_val = _MsgspecUnsupported(val=42)
+        pickle_data = serialize(pickle_val)
+        assert _routing_byte(pickle_data) == 0x80
+        assert fn(pickle_data) == pickle_val
+
+        # Msgspec path: int serialized via msgspec -- raises with hint
+        int_data = serialize(99)
+        assert _routing_byte(int_data) == 0x01
+        with pytest.raises(
+            DeserializationError, match="Cannot deserialize"
+        ) as exc_info:
+            fn(int_data)
+        # The cause is a DeserializationError with a hint about union types
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, DeserializationError)
+        assert "union" in str(cause).lower()
+        # The original TypeError from msgspec is chained one level deeper
+        assert isinstance(cause.__cause__, TypeError)


### PR DESCRIPTION
## Summary

- **Robust msgspec Decoder creation**: `make_deserialize_fn()` now handles types that msgspec can't build a Decoder for (e.g. union types with custom classes) by capturing the error and re-raising with a helpful hint only when a msgspec payload actually arrives
- **Fix `_dec_hook` for pickle-quarantined fields**: Values like `np.dtype` nested inside msgspec Structs now round-trip correctly — `_ext_hook` reconstructs the object, `_dec_hook` passes it through
- **Migrate all tracking record types to `msgspec.Struct`**: NamedTuples → `Struct(array_like=True)` (wire-compatible), dataclasses → `Struct(frozen=True)` (wire-compatible). Removes `@unpickle_safe` from all migrated types
- **Qdrant union fix**: Replace `_ResolvedQdrantVectorDef | Mapping[str, ...]` (unsupported by msgspec) with two tagged Structs
- **Developer guardrails**: Warning when `@serialize_by_pickle` is applied to msgspec-native types; improved error messages with union-type hints
- **Rewritten serialization docs**: Clearer supported types table, union type patterns with tagged Struct examples, streamlined troubleshooting

## Test plan
- [x] All 556 tests pass (25 SurrealDB errors are pre-existing — server not running)
- [x] mypy clean across all 9 changed source files
- CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
