### PR TITLE
docs(topbar): point v1 to /docs-v1 (soon), v0 to /docs (legacy)

### DIFF
--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -28,11 +28,11 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
           </svg>
         </a>
         <div class="nav-dd-menu" role="menu">
-          <a class="on" href={DOCS} role="menuitem">
+          <a class="on" href="/docs-v1" role="menuitem">
             <span class="ver">v1</span>
-            <span class="tag">current</span>
+            <span class="tag">soon</span>
           </a>
-          <a href="https://cocoindex.io/docs-v0/" role="menuitem">
+          <a href="/docs" role="menuitem">
             <span class="ver">v0</span>
             <span class="tag legacy">legacy</span>
           </a>


### PR DESCRIPTION
Fixes broken top-nav doc-version links.