### PR TITLE
fix: eagerly register attachment providers for orphaned cleanup

### DIFF
--- a/docs/docs/advanced_topics/custom_target_connector.md
+++ b/docs/docs/advanced_topics/custom_target_connector.md
@@ -42,8 +42,8 @@ class TargetHandler(Protocol[ValueT, TrackingRecordT, OptChildHandlerT]):
         ...
 
     # Optional: override to support attachment types (see "Implementing attachment providers")
-    def attachment(self, att_type: str) -> TargetHandler | None:
-        return None  # Default: no attachments
+    def attachments(self) -> dict[str, TargetHandler]:
+        return {}  # Default: no attachments
 ```
 
 **Type Parameters:**
@@ -478,10 +478,10 @@ The symbol keys (`@vector_index`, `@sql_command_attachment`) are path namespaces
 
 ### How it works
 
-1. **Handler implements `attachment()`**: The child handler (e.g., row handler) returns a handler for each supported attachment type.
-2. **User code calls `provider.attachment()`**: On a resolved child provider, this creates (or retrieves a cached) attachment sub-provider.
-3. **Target states declared under the attachment provider** are tracked independently from regular children.
-4. **Idempotent**: Calling `.attachment("x")` multiple times returns the same cached provider.
+1. **Handler implements `attachments()`**: The child handler (e.g., row handler) returns a dict of all supported attachment types and their handlers.
+2. **Engine eagerly registers attachment providers**: When the child handler is fulfilled, the engine calls `attachments()` and registers all returned types. This ensures orphaned attachments can be cleaned up even when not declared in the current run.
+3. **User code calls `provider.attachment()`**: On a resolved child provider, this retrieves the cached attachment sub-provider.
+4. **Target states declared under the attachment provider** are tracked independently from regular children.
 
 ### Step 1: Implement the attachment handler
 
@@ -518,9 +518,9 @@ class _VectorIndexHandler:
         ...
 ```
 
-### Step 2: Add `attachment()` to the parent handler
+### Step 2: Add `attachments()` to the parent handler
 
