### PR TITLE
docs: fix v1 Astro CLI doc EOF whitespace

### DIFF
--- a/docs-astro/src/content/docs/cli.mdx
+++ b/docs-astro/src/content/docs/cli.mdx
@@ -45,5 +45,3 @@ CocoIndex CLI supports the following global options:
 * `-d, --app-dir <path>`: Load apps from the specified directory. It will be treated as part of `PYTHONPATH`. Default to the current directory.
 * `-V, --version`: Show the CocoIndex version and exit.
 * `--help`: Show the main help message and exit.
-
-


### PR DESCRIPTION
## Summary
- remove the extra trailing blank line at the end of \
- clear the whitespace issue reported by \ for the merged v1 Astro scaffold diff
- keep the Astro docs build green after the content-only fix

## Validation
- \
- \ (in \ with Node from ~/.nvm)
