### PR TITLE
docs: add Python code formatting and linting commands to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,14 @@ uv run dmypy run         # Type check Python code (uses mypy daemon)
 uv run pytest python/    # Run Python tests (use after both Rust and Python changes)
 ```
 
+### Code Formatting and Linting
+
+```bash
+uv run ruff format .           # Format Python code
+uv run ruff format --check .   # Check formatting without making changes (same as CI)
+uv run ruff check .            # Lint Python code
+```
+
 ### Workflow Summary
 
 | Change Type | Commands to Run |
@@ -27,6 +35,7 @@ uv run pytest python/    # Run Python tests (use after both Rust and Python chan
 | Rust code only | `uv run maturin develop && cargo test` |
 | Python code only | `uv run dmypy run && uv run pytest python/` |
 | Both Rust and Python | Run all commands from both categories above |
+| Python formatting | `uv run ruff format .` |
 
 ## Code Structure
 


### PR DESCRIPTION
Fixes #1476

## Problem

CLAUDE.md currently has build and test commands but no formatting/linting instructions. This causes contributors to miss the fact that CI runs ruff format checks, leading to formatting-related CI failures.

## Solution

Add a dedicated **Code Formatting and Linting** section with the following commands:

```bash
uv run ruff format .           # Format Python code
uv run ruff format --check .   # Check formatting without making changes (same as CI)
uv run ruff check .            # Lint Python code
```

Also added a Python formatting row to the Workflow Summary table for quick reference.

## Testing

This is a documentation-only change to CLAUDE.md with no code changes.