### PR TITLE
docs: fix prek violations on migrated Astro content

### DIFF
--- a/docs/src/content/docs/core/cli.mdx
+++ b/docs/src/content/docs/core/cli.mdx
@@ -46,5 +46,3 @@ CocoIndex CLI supports the following global options:
 * `-d, --app-dir <path>`: Load apps from the specified directory. It will be treated as part of `PYTHONPATH`. Default to the current directory.
 * `-V, --version`: Show the CocoIndex version and exit.
 * `--help`: Show the main help message and exit.
-
-

--- a/docs/src/content/docs/core/data_types.mdx
+++ b/docs/src/content/docs/core/data_types.mdx
@@ -252,7 +252,7 @@ class PersonKeyTuple(NamedTuple):
 # Pydantic frozen model (if available)
 try:
     from pydantic import BaseModel
-    
+
     class PersonKeyModel(BaseModel):
         model_config = {"frozen": True}
         id_kind: str

--- a/docs/src/content/docs/core/flow_methods.mdx
+++ b/docs/src/content/docs/core/flow_methods.mdx
@@ -157,5 +157,3 @@ cocoindex evaluate main.py --output-dir ./eval_output
 ```
 
 ### Library API
-
-

--- a/docs/src/content/docs/custom_ops/custom_functions.mdx
+++ b/docs/src/content/docs/custom_ops/custom_functions.mdx
@@ -99,5 +99,3 @@ Sometimes batching is more efficient than processing them one by one, e.g. runni
 Batching can be enabled by setting the `batching` parameter to `True` in custom function parameters.
 Once it's set to `True`, type of the argument and return value must be a `list`.
 Currently we only support batching functions taking a single argument.
-
-

--- a/docs/src/content/docs/query.mdx
+++ b/docs/src/content/docs/query.mdx
@@ -110,5 +110,3 @@ It takes the following arguments:
 *   `target_name` (type: `str`): The export target name, appeared in the `export()` call.
 
 For example:
-
-

--- a/docs/src/content/docs/targets/chromadb.mdx
+++ b/docs/src/content/docs/targets/chromadb.mdx
@@ -109,5 +109,3 @@ def text_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoind
         ],
     )
 ```
-
-

--- a/docs/src/content/docs/targets/doris.mdx
+++ b/docs/src/content/docs/targets/doris.mdx
@@ -274,5 +274,3 @@ pip install aiohttp aiomysql
 ```
 
 ## Example
-
-

--- a/docs/src/content/docs/targets/index.mdx
+++ b/docs/src/content/docs/targets/index.mdx
@@ -331,6 +331,6 @@ graph TD
 ### Examples
 
 You can find end-to-end examples fitting into any of supported property graphs in the following directories:
-*   
 
-*   
+* [Property graph for a knowledge base](https://github.com/cocoindex-io/cocoindex/tree/main/examples/docs_to_knowledge_graph)
+* [Property graph for product catalog](https://github.com/cocoindex-io/cocoindex/tree/main/examples/product_taxonomy_knowledge_graph)

--- a/docs/src/content/docs/targets/ladybug.mdx
+++ b/docs/src/content/docs/targets/ladybug.mdx
@@ -39,5 +39,3 @@ pip install real_ladybug
 ```
 
 ## Example
-
-

--- a/docs/src/content/docs/targets/lancedb.mdx
+++ b/docs/src/content/docs/targets/lancedb.mdx
@@ -113,5 +113,3 @@ Once `db_uri` matches, it automatically reuses the same connection instance with
 This achieves strong consistency between your indexing and querying logic, if they run in the same process.
 
 ## Example
-
-

--- a/docs/src/content/docs/targets/pinecone.mdx
+++ b/docs/src/content/docs/targets/pinecone.mdx
@@ -122,5 +122,3 @@ def get_index(
 This helper creates a Pinecone index reference configured with your API key and index name, making it easy to query the data you've indexed with CocoIndex.
 
 ## Example
-
-

--- a/docs/src/content/docs/targets/postgres.mdx
+++ b/docs/src/content/docs/targets/postgres.mdx
@@ -91,5 +91,3 @@ collector.export(
 ```
 
 ## Example
-
-

--- a/docs/src/content/docs/targets/qdrant.mdx
+++ b/docs/src/content/docs/targets/qdrant.mdx
@@ -44,4 +44,3 @@ The spec takes the following fields:
 You can find an end-to-end example [here](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding_qdrant).
 
 ## Example
-


### PR DESCRIPTION
## Summary
- Trim trailing whitespace and collapse trailing blank lines across 13 `.mdx` files migrated in #1845 so `end-of-file-fixer` + `trailing-whitespace` pass on `main`.
- Restore the two property-graph example links in `docs/src/content/docs/targets/index.mdx` (left as empty bullets after the Docusaurus → Astro port).

## Test plan
- [x] `npm --prefix docs run build` — 43 pages, clean.
- [x] No remaining trailing whitespace or multi-blank EOFs under `docs/src/content/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)