-The parent handler (which manages regular children) returns attachment handlers by type:
+The parent handler (which manages regular children) returns a dict of all supported attachment types:
 
 ```python
 class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
@@ -530,12 +530,11 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self._schema_name = schema_name
         # ...
 
-    def attachment(self, att_type: str) -> _VectorIndexHandler | _SqlCommandHandler | None:
-        if att_type == "vector_index":
-            return _VectorIndexHandler(self._pool, self._table_name, self._schema_name)
-        if att_type == "sql_command_attachment":
-            return _SqlCommandHandler(self._pool, self._table_name, self._schema_name)
-        return None
+    def attachments(self) -> dict[str, _VectorIndexHandler | _SqlCommandHandler]:
+        return {
+            "vector_index": _VectorIndexHandler(self._pool, self._table_name, self._schema_name),
+            "sql_command_attachment": _SqlCommandHandler(self._pool, self._table_name, self._schema_name),
+        }
 
     def reconcile(self, ...):
         # Regular row reconciliation

--- a/python/cocoindex/_internal/target_state.py
+++ b/python/cocoindex/_internal/target_state.py
@@ -83,13 +83,13 @@ class _TypedTargetHandlerWrapper:
         records = [r.get(self._deserializer) for r in prev_possible_records]
         return self._handler.reconcile(key, desired, records, prev_may_be_missing)
 
-    def attachment(self, att_type: str) -> Any:
-        if not hasattr(self._handler, "attachment"):
-            return None
-        child = self._handler.attachment(att_type)
-        if child is not None:
-            return _TypedTargetHandlerWrapper(child)
-        return None
+    def attachments(self) -> dict[str, Any]:
+        if not hasattr(self._handler, "attachments"):
+            return {}
+        return {
+            k: _TypedTargetHandlerWrapper(v)
+            for k, v in self._handler.attachments().items()
+        }
 
 
 class ChildTargetDef(Generic[HandlerT_co], NamedTuple):

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -731,14 +731,17 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         async with self._pool.acquire() as conn:
             await conn.execute(sql, *params)
 
-    def attachment(
-        self, att_type: str
-    ) -> _VectorIndexHandler | _SqlCommandHandler | None:
-        if att_type == "vector_index":
-            return _VectorIndexHandler(self._pool, self._table_name, self._schema_name)
-        if att_type == "sql_command_attachment":
-            return _SqlCommandHandler(self._pool, self._table_name, self._schema_name)
-        return None
+    def attachments(
+        self,
+    ) -> dict[str, _VectorIndexHandler | _SqlCommandHandler]:
+        return {
+            "vector_index": _VectorIndexHandler(
+                self._pool, self._table_name, self._schema_name
+            ),
+            "sql_command_attachment": _SqlCommandHandler(
+                self._pool, self._table_name, self._schema_name
+            ),
+        }
 
     def reconcile(
         self,

--- a/python/tests/common/target_states.py
+++ b/python/tests/common/target_states.py
@@ -324,12 +324,13 @@ class _AttachmentChildHandler:
         self._attachment_stores = {}
         self._supported_types = supported_types
 
-    def attachment(self, att_type: str) -> DictTargetStateStore | None:
-        if att_type not in self._supported_types:
-            return None
-        if att_type not in self._attachment_stores:
-            self._attachment_stores[att_type] = DictTargetStateStore()
-        return self._attachment_stores[att_type]
+    def attachments(self) -> dict[str, DictTargetStateStore]:
+        return {
+            att_type: self._attachment_stores.setdefault(
+                att_type, DictTargetStateStore()
+            )
+            for att_type in self._supported_types
+        }
 
     def reconcile(
         self,

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -303,10 +303,6 @@ async def test_postgres_declare_vector_index_fingerprint_no_change(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Attachment teardown on removal not yet implemented: "
-    "engine skips orphaned attachment providers in Phase 2 of pre_commit"
-)
 async def test_postgres_declare_sql_command_attachment(pg_env: _PgEnv) -> None:
     """SQL command attachment lifecycle: create index → change → remove (with teardown)."""
     pool = pg_env.pool

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -1325,6 +1325,8 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     .encode()?;
     let contained_target_state_paths =
         std::mem::take(&mut finalized_fn_call_memos.contained_target_state_paths);
+
+    let mut pending_fulfillments: Vec<(TargetStateProvider<Prof>, Prof::TargetHdl)> = Vec::new();
     let target_states_providers_owned = target_states_providers.clone();
 
     // Reconcile and pre-commit target states
@@ -1363,7 +1365,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     let demote_component_only = pre_commit_out.demote_component_only;
     let actions_by_sinks = pre_commit_out.actions_by_sinks;
 
-    // Apply actions
+    // Apply actions and collect child handlers to fulfill.
     let host_runtime_ctx = comp_ctx.app_ctx().env().host_runtime_ctx();
     for (sink, input) in actions_by_sinks {
         let handlers = sink
@@ -1389,7 +1391,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
             {
                 if let Some(child_provider) = child_provider {
                     if let Some(child_target_state_def) = child_target_state_def {
-                        child_provider.fulfill_handler(child_target_state_def.handler)?;
+                        pending_fulfillments.push((child_provider, child_target_state_def.handler));
                     } else {
                         client_bail!("expect child provider returned by Sink to be fulfilled");
                     }
@@ -1408,6 +1410,14 @@ pub(crate) async fn submit<Prof: EngineProfile>(
             curr_version,
         )
         .await?;
+
+    // Fulfill child handlers and register their attachment providers.
+    // Done after commit so the immutable borrow on providers is released.
+    if let Some(ref mut registry) = built_target_states_providers {
+        for (child_provider, handler) in pending_fulfillments {
+            child_provider.fulfill_handler(handler, registry)?;
+        }
+    }
 
     Ok(SubmitOutput {
         built_target_states_providers,

--- a/rust/core/src/engine/target_state.rs
+++ b/rust/core/src/engine/target_state.rs
@@ -51,8 +51,11 @@ pub trait TargetHandler<Prof: EngineProfile>: Send + Sync + Sized + 'static {
         prev_may_be_missing: bool,
     ) -> Result<Option<TargetReconcileOutput<Prof>>>;
 
-    fn attachment(&self, _att_type: &str) -> Result<Option<Prof::TargetHdl>> {
-        Ok(None)
+    /// Return all attachment types this handler supports, keyed by type name.
+    /// The engine eagerly registers these as providers so that orphaned
+    /// attachments can be cleaned up even when not declared in the current run.
+    fn attachments(&self) -> Result<Vec<(Arc<str>, Prof::TargetHdl)>> {
+        Ok(vec![])
     }
 }
 
@@ -80,11 +83,19 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
         self.inner.handler.get()
     }
 
-    pub fn fulfill_handler(&self, handler: Prof::TargetHdl) -> Result<()> {
+    /// Fulfill the handler and eagerly register all its attachment providers
+    /// into the given registry so that `pre_commit` Phase 2 can clean up
+    /// orphaned attachments.
+    pub fn fulfill_handler(
+        &self,
+        handler: Prof::TargetHdl,
+        registry: &mut TargetStateProviderRegistry<Prof>,
+    ) -> Result<()> {
         self.inner
             .handler
             .set(handler)
-            .map_err(|_| internal_error!("Handler is already fulfilled"))
+            .map_err(|_| internal_error!("Handler is already fulfilled"))?;
+        self.register_all_attachment_providers(registry)
     }
 
     pub fn stable_key_chain(&self) -> Vec<StableKey> {
@@ -113,20 +124,73 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
             .map_err(|_| internal_error!("Provider generation already set"))
     }
 
+    fn register_all_attachment_providers(
+        &self,
+        registry: &mut TargetStateProviderRegistry<Prof>,
+    ) -> Result<()> {
+        let handler = match self.handler() {
+            Some(h) => h,
+            None => return Ok(()),
+        };
+        let att_entries = handler.attachments()?;
+        if att_entries.is_empty() {
+            return Ok(());
+        }
+
+        let mut attachments = self.inner.attachments.lock().unwrap();
+        let provider_generation = self.provider_generation().cloned().unwrap_or_default();
+
+        for (att_type, att_handler) in att_entries {
+            if attachments.contains_key(&*att_type) {
+                continue;
+            }
+            let symbol_key = StableKey::Symbol(att_type.clone());
+            let target_state_path = self.target_state_path().concat(&symbol_key);
+
+            let provider = TargetStateProvider {
+                inner: Arc::new(TargetStateProviderInner {
+                    parent_provider: Some(self.clone()),
+                    stable_key: symbol_key,
+                    target_state_path: target_state_path.clone(),
+                    handler: OnceLock::from(att_handler),
+                    orphaned: OnceLock::new(),
+                    provider_generation: OnceLock::from(provider_generation.clone()),
+                    attachments: Mutex::new(HashMap::new()),
+                }),
+            };
+
+            registry.add(target_state_path, provider.clone())?;
+            attachments.insert(att_type, provider);
+        }
+        Ok(())
+    }
+
+    /// Get or create an attachment provider for the given type.
+    /// Called from Python when an attachment is declared (e.g. `declare_vector_index`).
+    /// Returns the cached provider if already registered (by eager or prior lazy call).
     pub fn register_attachment_provider(
         &self,
         comp_ctx: &ComponentProcessorContext<Prof>,
         att_type: &str,
     ) -> Result<TargetStateProvider<Prof>> {
-        let mut attachments = self.inner.attachments.lock().unwrap();
+        // Fast path: already registered (eagerly or by a previous call).
+        let attachments = self.inner.attachments.lock().unwrap();
         if let Some(existing) = attachments.get(att_type) {
             return Ok(existing.clone());
         }
+        drop(attachments);
 
+        // Slow path: not yet registered. This can happen if the handler doesn't
+        // include this type in attachments(), or during the first run before
+        // eager registration has occurred. Build it from the handler.
         let handler = self
             .handler()
-            .ok_or_else(|| client_error!("Cannot register attachment on unfulfilled provider"))?
-            .attachment(att_type)?
+            .ok_or_else(|| client_error!("Cannot register attachment on unfulfilled provider"))?;
+        let att_entries = handler.attachments()?;
+        let att_handler = att_entries
+            .into_iter()
+            .find(|(k, _)| &**k == att_type)
+            .map(|(_, h)| h)
             .ok_or_else(|| {
                 client_error!("Handler does not support attachment type: {att_type:?}")
             })?;
@@ -148,7 +212,7 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
                 parent_provider: Some(self.clone()),
                 stable_key: symbol_key,
                 target_state_path: target_state_path.clone(),
-                handler: OnceLock::from(handler),
+                handler: OnceLock::from(att_handler),
                 orphaned: OnceLock::new(),
                 provider_generation: OnceLock::from(provider_generation),
                 attachments: Mutex::new(HashMap::new()),
@@ -162,6 +226,7 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
                 .add(target_state_path, provider.clone())
         })?;
 
+        let mut attachments = self.inner.attachments.lock().unwrap();
         attachments.insert(att_type.into(), provider.clone());
         Ok(provider)
     }

--- a/rust/py/src/target_state.rs
+++ b/rust/py/src/target_state.rs
@@ -166,17 +166,20 @@ impl TargetHandler<PyEngineProfile> for PyTargetHandler {
         .from_py_result()
     }
 
-    fn attachment(&self, att_type: &str) -> Result<Option<PyTargetHandler>> {
+    fn attachments(&self) -> Result<Vec<(Arc<str>, PyTargetHandler)>> {
         Python::attach(|py| -> PyResult<_> {
             let obj = self.0.bind(py);
-            if !obj.hasattr("attachment")? {
-                return Ok(None);
+            if !obj.hasattr("attachments")? {
+                return Ok(vec![]);
             }
-            let result = obj.call_method1("attachment", (att_type,))?;
-            if result.is_none() {
-                return Ok(None);
+            let result = obj.call_method0("attachments")?;
+            let dict = result.cast::<pyo3::types::PyDict>()?;
+            let mut entries = Vec::with_capacity(dict.len());
+            for (key, value) in dict.iter() {
+                let att_type: String = key.extract()?;
+                entries.push((Arc::from(att_type), PyTargetHandler(value.unbind())));
             }
-            Ok(Some(PyTargetHandler(result.unbind())))
+            Ok(entries)
         })
         .from_py_result()
     }


### PR DESCRIPTION
## Summary
- Fix orphaned attachment cleanup: when an attachment (e.g. `declare_vector_index`, `declare_sql_command_attachment`) was previously declared but not in a subsequent run, its teardown SQL was not executed because the attachment provider was missing from the engine's provider registry
- Root cause: attachment providers were only registered on-demand when explicitly declared, but the engine's `pre_commit` Phase 2 needs them to exist for cleanup even when not declared
- Fix: eagerly register all attachment providers when a child handler is propagated to the parent component, using a new `attachment_types()` trait method that returns the handler's supported attachment types

## Test plan
- `test_postgres_declare_sql_command_attachment` (previously skipped) now passes — verifies that removing an attachment triggers its teardown SQL
- All 14 postgres connector tests pass
- All 6 attachment target state tests pass
- `cargo test` passes
- `mypy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
