### PR TITLE
docs(examples): migrate cocoindex-io/examples walkthroughs into /docs…

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -17,4 +17,23 @@ const docs = defineCollection({
     .passthrough(),
 });
 
-export const collections = { docs };
+// Example walkthroughs — ported from github.com/cocoindex-io/examples.
+// One .md file per slug in src/content/example-posts, rendered by
+// src/pages/examples/[slug].astro beneath the shared hero.
+const examplePosts = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/example-posts' }),
+  schema: z
+    .object({
+      title: z.string(),
+      description: z.string().optional(),
+      slug: z.string(),
+      image: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      // YAML parses ISO dates into Date; accept either so hand-edited
+      // string dates also work.
+      last_reviewed: z.union([z.string(), z.date()]).optional(),
+    })
+    .passthrough(),
+});
+
+export const collections = { docs, examplePosts };

--- a/docs/src/content/example-posts/academic_papers_index.md
+++ b/docs/src/content/example-posts/academic_papers_index.md
@@ -1,0 +1,342 @@
+---
+title: Academic Papers Indexing
+description: 'Build a real-time academic papers index. Extract metadata, chunk and embed abstracts, and enable semantic and author-based search over academic PDFs.'
+slug: academic_papers_index
+image: https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/cover.png
+tags: [vector-index, metadata]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/paper_metadata)
+
+![Academic Papers Index](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/cover.png)
+
+## What we will achieve
+
+1. Extract the paper metadata, including file name, title, author information, abstract, and number of pages.
+
+2. Build vector embeddings for the metadata, such as the title and abstract, for semantic search.
+This enables better metadata-driven semantic search results. For example, you can match text queries against titles and abstracts.
+
+3. Build an index of authors and all the file names associated with each author
+to answer questions like "Give me all the papers by Jeff Dean."
+
+4. If you want to perform full PDF embedding for the paper, you can extend the flow.
+
+## Flow Overview
+![Flow Overview](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/flow.png)
+1. Import a list of papers in PDF.
+2. For each file:
+    - Extract the first page of the paper.
+    - Convert the first page to Markdown.
+    - Extract metadata (title, authors, abstract) from the first page.
+    - Split the abstract into chunks, and compute embeddings for each chunk.
+3. Export to the following tables in Postgres with PGVector:
+    - Metadata (title, authors, abstract) for each paper.
+    - Author-to-paper mapping, for author-based query.
+    - Embeddings for titles and abstract chunks, for semantic search.
+
+## Setup
+
+- [Install PostgreSQL](https://cocoindex.io/docs/getting_started/installation#-install-postgres).
+  CocoIndex uses PostgreSQL internally for incremental processing.
+- [Configure your OpenAI API key](https://cocoindex.io/docs/ai/llm#openai). Alternatively, we have native support for Gemini, Ollama, LiteLLM. You can choose your favorite LLM provider and work completely on-premises.
+
+  [→ LLM](https://cocoindex.io/docs/ai/llm)
+
+## Import the Papers
+
+```python
+@cocoindex.flow_def(name="PaperMetadata")
+def paper_metadata_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="papers", binary=True),
+        refresh_interval=datetime.timedelta(seconds=10),
+    )
+```
+
+`flow_builder.add_source` will create a table with sub fields (`filename`, `content`).
+[→ Sources](https://cocoindex.io/docs/sources)
+
+## Extract and collect metadata
+
+### Extract first page for basic info
+
+Define a custom function to extract the first page and number of pages of the PDF.
+
+```python
+@dataclasses.dataclass
+class PaperBasicInfo:
+    num_pages: int
+    first_page: bytes
+```
+
+```python
+@cocoindex.op.function()
+def extract_basic_info(content: bytes) -> PaperBasicInfo:
+    """Extract the first pages of a PDF."""
+    reader = PdfReader(io.BytesIO(content))
+
+    output = io.BytesIO()
+    writer = PdfWriter()
+    writer.add_page(reader.pages[0])
+    writer.write(output)
+
+    return PaperBasicInfo(num_pages=len(reader.pages), first_page=output.getvalue())
+
+```
+
+Now plug this into the flow. We extract metadata from the first page to minimize processing cost, since the entire PDF can be very large.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["basic_info"] = doc["content"].transform(extract_basic_info)
+```
+![Extract basic info](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/basic_info.png)
+
+After this step, we should have the basic info of each paper.
+
+### Parse basic info
+
+We will convert the first page to Markdown using Marker. Alternatively, you can easily plug in any PDF parser, such as Docling using CocoIndex's [custom function](https://cocoindex.io/docs/custom_ops/custom_functions).
+
+Define a marker converter function and cache it, since its initialization is resource-intensive.
+This ensures that the same converter instance is reused for different input files.
+
+```python
+@cache
+def get_marker_converter() -> PdfConverter:
+    config_parser = ConfigParser({})
+    return PdfConverter(
+        create_model_dict(), config=config_parser.generate_config_dict()
+    )
+```
+
+Plug it into a custom function.
+
+```python
+@cocoindex.op.function(gpu=True, cache=True, behavior_version=1)
+def pdf_to_markdown(content: bytes) -> str:
+    """Convert to Markdown."""
+
+    with tempfile.NamedTemporaryFile(delete=True, suffix=".pdf") as temp_file:
+        temp_file.write(content)
+        temp_file.flush()
+        text, _, _ = text_from_rendered(get_marker_converter()(temp_file.name))
+        return text
+```
+
+Pass it to your transform
+
+```python
+with data_scope["documents"].row() as doc:
+    # ... process
+    doc["first_page_md"] = doc["basic_info"]["first_page"].transform(
+            pdf_to_markdown
+        )
+```
+![First page in Markdown](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/first_page.png)
+
+After this step, you should have the first page of each paper in Markdown format.
+
+### Extract basic info with LLM
+
+Define a schema for LLM extraction. CocoIndex natively supports LLM-structured extraction with complex and nested schemas.
+If you are interested in learning more about nested schemas, refer to [this example](https://cocoindex.io/examples/patient_form_extraction).
+
+```python
+@dataclasses.dataclass
+class PaperMetadata:
+    """
+    Metadata for a paper.
+    """
+
+    title: str
+    authors: list[Author]
+    abstract: str
+```
+
+Plug it into the `ExtractByLlm` function. With a dataclass defined, CocoIndex will automatically parse the LLM response into the dataclass.
+
+```python
+doc["metadata"] = doc["first_page_md"].transform(
+    cocoindex.functions.ExtractByLlm(
+        llm_spec=cocoindex.LlmSpec(
+            api_type=cocoindex.LlmApiType.OPENAI, model="gpt-4o"
+        ),
+        output_type=PaperMetadata,
+        instruction="Please extract the metadata from the first page of the paper.",
+    )
+)
+```
+
+After this step, you should have the metadata of each paper.
+![Metadata](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/metadata.png)
+
+### Collect paper metadata
+
+```python
+paper_metadata = data_scope.add_collector()
+with data_scope["documents"].row() as doc:
+# ... process
+# Collect metadata
+paper_metadata.collect(
+    filename=doc["filename"],
+    title=doc["metadata"]["title"],
+    authors=doc["metadata"]["authors"],
+    abstract=doc["metadata"]["abstract"],
+    num_pages=doc["basic_info"]["num_pages"],
+)
+```
+
+Just collect anything you need :)
+
+### Collect `author` to `filename` information
+We’ve already extracted author list. Here we want to collect Author → Papers in a separate table to build a look up functionality.
+Simply collect by author.
+
+```python
+author_papers = data_scope.add_collector()
+
+with data_scope["documents"].row() as doc:
+    with doc["metadata"]["authors"].row() as author:
+        author_papers.collect(
+            author_name=author["name"],
+            filename=doc["filename"],
+        )
+```
+
+
+## Compute and collect embeddings
+
+### Title
+
+```python
+doc["title_embedding"] = doc["metadata"]["title"].transform(
+    cocoindex.functions.SentenceTransformerEmbed(
+        model="sentence-transformers/all-MiniLM-L6-v2"
+    )
+)
+```
+
+### Abstract
+
+Split abstract into chunks, embed each chunk and collect their embeddings.
+Sometimes the abstract could be very long.
+
+```python
+doc["abstract_chunks"] = doc["metadata"]["abstract"].transform(
+    cocoindex.functions.SplitRecursively(
+        custom_languages=[
+            cocoindex.functions.CustomLanguageSpec(
+                language_name="abstract",
+                separators_regex=[r"[.?!]+\s+", r"[:;]\s+", r",\s+", r"\s+"],
+            )
+        ]
+    ),
+    language="abstract",
+    chunk_size=500,
+    min_chunk_size=200,
+    chunk_overlap=150,
+)
+```
+
+After this step, you should have the abstract chunks of each paper.
+
+![Abstract chunks](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/abstract_chunks.png)
+
+Embed each chunk and collect their embeddings.
+
+```python
+with doc["abstract_chunks"].row() as chunk:
+    chunk["embedding"] = chunk["text"].transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"
+        )
+    )
+```
+
+After this step, you should have the embeddings of the abstract chunks of each paper.
+
+![Abstract chunks embeddings](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/chunk_embedding.png)
+
+### Collect embeddings
+
+```python
+metadata_embeddings = data_scope.add_collector()
+
+with data_scope["documents"].row() as doc:
+    # ... process
+    # collect title embedding
+    metadata_embeddings.collect(
+        id=cocoindex.GeneratedField.UUID,
+        filename=doc["filename"],
+        location="title",
+        text=doc["metadata"]["title"],
+        embedding=doc["title_embedding"],
+    )
+    with doc["abstract_chunks"].row() as chunk:
+        # ... process
+        # collect abstract chunks embeddings
+        metadata_embeddings.collect(
+            id=cocoindex.GeneratedField.UUID,
+            filename=doc["filename"],
+            location="abstract",
+            text=chunk["text"],
+            embedding=chunk["embedding"],
+        )
+```
+
+## Export
+Finally, we export the data to Postgres.
+
+```python
+paper_metadata.export(
+    "paper_metadata",
+    cocoindex.targets.Postgres(),
+    primary_key_fields=["filename"],
+)
+author_papers.export(
+    "author_papers",
+    cocoindex.targets.Postgres(),
+    primary_key_fields=["author_name", "filename"],
+)
+metadata_embeddings.export(
+    "metadata_embeddings",
+    cocoindex.targets.Postgres(),
+    primary_key_fields=["id"],
+    vector_indexes=[
+        cocoindex.VectorIndexDef(
+            field_name="embedding",
+            metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
+        )
+    ],
+)
+```
+
+In this example we use PGVector as embedding store. With CocoIndex, you can do one line switch on other supported Vector databases.
+
+[→ Targets](https://cocoindex.io/docs/targets)
+
+## Query the index
+
+You can refer to this section of [Text Embeddings](https://cocoindex.io/blogs/text-embeddings-101#3-query-the-index) about
+how to build query against embeddings.
+For now CocoIndex doesn't provide additional query interface. We can write SQL or rely on the query engine by the target storage.
+
+- Many databases already have optimized query implementations with their own best practices
+- The query space has excellent solutions for querying, reranking, and other search-related functionality.
+
+If you need assist with writing the query, please feel free to reach out to us at [Discord](https://discord.com/invite/zpA9S2DR7s).
+
+## CocoInsight
+
+You can walk through the project step by step in [CocoInsight](https://www.youtube.com/watch?v=MMrpUfUcZPk) to see exactly how each field is constructed and what happens behind the scenes.
+
+```sh
+cocoindex server -ci main
+```
+
+Follow the url `https://cocoindex.io/cocoinsight`.  It connects to your local CocoIndex server, with zero pipeline data retention.

--- a/docs/src/content/example-posts/code_index.md
+++ b/docs/src/content/example-posts/code_index.md
@@ -1,0 +1,242 @@
+---
+title: Real-time Codebase Indexing
+description: 'Build a real-time codebase index for retrieval-augmented generation (RAG) using CocoIndex and Tree-sitter. Chunk, embed, and search code with semantic understanding.'
+slug: code_index
+image: https://cocoindex.io/blobs/docs/img/examples/codebase_index/cover.png
+tags: [vector-index, codebase]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding)
+[→ Watch on YouTube](https://youtu.be/G3WstvhHO24?si=ndYfM0XRs03_hVPR)
+
+![Codebase Index](https://cocoindex.io/blobs/docs/img/examples/codebase_index/cover.png)
+
+## Overview
+
+In this tutorial, we will build codebase index. [CocoIndex](https://github.com/cocoindex-io/cocoindex) provides built-in support for codebase chunking, with native Tree-sitter support. It works with large codebases, and can be updated in near real-time with incremental processing - only reprocess what's changed.
+
+## Use Cases
+
+A wide range of applications can be built with an effective codebase index that is always up-to-date.
+
+![Codebase Index Use Cases](https://cocoindex.io/blobs/docs/img/examples/codebase_index/usecase.png)
+
+- Semantic code context for AI coding agents like Claude, Codex, Gemini CLI.
+- MCP for code editors such as Cursor, Windsurf, and VSCode.
+- Context-aware code search applications—semantic code search, natural language code retrieval.
+- Context for code review agents—AI code review, automated code analysis, code quality checks, pull request summarization.
+- Automated code refactoring, large-scale code migration.
+- SRE workflows: enable rapid root cause analysis, incident response, and change impact assessment by indexing infrastructure-as-code, deployment scripts, and config files for semantic search and lineage tracking.
+- Automatically generate design documentation from code—keep design docs up-to-date.
+
+## Flow Overview
+
+![Flow Overview](https://cocoindex.io/blobs/docs/img/examples/codebase_index/flow.png)
+
+The flow is composed of the following steps:
+
+- Read code files from the local filesystem
+- Extract file extensions, to get the language of the code for Tree-sitter to parse
+- Split code into semantic chunks using Tree-sitter
+- Generate embeddings for each chunk
+- Store in a vector database for retrieval
+
+## Setup
+
+- Install Postgres, follow [installation guide](https://cocoindex.io/docs/getting_started/installation#-install-postgres).
+- Install CocoIndex
+
+  ```sh
+  pip install -U cocoindex
+  ```
+
+## Add the codebase as a source
+
+We will index the CocoIndex codebase. Here we use the `LocalFile` source to ingest files from the CocoIndex codebase root directory.
+
+```python
+
+@cocoindex.flow_def(name="CodeEmbedding")
+def code_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["files"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path=os.path.join('..', '..'),
+                                    included_patterns=["*.py", "*.rs", "*.toml", "*.md", "*.mdx"],
+                                    excluded_patterns=[".*", "target", "**/node_modules"]))
+    code_embeddings = data_scope.add_collector()
+```
+
+- Include files with the extensions of `.py`, `.rs`, `.toml`, `.md`, `.mdx`
+- Exclude files and directories starting `.`,  `target` in the root and `node_modules` under any directory.
+
+`flow_builder.add_source` will create a table with sub fields (`filename`, `content`).
+[→ Sources](https://cocoindex.io/docs/sources)
+
+## Process each file and collect the information
+
+### Extract the extension of a filename
+
+We need to pass the language (or extension) to Tree-sitter to parse the code.
+Let's define a function to extract the extension of a filename while processing each file.
+
+```python
+@cocoindex.op.function()
+def extract_extension(filename: str) -> str:
+    """Extract the extension of a filename."""
+    return os.path.splitext(filename)[1]
+```
+
+[→ Custom Function](https://cocoindex.io/docs/custom_ops/custom_functions)
+
+### Split the file into chunks
+
+We use the `SplitRecursively` function to split the file into chunks.  `SplitRecursively` is CocoIndex building block, with native integration with Tree-sitter. You need to pass in the language to the `language` parameter if you are processing code.
+
+```python
+with data_scope["files"].row() as file:
+    # Extract the extension of the filename.
+    file["extension"] = file["filename"].transform(extract_extension)
+    file["chunks"] = file["content"].transform(
+          cocoindex.functions.SplitRecursively(),
+          language=file["extension"], chunk_size=1000, chunk_overlap=300)
+```
+
+[→ SplitRecursively](https://cocoindex.io/docs/ops/functions#splitrecursively)
+
+![SplitRecursively](https://cocoindex.io/blobs/docs/img/examples/codebase_index/chunk.png)
+
+### Embed the chunks
+
+We use `SentenceTransformerEmbed` to embed the chunks.
+
+```python
+@cocoindex.transform_flow()
+def code_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[list[float]]:
+    return text.transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"))
+```
+
+[→ SentenceTransformerEmbed](https://cocoindex.io/docs/ops/functions#sentencetransformerembed)
+
+:::tip
+`@cocoindex.transform_flow()` is needed to share the transformation across indexing and query. When building a vector index and querying against it, the embedding computation must remain consistent between indexing and querying.
+:::
+
+[→ Transform Flow](https://cocoindex.io/docs/query#transform-flow)
+
+Then for each chunk, we will embed it using the `code_to_embedding` function, and collect the embeddings to the `code_embeddings` collector.
+
+```python
+with data_scope["files"].row() as file:
+    with file["chunks"].row() as chunk:
+        chunk["embedding"] = chunk["text"].call(code_to_embedding)
+        code_embeddings.collect(filename=file["filename"], location=chunk["location"],
+                                code=chunk["text"], embedding=chunk["embedding"])
+```
+
+### Export the embeddings
+
+```python
+code_embeddings.export(
+    "code_embeddings",
+    cocoindex.storages.Postgres(),
+    primary_key_fields=["filename", "location"],
+    vector_indexes=[cocoindex.VectorIndex("embedding", cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY)])
+```
+
+We use [Cosine Similarity](https://en.wikipedia.org/wiki/Cosine_similarity) to measure the similarity between the query and the indexed data.
+
+## Query the index
+
+We match against user-provided text by a SQL query, reusing the embedding operation in the indexing flow.
+
+```python
+def search(pool: ConnectionPool, query: str, top_k: int = 5):
+    # Get the table name, for the export target in the code_embedding_flow above.
+    table_name = cocoindex.utils.get_target_storage_default_name(code_embedding_flow, "code_embeddings")
+    # Evaluate the transform flow defined above with the input query, to get the embedding.
+    query_vector = code_to_embedding.eval(query)
+    # Run the query and get the results.
+    with pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"""
+                SELECT filename, code, embedding <=> %s::vector AS distance
+                FROM {table_name} ORDER BY distance LIMIT %s
+            """, (query_vector, top_k))
+            return [
+                {"filename": row[0], "code": row[1], "score": 1.0 - row[2]}
+                for row in cur.fetchall()
+            ]
+```
+
+Define a main function to run the query in terminal.
+
+```python
+def main():
+    # Initialize the database connection pool.
+    pool = ConnectionPool(os.getenv("COCOINDEX_DATABASE_URL"))
+    # Run queries in a loop to demonstrate the query capabilities.
+    while True:
+        try:
+            query = input("Enter search query (or Enter to quit): ")
+            if query == '':
+                break
+            # Run the query function with the database connection pool and the query.
+            results = search(pool, query)
+            print("\nSearch results:")
+            for result in results:
+                print(f"[{result['score']:.3f}] {result['filename']}")
+                print(f"    {result['code']}")
+                print("---")
+            print()
+        except KeyboardInterrupt:
+            break
+
+if __name__ == "__main__":
+    main()
+```
+
+## Run the index setup & update
+
+- Install dependencies
+
+    ```sh
+    pip install -e .
+    ```
+
+- Setup and update the index
+
+    ```sh
+    cocoindex update main
+    ```
+
+    You'll see the index updates state in the terminal
+
+## Test the query
+
+At this point, you can start the CocoIndex server and develop your RAG runtime against the data. To test your index, you could
+
+``` bash
+python main.py
+```
+
+When you see the prompt, you can enter your search query. for example: spec.
+The returned results - each entry contains score (Cosine Similarity), filename, and the code snippet that get matched.
+
+## CocoInsight
+
+To get a better understanding of the indexing flow, you can use CocoInsight to help the development step by step.
+To spin up, it is super easy.
+
+```sh
+cocoindex server -ci main
+```
+
+Follow the url from the terminal - `https://cocoindex.io/cocoinsight` to access the CocoInsight.
+
+## Supported Languages
+
+SplitRecursively has native support for all major programming languages.
+
+[→ Supported Languages](https://cocoindex.io/docs/ops/functions#supported-languages)

--- a/docs/src/content/example-posts/custom_source_hackernews.md
+++ b/docs/src/content/example-posts/custom_source_hackernews.md
@@ -1,0 +1,547 @@
+---
+title: Extract structured information from HackerNews with a Custom Source and keep it in sync with Postgres
+description: 'Build a lightweight, incremental pipeline by treating any API as a data component—custom incremental connector for HackerNews using CocoIndex’s Custom Source API. Export the data to Postgres for semantic search and analytics.'
+slug: custom_source_hackernews
+image: https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/cover.png
+tags: [custom-building-blocks]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/custom_source_hn)
+
+
+![Extract structured information from HackerNews with a Custom Source and export in Postgres](https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/cover.png)
+
+
+Custom Sources are one of the most powerful concepts in CocoIndex. They let you turn *any* API—internal or external — into a first-class, incremental data stream that the framework can automatically diff, track, and sync.
+
+In this example, we build a custom connector for HackerNews. It fetches recent stories + nested comments, indexes them, and exposes a simple search interface powered by Postgres full-text search.
+
+
+
+## Why Use a Custom Source?
+
+In many scenarios, pipelines don't just read from clean tables. They depend on:
+
+- Internal REST services
+- Partner APIs
+- Legacy systems
+- Non-standard data models that don’t fit traditional connectors
+
+CocoIndex’s Custom Source API makes these integrations *declarative*, incremental, and safe by default.
+
+## Overview
+
+![HackerNews Custom Source Pipeline](https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/flow.png)
+
+The pipeline consists of three major parts:
+
+1. Define a custom source (`HackerNewsConnector`)
+    - Calls HackerNews API
+    - Emits rows for changed/updated threads
+    - Pulls full thread + comment tree
+2. Build an index with CocoIndex Flow
+    - Collect thread content
+    - Collect all comments recursively
+    - Export to a Postgres table
+3. Add a lightweight query handler
+    - Uses PostgreSQL full-text search
+    - Returns ranked matches for a keyword query
+
+
+## Prerequisites
+
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+
+
+## Defining the Data Model
+
+Every custom source defines two lightweight data types:
+
+- Key Type → uniquely identifies an item
+- Value Type → the full content for that item
+
+In hacker news, each news is a thread, and each thread can have multiple comments.
+![HackerNews Thread and Comments](https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/hackernews.png)
+
+For HackerNews, let’s define keys like this:
+
+```python
+class _HackerNewsThreadKey(NamedTuple):
+    """Row key type for HackerNews source."""
+    thread_id: str
+```
+
+Keys must be:
+
+- hashable
+- serializable
+- stable (doesn’t change over time)
+
+Values hold the actual dataset:
+
+```python
+@dataclasses.dataclass
+class _HackerNewsComment:
+    id: str
+    author: str | None
+    text: str | None
+    created_at: datetime | None
+
+@dataclasses.dataclass
+class _HackerNewsThread:
+    """Value type for HackerNews source."""
+    author: str | None
+    text: str
+    url: str | None
+    created_at: datetime | None
+    comments: list[_HackerNewsComment]
+```
+
+This tells CocoIndex exactly what every HackerNews “item” looks like when fully fetched:
+- `_HackerNewsThread` holds a post and all its comments
+- `_HackerNewsComment` represents individual comments
+
+## Building a Custom Source Connector
+
+A Custom Source has two parts:
+
+1. **SourceSpec** — declarative configuration
+2. **SourceConnector** — operational logic for reading data
+
+### Writing the SourceSpec
+
+A **SourceSpec** in CocoIndex is a declarative configuration that tells the system **what data to fetch** and **how to connect** to a source. It doesn’t fetch data itself — that’s handled by the source connector.
+
+```python
+class HackerNewsSource(SourceSpec):
+    """Source spec for HackerNews API."""
+    tag: str | None = None
+    max_results: int = 100
+```
+
+Fields:
+
+- `tag`
+    - Optional filter for the type of HackerNews content.
+    - Example: `"story"`, `"job"`, `"poll"`.
+    - If `None`, it fetches all types.
+- `max_results`
+    - Maximum number of threads to fetch from HackerNews at a time.
+    - Helps limit the size of the index for performance or testing.
+
+[→ Source Spec](https://cocoindex.io/docs/custom_ops/custom_sources#source-spec)
+
+
+### Defining the connector
+
+Sets up the connector's configuration so it can fetch HackerNews data efficiently.
+
+[→ Source Connector](https://cocoindex.io/docs/custom_ops/custom_sources#source-connector)
+
+```python
+@source_connector(
+    spec_cls=HackerNewsSource,
+    key_type=_HackerNewsThreadKey,
+    value_type=_HackerNewsThread,
+)
+class HackerNewsConnector:
+    """Custom source connector for HackerNews API."""
+
+    _spec: HackerNewsSource
+    _session: aiohttp.ClientSession
+
+    def __init__(self, spec: HackerNewsSource, session: aiohttp.ClientSession):
+        self._spec = spec
+        self._session = session
+
+    @staticmethod
+    async def create(spec: HackerNewsSource) -> "HackerNewsConnector":
+        """Create a HackerNews connector from the spec."""
+        return HackerNewsConnector(spec, aiohttp.ClientSession())
+```
+
+- `source_connector` tells CocoIndex that this class is a **custom source connector**. It specifies:
+    - `spec_cls`: the configuration class (`HackerNewsSource`)
+    - `key_type`: how individual items are identified (`_HackerNewsThreadKey`)
+    - `value_type`: the structure of the data returned (`_HackerNewsThread`)
+- `create()` is called by CocoIndex to initialize the connector, and it sets up a fresh `aiohttp.ClientSession` for making HTTP requests.
+
+### Listing Available Threads
+
+The `list()` method in `HackerNewsConnector` is responsible for **discovering all available HackerNews threads** that match the given criteria (tag, max results) and returning metadata about them. CocoIndex uses this to **know which threads exist** and which may have changed.
+
+[→ list() method](https://cocoindex.io/docs/custom_ops/custom_sources#async-def-listoptions-required)
+
+
+```python
+async def list(
+    self,
+) -> AsyncIterator[PartialSourceRow[_HackerNewsThreadKey, _HackerNewsThread]]:
+    """List HackerNews threads using the search API."""
+    # Use HackerNews search API
+    search_url = "https://hn.algolia.com/api/v1/search_by_date"
+    params: dict[str, Any] = {"hitsPerPage": self._spec.max_results}
+
+    if self._spec.tag:
+        params["tags"] = self._spec.tag
+    async with self._session.get(search_url, params=params) as response:
+        response.raise_for_status()
+        data = await response.json()
+        for hit in data.get("hits", []):
+            if thread_id := hit.get("objectID", None):
+                utime = hit.get("updated_at")
+                ordinal = (
+                    int(datetime.fromisoformat(utime).timestamp())
+                    if utime
+                    else NO_ORDINAL
+                )
+                yield PartialSourceRow(
+                    key=_HackerNewsThreadKey(thread_id=thread_id),
+                    data=PartialSourceRowData(ordinal=ordinal),
+                )
+```
+
+`list()` fetches **metadata for all recent HackerNews threads**.
+
+- For each thread:
+    - It generates a `PartialSourceRow` with:
+        - `key`: the thread ID
+        - `ordinal`: the last updated timestamp
+- **Purpose:** allows CocoIndex to track what threads exist and which have changed without fetching full thread content.
+
+### Fetching Full Thread Content
+
+This async method fetches a **single HackerNews thread** (including its comments) from the **API**, and wraps the result in a `PartialSourceRowData` object — the structure CocoIndex uses for row-level ingestion.
+
+```python
+async def get_value(
+    self, key: _HackerNewsThreadKey
+) -> PartialSourceRowData[_HackerNewsThread]:
+    """Get a specific HackerNews thread by ID using the items API."""
+
+    # Use HackerNews items API to get full thread with comments
+    item_url = f"https://hn.algolia.com/api/v1/items/{key.thread_id}"
+
+    async with self._session.get(item_url) as response:
+        response.raise_for_status()
+        data = await response.json()
+
+        if not data:
+            return PartialSourceRowData(
+                value=NON_EXISTENCE,
+                ordinal=NO_ORDINAL,
+                content_version_fp=None,
+            )
+        return PartialSourceRowData(
+            value=HackerNewsConnector._parse_hackernews_thread(data)
+        )
+```
+
+- `get_value()` fetches the **full content of a specific thread**, including comments.
+- Parses the raw JSON into structured Python objects (`_HackerNewsThread` + `_HackerNewsComment`).
+- Returns a `PartialSourceRowData` containing the full thread.
+
+### Ordinal Support
+
+Tells CocoIndex that this source provides timestamps (ordinals).
+
+```python
+def provides_ordinal(self) -> bool:
+    return True
+```
+
+CocoIndex uses ordinals to incrementally update only changed threads, improving efficiency.
+
+### Parsing JSON into Structured Data
+
+This static method takes the raw JSON response from the **API** and turns it into a normalized `_HackerNewsThread` object containing:
+
+- The post (title, text, metadata)
+- All nested comments, flattened into a single list
+- Proper Python datetime objects
+
+It performs **recursive traversal** of the comment tree.
+
+```python
+@staticmethod
+def _parse_hackernews_thread(data: dict[str, Any]) -> _HackerNewsThread:
+    comments: list[_HackerNewsComment] = []
+
+    def _add_comments(parent: dict[str, Any]) -> None:
+        children = parent.get("children", None)
+        if not children:
+            return
+        for child in children:
+            ctime = child.get("created_at")
+            if comment_id := child.get("id", None):
+                comments.append(
+                    _HackerNewsComment(
+                        id=str(comment_id),
+                        author=child.get("author", ""),
+                        text=child.get("text", ""),
+                        created_at=datetime.fromisoformat(ctime) if ctime else None,
+                    )
+                )
+            _add_comments(child)
+
+    _add_comments(data)
+
+    ctime = data.get("created_at")
+    text = data.get("title", "")
+    if more_text := data.get("text", None):
+        text += "\n\n" + more_text
+    return _HackerNewsThread(
+        author=data.get("author"),
+        text=text,
+        url=data.get("url"),
+        created_at=datetime.fromisoformat(ctime) if ctime else None,
+        comments=comments,
+    )
+```
+
+- Converts raw HackerNews API response into `_HackerNewsThread` and `_HackerNewsComment`.
+- `_add_comments()` recursively parses nested comments.
+- Combines `title` + `text` into the main thread content.
+- Produces a fully structured object ready for indexing.
+
+
+## Putting It All Together in a Flow
+
+Your flow now reads exactly like a React component.
+
+### Define the flow and connect source
+
+```python
+@cocoindex.flow_def(name="HackerNewsIndex")
+def hackernews_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+
+    # Add the custom source to the flow
+    data_scope["threads"] = flow_builder.add_source(
+        HackerNewsSource(tag="story", max_results=500),
+        refresh_interval=timedelta(minutes=1),
+    )
+
+    # Create collectors for different types of searchable content
+    message_index = data_scope.add_collector()
+```
+
+![data flow](https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/data.png)
+
+### Process each thread and collect structured information
+
+```python
+with data_scope["threads"].row() as thread:
+    # Index the main thread content
+    message_index.collect(
+        id=thread["thread_id"],
+        thread_id=thread["thread_id"],
+        content_type="thread",
+        author=thread["author"],
+        text=thread["text"],
+        url=thread["url"],
+        created_at=thread["created_at"],
+    )
+```
+
+### Process each comment of a thread and collect structured information
+
+```python
+with thread["comments"].row() as comment:
+    message_index.collect(
+        id=comment["id"],
+        thread_id=thread["thread_id"],
+        content_type="comment",
+        author=comment["author"],
+        text=comment["text"],
+        created_at=comment["created_at"],
+    )
+```
+
+# Export to database tables
+
+```python
+message_index.export(
+    "hn_messages",
+    cocoindex.targets.Postgres(),
+    primary_key_fields=["id"],
+)
+```
+
+CocoIndex now:
+
+- polls the HackerNews API
+- tracks changes incrementally
+- flattens nested comments
+- exports to Postgres
+- supports live mode
+
+Your app can now query it as a real-time search index.
+
+
+## Querying & Searching the HackerNews Index
+
+With the index flow complete, the next step is to add a query handler.
+This allows you to search and explore your indexed HackerNews data directly in CocoInsight.
+You can implement the query logic using any preferred library or framework.
+
+[→ Query Handler](https://cocoindex.io/docs/query#query-handler)
+
+
+```python
+@hackernews_flow.query_handler()
+def search_text(query: str) -> cocoindex.QueryOutput:
+    """Search HackerNews threads by title and content."""
+    table_name = cocoindex.utils.get_target_default_name(hackernews_flow, "hn_messages")
+
+    with connection_pool().connection() as conn:
+        with conn.cursor() as cur:
+            # Simple text search using PostgreSQL's text search capabilities
+            cur.execute(
+                f"""
+                SELECT id, thread_id, author, content_type, text, created_at,
+                       ts_rank(to_tsvector('english', text), plainto_tsquery('english', %s)) as rank
+                FROM {table_name}
+                WHERE to_tsvector('english', text) @@ plainto_tsquery('english', %s)
+                ORDER BY rank DESC, created_at DESC
+                """,
+                (query, query),
+            )
+
+            results = []
+            for row in cur.fetchall():
+                results.append(
+                    {
+                        "id": row[0],
+                        "thread_id": row[1],
+                        "author": row[2],
+                        "content_type": row[3],
+                        "text": row[4],
+                        "created_at": row[5].isoformat(),
+                    }
+                )
+
+            return cocoindex.QueryOutput(results=results)
+```
+
+This example shows how to create a query handler that lets you search HackerNews threads and comments stored in CocoIndex.
+- The handler looks up the correct database table, then uses PostgreSQL’s full-text search functions (`to_tsvector` and `plainto_tsquery`) to find entries that match your search terms.
+- Matching results are sorted by their relevance (`ts_rank`) and by creation time, then converted to dictionaries.
+- Finally, these results are returned in a `cocoindex.QueryOutput` object—making it easy to perform fast, ranked searches across your indexed HackerNews content.
+
+##  Running Your HackerNews Custom Source
+
+Once your custom source and flow are ready, running it with CocoIndex is straightforward. You can either **update the index on-demand** or **keep it continuously in sync** with HackerNews.
+
+
+## 1. Install Dependencies
+
+Make sure you have Python installed and then install your project in editable mode:
+
+```sh
+pip install -e .
+```
+
+This installs CocoIndex along with all required dependencies, letting you develop and update the connector without reinstalling.
+
+
+## 2. Update the Target (On-Demand)
+
+To populate your target (e.g., Postgres) with the latest HackerNews threads:
+
+```sh
+cocoindex update main
+```
+
+- Only threads that **have changed** will be re-processed.
+- Your target remains in sync with the **most recent 500 HackerNews threads**.
+- Efficient incremental updates save time and compute resources.
+
+Note that each time when you run the update command, CocoIndex will only re-process threads that have changed, and keep the target in sync with the recent 500 threads from HackerNews.
+You can also run update command in live mode, which will keep the target in sync with the source continuously:
+
+```sh
+cocoindex update -L main
+```
+
+- Runs the flow in **live mode**, polling HackerNews periodically.
+- CocoIndex automatically handles incremental changes and keeps the target synchronized.
+- Ideal for dashboards, search, or AI pipelines that require real-time data.
+
+
+## 3. Troubleshoot & Inspect with CocoInsight
+
+CocoInsight lets you **visualize and debug your flow**, see the lineage of your data, and understand what’s happening under the hood.
+
+Start the server:
+
+```sh
+cocoindex server -ci main
+```
+
+Then open the UI in your browser: [`https://cocoindex.io/cocoinsight`](https://cocoindex.io/cocoinsight)
+
+> CocoInsight has zero pipeline data retention — it’s safe for debugging and inspecting your flows locally.
+>
+
+Note that this requires QueryHandler setup in previous step.
+
+
+## What You Can Build Next
+
+This simple example opens the door to a lot more:
+
+- Build a trending-topic detector
+- Run LLM summarization pipelines on top of indexed threads
+- Add embeddings + vector search
+- Mirror HN into your internal data warehouse
+- Build a real-time HN dashboard
+- Extend to other news sources (Reddit, Lobsters, etc.)
+
+Because the whole pipeline is declarative and incremental, extending it is straightforward.
+
+Since Custom Sources allow you to wrap *any* Python logic into an incremental data stream, the best use cases are usually **"Hard-to-Reach"** data—systems that don't have standard database connectors, have complex nesting, or require heavy pre-processing.
+
+### The Knowledge Aggregator for LLM Context
+
+Building a context engine for an AI bot often requires pulling from non-standard documentation sources.
+
+### The "Composite" Entity (Data Stitching)
+
+Most companies have user data fragmented across multiple microservices. You can build a Custom Source that acts as a "virtual join" before the data ever hits your index. **For example the Source:**
+
+1. Fetches a User ID from an **Auth Service** (Okta/Auth0).
+2. Uses that ID to fetch billing status from **Stripe API**.
+3. Uses that ID to fetch usage logs from an **Internal Redis**.
+
+Instead of managing complex ETL joins downstream, the Custom Source yields a single `User360` object. CocoIndex tracks the state of this composite object; if the user upgrades in Stripe *or* changes their email in Auth0, the index updates automatically.
+
+### The "Legacy Wrapper" (Modernization Layer)
+
+Enterprises often have valuable data locked in systems that are painful to query (SOAP, XML, Mainframes). You get a modern, queryable SQL interface (via the CocoIndex target) on top of a 20-year-old system without rewriting the legacy system itself.
+
+### Public Data Monitor (Competitive Intelligence)
+
+Tracking changes on public websites or APIs that don't offer webhooks.
+
+- **The Source:**
+    - **Competitor Pricing:** Scraping e-commerce product pages.
+    - **Regulatory Feeds:** Polling a government RSS feed or FDA drug approval database.
+    - **Crypto/Stocks:** Hitting a CoinGecko or Yahoo Finance API.
+
+**The CocoIndex Value:** Using the `diff` capabilities, you can trigger downstream alerts only when a price changes by >5% or a new regulation is posted, rather than spamming your database with identical polling results.
+
+# Why This Matters
+
+Custom Sources extend this model to *any* API — internal, external, legacy, or real-time.
+
+This unlocks a simple but powerful pattern:
+
+> If you can fetch it, CocoIndex can index it, diff it, and sync it.
+>
+
+## ⭐ Try It, Fork It, Star It
+
+If you found this useful, a **star on [GitHub](https://github.com/cocoindex-io/cocoindex)** means a lot — it helps others discover CocoIndex and supports further development.

--- a/docs/src/content/example-posts/custom_targets.md
+++ b/docs/src/content/example-posts/custom_targets.md
@@ -1,0 +1,217 @@
+---
+title: Export markdown files to local Html with Custom Targets
+description: 'Simple example to export Markdown files to local HTML files using Custom Targets.'
+slug: custom_targets
+image: https://cocoindex.io/blobs/docs/img/examples/custom_targets/cover.png
+tags: [custom-building-blocks]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/custom_output_files)
+
+![Custom Targets](https://cocoindex.io/blobs/docs/img/examples/custom_targets/cover.png)
+
+## Overview
+
+Let’s walk through a simple example—exporting `.md` files as `.html` using a custom file-based target. This project monitors folder changes and continuously converts markdown to HTML incrementally. The overall flow is simple and primarily focuses on how to configure your custom target.
+
+## Ingest files
+
+Ingest a list of markdown files:
+
+```python
+@cocoindex.flow_def(name="CustomOutputFiles")
+def custom_output_files(
+flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+ data_scope["documents"] = flow_builder.add_source(
+  cocoindex.sources.LocalFile(path="data", included_patterns=["*.md"]),
+  refresh_interval=timedelta(seconds=5),
+ )
+```
+
+This ingestion creates a table with `filename` and `content` fields.
+[→ Sources](https://cocoindex.io/docs/sources)
+
+## Process each file and collect
+
+Define custom function that converts markdown to HTML
+
+```python
+@cocoindex.op.function()
+def markdown_to_html(text: str) -> str:
+    return _markdown_it.render(text)
+```
+
+[→ Custom Function](https://cocoindex.io/docs/custom_ops/custom_functions)
+
+Define data collector and transform each document to html.
+
+```python
+output_html = data_scope.add_collector()
+with data_scope["documents"].row() as doc:
+    doc["html"] = doc["content"].transform(markdown_to_html)
+    output_html.collect(filename=doc["filename"], html=doc["html"])
+```
+
+![Convert markdown to html](https://cocoindex.io/blobs/docs/img/examples/custom_targets/convert.png)
+
+## Define the custom target
+
+### Define the target spec
+
+[→ Target Spec](https://cocoindex.io/docs/custom_ops/custom_targets#target-spec)
+
+The target spec contains a directory for output files:
+
+```python
+class LocalFileTarget(cocoindex.op.TargetSpec):
+    directory: str
+```
+
+### Implement the connector
+
+[→ Target Connector](https://cocoindex.io/docs/custom_ops/custom_targets#target-connector)
+
+`get_persistent_key()` defines the persistent key,
+which uniquely identifies the target for change tracking and incremental updates. Here, we simply use the target directory as the key (e.g., `./data/output`).
+
+```python
+@cocoindex.op.target_connector(spec_cls=LocalFileTarget)
+class LocalFileTargetConnector:
+    @staticmethod
+    def get_persistent_key(spec: LocalFileTarget, target_name: str) -> str:
+        """Use the directory path as the persistent key for this target."""
+        return spec.directory
+
+```
+
+The `describe()` method returns a human-readable string that describes the target, which is displayed in the CLI logs.
+For example, it prints:
+
+`Target: Local directory ./data/output`
+
+```python
+@staticmethod
+def describe(key: str) -> str:
+    """(Optional) Return a human-readable description of the target."""
+    return f"Local directory {key}"
+```
+
+`apply_setup_change()` applies setup changes to the backend. The previous and current specs are passed as arguments,
+and the method is expected to update the backend setup to match the current state.
+
+A `None` spec indicates non-existence, so when `previous` is `None`, we need to create it,
+and when `current` is `None`, we need to delete it.
+
+```python
+@staticmethod
+def apply_setup_change(
+    key: str, previous: LocalFileTarget | None, current: LocalFileTarget | None
+) -> None:
+    """
+    Apply setup changes to the target.
+
+    Best practice: keep all actions idempotent.
+    """
+
+    # Create the directory if it didn't exist.
+    if previous is None and current is not None:
+        os.makedirs(current.directory, exist_ok=True)
+
+    # Delete the directory with its contents if it no longer exists.
+    if previous is not None and current is None:
+        if os.path.isdir(previous.directory):
+            for filename in os.listdir(previous.directory):
+                if filename.endswith(".html"):
+                    os.remove(os.path.join(previous.directory, filename))
+            os.rmdir(previous.directory)
+```
+
+The `mutate()` method is called by CocoIndex to apply data changes to the target,
+batching mutations to potentially multiple targets of the same type.
+This allows the target connector flexibility in implementation (e.g., atomic commits, or processing items with dependencies in a specific order).
+
+Each element in the batch corresponds to a specific target and is represented by a tuple containing:
+
+- the target specification
+- all mutations for the target, represented by a `dict` mapping primary keys to value fields. Value fields can be represented by a dataclass—`LocalFileTargetValues` in this case:
+
+```python
+@dataclasses.dataclass
+class LocalFileTargetValues:
+    """Represents value fields of exported data. Used in `mutate` method below."""
+
+    html: str
+```
+
+The value type of the `dict` is `LocalFileTargetValues | None`,
+where a non-`None` value means an upsert and `None` value means a delete. Similar to `apply_setup_changes()`,
+idempotency is expected here.
+
+```python
+@staticmethod
+def mutate(
+    *all_mutations: tuple[LocalFileTarget, dict[str, LocalFileTargetValues | None]],
+) -> None:
+    """
+    Mutate the target.
+    """
+    for spec, mutations in all_mutations:
+        for filename, mutation in mutations.items():
+            full_path = os.path.join(spec.directory, filename) + ".html"
+            if mutation is None:
+                # Delete the file
+                try:
+                    os.remove(full_path)
+                except FileNotFoundError:
+                    pass
+            else:
+                # Create/update the file
+                with open(full_path, "w") as f:
+                    f.write(mutation.html)
+```
+
+### Use it in the Flow
+
+```python
+output_html.export(
+    "OutputHtml",
+    LocalFileTarget(directory="output_html"),
+    primary_key_fields=["filename"],
+)
+```
+
+## Run the example
+
+```sh
+pip install -e .
+cocoindex update main
+```
+
+You can add, modify, or remove files in the `data/` directory — CocoIndex will only reprocess the changed files and update the target accordingly.
+
+For **real-time updates**, run in live mode:
+
+    ```sh
+    cocoindex update -L main
+    ```
+
+This keeps your knowledge graph continuously synchronized with your document source — perfect for fast-changing environments like internal wikis or technical documentation.
+
+## Best Practices
+
+- **Idempotency matters**: `apply_setup_change()` and `mutate()` should be safe to run multiple times without unintended effects.
+- **Prepare once, mutate many**: If you need setup (such as establishing a connection), use `prepare()` to avoid repeating work.
+- **Use structured types**: For primary keys or values, CocoIndex supports simple types as well as dataclasses and NamedTuples.
+
+## Why Custom Targets?
+
+### Integration with internal system
+
+Sometimes there may be an internal/homegrown tool or API (e.g. within a company) that's not publicly available.
+These can only be connected through custom targets.
+
+### Faster adoption of new export logic
+
+When a new tool, database, or API joins your stack, simply define a Target Spec and Target Connector — start exporting right away, with no pipeline refactoring required.

--- a/docs/src/content/example-posts/document_ai.md
+++ b/docs/src/content/example-posts/document_ai.md
@@ -1,0 +1,151 @@
+---
+title: Bring your own parser as building block with Google Document AI
+description: 'Use Google Document AI to parse document, embed the resulting text, and store it in a vectorized database for semantic search.'
+slug: document_ai
+image: https://cocoindex.io/blobs/docs/img/examples/document_ai/cover.png
+tags: [vector-index, custom-building-blocks]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex-etl-with-document-ai)
+
+![Document AI](https://cocoindex.io/blobs/docs/img/examples/document_ai/cover.png)
+
+CocoIndex is a flexible ETL framework with incremental processing.  We don’t build parser ourselves, and users can bring in any open source or commercial parser that works best for their scenarios.  In this example, we show how to use **Google Document AI to parse document**, embed the resulting text, and store it in a vectorized database for semantic search.
+
+## Set up
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+- Configure Project and Processor ID for Document AI API
+    - [Official Google document AI API](https://cloud.google.com/document-ai/docs/try-docai) with free live demo.
+    - Sign in to [Google Cloud Console](https://console.cloud.google.com/), create or open a project, and enable Document AI API.
+      - ![image.png](https://cocoindex.io/blobs/docs/img/examples/document_ai/document_ai.png)
+      - ![image.png](https://cocoindex.io/blobs/docs/img/examples/document_ai/processor.png)
+- update `.env` with `GOOGLE_CLOUD_PROJECT_ID` and `GOOGLE_CLOUD_PROCESSOR_ID`.
+
+
+## Create Your building block to convert PDFs to Markdown
+
+We define a `ToMarkdown` custom function spec, which leverages Google Document AI to parse PDF content:
+
+```python
+class ToMarkdown(cocoindex.op.FunctionSpec):
+    """Convert a PDF to markdown using Google Document AI."""
+```
+
+The corresponding executor class handles API initialization and parsing logic:
+
+```python
+@cocoindex.op.executor_class(cache=True, behavior_version=1)
+class DocumentAIExecutor:
+    """Executor for Google Document AI to parse PDF files."""
+
+    spec: ToMarkdown
+    _client: documentai.DocumentProcessorServiceClient
+    _processor_name: str
+
+    def prepare(self):
+        # Initialize the Document AI client
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT_ID")
+        location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us")
+        processor_id = os.environ.get("GOOGLE_CLOUD_PROCESSOR_ID")
+
+        opts = ClientOptions(api_endpoint=f"{location}-documentai.googleapis.com")
+        self._client = documentai.DocumentProcessorServiceClient(client_options=opts)
+        self._processor_name = self._client.processor_path(project_id, location, processor_id)
+
+    async def __call__(self, content: bytes) -> str:
+        """Parse PDF content and convert to markdown text."""
+        request = documentai.ProcessRequest(
+            name=self._processor_name,
+            raw_document=documentai.RawDocument(content=content, mime_type="application/pdf")
+        )
+        response = self._client.process_document(request=request)
+        return response.document.text
+```
+
+Make sure you configure the `cache` and `behavior_version` parameters for heavy operations like this.
+
+- `cache`: Whether the executor will enable cache for this function. When True, the executor will cache the result of the function for reuse during reprocessing. We recommend to set this to True for any function that is computationally intensive.
+
+- `behavior_version`: The version of the behavior of the function. When the version is changed, the function will be re-executed even if cache is enabled. It's required to be set if cache is True.
+
+
+[→ Custom Functions](https://cocoindex.io/docs/custom_ops/custom_functions#option-2-by-a-function-spec-and-an-executor)
+
+[→ Parameters for Custom Functions](https://cocoindex.io/docs/custom_ops/custom_functions#parameters-for-custom-functions)
+
+## Define the flow
+
+```python
+@cocoindex.flow_def(name="DocumentAiPdfEmbedding")
+def pdf_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    # flow definition
+```
+
+### Add source & collector
+
+```python
+data_scope["documents"] = flow_builder.add_source(
+    cocoindex.sources.LocalFile(path="pdf_files", binary=True)
+)
+
+doc_embeddings = data_scope.add_collector()
+```
+
+[→ Source](https://cocoindex.io/docs/sources)
+
+[→ Collector](https://cocoindex.io/docs/ops/collectors)
+
+### Process each document
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["markdown"] = doc["content"].transform(ToMarkdown())
+    doc["chunks"] = doc["markdown"].transform(
+        cocoindex.functions.SplitRecursively(),
+        language="markdown",
+        chunk_size=2000,
+        chunk_overlap=500
+    )
+    with doc["chunks"].row() as chunk:
+        chunk["embedding"] = chunk["text"].call(text_to_embedding)
+        doc_embeddings.collect(
+            id=cocoindex.GeneratedField.UUID,
+            filename=doc["filename"],
+            location=chunk["location"],
+            text=chunk["text"],
+            embedding=chunk["embedding"]
+        )
+```
+
+1. Convert them to Markdown using Document AI.
+2. Split the Markdown into chunks.
+3. Embed each chunk.
+
+## Export to Postgres
+
+```python
+doc_embeddings.export(
+    "doc_embeddings",
+    cocoindex.storages.Postgres(),
+    primary_key_fields=["id"],
+    vector_indexes=[
+        cocoindex.VectorIndexDef(
+            field_name="embedding",
+            metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY
+        )
+    ]
+)
+```
+
+## End to End Example
+
+For a step-by-step walkthrough of each indexing stage and the query path, check out this example:
+
+
+
+## Other sources
+
+CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more with native incremental processing out of box - when new or updated files are detected, the pipeline will capture the changes and only process what's changed.
+
+[→ Sources](https://cocoindex.io/docs/sources)

--- a/docs/src/content/example-posts/hackernews-trending-topics.md
+++ b/docs/src/content/example-posts/hackernews-trending-topics.md
@@ -1,0 +1,845 @@
+---
+title: 'Building a Real-Time HackerNews Trending Topics Detector with CocoIndex: A Deep Dive into Custom Sources and AI'
+description: "Build a real-time trending topics detector by indexing HackerNews threads and comments, extracting structured topics using LLM-powered extraction, and querying trending discussions with CocoIndex's Custom Sources and Postgres."
+slug: hackernews-trending-topics
+image: https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/cover.png
+tags: [custom-building-blocks, structured-data-extraction]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/hn_trending_topics)
+
+![Building a Real-Time HackerNews Trending Topics Detector with CocoIndex: A Deep Dive into Custom Sources and AI](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/cover.png)
+
+
+In the age of information overload, understanding what's trending—and why—is crucial for developers, researchers, and data engineers. HackerNews is one of the most influential tech communities, but manually tracking emerging topics across thousands of threads and comments is practically impossible.
+
+What if you could automatically index HackerNews content, extract topics using AI, and query trending discussions in real-time? That's exactly what CocoIndex enables through its [**Custom Sources**](https://cocoindex.io/blogs/custom-source) framework
+combined with [LLM-powered extraction](https://cocoindex.io/docs/ai/llm).
+
+In this post, we'll explore the **HackerNews Trending Topics** example, a production-ready pipeline that demonstrates some of the most powerful concepts in CocoIndex: incremental data syncing, LLM-powered information extraction, and queryable indexes.
+
+
+## Why build from HackerNews?
+
+![HackerNews Cover](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/hackernews_cover.png)
+
+HackerNews creates thousands of new threads and comments daily. Each thread can have hundreds of nested comments, each potentially discussing important technologies, products, or companies. HackerNews is one of the best signals for:
+
+- what technologies are trending
+- what topics developers are discussing
+- emerging products, companies, and ideas
+- sentiment and early-stage feedback
+
+## Traditional approaches to topic tracking are painful:
+
+- **Manual monitoring**: Impossible to scale
+- **Dumb polling**: Fetching everything every time wastes API calls
+- **Batch processing**: Creates latency and data staleness
+- **Monolithic pipelines**: Hard to maintain and extend
+
+CocoIndex solves all of these through a declarative, incremental approach.
+
+This demo illustrates:
+
+```sh
+Custom Source → Flow Definition → Query Handlers
+    (API)        (Transform)      (Real-time Search)
+```
+
+- How to wrap an external API (HackerNews Algolia API) into a **first-class incremental source**
+- How to extract **structured topics** from free-form text using LLMs
+- How CocoIndex automatically **diffs, syncs, and exports** data into Postgres
+- How to write **Query Handlers** to serve topic search and trending queries
+- How to build foundation blocks for **continuous-agent workflows** that reason over structured data
+
+## The Full Data Pipeline
+
+```sh
+The Full Data Pipeline
+Here's the complete flow:
+
+text
+HackerNews API
+    ↓
+HackerNewsConnector
+    ├─ list()      → Thread IDs + timestamps
+    ├─ get_value() → Full threads + comments
+    └─ provides_ordinal() → Enable incremental syncing
+    ↓
+Flow Definition
+    ├─ Register source (auto-refresh every 30s)
+    ├─ Create collectors (message_index, topic_index)
+    ├─ For each thread:
+    │  ├─ Extract topics with LLM
+    │  ├─ Collect thread metadata
+    │  ├─ Collect extracted topics
+    │  └─ For each comment:
+    │     ├─ Extract topics with LLM
+    │     ├─ Collect comment metadata
+    │     └─ Collect extracted topics
+    └─ Export
+    ↓
+Postgres Tables
+    ├─ hn_messages (full-text search)
+    └─ hn_topics (topic tracking)
+    ↓
+Query Handlers
+    ├─ search_by_topic(query) → Find discussions about X
+    ├─ get_trending_topics(limit) → Top 20 topics by score
+    └─ get_threads_for_topic(topic) → Threads discussing X
+    ↓
+CocoInsight UI / API Clients
+```
+
+## Index Flow
+
+![HackerNews Index Flow](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/flow.png)
+
+
+## Custom Source
+
+[→ Custom Sources](https://cocoindex.io/docs/custom_ops/custom_sources)
+
+### Defining the Data Model
+![HackerNews Data Model](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/hackernews.png)
+
+#### Row Key Type
+
+Purpose: uniquely identify each HackerNews thread from the source
+
+```python
+class _HackerNewsThreadKey(NamedTuple):
+    thread_id: str
+```
+
+CocoIndex recommends using stable keys. HN thread IDs are perfect keys.
+
+#### Value Type
+
+```python
+@dataclasses.dataclass
+class _HackerNewsComment:
+    id: str
+    author: str | None
+    text: str | None
+    created_at: datetime | None
+
+@dataclasses.dataclass
+class _HackerNewsThread:
+    """Value type for HackerNews source."""
+    author: str | None
+    text: str
+    url: str | None
+    created_at: datetime | None
+    comments: list[_HackerNewsComment]
+
+```
+
+This code defines two Python dataclasses for structuring HackerNews data:
+
+A HackerNews thread (`_HackerNewsThread`) has a bunch of metadata (e.g., `author`, `text`, etc.) and a list of comments (`_HackerNewsComment`).
+
+### Building a Custom Source Connector
+
+A Custom Source has two parts:
+
+1. **SourceSpec** — declarative configuration
+2. **SourceConnector** — operational logic for reading data
+
+#### Writing the SourceSpec
+
+A **SourceSpec** in CocoIndex is a declarative configuration that tells the system **what data to fetch** and **how to connect** to a source.
+
+```python
+class HackerNewsSource(SourceSpec):
+    """Source spec for HackerNews API."""
+    tag: str | None = None
+    max_results: int = 100
+```
+
+A `SourceSpec` holds config for the source:
+
+| Field | Purpose |
+| --- | --- |
+| `tag` | HN API filter (e.g., "story") |
+| `max_results` | number of search results per poll |
+
+When the flow is created, these parameters feed into the connector.
+
+[→ Source Spec](https://cocoindex.io/docs/custom_ops/custom_sources#source-spec)
+
+#### Defining the Connector
+
+This is the core of the custom source.
+
+It defines:
+
+- how to list items (discover threads)
+- how to fetch values (fetch metadata + comments)
+- how to parse deeply nested structures
+
+##### Constructor & Factory Method
+
+```python
+@source_connector(
+    spec_cls=HackerNewsSource,
+    key_type=_HackerNewsThreadKey,
+    value_type=_HackerNewsThread,
+)
+class HackerNewsConnector:
+    """Custom source connector for HackerNews API."""
+
+    _spec: HackerNewsSource
+    _session: aiohttp.ClientSession
+
+    def __init__(self, spec: HackerNewsSource, session: aiohttp.ClientSession):
+        self._spec = spec
+        self._session = session
+
+    @staticmethod
+    async def create(spec: HackerNewsSource) -> "HackerNewsConnector":
+        """Create a HackerNews connector from the spec."""
+        return HackerNewsConnector(spec, aiohttp.ClientSession())
+```
+
+- Stores the spec
+- Creates an async HTTP session
+
+CocoIndex calls `create` once when building the flow.
+
+[→ Source Connector](https://cocoindex.io/docs/custom_ops/custom_sources#source-connector)
+
+#### Listing Available Threads
+
+The `list()` method in `HackerNewsConnector` is responsible for **discovering all available HackerNews threads** that match the given criteria (tag, max results) and returning metadata about them. CocoIndex uses this to **know which threads exist** and which may have changed.
+
+```python
+async def list(
+    self,
+) -> AsyncIterator[PartialSourceRow[_HackerNewsThreadKey, _HackerNewsThread]]:
+    """List HackerNews threads using the search API."""
+    # Use HackerNews search API
+    search_url = "https://hn.algolia.com/api/v1/search_by_date"
+    params: dict[str, Any] = {"hitsPerPage": self._spec.max_results}
+
+    if self._spec.tag:
+        params["tags"] = self._spec.tag
+    async with self._session.get(search_url, params=params) as response:
+        response.raise_for_status()
+        data = await response.json()
+        for hit in data.get("hits", []):
+            if thread_id := hit.get("objectID", None):
+                utime = hit.get("updated_at")
+                ordinal = (
+                    int(datetime.fromisoformat(utime).timestamp())
+                    if utime
+                    else NO_ORDINAL
+                )
+                yield PartialSourceRow(
+                    key=_HackerNewsThreadKey(thread_id=thread_id),
+                    data=PartialSourceRowData(ordinal=ordinal),
+                )
+```
+
+`list()` fetches **metadata for all recent HackerNews threads**.
+
+- For each thread:
+    - It generates a `PartialSourceRow` with:
+        - `key`: the thread ID
+        - `ordinal`: the last updated timestamp
+
+❗ **Important:**
+
+Only lightweight metadata is fetched here (IDs + updated_at), not full content.
+
+This enables incremental refresh:
+
+- CocoIndex remembers ordinals
+- Only fetches full items when ordinals change
+
+[→ list() method](https://cocoindex.io/docs/custom_ops/custom_sources#async-def-listoptions-required)
+
+#### Fetching Full Thread Content
+
+This async method fetches a **single HackerNews thread** (including its comments) from the **API**, and wraps the result in a `PartialSourceRowData` object — the structure CocoIndex uses for row-level ingestion.
+
+```python
+async def get_value(
+    self, key: _HackerNewsThreadKey
+) -> PartialSourceRowData[_HackerNewsThread]:
+    """Get a specific HackerNews thread by ID using the items API."""
+
+    # Use HackerNews items API to get full thread with comments
+    item_url = f"https://hn.algolia.com/api/v1/items/{key.thread_id}"
+
+    async with self._session.get(item_url) as response:
+        response.raise_for_status()
+        data = await response.json()
+
+        if not data:
+            return PartialSourceRowData(
+                value=NON_EXISTENCE,
+                ordinal=NO_ORDINAL,
+                content_version_fp=None,
+            )
+        return PartialSourceRowData(
+            value=HackerNewsConnector._parse_hackernews_thread(data)
+        )
+```
+
+- `get_value()` fetches the **full content of a specific thread**, including comments.
+- Parses the raw JSON into structured Python objects (`_HackerNewsThread` + `_HackerNewsComment`).
+- Returns a `PartialSourceRowData` containing the full thread.
+
+[→ get_value() method](https://cocoindex.io/docs/custom_ops/custom_sources#async-def-get_valuekey-options-required)
+
+
+#### Ordinal Support
+
+Tells CocoIndex that this source provides ordinals. You can use any property that increases monotonically on change as an ordinal. We use a timestamp here. E.g., a timestamp or a version number.
+
+```python
+def provides_ordinal(self) -> bool:
+    return True
+```
+
+CocoIndex uses ordinals to incrementally update only changed threads, improving efficiency.
+
+The genius of Custom Sources is the **separation of discovery from fetching**.
+
+```sh
+Sync 1:
+  list()      → 200 thread IDs + timestamps (fast)
+  get_value() → 200 full threads (expensive)
+
+Sync 2 (30s later):
+  list()      → 200 thread IDs + timestamps (fast)
+  [CocoIndex detects only 15 changed]
+  get_value() → 15 full threads only
+  [Result: 92% fewer API calls!]
+```
+
+This is why ordinals (timestamps) matter. Without them, you'd fetch everything every time.
+
+[→ provides_ordinal() method](https://cocoindex.io/docs/custom_ops/custom_sources#def-provides_ordinal-optional)
+
+#### Parsing JSON into Structured Data
+
+HackerNews returns comments in a tree structure:
+
+```sh
+Thread
+  ├─ Comment A
+  │   ├─ Reply to A (Comment B)
+  │   │   └─ Reply to B (Comment C)
+  └─ Comment D
+```
+
+This static method takes the raw JSON response from the **API** and turns it into a normalized `_HackerNewsThread` object containing:
+
+- The post (title, text, metadata)
+- All nested comments, flattened into a single list
+- Proper Python datetime objects
+
+It performs **recursive traversal** of the comment tree.
+
+```python
+@staticmethod
+def _parse_hackernews_thread(data: dict[str, Any]) -> _HackerNewsThread:
+    comments: list[_HackerNewsComment] = []
+
+    def _add_comments(parent: dict[str, Any]) -> None:
+        children = parent.get("children", None)
+        if not children:
+            return
+        for child in children:
+            ctime = child.get("created_at")
+            if comment_id := child.get("id", None):
+                comments.append(
+                    _HackerNewsComment(
+                        id=str(comment_id),
+                        author=child.get("author", ""),
+                        text=child.get("text", ""),
+                        created_at=datetime.fromisoformat(ctime) if ctime else None,
+                    )
+                )
+            _add_comments(child)
+
+    _add_comments(data)
+
+    ctime = data.get("created_at")
+    text = data.get("title", "")
+    if more_text := data.get("text", None):
+        text += "\n\n" + more_text
+    return _HackerNewsThread(
+        author=data.get("author"),
+        text=text,
+        url=data.get("url"),
+        created_at=datetime.fromisoformat(ctime) if ctime else None,
+        comments=comments,
+    )
+```
+
+- Converts raw HackerNews API response into `_HackerNewsThread` and `_HackerNewsComment`.
+- `_add_comments()` recursively parses nested comments.
+- Combines `title` + `text` into the main thread content.
+- Produces a fully structured object ready for indexing.
+
+## Flow Definition: hackernews_trending_topics_flow
+
+### Declare Flow
+
+```python
+@cocoindex.flow_def(name="HackerNewsTrendingTopics")
+def hackernews_trending_topics_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    """
+    Define a flow that indexes HackerNews threads, comments, and extracts trending topics.
+    """
+
+    # Add the custom source to the flow
+    data_scope["threads"] = flow_builder.add_source(
+        HackerNewsSource(tag="story", max_results=200),
+        refresh_interval=timedelta(seconds=30),
+    )
+
+    # Create collectors for different types of searchable content
+    message_index = data_scope.add_collector()
+    topic_index = data_scope.add_collector()
+
+```
+
+This block sets up a CocoIndex flow that fetches HackerNews stories and prepares them for indexing. It registers a flow called **HackerNewsTrendingTopics**, then adds a `HackerNewsSource` that retrieves up to 200 stories and refreshes every 30 seconds, storing the result in `data_scope["threads"]` for downstream steps.
+
+[→ Flow Definition Docs](https://cocoindex.io/docs/core/flow_def)
+
+Finally, it creates two collectors—one for storing indexed messages and another for extracted topics—providing the core storage layers the rest of the pipeline will build on.
+
+[→ Data Collector](https://cocoindex.io/docs/core/flow_def#data-collector)
+
+![Ingesting Data](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/ingest.png)
+
+### Process Each Thread
+
+#### Define Topics for LLM Extraction
+
+```python
+@dataclasses.dataclass
+class Topic:
+    """
+    A single topic extracted from text.
+
+    The topic can be a product name, technology, model, people, company name, business domain, etc.
+    Capitalize for proper nouns and acronyms only.
+    Use the form that is clear alone.
+    Avoid acronyms unless very popular and unambiguous for common people even without context.
+
+    Examples:
+    - "Anthropic" (not "ANTHR")
+    - "Claude" (specific product name)
+    - "React" (well-known library)
+    - "PostgreSQL" (canonical database name)
+
+    For topics that are a phrase combining multiple things, normalize into multiple topics if needed. Examples:
+    - "books for autistic kids" -> "book", "autistic", "autistic kids"
+    - "local Large Language Model" -> "local Large Language Model", "Large Language Model"
+
+    For people, use preferred name and last name. Examples:
+    - "Bill Clinton" instead of "William Jefferson Clinton"
+
+    When there're multiple common ways to refer to the same thing, use multiple topics. Examples:
+    - "John Kennedy", "JFK"
+    """
+
+    topic: str
+```
+
+This dataclass defines a **Topic**, representing a single normalized concept extracted from text—such as a product, technology, company, person, or domain. It provides a prompt for the LLM to extract topics into structured information. Here we used a simple string. You could also generate [knowledge graphs](https://cocoindex.io/examples/knowledge-graph-for-docs), or use it to extract other information too.
+
+
+#### Process Each Thread and Use LLM for Extraction
+
+```python
+with data_scope["threads"].row() as thread:
+    # Extract topics from thread text using LLM
+    thread["topics"] = thread["text"].transform(
+        cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                api_type=cocoindex.LlmApiType.OPENAI, model="gpt-5-mini"
+            ),
+            output_type=list[Topic],
+        )
+    )
+
+    # Index the main thread content
+    message_index.collect(
+        id=thread["thread_id"],
+        thread_id=thread["thread_id"],
+        content_type="thread",
+        author=thread["author"],
+        text=thread["text"],
+        url=thread["url"],
+        created_at=thread["created_at"],
+    )
+
+    # Collect topics from thread
+    with thread["topics"].row() as topic:
+        topic_index.collect(
+            message_id=thread["thread_id"],
+            thread_id=thread["thread_id"],
+            topic=topic["topic"],
+            content_type="thread",
+            created_at=thread["created_at"],
+        )
+```
+
+This block processes each HackerNews thread as it flows through the pipeline. Inside `data_scope["threads"].row()`, each `thread` represents a single story record.
+
+- We use an LLM (`gpt-5-mini`) to extract semantic **topics** from the thread's text by applying `ExtractByLlm`, which returns a list of `Topic` objects.
+- We use `message_index` to collect relevant metadata for this thread.
+- We use `topic_index` to collect extracted topics and their relationships with threads.
+
+[→ ExtractByLlm](https://cocoindex.io/docs/ops/functions#extractbyllm)
+
+![Extract topic](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/topic.png)
+
+### Index Individual Comments
+
+```python
+# Index individual comments
+with thread["comments"].row() as comment:
+    # Extract topics from comment text using LLM
+    comment["topics"] = comment["text"].transform(
+        cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                api_type=cocoindex.LlmApiType.OPENAI, model="gpt-5-mini"
+            ),
+            output_type=list[Topic],
+        )
+    )
+
+    message_index.collect(
+        id=comment["id"],
+        thread_id=thread["thread_id"],
+        content_type="comment",
+        author=comment["author"],
+        text=comment["text"],
+        url="",
+        created_at=comment["created_at"],
+    )
+
+    # Collect topics from comment
+    with comment["topics"].row() as topic:
+        topic_index.collect(
+            message_id=comment["id"],
+            thread_id=thread["thread_id"],
+            topic=topic["topic"],
+            content_type="comment",
+            created_at=comment["created_at"],
+        )
+```
+
+This block processes every comment attached to a thread. For each `comment`, it:
+
+- Extracts semantic **topics** from the comment text using the same LLM-based `ExtractByLlm` function, storing the resulting list of `Topic` objects in `comment["topics"]`.
+- Collects the comment and metadata in `message_index`.
+- Collects each `topic` from a comment. Each topic record links back to the comment and thread and includes the normalized topic string and timestamp.
+
+![Extract topic from comment](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/comment_topic.png)
+
+In short, this block enriches every comment with LLM-derived topics, indexes the comment itself, and separately indexes each individual topic for topic-level search and trend analysis.
+
+### Export Index to Database
+
+```python
+    # Export to database tables
+    message_index.export(
+        "hn_messages",
+        cocoindex.targets.Postgres(),
+        primary_key_fields=["id"],
+    )
+
+    # Export topics to separate table
+    topic_index.export(
+        "hn_topics",
+        cocoindex.targets.Postgres(),
+        primary_key_fields=["topic", "message_id"],
+    )
+```
+
+[→ Postgres Target](https://cocoindex.io/docs/targets/postgres)
+
+## Query Handlers
+
+### search_by_topic(query) → Find discussions about X
+
+```python
+@functools.cache
+def connection_pool() -> ConnectionPool:
+    """Get a connection pool to the database."""
+    return ConnectionPool(os.environ["COCOINDEX_DATABASE_URL"])
+
+@hackernews_trending_topics_flow.query_handler()
+def search_by_topic(topic: str) -> cocoindex.QueryOutput:
+    """Search HackerNews content by topic."""
+    topic_table = cocoindex.utils.get_target_default_name(
+        hackernews_trending_topics_flow, "hn_topics"
+    )
+    message_table = cocoindex.utils.get_target_default_name(
+        hackernews_trending_topics_flow, "hn_messages"
+    )
+
+    with connection_pool().connection() as conn:
+        with conn.cursor() as cur:
+            # Search for matching topics and join with messages
+            cur.execute(
+                f"""
+                SELECT m.id, m.thread_id, m.author, m.content_type, m.text, m.created_at, t.topic
+                FROM {topic_table} t
+                JOIN {message_table} m ON t.message_id = m.id
+                WHERE LOWER(t.topic) LIKE LOWER(%s)
+                ORDER BY m.created_at DESC
+                """,
+                (f"%{topic}%",),
+            )
+
+            results = []
+            for row in cur.fetchall():
+                results.append(
+                    {
+                        "id": row[0],
+                        "url": f"https://news.ycombinator.com/item?id={row[1]}",
+                        "author": row[2],
+                        "type": row[3],
+                        "text": row[4],
+                        "created_at": row[5].isoformat(),
+                        "topic": row[6],
+                    }
+                )
+
+            return cocoindex.QueryOutput(results=results)
+
+```
+
+This block adds a query interface to the flow so users can search HackerNews content by topic.
+
+The `@hackernews_trending_topics_flow.query_handler()` decorator registers `search_by_topic()` as a query endpoint for the flow.
+
+When a topic string is provided, the function determines the actual database table names for the topics and messages collectors, then connects to the database and runs a SQL query that finds all topic records matching the search term (case-insensitive) and joins them with their corresponding message entries.
+
+[→ Query Handler](https://cocoindex.io/docs/query#query-handler)
+
+### get_threads_for_topic(topic) → Threads discussing X
+
+```python
+def get_threads_for_topic(topic: str) -> list[dict[str, Any]]:
+    """Get the threads for a given topic."""
+    topic_table = cocoindex.utils.get_target_default_name(
+        hackernews_trending_topics_flow, "hn_topics"
+    )
+    with connection_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                    thread_id,
+                    SUM(CASE WHEN content_type = 'thread' THEN {THREAD_LEVEL_MENTION_SCORE} ELSE {COMMENT_LEVEL_MENTION_SCORE} END) AS score,
+                    MAX(created_at) AS latest_mention
+                FROM {topic_table} WHERE topic = %s
+                GROUP BY thread_id ORDER BY score DESC, latest_mention DESC""",
+                (topic,),
+            )
+            return [
+                {
+                    "url": f"https://news.ycombinator.com/item?id={row[0]}",
+                    "score": row[1],
+                    "latest_time": row[2].isoformat(),
+                }
+                for row in cur.fetchall()
+            ]
+```
+
+This function finds all HackerNews threads related to a given topic and ranks them. It looks up the topic table in the database, calculates a **score** for each thread (higher for main threads, lower for comments), and finds the most recent mention.
+
+It then returns a list of threads with their URL, score, and latest mention time, so you can see which threads are most relevant or trending for that topic.
+
+Why weighted score in SQL:
+
+- A topic in the original thread = primary subject
+- A topic in comments = supporting discussion
+
+By weighting 5:1, the system prioritizes original discussions over tangential mentions. This creates better trending rankings.
+
+### get_trending_topics(limit) → Top 20 topics by score
+
+This function finds the **most popular topics** on HackerNews.
+
+```python
+@hackernews_trending_topics_flow.query_handler()
+def get_trending_topics(_query: str = "", limit: int = 20) -> cocoindex.QueryOutput:
+    """Get the most trending topics across all HackerNews content."""
+    topic_table = cocoindex.utils.get_target_default_name(
+        hackernews_trending_topics_flow, "hn_topics"
+    )
+
+    with connection_pool().connection() as conn:
+        with conn.cursor() as cur:
+            # Aggregate topics by frequency
+            cur.execute(
+                f"""
+                SELECT
+                    topic,
+                    SUM(CASE WHEN content_type = 'thread' THEN {THREAD_LEVEL_MENTION_SCORE} ELSE {COMMENT_LEVEL_MENTION_SCORE} END) AS score,
+                    MAX(created_at) AS latest_mention
+                FROM {topic_table}
+                GROUP BY topic
+                ORDER BY score DESC, latest_mention DESC
+                LIMIT %s
+                """,
+                (limit,),
+            )
+
+            results = []
+            for row in cur.fetchall():
+                results.append(
+                    {
+                        "topic": row[0],
+                        "score": row[1],
+                        "latest_time": row[2].isoformat(),
+                        "threads": get_threads_for_topic(row[0]),
+                    }
+                )
+
+            return cocoindex.QueryOutput(results=results)
+```
+
+It looks at all indexed threads and comments, calculates a score for each topic (giving higher weight to main threads), and records the most recent mention. It then sorts the topics by score and recency, takes the top results (up to `limit`), and also fetches the threads related to each topic. Finally, it returns this information in a structured format so you can see trending topics along with the threads where they appear.
+
+## Running the Pipeline
+
+### On-Demand Update
+
+```sh
+cocoindex update main
+```
+
+### Live Mode
+
+```sh
+cocoindex update -L main
+```
+
+- Polls HackerNews every 30 seconds (configurable)
+- Automatically keeps index in sync
+- Perfect for dashboards and real-time apps
+
+### Debug with CocoInsight
+
+CocoInsight lets you **visualize and debug your flow**, see the lineage of your data, and understand what’s happening under the hood.
+
+Start the server:
+
+```bash
+cocoindex server -ci main
+```
+
+Then open the UI in your browser: [**`https://cocoindex.io/cocoinsight`**](https://cocoindex.io/cocoinsight)
+
+> CocoInsight has zero pipeline data retention — it’s safe for debugging and inspecting your flows locally.
+>
+
+Note that this requires QueryHandler setup in previous step.
+
+
+## Test queries
+After running the pipeline, you can query the extracted topics:
+
+```sh
+# Get trending topics
+cocoindex query main.py get_trending_topics --limit 20
+
+# Search content by specific topic
+cocoindex query main.py search_by_topic --topic "Claude"
+
+# Search by text content
+cocoindex query main.py search_text --query "artificial intelligence"
+```
+
+You can also test the query handlers in CocoInsight. It shows the query results and the data lineage to debug, iterate, and audit easily.
+
+![CocoInsight](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/cocoinsight.png)
+
+
+
+## What Can Be Built on Top of This Pipeline?
+
+Once you have structured topics extracted from HackerNews in real-time, the possibilities are vast. Here are some ideas:
+
+### 1. Real-Time Trending Dashboards
+
+With the `get_trending_topics()` and `get_threads_for_topic()` query handlers, you can create a live dashboard showing the hottest topics, which threads are driving discussion, and how the conversation evolves over time.
+
+- **Use case:** A tech news portal that surfaces trending technologies and products daily.
+- **Benefit:** Decision-makers, researchers, and investors can act on emerging trends faster than traditional news aggregation.
+
+### 2. Sentiment-Aware Trend Analysis
+
+By enriching this pipeline with an LLM-powered sentiment extraction function, you can track not just what’s trending, but **how people feel about it**.
+
+- **Use case:** Detect early hype or criticism for a new product or technology.
+- **Benefit:** Investors or product managers can gauge public reception in near real-time.
+
+### 3. Influencer or Key Contributor Tracking
+
+Since each message stores the `author` field, you can analyze **which users drive conversations around trending topics**.
+
+- **Use case:** Identify top contributors in AI, Web3, or other domains.
+- **Benefit:** Build targeted outreach, influencer networks, or citation metrics.
+
+### 4. Continuous Knowledge Graphs
+
+The extracted topics can feed a **knowledge graph**, connecting companies, products, technologies, and people.
+
+- **Use case:** Map relationships between emerging tech products, startups, and contributors on HackerNews.
+- **Benefit:** Supports advanced AI agents or recommendation systems that reason over real-world tech trends.
+
+### 5. Real-Time AI Agents
+
+By integrating with an AI agent framework, the indexed topics and threads become actionable knowledge. Your agent could:
+
+- Answer questions like “What are the top AI models being discussed today?”
+- Suggest investment opportunities or competitive intelligence insights.
+- Automatically generate summaries or reports for Slack/email.
+
+## Why Use CocoIndex for This?
+
+1. **Incremental Sync**
+
+    Traditional pipelines fetch everything repeatedly. CocoIndex fetches only new or updated threads, dramatically reducing API calls and latency.
+
+2. **Declarative & Modular**
+
+    Flows, collectors, and query handlers are modular. You can add new sources (Reddit, Twitter, internal chat logs) or new transformations (summaries, sentiment analysis, embeddings) without rewriting the entire pipeline.
+
+3. **LLM Integration is Seamless**
+
+    CocoIndex treats LLMs as first-class citizens for structured extraction. You don’t need complex glue code — the framework handles transformation, type enforcement, and storage.
+
+4. **Queryable Structured Index**
+
+    Topics and messages are stored in Postgres, ready for SQL queries or API-based search. You can serve both analytics dashboards and AI agents from the same structured store.
+
+5. **Supports Continuous Workflows**
+
+    CocoIndex pipelines can run live, with real-time updates every few seconds. Combine this with AI agents, and you have a **self-updating knowledge system** that reasons over the latest information.
+
+
+## Why CocoIndex Fits Continuous Monitoring Workloads
+
+CocoIndex is designed for systems that need to continuously monitor, detect, and respond to change with minimal engineering overhead. Its incremental syncing, structured extraction, and automatic index updates let you react to new data instantly—without rebuilding pipelines, reprocessing everything, or managing complex workflows. It’s a lightweight but powerful foundation for real-time analytics, alerting, and autonomous agents.
+
+## Support Us ❤️
+
+Enjoying CocoIndex? Give us a [⭐️ on GitHub](https://github.com/cocoindex-io/cocoindex) and share it with your peers. Every star helps more developers discover the project and strengthens the community.

--- a/docs/src/content/example-posts/image_search.md
+++ b/docs/src/content/example-posts/image_search.md
@@ -1,0 +1,265 @@
+---
+title: Image Search App with ColPali and FastAPI
+description: 'Build image search index with ColPali and FastAPI'
+slug: image_search
+image: https://cocoindex.io/blobs/docs/img/examples/image_search/cover.png
+tags: [vector-index, multi-modal]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search)
+
+![Image Search](https://cocoindex.io/blobs/docs/img/examples/image_search/cover.png)
+
+## Overview
+CocoIndex supports native integration with ColPali - with just a few lines of code, you embed and index images with ColPali’s late-interaction architecture. We also build a light weight image search application with FastAPI.
+
+
+## ColPali
+
+**ColPali (Contextual Late-interaction over Patches)** is a powerful model for multimodal retrieval.
+
+It fundamentally rethinks how documents—especially visually complex or image-rich ones—are represented and searched. Instead of reducing each image or page to a single dense vector (as in traditional bi-encoders), ColPali breaks an image into many smaller patches, preserving local spatial and semantic structure. Each patch receives its own embedding, which together form a multi-vector representation of the complete document.
+
+![ColPali Architecture](https://cocoindex.io/blobs/docs/img/examples/image_search/multi_modal_architecture.png)
+
+
+## Flow Overview
+![Flow](https://cocoindex.io/blobs/docs/img/examples/image_search/flow.png)
+
+1. Ingest image files from the local filesystem
+2. Use **ColPali** to embed each image into patch-level multi-vectors
+3. Optionally extract image captions using an LLM
+4. Export the embeddings (and optional captions) to a Qdrant collection
+
+## Setup
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+
+- Make sure Qdrant is running
+  ```
+  docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
+  ```
+
+
+## Add Source
+
+We start by defining a flow to read `.jpg`, `.jpeg`, and `.png` files from a local directory using `LocalFile`.
+
+```python
+@cocoindex.flow_def(name="ImageObjectEmbeddingColpali")
+def image_object_embedding_flow(flow_builder, data_scope):
+    data_scope["images"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(
+            path="img",
+            included_patterns=["*.jpg", "*.jpeg", "*.png"],
+            binary=True
+        ),
+        refresh_interval=datetime.timedelta(minutes=1),
+    )
+```
+
+The `add_source` function sets up a table with fields like `filename` and `content`. Images are automatically re-scanned every minute.
+
+[→ LocalFile](https://cocoindex.io/docs/sources/localfile)
+
+
+## Process Each Image and Collect the Embedding
+
+We use CocoIndex's built-in `ColPaliEmbedImage` function, which returns a **multi-vector representation** for each image. Each patch receives its own vector, preserving spatial and semantic information.
+
+[→ ColPaliEmbedImage](https://cocoindex.io/docs/ops/functions#colpaliembedimage)
+
+```python
+img_embeddings = data_scope.add_collector()
+with data_scope["images"].row() as img:
+    img["embedding"] = img["content"].transform(cocoindex.functions.ColPaliEmbedImage(model="vidore/colpali-v1.2"))
+    collect_fields = {
+        "id": cocoindex.GeneratedField.UUID,
+        "filename": img["filename"],
+        "embedding": img["embedding"],
+    }
+    img_embeddings.collect(**collect_fields)
+```
+
+This transformation turns the raw image bytes into a list of vectors — one per patch — that can later be used for **late interaction search**. And then we collect the embeddings.
+
+![ColPali Embedding](https://cocoindex.io/blobs/docs/img/examples/image_search/embedding.png)
+
+## Export the Embeddings
+
+```python
+img_embeddings.export(
+    "img_embeddings",
+    cocoindex.targets.Qdrant(collection_name="ImageSearchColpali"),
+    primary_key_fields=["id"],
+)
+```
+
+This creates a vector collection in Qdrant that supports **multi-vector fields** — required for ColPali-style late interaction search.
+
+
+## Enable Real-Time Indexing
+
+To keep the image index up to date automatically, we wrap the flow in a `FlowLiveUpdater`:
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    load_dotenv()
+    cocoindex.init()
+    image_object_embedding_flow.setup(report_to_stdout=True)
+    app.state.live_updater = cocoindex.FlowLiveUpdater(image_object_embedding_flow)
+    app.state.live_updater.start()
+    yield
+```
+
+This keeps your vector index fresh as new images arrive.
+
+## Fast API Application
+
+We build a simple FastAPI application to query the index.
+
+```python
+app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+# Serve images from the 'img' directory at /img
+app.mount("/img", StaticFiles(directory="img"), name="img")
+```
+
+## Search API & Query the index
+
+We use `ColPaliEmbedQuery` to embed the query text into a multi-vector format.
+
+[→ ColPaliEmbedQuery](https://cocoindex.io/docs/ops/functions#colpaliembedquery)
+
+```python
+@cocoindex.transform_flow()
+def text_to_colpali_embedding(
+    text: cocoindex.DataSlice[str],
+) -> cocoindex.DataSlice[list[list[float]]]:
+    return text.transform(
+        cocoindex.functions.ColPaliEmbedQuery(model=COLPALI_MODEL_NAME)
+    )
+```
+Then we build a search API to query the index.
+
+```python
+# --- Search API ---
+@app.get("/search")
+def search(
+    q: str = Query(..., description="Search query"),
+    limit: int = Query(5, description="Number of results"),
+) -> Any:
+    # Get the multi-vector embedding for the query
+    query_embedding = text_to_colpali_embedding.eval(q)
+    print(
+        f"🔍 Query multi-vector shape: {len(query_embedding)} tokens x {len(query_embedding[0]) if query_embedding else 0} dims"
+    )
+
+    # Search in Qdrant with multi-vector MaxSim scoring using query_points API
+    search_results = app.state.qdrant_client.query_points(
+        collection_name=QDRANT_COLLECTION,
+        query=query_embedding,  # Multi-vector format: list[list[float]]
+        using="embedding",  # Specify the vector field name
+        limit=limit,
+        with_payload=True,
+    )
+
+    print(f"📈 Found {len(search_results.points)} results with MaxSim scoring")
+
+    return {
+        "results": [
+            {
+                "filename": result.payload["filename"],
+                "score": result.score,
+                "caption": result.payload.get("caption"),
+            }
+            for result in search_results.points
+        ]
+    }
+```
+
+## Run the application
+
+- Install dependencies:
+  ```
+  pip install -e .
+  pip install 'cocoindex[colpali]'  # Adds ColPali support
+  ```
+
+- Configure model (optional):
+  ```sh
+  # All ColVision models supported by colpali-engine are available
+  # See https://github.com/illuin-tech/colpali#list-of-colvision-models for the complete list
+
+  # ColPali models (colpali-*) - PaliGemma-based, best for general document retrieval
+  export COLPALI_MODEL="vidore/colpali-v1.2"  # Default model
+  export COLPALI_MODEL="vidore/colpali-v1.3"  # Latest version
+
+  # ColQwen2 models (colqwen-*) - Qwen2-VL-based, excellent for multilingual text (29+ languages) and general vision
+  export COLPALI_MODEL="vidore/colqwen2-v1.0"
+  export COLPALI_MODEL="vidore/colqwen2.5-v0.2"  # Latest Qwen2.5 model
+
+  # ColSmol models (colsmol-*) - Lightweight, good for resource-constrained environments
+  export COLPALI_MODEL="vidore/colSmol-256M"
+
+  # Any other ColVision models from https://github.com/illuin-tech/colpali are supported
+  ```
+
+- Run ColPali Backend:
+  ```
+  uvicorn colpali_main:app --reload --host 0.0.0.0 --port 8000
+  ```
+    :::warning
+    Note that recent Nvidia GPUs (such as the RTX 5090) are not supported by the stable PyTorch version up to 2.7.1.
+    :::
+
+    If you get this error:
+
+    ```
+    The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_61 sm_70 sm_75 sm_80 sm_86 sm_90 compute_37.
+    ```
+
+    You can install the nightly pytorch build here: https://pytorch.org/get-started/locally/
+
+    ```sh
+    pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu129
+    ```
+- Run Frontend:
+  ```
+  cd frontend
+  npm install
+  npm run dev
+  ```
+
+ Go to `http://localhost:5173` to search. The frontend works with both backends identically.
+
+ ![Result](https://cocoindex.io/blobs/docs/img/examples/image_search/result.png)
+
+## CLIP Model & Comparison with ColPali
+We've also had a similar application built with CLIP model.
+
+[→ Image Search App with CLIP](https://cocoindex.io/blogs/live-image-search)
+
+In general,
+- CLIP: Faster, good for general image-text matching
+- ColPali: More accurate for document images and text-heavy content, supports multi-vector late interaction for better precision
+
+## Connect to Any Data Source
+
+One of CocoIndex’s core strengths is its ability to connect to your existing data sources and automatically keep your index fresh. Beyond local files, CocoIndex natively supports source connectors including:
+
+- Google Drive
+- Amazon S3 / SQS
+- Azure Blob Storage
+
+[→ Sources](https://cocoindex.io/docs/sources)
+
+Once connected, CocoIndex continuously watches for changes — new uploads, updates, or deletions — and applies them to your index in real time.

--- a/docs/src/content/example-posts/image_search_clip.md
+++ b/docs/src/content/example-posts/image_search_clip.md
@@ -1,0 +1,317 @@
+---
+title: Build image search and query with natural language with vision model CLIP
+description: 'Indexing images with CocoIndex and Vision Model CLIP for efficient image search and natural language querying'
+slug: image_search_clip
+image: https://cocoindex.io/blobs/docs/img/examples/image_search_clip/cover.png
+tags: [vector-index, multi-modal]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/blob/main/examples/image_search/main.py)
+
+![Image Search](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/cover.png)
+
+## Overview
+In this project, you'll create an image search system that lets you find images using natural language queries—such as "a cute animal" or "a red car". The system will automatically return the most visually relevant results, without the need for manual labeling or tagging.
+
+We are going to use multi-modal embedding model CLIP to understand and directly embed the image; and build a vector index for efficient retrieval.
+
+We are going use CocoIndex to build the indexing flow. It supports long running flow and only process changed files - we can keep adding new files to the folder and it will be indexed within a minute.
+
+
+## CLIP ViT-L/14
+[CLIP ViT-L/14](https://huggingface.co/openai/clip-vit-large-patch14) is a powerful vision-language model that can understand both images and texts.
+It's trained to align visual and textual representations in a shared embedding space, making it perfect for our image search use case.
+
+In our project, we use CLIP to:
+1. Generate embeddings of the images directly
+2. Convert natural language search queries into the same embedding space
+3. Enable semantic search by comparing query embeddings with caption embeddings
+
+**Alternative:** [CLIP ViT-B/32](https://huggingface.co/openai/clip-vit-base-patch32) is a lighter-weight model that runs faster than ViT-L/14. While it may not be quite as accurate, it offers improved speed and requires fewer resources.
+
+## Flow Overview
+![Flow](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/flow.png)
+
+1. Ingest image files from your local directory
+2. Generate embeddings for each image using the CLIP model
+3. Save these embeddings into a vector database for efficient search and retrieval
+
+## Setup
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+
+- Make sure Qdrant is running
+  ```
+  docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
+  ```
+
+
+## Flow
+
+### Define the flow and ingest the images
+
+```python
+@cocoindex.flow_def(name="ImageObjectEmbedding")
+def image_object_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["images"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="img", included_patterns=["*.jpg", "*.jpeg", "*.png"], binary=True),
+        refresh_interval=datetime.timedelta(minutes=1)  # Poll for changes every 1 minute
+    )
+    img_embeddings = data_scope.add_collector()
+```
+
+`flow_builder.add_source` will create a table with sub fields (`filename`, `content`)
+
+[→ Sources](https://cocoindex.io/docs/sources)
+
+**interval**
+The `refresh_interval` parameter in `add_source` specifies how frequently CocoIndex will check the source directory (`img`) for new, modified, or deleted images. For example, `datetime.timedelta(minutes=1)` means the system will poll for changes every 1 minute, enabling near-real-time indexing of added or updated files.
+
+
+![Ingest Images](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/ingest.png)
+
+### Process each image and collect the information.
+
+#### Define Custom function to embed the image with CLIP
+
+```python
+@functools.cache
+def get_clip_model() -> tuple[CLIPModel, CLIPProcessor]:
+    model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
+    processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
+    return model, processor
+```
+The `@functools.cache` decorator caches the results of a function call. In this case, it ensures that we only load the CLIP model and processor once.
+
+
+```python
+@cocoindex.op.function(cache=True, behavior_version=1, gpu=True)
+def embed_image(img_bytes: bytes) -> cocoindex.Vector[cocoindex.Float32, Literal[384]]:
+    model, processor = get_clip_model()
+    image = Image.open(io.BytesIO(img_bytes)).convert("RGB")
+    inputs = processor(images=image, return_tensors="pt")
+    with torch.no_grad():
+        features = model.get_image_features(**inputs)
+    return features[0].tolist()
+```
+
+`embed_image` is a custom function that uses the CLIP model to convert an image into a vector embedding.
+It accepts image data in bytes format and returns a list of floating-point numbers representing the image's embedding.
+
+[→ Custom Function Documentation](https://cocoindex.io/docs/core/custom_function)
+
+
+The function supports caching through the `cache` parameter.
+When enabled, the executor will store the function's results for reuse during reprocessing,
+which is particularly useful for computationally intensive operations.
+
+
+#### Process each image and collect the information.
+
+```python
+with data_scope["images"].row() as img:
+    img["embedding"] = img["content"].transform(embed_image)
+    img_embeddings.collect(
+        id=cocoindex.GeneratedField.UUID,
+        filename=img["filename"],
+        embedding=img["embedding"],
+    )
+```
+
+![Embed Images](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/embedding.png)
+
+
+#### Collect the embeddings
+
+Export the embeddings to a table in Qdrant.
+
+```python
+img_embeddings.export(
+    "img_embeddings",
+    cocoindex.storages.Qdrant(
+        collection_name="image_search",
+        grpc_url=QDRANT_GRPC_URL,
+    ),
+    primary_key_fields=["id"],
+    setup_by_user=True,
+)
+```
+
+[→ Qdrant Connector](https://cocoindex.io/docs/targets/qdrant)
+
+### Alternative Connectors
+
+CocoIndex supports multiple connectors for storing and querying vector data.
+
+[→ Targets](https://cocoindex.io/docs/targets)
+
+It also supports custom connectors if native connectors don't fit your needs.
+
+[→ Custom Targets](https://cocoindex.io/docs/custom_ops/custom_targets)
+
+### Query the index
+
+Embed the query with CLIP, which maps both text and images into the same embedding space, allowing for cross-modal similarity search.
+
+```python
+def embed_query(text: str) -> list[float]:
+    model, processor = get_clip_model()
+    inputs = processor(text=[text], return_tensors="pt", padding=True)
+    with torch.no_grad():
+        features = model.get_text_features(**inputs)
+    return features[0].tolist()
+```
+
+
+Defines a FastAPI endpoint `/search` that performs semantic image search.
+
+```python
+@app.get("/search")
+def search(q: str = Query(..., description="Search query"), limit: int = Query(5, description="Number of results")):
+    # Get the embedding for the query
+    query_embedding = embed_query(q)
+
+    # Search in Qdrant
+    search_results = app.state.qdrant_client.search(
+        collection_name="image_search",
+        query_vector=("embedding", query_embedding),
+        limit=limit
+    )
+
+```
+
+This searches the Qdrant vector database for similar embeddings. Returns the top `limit` results
+
+```python
+# Format results
+out = []
+for result in search_results:
+    out.append({
+        "filename": result.payload["filename"],
+        "score": result.score
+    })
+return {"results": out}
+```
+
+
+This endpoint enables semantic image search where users can find images by describing them in natural language,
+rather than using exact keyword matches.
+
+
+## Application
+### Fast API
+```python
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+# Serve images from the 'img' directory at /img
+app.mount("/img", StaticFiles(directory="img"), name="img")
+```
+
+FastAPI application setup with CORS middleware and static file serving
+The app is configured to:
+- Allow cross-origin requests from any origin
+- Serve static image files from the 'img' directory
+- Handle API endpoints for image search functionality
+
+
+```python
+@app.on_event("startup")
+def startup_event():
+    load_dotenv()
+    cocoindex.init()
+    # Initialize Qdrant client
+    app.state.qdrant_client = QdrantClient(
+        url=QDRANT_GRPC_URL,
+        prefer_grpc=True
+    )
+    app.state.live_updater = cocoindex.FlowLiveUpdater(image_object_embedding_flow)
+    app.state.live_updater.start()
+```
+
+The startup event handler initializes the application when it first starts up. Here's what each part does:
+
+1. `load_dotenv()`: Loads environment variables from a .env file, which is useful for configuration like API keys and URLs
+
+2. `cocoindex.init()`: Initializes the CocoIndex framework, setting up necessary components and configurations
+
+3. Qdrant Client Initialization:
+   - Initializes a `QdrantClient` using the gRPC URL from your environment variables.
+   - Sets the client to prefer gRPC for optimal speed.
+   - Saves the client to the FastAPI application state, making it accessible in API requests.
+
+4. Live Updater Initialization:
+   - Instantiates a `FlowLiveUpdater` with the `image_object_embedding_flow`.
+   - The live updater automatically keeps your image search index updated with any changes to the image folder.
+   - Activates the updater to continuously monitor and process new or updated images.
+
+This initialization ensures that all necessary components are properly configured and running when the application starts.
+
+
+### Frontend
+You can check the frontend code [here](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search/frontend). We intentionally kept it simple and minimalistic to focus on the image search functionality.
+
+
+## Time to have fun!
+- Create a collection in Qdrant
+    ```sh
+    curl -X PUT 'http://localhost:6333/collections/image_search' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "vectors": {
+        "embedding": {
+            "size": 768,
+            "distance": "Cosine"
+        }
+        }
+    }'
+    ```
+
+- Setup indexing flow
+    ```sh
+    cocoindex setup main
+    ```
+    It is setup with a live updater, so you can add new files to the folder and it will be indexed within a minute.
+
+- Run backend
+    ```sh
+    uvicorn main:app --reload --host 0.0.0.0 --port 8000
+    ```
+
+- Run frontend
+    ```sh
+    cd frontend
+    npm install
+    npm run dev
+    ```
+
+Go to http://localhost:5174 to search.
+
+![Search](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/search1.png)
+![Search](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/search2.png)
+
+Now add another image in the `img` folder, for example, this [cute squirrel](https://www.pexels.com/photo/brown-squirrel-47547/), or any picture you like.
+Wait a minute for the new image to be processed and indexed.
+
+![Search](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/search3.png)
+
+If you want to monitor the indexing progress, you can view it in CocoInsight `cocoindex server -ci main`.
+
+![Index Status In CocoInsight](https://cocoindex.io/blobs/docs/img/examples/image_search_clip/index-status.png)
+
+## Connect to Any Data Source
+
+One of CocoIndex’s core strengths is its ability to connect to your existing data sources and automatically keep your index fresh. Beyond local files, CocoIndex natively supports source connectors including:
+
+- Google Drive
+- Amazon S3 / SQS
+- Azure Blob Storage
+
+[→ Sources](https://cocoindex.io/docs/sources)
+
+Once connected, CocoIndex continuously watches for changes — new uploads, updates, or deletions — and applies them to your index in real time.

--- a/docs/src/content/example-posts/knowledge-graph-for-docs.md
+++ b/docs/src/content/example-posts/knowledge-graph-for-docs.md
@@ -1,0 +1,375 @@
+---
+title: Real-Time Knowledge Graph for Documents with LLM
+description: 'CocoIndex now supports knowledge graph with incremental processing. Build live knowledge for agents is super easy with CocoIndex.'
+slug: knowledge-graph-for-docs
+image: https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/cover.png
+tags: [knowledge-graph, structured-data-extraction]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/docs_to_knowledge_graph)
+[→ Watch on YouTube](https://youtu.be/2KVkpUGRtnk?si=MRalDweWrid-IFje)
+
+![Knowledge Graph for Docs](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/cover.png)
+
+## Overview
+
+[CocoIndex](https://github.com/cocoindex-io/cocoindex) makes it easy to build and maintain knowledge graphs with continuous source updates. In this tutorial, we will use LLM to extract relationships between the concepts in each document, and generate two kinds of relationships:
+
+1. Relationships between subjects and objects. E.g., "CocoIndex supports Incremental Processing"
+2. Mentions of entities in a document. E.g., "core/basics.mdx" mentions `CocoIndex` and `Incremental Processing`.
+
+and then build a knowledge graph.
+
+![Relationship between subjects and objects](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/relationship.png)
+
+## Flow Overview
+
+![Flow overview](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/flow.png)
+
+- Add documents as source.
+- For each document, extract the title and summary, and collects to `Document` nodes.
+- For each document, use LLM to extract relationships — `subject`, `predicate`, `object`, and collect different kinds of relationships.
+- CocoIndex can direct map the collected data to Neo4j nodes and relationships.
+
+## Setup
+
+* [Install PostgreSQL](https://cocoindex.io/docs/getting_started/installation#-install-postgres). CocoIndex uses PostgreSQL internally for incremental processing.
+- [Install Neo4j](https://cocoindex.io/docs/targets/neo4j#neo4j-dev-instance), a graph database.
+
+    [→ Neo4j](https://cocoindex.io/docs/targets/neo4j)
+- [Configure your OpenAI API key](https://cocoindex.io/docs/ai/llm#openai).  Alternatively, we have native support for Gemini, Ollama, LiteLLM. You can choose your favorite LLM provider and work completely on-premises.
+
+    [→ LLM](https://cocoindex.io/docs/ai/llm)
+
+## Documentation
+
+[→ Property Graph Targets](https://cocoindex.io/docs/targets#property-graph-targets)
+
+## Data flow to build knowledge graph
+
+### Add documents as source
+
+We will process CocoIndex documentation markdown files (`.md`, `.mdx`) from the `docs/core` directory ([markdown files](https://github.com/cocoindex-io/cocoindex/tree/main/docs/docs/core), [deployed docs](https://cocoindex.io/docs/core/basics)).
+
+```python
+
+@cocoindex.flow_def(name="DocsToKG")
+def docs_to_kg_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path=os.path.join('..', '..', 'docs', 'docs', 'core'),
+                                    included_patterns=["*.md", "*.mdx"]))
+```
+
+Here `flow_builder.add_source` creates a [KTable](https://cocoindex.io/docs/core/data_types#KTable).
+`filename` is the key of the KTable.
+
+[→ Sources](https://cocoindex.io/docs/sources)
+
+### Add data collectors
+
+Add collectors at the root scope:
+
+```python
+document_node = data_scope.add_collector()
+entity_relationship = data_scope.add_collector()
+entity_mention = data_scope.add_collector()
+```
+
+- `document_node` collects documents. E.g., [`core/basics.mdx`](https://cocoindex.io/docs/core/basics) is a document.
+- `entity_relationship` collects relationships. E.g., "CocoIndex supports Incremental Processing" indicates a relationship between `CocoIndex` and `Incremental Processing`.
+- `entity_mention` collects mentions of entities in a document. E.g., [`core/basics.mdx`](https://cocoindex.io/docs/core/basics) mentions `CocoIndex` and `Incremental Processing`.
+
+### Process each document and extract summary
+
+Define a `DocumentSummary` data class to extract the summary of a document.
+
+```python
+@dataclasses.dataclass
+class DocumentSummary:
+    title: str
+    summary: str
+```
+
+Within the flow, use [`cocoindex.functions.ExtractByLlm`](https://cocoindex.io/docs/ops/functions#extractbyllm) for structured output.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["summary"] = doc["content"].transform(
+            cocoindex.functions.ExtractByLlm(
+                llm_spec=cocoindex.LlmSpec(
+                    api_type=cocoindex.LlmApiType.OPENAI, model="gpt-4o"),
+                output_type=DocumentSummary,
+                instruction="Please summarize the content of the document."))
+
+    document_node.collect(
+        filename=doc["filename"], title=doc["summary"]["title"],
+        summary=doc["summary"]["summary"])
+```
+
+`doc["summary"]` adds a new column to the KTable `data_scope["documents"]`.
+
+![Document summary](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/summary.png)
+
+### Extract relationships from the document using LLM
+
+Define a data class to represent relationship for the LLM extraction.
+
+```python
+@dataclasses.dataclass
+class Relationship:
+    """
+    Describe a relationship between two entities.
+    Subject and object should be Core CocoIndex concepts only, should be nouns. For example, `CocoIndex`, `Incremental Processing`, `ETL`,  `Data` etc.
+    """
+    subject: str
+    predicate: str
+    object: str
+```
+
+The Data class defines a knowledge graph relationship. We recommend putting detailed instructions in the class-level docstring to help the LLM extract relationships correctly.
+
+- `subject`: Represents the entity the statement is about (e.g., 'CocoIndex').
+- `predicate`: Describes the type of relationship or property connecting the subject and object (e.g., 'supports').
+- `object`: Represents the entity or value that the subject is related to via the predicate (e.g., 'Incremental Processing').
+
+This structure represents facts like "CocoIndex supports Incremental Processing". Its graph representation is:
+
+Next, we will use `cocoindex.functions.ExtractByLlm` to extract the relationships from the document.
+
+```python
+doc["relationships"] = doc["content"].transform(
+    cocoindex.functions.ExtractByLlm(
+        llm_spec=cocoindex.LlmSpec(
+            api_type=cocoindex.LlmApiType.OPENAI,
+            model="gpt-4o"
+        ),
+        output_type=list[Relationship],
+        instruction=(
+            "Please extract relationships from CocoIndex documents. "
+            "Focus on concepts and ignore examples and code. "
+        )
+    )
+)
+```
+
+`doc["relationships"]` adds a new field `relationships` to each document. `output_type=list[Relationship]` specifies that the output of the transformation is a [LTable](https://cocoindex.io/docs/core/data_types#LTable).
+
+![Extract Relationships](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/extract_relationship.png)
+
+### Collect relationships
+
+```python
+with doc["relationships"].row() as relationship:
+    # relationship between two entities
+    entity_relationship.collect(
+        id=cocoindex.GeneratedField.UUID,
+        subject=relationship["subject"],
+        object=relationship["object"],
+        predicate=relationship["predicate"],
+    )
+    # mention of an entity in a document, for subject
+    entity_mention.collect(
+        id=cocoindex.GeneratedField.UUID, entity=relationship["subject"],
+        filename=doc["filename"],
+    )
+    # mention of an entity in a document, for object
+    entity_mention.collect(
+        id=cocoindex.GeneratedField.UUID, entity=relationship["object"],
+        filename=doc["filename"],
+    )
+```
+
+- `entity_relationship` collects relationships between subjects and objects.
+- `entity_mention` collects mentions of entities (as subjects or objects) in the document separately. For example, `core/basics.mdx` has a sentence `CocoIndex supports Incremental Processing`. We want to collect:
+  - `core/basics.mdx` mentions `CocoIndex`.
+  - `core/basics.mdx` mentions `Incremental Processing`.
+
+### Build knowledge graph
+
+#### Basic concepts
+
+All nodes for Neo4j need two things:
+
+1. Label: The type of the node. E.g., `Document`, `Entity`.
+2. Primary key field: The field that uniquely identifies the node. E.g., `filename` for `Document` nodes.
+
+CocoIndex uses the primary key field to match the nodes and deduplicate them. If you have multiple nodes with the same primary key, CocoIndex keeps only one of them.
+
+![Deduplication](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/dedupe.png)
+
+There are two ways to map nodes:
+
+1. When you have a collector just for the node, you can directly export it to Neo4j.
+2. When you have a collector for relationships connecting to the node, you can map nodes from selected fields in the relationship collector. You must declare a node label and primary key field.
+
+#### Configure Neo4j connection
+
+```python
+conn_spec = cocoindex.add_auth_entry(
+    "Neo4jConnection",
+    cocoindex.storages.Neo4jConnection(
+        uri="bolt://localhost:7687",
+        user="neo4j",
+        password="cocoindex",
+))
+```
+
+#### Export `Document` nodes to Neo4j
+
+![Document nodes](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/export_document.png)
+
+```python
+document_node.export(
+    "document_node",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Nodes(label="Document")),
+    primary_key_fields=["filename"],
+)
+```
+
+This exports Neo4j nodes with label `Document` from the `document_node` collector.
+
+- It declares Neo4j node label `Document`. It specifies `filename` as the primary key field.
+- It carries all the fields from `document_node` collector to Neo4j nodes with label `Document`.
+
+#### Export `RELATIONSHIP` and `Entity` nodes to Neo4j
+
+We don't have explicit collector for `Entity` nodes.
+They are part of the `entity_relationship` collector and fields are collected during the relationship extraction.
+
+To export them as Neo4j nodes, we need to first declare `Entity` nodes.
+
+```python
+flow_builder.declare(
+    cocoindex.storages.Neo4jDeclaration(
+        connection=conn_spec,
+        nodes_label="Entity",
+        primary_key_fields=["value"],
+    )
+)
+```
+
+Next, export the `entity_relationship` to Neo4j.
+
+![Export relationship](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/export_relationship.png)
+
+```python
+entity_relationship.export(
+    "entity_relationship",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Relationships(
+            rel_type="RELATIONSHIP",
+            source=cocoindex.storages.NodeFromFields(
+                label="Entity",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="subject", target="value"),
+                ]
+            ),
+            target=cocoindex.storages.NodeFromFields(
+                label="Entity",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="object", target="value"),
+                ]
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+The `cocoindex.storages.Relationships` declares how to map relationships in Neo4j.
+
+In a relationship, there's:
+
+1. A source node and a target node.
+2. A relationship connecting the source and target.
+Note that different relationships may share the same source and target nodes.
+
+`NodeFromFields` takes the fields from the `entity_relationship` collector and creates `Entity` nodes.
+
+#### Export the `entity_mention` to Neo4j
+
+![Export Entity Mention](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/relationship.png)
+
+```python
+entity_mention.export(
+    "entity_mention",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Relationships(
+            rel_type="MENTION",
+            source=cocoindex.storages.NodesFromFields(
+                label="Document",
+                fields=[cocoindex.storages.TargetFieldMapping("filename")],
+            ),
+            target=cocoindex.storages.NodesFromFields(
+                label="Entity",
+                fields=[cocoindex.storages.TargetFieldMapping(
+                    source="entity", target="value")],
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+Similarly here, we export `entity_mention` to Neo4j Relationships using `cocoindex.storages.Relationships`.
+It creates relationships by:
+
+- Creating `Document` nodes and `Entity` nodes from the `entity_mention` collector.
+- Connecting `Document` nodes and `Entity` nodes with relationship `MENTION`.
+
+## Query and test your index
+
+1. Install the dependencies:
+
+    ```sh
+    pip install -e .
+    ```
+
+2. Run following commands to setup and update the index.
+
+    ```sh
+    cocoindex update main
+    ```
+
+    You'll see the index updates state in the terminal. For example,
+
+    ```
+    documents: 7 added, 0 removed, 0 updated
+    ```
+
+## CocoInsight
+
+I used CocoInsight to troubleshoot the index generation and understand the data lineage of the pipeline.  It is in free beta now, you can give it a try.
+
+```sh
+cocoindex server -ci main
+```
+
+And then open the url `https://cocoindex.io/cocoinsight`.  It just connects to your local CocoIndex server, with zero pipeline data retention.
+
+## Browse the knowledge graph
+
+After the knowledge graph is built, you can explore the knowledge graph you built in Neo4j Browser.
+
+[→ Neo4j](https://cocoindex.io/docs/targets/neo4j)
+
+For the dev environment, you can connect to Neo4j browser using credentials:
+
+- username: `Neo4j`
+- password: `cocoindex`
+which is pre-configured in our docker compose [config.yaml](https://raw.githubusercontent.com/cocoindex-io/cocoindex/refs/heads/main/dev/Neo4j.yaml).
+
+You can open it at [http://localhost:7474](http://localhost:7474), and run the following Cypher query to get all relationships:
+
+```cypher
+MATCH p=()-->() RETURN p
+```
+
+![Neo4j Browser](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/neo4j_browser.png)

--- a/docs/src/content/example-posts/manual_extraction.md
+++ b/docs/src/content/example-posts/manual_extraction.md
@@ -1,0 +1,260 @@
+---
+title: Extract Structured Data from Python Manual markdowns with Ollama
+description: 'Extract structured data from markdowns (Python Manual)'
+slug: manual_extraction
+image: https://cocoindex.io/blobs/docs/img/examples/manual_extraction/cover.png
+tags: [structured-data-extraction, data-mapping]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/manuals_llm_extraction)
+
+![Manual Extraction](https://cocoindex.io/blobs/docs/img/examples/manual_extraction/cover.png)
+
+## Overview
+
+This example shows how to extract structured data from Python Manuals using Ollama.
+
+## Flow Overview
+
+![Flow Overview](https://cocoindex.io/blobs/docs/img/examples/manual_extraction/flow.png)
+
+- For each PDF file:
+  - Parse to markdown.
+  - Extract structured data from the markdown using LLM.
+  - Add summary to the module info.
+  - Collect the data.
+- Export the data to a table.
+
+## Prerequisites
+
+- If you don't have Postgres installed, please refer to the [installation guide](https://cocoindex.io/docs/getting_started/installation).
+
+- [Download](https://ollama.com/download) and install Ollama. Pull your favorite LLM models by:
+
+    ```sh
+    ollama pull llama3.2
+    ```
+
+    [→ Ollama](https://cocoindex.io/docs/ai/llm#ollama)
+
+    Alternatively, CocoIndex has native support for Gemini, Ollama, and LiteLLM. You can choose your favorite LLM provider and work completely on-premises.
+
+    [→ LLM](https://cocoindex.io/docs/ai/llm)
+
+## Add Source
+
+Let's add Python docs as a source.
+
+```python
+@cocoindex.flow_def(name="ManualExtraction")
+def manual_extraction_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+):
+    """
+    Define an example flow that extracts manual information from a Markdown.
+    """
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="manuals", binary=True)
+    )
+
+    modules_index = data_scope.add_collector()
+```
+
+`flow_builder.add_source` will create a table with the following sub fields:
+
+- `filename` (key, type: `str`): the filename of the file, e.g. `dir1/file1.md`
+- `content` (type: `str` if `binary` is `False`, otherwise `bytes`): the content of the file
+
+[→ LocalFile](https://cocoindex.io/docs/sources)
+
+## Parse Markdown
+
+To do this, we can plug in a custom function to convert PDF to markdown. There are so many different parsers commercially and open source available, you can bring your own parser here.
+
+```python
+class PdfToMarkdown(cocoindex.op.FunctionSpec):
+    """Convert a PDF to markdown."""
+
+
+@cocoindex.op.executor_class(gpu=True, cache=True, behavior_version=1)
+class PdfToMarkdownExecutor:
+    """Executor for PdfToMarkdown."""
+
+    spec: PdfToMarkdown
+    _converter: PdfConverter
+
+    def prepare(self):
+        config_parser = ConfigParser({})
+        self._converter = PdfConverter(
+            create_model_dict(), config=config_parser.generate_config_dict()
+        )
+
+    def __call__(self, content: bytes) -> str:
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".pdf") as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            text, _, _ = text_from_rendered(self._converter(temp_file.name))
+            return text
+```
+
+You may wonder why we want to define a spec + executor (instead of using a standalone function) here. The main reason is there's some heavy preparation work (initialize the parser) that needs to be done before being ready to process real data.
+
+[→ Custom Function](https://cocoindex.io/docs/custom_ops/custom_functions)
+
+Plug in the function to the flow.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["markdown"] = doc["content"].transform(PdfToMarkdown())
+```
+
+It transforms each document to markdown.
+
+## Extract Structured Data from Markdown files
+
+### Define schema
+
+Let's define the schema `ModuleInfo` using Python dataclasses, and we can pass it to the LLM to extract the structured data. It's easy to do this with CocoIndex.
+
+``` python
+@dataclasses.dataclass
+class ArgInfo:
+    """Information about an argument of a method."""
+    name: str
+    description: str
+
+@dataclasses.dataclass
+class MethodInfo:
+    """Information about a method."""
+    name: str
+    args: list[ArgInfo]
+    description: str
+
+@dataclasses.dataclass
+class ClassInfo:
+    """Information about a class."""
+    name: str
+    description: str
+    methods: list[MethodInfo]
+
+@dataclasses.dataclass
+class ModuleInfo:
+    """Information about a Python module."""
+    title: str
+    description: str
+    classes: list[ClassInfo]
+    methods: list[MethodInfo]
+```
+
+### Extract structured data
+
+CocoIndex provides built-in functions (e.g. ExtractByLlm) that process data using LLM.  This example uses Ollama.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["module_info"] = doc["content"].transform(
+        cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                    api_type=cocoindex.LlmApiType.OLLAMA,
+                    # See the full list of models: https://ollama.com/library
+                    model="llama3.2"
+            ),
+            output_type=ModuleInfo,
+            instruction="Please extract Python module information from the manual."))
+```
+
+[→ ExtractByLlm](https://cocoindex.io/docs/core/functions#extractbyllm)
+
+![ExtractByLlm](https://cocoindex.io/blobs/docs/img/examples/manual_extraction/extraction.png)
+
+## Add summarization to module info
+
+Using CocoIndex as framework, you can easily add any transformation on the data, and collect it as part of the data index. Let's add some simple summary to each module - like number of classes and methods, using simple Python function.
+
+### Define Schema
+
+``` python
+@dataclasses.dataclass
+class ModuleSummary:
+    """Summary info about a Python module."""
+    num_classes: int
+    num_methods: int
+```
+
+### A simple custom function to summarize the data
+
+```python
+@cocoindex.op.function()
+def summarize_module(module_info: ModuleInfo) -> ModuleSummary:
+    """Summarize a Python module."""
+    return ModuleSummary(
+        num_classes=len(module_info.classes),
+        num_methods=len(module_info.methods),
+    )
+```
+
+### Plug in the function into the flow
+
+```python
+with data_scope["documents"].row() as doc:
+    # ... after the extraction
+    doc["module_summary"] = doc["module_info"].transform(summarize_module)
+```
+
+[→ Custom Function](https://cocoindex.io/docs/custom_ops/custom_functions)
+
+![Summarize Module](https://cocoindex.io/blobs/docs/img/examples/manual_extraction/summary.png)
+
+## Collect the data
+
+After the extraction, we need to cherry-pick anything we like from the output using the `collect` function from the collector of a data scope defined above.
+
+```python
+modules_index.collect(
+    filename=doc["filename"],
+    module_info=doc["module_info"],
+)
+```
+
+Finally, let's export the extracted data to a table.
+
+```python
+modules_index.export(
+    "modules",
+    cocoindex.storages.Postgres(table_name="modules_info"),
+    primary_key_fields=["filename"],
+)
+```
+
+## Query and test your index
+
+Run the following command to set up and update the index.
+
+```sh
+cocoindex update -L main
+```
+
+You'll see the index updates state in the terminal
+
+After the index is built, you have a table with the name `modules_info`. You can query it at any time, e.g., start a Postgres shell:
+
+```sh
+psql postgres://cocoindex:cocoindex@localhost/cocoindex
+```
+
+And run the SQL query:
+
+```sql
+SELECT filename, module_info->'title' AS title, module_summary FROM modules_info;
+```
+
+## CocoInsight
+
+[CocoInsight](https://www.youtube.com/watch?v=ZnmyoHslBSc) is a really cool tool to help you understand your data pipeline and data index. It is in Early Access now (Free).
+
+```sh
+cocoindex server -ci main
+```
+
+CocoInsight dashboard is here `https://cocoindex.io/cocoinsight`.  It connects to your local CocoIndex server with zero data retention.

--- a/docs/src/content/example-posts/meeting_notes_graph.md
+++ b/docs/src/content/example-posts/meeting_notes_graph.md
@@ -1,0 +1,554 @@
+---
+title: Building a Knowledge Graph from Meeting Notes that automatically updates
+description: 'Turn Google Drive meeting notes into an automatically updating Neo4j knowledge graph using CocoIndex’s incremental processing and LLM extraction.'
+slug: meeting_notes_graph
+image: https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/cover.png
+tags: [knowledge-graph, structured-data-extraction]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph)
+
+![Meeting Notes Graph](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/cover.png)
+
+
+Meeting notes capture decisions, action items, participant information, and the relationships between people and tasks. Yet most organizations treat them as static documents—searchable only through basic text search.
+
+With a knowledge graph, you can run queries like: *"Who attended meetings where the topic was 'budget planning'?"* or *"What tasks did Sarah get assigned across all meetings?"*
+
+This example shows how to build a meeting knowledge graph from Google Drive Markdown notes using LLM extraction and Neo4j, with automatic continuous updates.
+
+
+![Neo4j Property Graph](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/neo4j.png)
+
+## The Problem: Unstructured Meeting Data at Enterprise Scale
+
+Even for a conservative estimate, [80% of enterprise data](https://arxiv.org/abs/2406.02962) resides in unstructured files, stored in data lakes that accommodate heterogeneous formats. Organizations hold [62-80 million](https://myhours.com/articles/meeting-statistics-2025) meetings per day in the US.
+
+- **Massive document volumes** - Tens of thousands to millions of meeting notes across departments, teams, and time periods
+- **Continuous editing and updates** - Meeting notes are living documents. Participants correct information, tasks get reassigned, attendee names get fixed, and decisions get updated as situations evolve
+- **Information scattered across systems** - Organizations often use multiple document repositories to store information, and the majority of business documents reside in email inboxes. This fragmentation makes it challenging to build a comprehensive knowledge graph without intelligent, incremental processing.
+
+In a typical large enterprise with thousands of employees, even a conservative estimate of documents needing re-processing due to edits, corrections, and task reassignments could easily reach hundreds or thousands monthly. Without incremental processing capabilities, this creates either unsustainable computational costs or forces organizations to accept stale, outdated knowledge graphs.
+
+## Architecture Overview
+
+The pipeline follows a clear data flow with incremental processing built in at every stage:
+
+```
+Google Drive (Documents - with change tracking)
+  → Identify changed documents
+  → Split into meetings
+  → Extract structured data with LLM (only for changed documents)
+  → Collect nodes and relationships
+  → Export to Neo4j (with upsert logic)
+```
+
+**Prerequisites**
+
+- Install [Neo4j](https://cocoindex.io/docs/targets/neo4j) and start it locally
+    - Default local browser: [http://localhost:7474](http://localhost:7474/)
+    - Default credentials used in this example: username `neo4j`, password `cocoindex`
+    [→ Neo4j Target](https://cocoindex.io/docs/targets/neo4j)
+
+- [Configure your OpenAI API key](https://cocoindex.io/docs/ai/llm#openai)
+- Prepare Google Drive:
+    - Create a Google Cloud service account and download its JSON credential
+    - Share the source folders with the service account email
+    - Collect the root folder IDs you want to ingest
+    - See [Setup for Google Drive](https://cocoindex.io/docs/sources/googledrive#setup-for-google-drive) for details
+    [→ GoogleDrive Source Setup](https://cocoindex.io/docs/sources/googledrive)
+
+**Environment**
+
+Set the following environment variables:
+
+```sh
+export OPENAI_API_KEY=sk-...
+export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/absolute/path/to/service_account.json
+export GOOGLE_DRIVE_ROOT_FOLDER_IDS=folderId1,folderId2
+```
+
+:::info
+- `GOOGLE_DRIVE_ROOT_FOLDER_IDS` accepts a comma-separated list of folder IDs
+- The flow polls recent changes and refreshes periodically
+:::
+
+
+## Flow Definition
+
+### Overview
+
+![Overview](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/flow.png)
+
+### Add source and collector
+
+```python
+@cocoindex.flow_def(name="MeetingNotesGraph")
+def meeting_notes_graph_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    """
+    Define an example flow that extracts triples from files and builds knowledge graph.
+    """
+    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
+    root_folder_ids = os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
+
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.GoogleDrive(
+            service_account_credential_path=credential_path,
+            root_folder_ids=root_folder_ids,
+            recent_changes_poll_interval=datetime.timedelta(seconds=10),
+        ),
+        refresh_interval=datetime.timedelta(minutes=1),
+    )
+```
+
+The pipeline starts by connecting to Google Drive using a service account. CocoIndex's built-in source connector handles authentication and provides **incremental change detection**. The **`recent_changes_poll_interval`** parameter means the source checks for new or modified files every 10 seconds, while the **`refresh_interval`** determines when the entire flow re-runs (every minute).
+
+[→ GoogleDrive Source](https://cocoindex.io/docs/sources/googledrive)
+
+![Ingest documents](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/ingest.png)
+
+This is one of CocoIndex's superpowers: **incremental processing with automatic change tracking**. Instead of reprocessing all documents on every run, the framework:
+
+1. Lists files from Google Drive with last modified time
+2. Identifies only the files that have been added or modified since the last successful run
+3. Skips unchanged files entirely
+4. Passes only changed documents downstream
+
+The result? In an enterprise with 1% daily churn, only 1% of documents trigger downstream processing. Unchanged files never hit your LLM API, never generate Neo4j queries, and never consume compute resources.
+
+Check out How live updates work in CocoIndex:
+
+[→ How live updates work in CocoIndex](https://cocoindex.io/docs/tutorials/live_updates)
+
+
+### Add collector
+
+```python
+meeting_nodes = data_scope.add_collector()
+attended_rels = data_scope.add_collector()
+decided_tasks_rels = data_scope.add_collector()
+assigned_rels = data_scope.add_collector()
+```
+
+[→ Collectors](https://cocoindex.io/docs/core/flow_def#data-collector)
+
+The pipeline then collects data into specialized collectors for different entity types and relationships:
+
+- **Meeting Nodes** - Store the meeting itself with its date and notes
+- **Attendance Relationships** - Capture who attended meetings and whether they were the organizer
+- **Task Decision Relationships** - Link meetings to decisions (tasks that were decided upon)
+- **Task Assignment Relationships** - Assign specific tasks to people
+
+## Process each document
+
+### Extract meetings
+
+```python
+with data_scope["documents"].row() as document:
+    document["meetings"] = document["content"].transform(
+        cocoindex.functions.SplitBySeparators(
+            separators_regex=[r"\n\n##?\ "], keep_separator="RIGHT"
+        )
+    )
+```
+
+Meeting documents often contain multiple meetings in a single file. This step splits documents on Markdown headers (## or #) preceded by blank lines, treating each section as a separate meeting. The **`keep_separator="RIGHT"`** means the separator (header) is kept with the right segment, preserving context.
+
+![Extract meetings](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/meetings.png)
+
+## Extract meeting
+
+### Define Meeting schema
+
+```python
+@dataclass
+class Person:
+    name: str
+
+@dataclass
+class Task:
+    description: str
+    assigned_to: list[Person]
+
+@dataclass
+class Meeting:
+    time: datetime.date
+    note: str
+    organizer: Person
+    participants: list[Person]
+    tasks: list[Task]
+```
+
+The LLM uses the schema of this dataclass as its "extraction template," automatically returning structured data that matches the Python types. This provides direct guidance for the LLM about what information to extract and their schema. This is far more reliable than asking an LLM to generate free-form output, from which we cannot get structured information to build a knowledge graph.
+
+### Extract and collect relationship
+
+```python
+with document["meetings"].row() as meeting:
+    parsed = meeting["parsed"] = meeting["text"].transform(
+        cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                api_type=cocoindex.LlmApiType.OPENAI, model="gpt-5"
+            ),
+            output_type=Meeting,
+        )
+    )
+```
+
+Importantly, this step also benefits from incremental processing. Since `ExtractByLlm` is a heavy step, we keep the output in cache, and as long as inputs (input data text, model, output type definition) have no change, we reuse the cached output without re-running the LLM.
+
+[→ ExtractByLlm](https://cocoindex.io/docs/functions/extract_by_llm)
+
+![Extract metadata](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/metadata.png)
+
+
+## Collect relationship
+
+```python
+meeting_key = {"note_file": document["filename"], "time": parsed["time"]}
+meeting_nodes.collect(**meeting_key, note=parsed["note"])
+
+attended_rels.collect(
+    id=cocoindex.GeneratedField.UUID,
+    **meeting_key,
+    person=parsed["organizer"]["name"],
+    is_organizer=True,
+)
+
+with parsed["participants"].row() as participant:
+    attended_rels.collect(
+        id=cocoindex.GeneratedField.UUID,
+        **meeting_key,
+        person=participant["name"],
+    )
+
+with parsed["tasks"].row() as task:
+    decided_tasks_rels.collect(
+        id=cocoindex.GeneratedField.UUID,
+        **meeting_key,
+        description=task["description"],
+    )
+    with task["assigned_to"].row() as assigned_to:
+        assigned_rels.collect(
+            id=cocoindex.GeneratedField.UUID,
+            **meeting_key,
+            task=task["description"],
+            person=assigned_to["name"],
+        )
+```
+
+**Collectors** in CocoIndex act like in‑memory buffers: you declare collectors for different categories (meeting nodes, attendance, tasks, assignments), then as you process each document you “collect” relevant entries.
+
+This block **collects nodes and relationships** from parsed meeting notes to build a knowledge graph in Neo4j using CocoIndex:
+
+- **Person → Meeting (ATTENDED)**
+
+    Links participants (including organizers) to the meetings they attended.
+
+- **Meeting → Task (DECIDED)**
+
+    Links meetings to tasks or decisions that were made.
+
+- **Person → Task (ASSIGNED_TO)**
+
+    Links tasks back to the people responsible for them.
+
+
+## Map to graph database
+
+### Overview
+
+We will be creating a property graph with following nodes and relationships:
+![Graph](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/graph.png)
+
+To learn more about property graph, please refer to CocoIndex's [Property Graph Targets](https://cocoindex.io/docs/targets#property-graph-targets) documentation.
+
+[→ Neo4j Target](https://cocoindex.io/docs/targets/neo4j)
+
+[→ Property Graph Targets](https://cocoindex.io/docs/targets/#property-graph-targets)
+### Map Meeting Nodes
+
+```python
+meeting_nodes.export(
+    "meeting_nodes",
+    cocoindex.targets.Neo4j(
+        connection=conn_spec, mapping=cocoindex.targets.Nodes(label="Meeting")
+    ),
+    primary_key_fields=["note_file", "time"],
+)
+```
+
+- This uses CocoIndex’s **Neo4j target** to export data to a graph database.
+- The `mapping=cocoindex.targets.Nodes(label="Meeting")` part tells CocoIndex: "Take each row collected in `meeting_nodes` and map it to a **node** in the Neo4j graph, with label `Meeting`."
+- `primary_key_fields=["note_file", "time"]` instructs CocoIndex which fields uniquely identify a node. That way, if the same meeting (same `note_file` and `time`) appears in different runs/updates, it will map to the same node — avoiding duplicates.
+
+### What “node export” means in CocoIndex → Neo4j context
+
+| Collector rows | Graph entities |
+| --- | --- |
+| Each collected row (meeting with its fields) | One node in Neo4j with label `Meeting` |
+| Fields of that row | Properties of the node (e.g. `note_file`, `time`, `note`) |
+
+### Declare Person and Task Nodes
+
+```python
+flow_builder.declare(
+    cocoindex.targets.Neo4jDeclaration(
+        connection=conn_spec,
+        nodes_label="Person",
+        primary_key_fields=["name"],
+    )
+)
+flow_builder.declare(
+    cocoindex.targets.Neo4jDeclaration(
+        connection=conn_spec,
+        nodes_label="Task",
+        primary_key_fields=["description"],
+    )
+)
+```
+
+- The `declare(...)` [method](https://cocoindex.io/docs/core/flow_def) on `flow_builder` lets you **pre‐declare** node labels that may appear as source or target nodes in relationships — even if you don’t have an explicit collector exporting them as standalone node rows.
+- `Neo4jDeclaration` is the specification for such declared nodes: you give it the connection, the node label (type), and the `primary_key_fields` that uniquely identify instances of that node
+
+For example, for the `Person` Declaration,
+
+- You tell CocoIndex: “We expect `Person`‑labeled nodes to exist in the graph. They will be referenced in relationships (e.g. a meeting’s organizer or attendees, task assignee), but we don’t have a dedicated collector exporting Person rows.”
+- By declaring `Person`, CocoIndex will handle deduplication: multiple relationships referencing the same `name` will map to the same `Person` node in Neo4j (because `name` is the primary key).
+
+#### How declaration works with relationships & export logic
+
+- When you later export relationship collectors (e.g. ATTENDED, DECIDED, ASSIGNED_TO), those relationships will reference nodes of type `Person` or `Task`. CocoIndex needs to know how to treat those node labels so it can create or match the corresponding nodes properly. `declare(...)` gives CocoIndex that knowledge.
+- CocoIndex handles **matching & deduplication** of nodes by checking primary‑key fields. If a node with the same primary key already exists, it reuses it rather than creating a duplicate.
+
+### Map ATTENDED Relationship
+
+**ATTENDED relationships**
+
+```python
+attended_rels.export(
+    "attended_rels",
+    cocoindex.targets.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.targets.Relationships(
+            rel_type="ATTENDED",
+            source=cocoindex.targets.NodeFromFields(
+                label="Person",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping(
+                        source="person", target="name"
+                    )
+                ],
+            ),
+            target=cocoindex.targets.NodeFromFields(
+                label="Meeting",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping("note_file"),
+                    cocoindex.targets.TargetFieldMapping("time"),
+                ],
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+- This call ensures that **ATTENDED relationships** — i.e. “Person → Meeting” (organizer or participant → the meeting) — are explicitly encoded as edges in the Neo4j graph.
+- It links `Person` nodes with `Meeting` nodes via `ATTENDED` relationships, enabling queries like “which meetings did Alice attend?” or “who attended meeting X?”.
+- By mapping `Person` and `Meeting` nodes correctly and consistently (using unique keys), it ensures a clean graph with no duplicate persons or meetings.
+- Because relationships get unique IDs and are exported with consistent keys, the graph remains stable across incremental updates: re-runs won’t duplicate edges or nodes.
+
+![Map ATTENDED relationship](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/export.png)
+
+### Map DECIDED Relationship
+
+**DECIDED relationships**
+
+```python
+decided_tasks_rels.export(
+    "decided_tasks_rels",
+    cocoindex.targets.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.targets.Relationships(
+            rel_type="DECIDED",
+            source=cocoindex.targets.NodeFromFields(
+                label="Meeting",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping("note_file"),
+                    cocoindex.targets.TargetFieldMapping("time"),
+                ],
+            ),
+            target=cocoindex.targets.NodeFromFields(
+                label="Task",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping("description"),
+                ],
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+- Encodes **DECIDED** edges: links `Meeting` → `Task` in the graph.
+- Enables queries like: “Tasks decided in Meeting X?” or “Which meeting decided Task Y?”
+- Consistent mapping avoids duplicate nodes; unique IDs keep the graph deduped on re-runs.
+
+### Map ASSIGNED_TO Relationship
+
+**ASSIGNED_TO relationships**
+
+```python
+assigned_rels.export(
+    "assigned_rels",
+    cocoindex.targets.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.targets.Relationships(
+            rel_type="ASSIGNED_TO",
+            source=cocoindex.targets.NodeFromFields(
+                label="Person",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping(
+                        source="person", target="name"
+                    ),
+                ],
+            ),
+            target=cocoindex.targets.NodeFromFields(
+                label="Task",
+                fields=[
+                    cocoindex.targets.TargetFieldMapping(
+                        source="task", target="description"
+                    ),
+                ],
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+It takes all the **task assignment data** you collected (`assigned_rels`) — i.e., which person is responsible for which task.
+
+- This explicitly encodes **task ownership** in the graph, linking people to the tasks they are responsible for.
+- It enables queries like:
+    - "Which tasks is Alice assigned to?"
+    - "Who is responsible for Task X?"
+- By using consistent node mappings (`name` for `Person`, `description` for `Task`), it prevents duplicate person or task nodes.
+- Unique IDs on relationships ensure the graph remains stable across incremental updates — re-running the flow won't create duplicate edges.
+
+## The Resulting Graph
+
+After running this pipeline, your Neo4j database contains a rich, queryable graph:
+
+![Resulting Graph](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/neo4j.png)
+
+**Nodes:**
+- `Meeting`: Individual meetings (date, notes)
+- `Person`: Participants
+- `Task`: Action items
+
+**Relationships:**
+- `ATTENDED`: Person attended Meeting
+- `DECIDED`: Meeting decided Task
+- `ASSIGNED_TO`: Person assigned to Task
+
+CocoIndex exports to Neo4j incrementally—only changed nodes or relationships are updated, avoiding duplicates and minimizing unnecessary writes.
+
+## Run
+
+**Build/update the graph**
+
+Install dependencies:
+
+```sh
+pip install -e .
+```
+
+Update the index (run the flow once to build/update the graph):
+
+```sh
+cocoindex update main
+```
+
+**Browse the knowledge graph**
+
+Open Neo4j Browser at [http://localhost:7474](http://localhost:7474/).
+
+Sample Cypher queries:
+
+```cypher
+// All relationships
+MATCH p=()-->() RETURN p
+
+// Who attended which meetings (including organizer)
+MATCH (p:Person)-[:ATTENDED]->(m:Meeting)
+RETURN p, m
+
+// Tasks decided in meetings
+MATCH (m:Meeting)-[:DECIDED]->(t:Task)
+RETURN m, t
+
+// Task assignments
+MATCH (p:Person)-[:ASSIGNED_TO]->(t:Task)
+RETURN p, t
+```
+
+
+**CocoInsight**
+
+ CocoInsight (Free beta now) is a tool to troubleshoot the index generation and understand the data lineage of the pipeline. It connects to your local CocoIndex server, with Zero pipeline data retention.
+
+Start CocoInsight:
+
+```sh
+cocoindex server -ci main
+```
+
+
+## Key CocoIndex Features Demonstrated
+
+This example showcases several powerful CocoIndex capabilities, each critical for enterprise deployment:
+
+### 1. Incremental Processing with Change Detection
+
+Changes to only a few meeting notes files trigger re-processing of just those files, not the entire document set. This dramatically reduces:
+
+- LLM API costs (99%+ reduction for typical 1% daily churn)
+- Compute resource consumption
+- Database I/O and storage operations
+- Overall pipeline execution time
+
+In large enterprises, this transforms knowledge graph pipelines from expensive luxury to cost-effective standard practice.
+
+### 2. Data Lineage and Observability
+
+CocoIndex tracks data transformations step-by-step. You can see where every field in your Neo4j graph came from—tracing back through LLM extraction, collection, and mapping. This becomes critical when meeting notes are edited: you can identify which changes propagated to the graph and when.
+
+### 3. Declarative Data Flow
+
+The entire pipeline is defined declaratively in Python without complex plumbing. The framework handles scheduling, error recovery, state management, and change tracking automatically. This reduces development time and operational burden compared to building incremental ETL logic from scratch.
+
+### 4. Schema Management and Idempotency
+
+CocoIndex automatically manages Neo4j schema based on your data transformations—creating nodes and relationships on-the-fly while enforcing primary key constraints for data consistency. Primary key fields ensure that document edits, section deletions, and task reassignments update existing records rather than creating duplicates—essential for maintaining data quality in large, evolving document sets.
+
+### 5. Real-time Update Capability
+
+By changing the execution mode from batch to live, the pipeline continuously monitors Google Drive for changes and updates your knowledge graph in near real-time. The moment a meeting note is updated, edited, or a section is deleted, the graph reflects those changes within the next polling interval.
+
+## Summary
+
+The combination of CocoIndex's incremental processing, LLM-powered extraction, and Neo4j's graph database creates a powerful system for turning unstructured meeting notes into queryable, actionable intelligence. In enterprise environments where document volumes reach millions and change rates run into thousands daily, incremental processing isn't a nice-to-have—it's essential for cost-effective, scalable knowledge graph operations.
+
+Rather than drowning in plain-text documents or reprocessing the entire corpus constantly, organizations can now explore meeting data as a connected graph, uncovering patterns and relationships invisible in static documents—without the prohibitive costs of full reprocessing.
+
+This example demonstrates a broader principle: **modern data infrastructure combines AI, databases, and intelligent orchestration**. CocoIndex handles the orchestration with change detection and incremental processing, LLMs provide intelligent understanding, and Neo4j provides efficient relationship querying. Together, they form a foundation for knowledge extraction at enterprise scale.
+
+## Support CocoIndex ❤️
+
+If this example was helpful, the easiest way to support CocoIndex is to [give the project a ⭐ on GitHub](https://github.com/cocoindex-io/cocoindex).
+
+Your stars help us grow the community, stay motivated, and keep shipping better tools for real-time data ingestion and transformation.

--- a/docs/src/content/example-posts/multi_format_index.md
+++ b/docs/src/content/example-posts/multi_format_index.md
@@ -1,0 +1,199 @@
+---
+title: Index PDFs, Images, Slides without OCR
+description: 'Build a visual document indexing pipeline using ColPali to index scanned documents, PDFs, academic papers, presentation slides, and standalone images — all mixed together with charts, tables, and figures - into the same vector space.'
+slug: multi_format_index
+image: https://cocoindex.io/blobs/docs/img/examples/multi_format_index/cover.png
+tags: [vector-index, multi-modal]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/multi_format_indexing)
+
+![Multi Format Index](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/cover.png)
+
+## Overview
+Do you have a messy collection of scanned documents, PDFs, academic papers, presentation slides, and standalone images — all mixed together with charts, tables, and figures — that you want to process into the same vector space for semantic search or to power an AI agent?
+
+In this example, we’ll walk through how to build a visual document indexing pipeline using ColPali for embedding both PDFs and images — and then query the index using natural language.
+
+We’ll skip OCR entirely — ColPali can directly understand document layouts, tables, and figures from images, making it perfect for semantic search across visual-heavy content.
+
+
+## Flow Overview
+![Flow](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/flow.png)
+
+We’ll build a pipeline that:
+
+- **Ingests PDFs and images** from a local directory
+    - **Converts PDF pages** into high-resolution images (300 DPI)
+    - **Generates visual embeddings** for each page/image using ColPali
+- **Stores embeddings + metadata** in a Qdrant vector database
+- **Supports natural language queries** directly against the visual index
+
+Example queries:
+
+- *"handwritten lab notes about physics"*
+- *"architectural floor plan with annotations"*
+- *"pie chart of Q3 revenue"*
+
+
+## Image Ingestion
+
+We use CocoIndex’s `LocalFile` source to read PDFs and images:
+
+```python
+data_scope["documents"] = flow_builder.add_source(
+    cocoindex.sources.LocalFile(path="source_files", binary=True)
+)
+```
+[→ LocalFile](https://cocoindex.io/docs/sources/localfile)
+
+
+## Convert Files to Pages
+
+We classify files by MIME type and process accordingly.
+
+Define a dataclass:
+
+- `page_number`: The page number (if applicable — only for PDFs)
+- `image`: The binary content of that page as a PNG image
+
+```python
+@dataclass
+class Page:
+  page_number: int | None
+  image: bytes
+```
+
+Normalizes different file formats into a **list of page images** so the rest of the pipeline can process them uniformly. This `file_to_pages` function takes a **filename** and its **raw binary content** (`bytes`) and returns a list of `Page` objects, where each `Page` contains:
+
+```python
+@cocoindex.op.function()
+def file_to_pages(filename: str, content: bytes) -> list[Page]:
+    mime_type, _ = mimetypes.guess_type(filename)
+
+    if mime_type == "application/pdf":
+        images = convert_from_bytes(content, dpi=300)
+        pages = []
+        for i, image in enumerate(images):
+            with BytesIO() as buffer:
+                image.save(buffer, format="PNG")
+                pages.append(Page(page_number=i + 1, image=buffer.getvalue()))
+        return pages
+    elif mime_type and mime_type.startswith("image/"):
+        return [Page(page_number=None, image=content)]
+    else:
+        return []
+```
+
+For each document:
+- If the file is an image → `file_to_pages` returns a single `Page` where `page["image"]` is just the original image binary.
+- If the file is a PDF → `file_to_pages` converts each page to a PNG, so `page["image"]` contains that page’s PNG binary.
+
+
+In the flow we convert all the files to pages. this makes each pages and all images in the output data - pages.
+
+```jsx
+ output_embeddings = data_scope.add_collector()
+
+ with data_scope["documents"].row() as doc:
+    doc["pages"] = flow_builder.transform(
+        file_to_pages, filename=doc["filename"], content=doc["content"]
+    )
+```
+![Pages](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/pages.png)
+
+
+## Generate Visual Embeddings
+
+We use ColPali to generate embeddings for images on each page.
+
+```python
+with doc["pages"].row() as page:
+    page["embedding"] = page["image"].transform(
+        cocoindex.functions.ColPaliEmbedImage(model=COLPALI_MODEL_NAME)
+    )
+    output_embeddings.collect(
+                id=cocoindex.GeneratedField.UUID,
+                filename=doc["filename"],
+                page=page["page_number"],
+                embedding=page["embedding"],
+            )
+```
+
+[→ ColPaliEmbedImage](https://cocoindex.io/docs/ops/functions#colpaliembedimage)
+
+
+![Embedding](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/embed.png)
+
+ColPali Architecture fundamentally rethinks how documents, especially visually complex or image-rich ones, are represented and searched. Instead of reducing each image or page to a single dense vector (as in traditional bi-encoders), ColPali breaks an image into many smaller patches, preserving local spatial and semantic structure.
+
+Each patch receives its own embedding, which together form a multi-vector representation of the complete document.
+
+![ColPali](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/colpali_architecture.png)
+
+[→ Colpali Architecture](https://cocoindex.io/blogs/colpali)
+
+
+## Export to Qdrant
+
+Note the way to embed image and query are different, as they’re two different types of data.
+
+Create a function to embed query:
+
+```python
+@cocoindex.transform_flow()
+def query_to_colpali_embedding(
+    text: cocoindex.DataSlice[str],
+) -> cocoindex.DataSlice[list[list[float]]]:
+    return text.transform(
+        cocoindex.functions.ColPaliEmbedQuery(model=COLPALI_MODEL_NAME)
+    )
+```
+
+[→ ColPaliEmbedQuery](https://cocoindex.io/docs/ops/functions#colpaliembedquery)
+
+We store metadata and embeddings in Qdrant:
+
+```jsx
+output_embeddings.export(
+    "multi_format_indexings",
+    cocoindex.targets.Qdrant(
+        connection=qdrant_connection,
+        collection_name=QDRANT_COLLECTION,
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+## Query the Index with Natural Language
+
+ColPali supports **text-to-visual embeddings**, so we can search using natural language:
+
+```python
+query_embedding = query_to_colpali_embedding.eval(query)
+
+search_results = client.query_points(
+    collection_name=QDRANT_COLLECTION,
+    query=query_embedding,
+    using="embedding",
+    limit=5,
+    with_payload=True,
+)
+```
+
+## CocoInsight
+
+You can walk through the project step by step in [CocoInsight](https://www.youtube.com/watch?v=MMrpUfUcZPk) to see exactly how each field is constructed and what happens behind the scenes.
+
+```sh
+cocoindex server -ci main
+```
+
+Follow the url `https://cocoindex.io/cocoinsight`.  It connects to your local CocoIndex server, with zero pipeline data retention. You can use it to view extracted pages, see embedding vectors and metadata.
+
+
+## Connect to other sources
+CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more.
+
+[→ Sources](https://cocoindex.io/docs/sources)

--- a/docs/src/content/example-posts/patient_form_extraction.md
+++ b/docs/src/content/example-posts/patient_form_extraction.md
@@ -1,0 +1,298 @@
+---
+title: Extract Nested Structured Data from Patient Form
+description: 'Extract nested structured data from patient form and performs data mapping and field level transformation.'
+slug: patient_form_extraction
+image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/cover.png
+tags: [structured-data-extraction, data-mapping]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction)
+[→ Watch on YouTube](https://youtu.be/_mjlwVtnBn0?si=-TBImMyZbnKh-5FB)
+
+![Patient Form Extraction](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/cover.png)
+
+## Overview
+
+With CocoIndex, you can easily define nested schema in Python dataclass and use LLM to extract structured data from unstructured data. This example shows how to extract structured data from patient intake forms.
+
+:::info
+The extraction quality is highly dependent on the OCR quality. You can use CocoIndex with any commercial parser or open source ones that is tailored for your domain for better results. For example, Document AI from Google Cloud and more.
+:::
+
+## Flow Overview
+
+![Flow overview](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/flow.png)
+
+The flow itself is fairly simple.
+
+1. Import a list o intake forms.
+2. For each file:
+    - Convert the file to Markdown.
+    - Extract structured data from the Markdown.
+3. Export selected fields to tables in Postgres with PGVector.
+
+## Setup
+
+- If you don't have Postgres installed, please refer to the [installation guide](https://cocoindex.io/docs/getting_started/installation).
+- [Configure your OpenAI API key](https://cocoindex.io/docs/ai/llm#openai). Create a `.env` file from `.env.example`, and fill `OPENAI_API_KEY`.
+
+Alternatively, we have native support for Gemini, Ollama, LiteLLM. You can choose your favorite LLM provider and work completely on-premises.
+
+  [→ LLM](https://cocoindex.io/docs/ai/llm)
+
+## Add source
+
+Add source from local files.
+
+```python
+
+@cocoindex.flow_def(name="PatientIntakeExtraction")
+def patient_intake_extraction_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+):
+    """
+    Define a flow that extracts patient information from intake forms.
+    """
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path=os.path.join('data', 'patient_forms'), binary=True)
+    )
+```
+
+`flow_builder.add_source` will create a table with a few sub fields.
+
+[→ Sources](https://cocoindex.io/docs/sources)
+
+## Parse documents with different formats to Markdown
+
+Define a custom function to parse documents in any format to Markdown. Here we use [MarkItDown](https://github.com/microsoft/markitdown) to convert the file to Markdown. It also provides options to parse by LLM, like `gpt-4o`. At present, MarkItDown supports: PDF, Word, Excel, Images (EXIF metadata and OCR), etc.
+
+```python
+class ToMarkdown(cocoindex.op.FunctionSpec):
+    """Convert a document to markdown."""
+
+@cocoindex.op.executor_class(gpu=True, cache=True, behavior_version=1)
+class ToMarkdownExecutor:
+    """Executor for ToMarkdown."""
+
+    spec: ToMarkdown
+    _converter: MarkItDown
+
+    def prepare(self):
+        client = OpenAI()
+        self._converter = MarkItDown(llm_client=client, llm_model="gpt-4o")
+
+    def __call__(self, content: bytes, filename: str) -> str:
+        suffix = os.path.splitext(filename)[1]
+        with tempfile.NamedTemporaryFile(delete=True, suffix=suffix) as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            text = self._converter.convert(temp_file.name).text_content
+            return text
+```
+
+Next we plug it into the data flow.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["markdown"] = doc["content"].transform(ToMarkdown(), filename=doc["filename"])
+```
+
+![Markdown](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/tomarkdown.png)
+
+## Define output schema
+
+We are going to define the patient info schema for structured extraction. One of the best examples to define a patient info schema is probably following the [FHIR standard - Patient Resource](https://build.fhir.org/patient.html#resource).
+
+In this tutorial, we'll define a simplified schema in nested dataclass for patient information extraction:
+
+```python
+@dataclasses.dataclass
+class Contact:
+    name: str
+    phone: str
+    relationship: str
+
+@dataclasses.dataclass
+class Address:
+    street: str
+    city: str
+    state: str
+    zip_code: str
+
+@dataclasses.dataclass
+class Pharmacy:
+    name: str
+    phone: str
+    address: Address
+
+@dataclasses.dataclass
+class Insurance:
+    provider: str
+    policy_number: str
+    group_number: str | None
+    policyholder_name: str
+    relationship_to_patient: str
+
+@dataclasses.dataclass
+class Condition:
+    name: str
+    diagnosed: bool
+
+@dataclasses.dataclass
+class Medication:
+    name: str
+    dosage: str
+
+@dataclasses.dataclass
+class Allergy:
+    name: str
+
+@dataclasses.dataclass
+class Surgery:
+    name: str
+    date: str
+
+@dataclasses.dataclass
+class Patient:
+    name: str
+    dob: datetime.date
+    gender: str
+    address: Address
+    phone: str
+    email: str
+    preferred_contact_method: str
+    emergency_contact: Contact
+    insurance: Insurance | None
+    reason_for_visit: str
+    symptoms_duration: str
+    past_conditions: list[Condition]
+    current_medications: list[Medication]
+    allergies: list[Allergy]
+    surgeries: list[Surgery]
+    occupation: str | None
+    pharmacy: Pharmacy | None
+    consent_given: bool
+    consent_date: datetime.date | None
+```
+
+A simplified illustration of the nested fields and its definition:
+
+![Patient Fields](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/fields.png)
+
+## Extract structured data from Markdown
+
+CocoIndex provides built-in functions (e.g. `ExtractByLlm`) that process data using LLMs. With CocoIndex, you can directly pass the Python dataclass `Patient` to the function, and it will automatically parse the LLM response into the dataclass.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["patient_info"] = doc["markdown"].transform(
+        cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                api_type=cocoindex.LlmApiType.OPENAI, model="gpt-4o"),
+            output_type=Patient,
+            instruction="Please extract patient information from the intake form."))
+    patients_index.collect(
+        filename=doc["filename"],
+        patient_info=doc["patient_info"],
+    )
+```
+
+[→ ExtractByLlm](https://cocoindex.io/docs/ops/functions#extractbyllm)
+
+![Extracted](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/extraction.png)
+
+After the extraction, we collect all the fields for simplicity. You can also select any fields and also perform data mapping and field level transformation on the fields before the collection.
+
+## Export the extracted data to a table
+
+```python
+patients_index.export(
+    "patients",
+    cocoindex.storages.Postgres(table_name="patients_info"),
+    primary_key_fields=["filename"],
+)
+```
+
+## Run and Query
+
+### Install dependencies
+
+    ```sh
+    pip install -e .
+    ```
+
+### Setup and update the index
+
+    ```sh
+    cocoindex update main
+    ```
+    You'll see the index updates state in the terminal
+
+### Query the output table
+
+After the index is built, you have a table with the name `patients_info`. You can query it at any time, e.g., start a Postgres shell:
+
+```sh
+psql postgres://cocoindex:cocoindex@localhost/cocoindex
+```
+
+The run:
+
+```sql
+select * from patients_info;
+```
+
+You could see the patients_info table.
+
+## Evaluate
+
+For mission-critical use cases, it is important to evaluate the quality of the extraction. CocoIndex supports a simple way to evaluate the extraction. More updates are coming soon.
+
+1. Dump the extracted data to YAML files.
+
+    ```sh
+    python3 main.py cocoindex evaluate
+    ```
+
+    It dumps what should be indexed to files under a directory. Using my example data sources, it looks like [the golden files](https://github.com/cocoindex-io/patient-intake-extraction/tree/main/data/eval_PatientIntakeExtraction_golden) with a timestamp on the directory name.
+
+2. Compare the extracted data with golden files.
+    We created a directory with golden files for each patient intake form. You can find them [here](https://github.com/cocoindex-io/patient-intake-extraction/tree/main/data/eval_PatientIntakeExtraction_golden).
+
+    You can run the following command to see the diff:
+
+    ```sh
+    diff -r data/eval_PatientIntakeExtraction_golden data/eval_PatientIntakeExtraction_output
+    ```
+
+    I used a tool called [DirEqual](https://apps.apple.com/us/app/direqual/id1435575700) for mac. We also recommend [Meld](https://meldmerge.org/) for Linux and Windows.
+
+    A diff from DirEqual looks like this:
+
+    And double click on any row to see file level diff. In my case, there's missing `condition` for `Patient_Intake_Form_Joe.pdf` file.
+
+## Troubleshooting
+
+If extraction is not ideal, this is how I troubleshoot. My original golden file for this record is [this one](https://github.com/cocoindex-io/patient-intake-extraction/blob/main/data/example_forms/Patient_Intake_Form_Joe_Artificial.pdf).
+
+We could troubleshoot in two steps:
+
+1. Convert to Markdown
+2. Extract structured data from Markdown
+
+I also use CocoInsight to help me troubleshoot.
+
+```sh
+cocoindex server -ci main
+```
+
+Go to `https://cocoindex.io/cocoinsight`. You could see an interactive UI to explore the data.
+
+Click on the `markdown` column for `Patient_Intake_Form_Joe.pdf`, you could see the Markdown content. We could try a few different models with the Markdown converter/LLM to iterate and see if we can get better results, or needs manual correction.
+
+## Connect to other sources
+
+CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more.
+
+[→ Sources](https://cocoindex.io/docs/sources)

--- a/docs/src/content/example-posts/patient_form_extraction_baml.md
+++ b/docs/src/content/example-posts/patient_form_extraction_baml.md
@@ -1,0 +1,312 @@
+---
+title: Extracting Intake Forms with BAML and CocoIndex
+description: 'How to use BAML together with CocoIndex to build a data pipeline that extracts structured patient information from PDF intake forms.'
+slug: patient_form_extraction_baml
+image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/cover.png
+tags: [structured-data-extraction, custom-building-blocks]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_baml)
+
+![Patient Form Extraction](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/cover.png)
+
+## Overview
+
+
+This tutorial shows how to use BAML together with CocoIndex to build a data pipeline that extracts structured patient information from PDF intake forms.  The BAML definitions describe the desired output schema and prompt logic, while CocoIndex orchestrates file input, transformation, and incremental indexing.
+
+:::info
+The extraction quality is highly dependent on the OCR quality. You can use CocoIndex with any commercial parser or open source ones that is tailored for your domain for better results. For example, Document AI from Google Cloud and more.
+:::
+
+## Flow Overview
+
+![Flow overview](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/flow.png)
+
+The flow itself is fairly simple.
+
+1. Read PDF files from a directory.
+2. For each file, call the BAML function to get a structured `Patient`.
+3. Collect results and export to Postgres.
+
+## Setup
+
+1. [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+2. Install dependencies
+
+    ```
+    pip install -U cocoindex baml-py
+    ```
+3. Create a `.env` file. You can copy it from `.env.example` first:
+
+    ```
+    cp .env.example .env
+    ```
+
+    Then edit the file to fill in your `GEMINI_API_KEY`.
+
+
+## Structured Extraction Component with BAML
+
+Create a `baml_src/` directory for your BAML definitions. We’ll define a schema for patient intake data (nested classes) and a function that prompts Gemini to extract those fields from a PDF. Save this as `baml_src/patient.baml`
+
+### Define Patient Schema
+
+**Classes**: We defined Pydantic-style classes (`Contact`, `Address`, `Insurance`, etc.) to match the FHIR-inspired patient schema. These become typed output models. Required fields are non-nullable; optional fields use `?`.
+
+![Schema](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/schema.png)
+
+```python
+class Contact {
+  name string
+  phone string
+  relationship string
+}
+
+class Address {
+  street string
+  city string
+  state string
+  zip_code string
+}
+
+class Pharmacy {
+  name string
+  phone string
+  address Address
+}
+
+class Insurance {
+  provider string
+  policy_number string
+  group_number string?
+  policyholder_name string
+  relationship_to_patient string
+}
+
+class Condition {
+  name string
+  diagnosed bool
+}
+
+class Medication {
+  name string
+  dosage string
+}
+
+class Allergy {
+  name string
+}
+
+class Surgery {
+  name string
+  date string
+}
+
+class Patient {
+  name string
+  dob string
+  gender string
+  address Address
+  phone string
+  email string
+  preferred_contact_method string
+  emergency_contact Contact
+  insurance Insurance?
+  reason_for_visit string
+  symptoms_duration string
+  past_conditions Condition[]
+  current_medications Medication[]
+  allergies Allergy[]
+  surgeries Surgery[]
+  occupation string?
+  pharmacy Pharmacy?
+  consent_given bool
+  consent_date string?
+}
+```
+
+### Define the BAML function to extract patient info from a PDF
+
+```python
+function ExtractPatientInfo(intake_form: pdf) -> Patient {
+  client Gemini
+  prompt #"
+    Extract all patient information from the following intake form document.
+    Please be thorough and extract all available information accurately.
+
+    {{ _.role("user") }}
+    {{ intake_form }}
+
+    Fill in with "N/A" for required fields if the information is not available.
+
+    {{ ctx.output_format }}
+  "#
+}
+```
+
+We specify `client Gemini` and a prompt template. The special variable `{{ intake_form }}` injects the PDF, and `{{ ctx.output_format }}` tells BAML to expect the structured format defined by the return type. The prompt explicitly asks Gemini to extract all fields, filling “N/A” if missing.
+
+:::tip Why `role("user")` Matters in BAML Extraction
+
+In our BAML example above, there's a subtle but **crucial line**: `{{ _.role("user") }}` is added at the start of the prompt.
+
+> This ensures the PDF content is explicitly included as part of the user message*, rather than the system prompt.
+
+For **OpenAI models**, if the PDF is not in the user role, the model doesn't see the file content — so extractions will fail or return empty fields. This can easily trip you up.
+
+:::
+
+
+
+## Configure the LLM client to use Google’s Gemini model
+
+```python
+client<llm> Gemini {
+  provider google-ai
+  options {
+    model gemini-2.5-flash
+    api_key env.GEMINI_API_KEY
+  }
+}
+```
+
+### Configure BAML generator
+
+In `baml_src` folder add `generator.baml`
+
+```python
+generator python_client {
+  output_type python/pydantic
+  output_dir "../"
+  version "0.213.0"
+}
+```
+
+The `generator` block tells `baml-cli` to create a Python client with Pydantic models in the parent directory.
+
+When we run `baml-cli generate`
+
+This will compile the `.baml` definitions into a `baml_client/` Python package in your project root. It contains:
+
+- `baml_client/types.py` with Pydantic classes (`Patient`, etc.).
+- `baml_client/sync_client.py` and `async_client.py` with a callable `b` object. For example, `b.ExtractPatientInfo(pdf)` will return a `Patient`.
+
+## Alternative - Native ExtractByLLM Component
+If you prefer to define the extraction logic in a native CocoIndex function with native Python class, you could also use the `ExtractByLLM` component.
+
+[→ ExtractByLLM](https://cocoindex.io/docs/ops/functions#extractbyllm)
+
+You could see an example [here](/examples/patient_form_extraction).
+
+
+## Continuous Data Transformation flow with incremental processing
+
+Next we will define data transformation flow with CocoIndex. Once you declared the state and transformation logic,  CocoIndex will take care of all the state change for you from source to target.
+
+### CocoIndex Flow
+
+#### Declare Flow
+
+Declare a CocoIndex flow, connect to the source, add a data collector to collect processed data.
+
+```python
+@cocoindex.flow_def(name="PatientIntakeExtractionBaml")
+def patient_intake_extraction_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(
+            path=os.path.join("data", "patient_forms"), binary=True
+        )
+    )
+
+    patients_index = data_scope.add_collector()
+```
+
+This iterates over each document. We transform `doc["content"]` (the bytes) by our `extract_patient_info` function. The result is stored in a new field `patient_info`. Then we collect a row with the filename and extracted patient info.
+
+![Ingesting Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/ingest.png)
+
+#### Define a custom function to use BAML extraction to transform a PDF
+
+```python
+@cocoindex.op.function(cache=True, behavior_version=1)
+async def extract_patient_info(content: bytes) -> Patient:
+    pdf = baml_py.Pdf.from_base64(base64.b64encode(content).decode("utf-8"))
+    return await b.ExtractPatientInfo(pdf)
+```
+
+- `@cocoindex.op.function(cache=True, behavior_version=1)` caches results for incremental processing; bump `behavior_version` to refresh cache if logic changes.
+- The function base64-encodes input bytes, creates a BAML `Pdf`, and calls `await b.ExtractPatientInfo(pdf)` to return a `Patient` object.
+
+[→ Custom Function](https://cocoindex.io/docs/custom_ops/custom_functions)
+
+
+#### Process each document
+
+1. Transform each doc with BAML
+2. collect the structured output
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["patient_info"] = doc["content"].transform(extract_patient_info)
+
+    patients_index.collect(
+        filename=doc["filename"],
+        patient_info=doc["patient_info"],
+    )
+```
+
+![Transforming Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/transform.png)
+
+It is common to have heavy nested data, CocoIndex is natively designed to handle heavily nested data structures.
+
+![Nested Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/nested.png)
+
+### Export to Postgres
+
+```python
+patients_index.export(
+    "patients",
+    cocoindex.storages.Postgres(),
+    primary_key_fields=["filename"],
+)
+```
+
+Exports the index to Postgres as the `patients` table, with automatic updates and deletions when source files change.
+
+## Running the Pipeline
+
+**Generate BAML client code** (required step, in case you didn’t do it earlier. )
+
+```sh
+baml generate
+```
+
+This generates the `baml_client/` directory with Python code to call your BAML functions.
+
+Update the index:
+
+```sh
+cocoindex update main
+```
+
+**CocoInsight**
+
+I used CocoInsight (Free beta now) to troubleshoot the index generation and understand the data lineage of the pipeline. It just connects to your local CocoIndex server, with zero pipeline data retention.
+
+```sh
+cocoindex server -ci main
+```
+
+## Composable by Default: Use the Best Components for Your Use Case
+
+CocoIndex offers a comprehensive toolkit for building robust LLM pipelines, but it's intentionally built as an open and interoperable system. You can seamlessly incorporate your own preferred components—such as custom document parsers or structured extraction tools like BAML—according to your domain requirements.
+
+## Connect to other sources
+
+CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more.
+
+[→ Sources](https://cocoindex.io/docs/sources)

--- a/docs/src/content/example-posts/patient_form_extraction_dspy.md
+++ b/docs/src/content/example-posts/patient_form_extraction_dspy.md
@@ -1,0 +1,465 @@
+---
+title: Extracting Intake Forms with DSPy and CocoIndex
+description: 'How to use DSPy together with CocoIndex to build a data pipeline that extracts structured patient information from PDF intake forms using vision models.'
+slug: patient_form_extraction_dspy
+image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/cover.png
+tags: [structured-data-extraction, custom-building-blocks, vision-models]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_dspy)
+
+![Patient Form Extraction with DSPy](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/cover.png)
+
+## Overview
+
+This tutorial shows how to use DSPy together with CocoIndex to build a data pipeline that extracts structured patient information from PDF intake forms using vision models. DSPy provides a programming framework for LLMs with typed Signatures and Modules, while CocoIndex orchestrates file input, transformation, and incremental indexing.
+
+:::info
+The extraction quality is highly dependent on the OCR quality. You can use CocoIndex with any commercial parser or open source ones that is tailored for your domain for better results. For example, Document AI from Google Cloud and more.
+:::
+
+## Why DSPy + CocoIndex?
+
+### DSPy: A programming framework for LLMs
+
+Traditional LLM apps rely on prompt engineering: you write a prompt with instructions, few‑shot examples, and formatting, then call the model and parse the raw text. This approach is fragile:
+
+- Small changes in the prompt, model, or data can break the output format or quality.
+- Logic is buried in strings, making it hard to test, compose, or version.
+
+[DSPy](https://github.com/stanfordnlp/dspy) replaces this with a programming model: you define what each LLM step should do (inputs, outputs, constraints), and the framework figures out how to prompt the model to satisfy that spec.
+
+### CocoIndex: An ultra performant data processing engine for AI workloads
+
+[CocoIndex](https://github.com/cocoindex-io/cocoindex) is an ultra performant compute framework for AI workloads, with incremental processing. Users write simple in-memory computations in Python and coco runs it as a resilient, scalable data pipeline (with Rust Engine) – with fresh data always ready for serving. Same flow definition you use in a notebook can be lifted easily into production.
+
+With CocoIndex, changes in sources or transformation logic only trigger minimal recompute, cutting cold-start "backfill" latencies from hours to seconds while reducing GPU/API spend. In production, this manifests as always-fresh targets: you run in "live" mode with change data capture or polling, and CocoIndex keeps derived stores in sync with complex unstructured sources like codebases, PDFs, and multi-hop API compositions.
+
+Because every transformation step is observable with lineage, teams get auditability and explainability out of the box, which helps for regulated scenarios like healthcare extraction or financial workflows.
+
+### DSPy & CocoIndex Synergy
+
+The synergy shows up most clearly in end-to-end AI data products: DSPy defines robust, typed extractors or decision modules, and CocoIndex wires them into a resilient, incremental pipeline that can meet SLOs and compliance needs. Any change in documents, code, or business rules is reflected quickly and explainably in the targets and features those agents consume.
+
+## Flow Overview
+
+![Flow overview](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/flow.png)
+
+The flow itself is fairly simple.
+
+1. Read PDF files from a directory.
+2. For each file, convert PDF pages to images and use DSPy with Gemini Vision to extract structured `Patient` data.
+3. Collect results and export to Postgres.
+
+## Setup
+
+1. [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+2. Install dependencies
+
+    ```
+    pip install -U cocoindex dspy-ai pydantic pymupdf
+    ```
+
+3. Create a `.env` file:
+
+    ```
+    # Postgres database address for cocoindex
+    COCOINDEX_DATABASE_URL=postgres://cocoindex:cocoindex@localhost/cocoindex
+
+    # Gemini API key
+    GEMINI_API_KEY=YOUR_GEMINI_API_KEY
+    ```
+
+## Pydantic Models: Define the structured schema
+
+We defined Pydantic-style classes (`Contact`, `Address`, `Insurance`, etc.) to match a *FHIR-inspired patient schema*, enabling structured and validated representations of patient data. Each model corresponds to a key aspect of a patient's record, ensuring both type safety and nested relationships.
+
+![Patient schema](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/schema.png)
+
+### 1. Contact Model
+
+```python
+class Contact(BaseModel):
+    name: str
+    phone: str
+    relationship: str
+```
+
+- Represents an **emergency or personal contact** for the patient.
+- Fields:
+    - `name`: Contact's full name.
+    - `phone`: Contact phone number.
+    - `relationship`: Relation to the patient (e.g., parent, spouse, friend).
+
+### 2. Address Model
+
+```python
+class Address(BaseModel):
+    street: str
+    city: str
+    state: str
+    zip_code: str
+```
+
+- Represents a **postal address**.
+- Fields:
+    - `street`, `city`, `state`, `zip_code`: Standard address fields.
+
+### 3. Pharmacy Model
+
+```python
+class Pharmacy(BaseModel):
+    name: str
+    phone: str
+    address: Address
+```
+
+- Represents the **patient's preferred pharmacy**.
+- Fields:
+    - `name`: Pharmacy name.
+    - `phone`: Pharmacy contact number.
+    - `address`: Uses the `Address` model for structured address information.
+
+### 4. Insurance Model
+
+```python
+class Insurance(BaseModel):
+    provider: str
+    policy_number: str
+    group_number: str | None = None
+    policyholder_name: str
+    relationship_to_patient: str
+```
+
+- Represents the patient's **insurance information**.
+- Fields:
+    - `provider`: Insurance company name.
+    - `policy_number`: Unique policy number.
+    - `group_number`: Optional group number.
+    - `policyholder_name`: Name of the person covered under the insurance.
+    - `relationship_to_patient`: Relationship to patient (e.g., self, parent).
+
+### 5. Condition Model
+
+```python
+class Condition(BaseModel):
+    name: str
+    diagnosed: bool
+```
+
+- Represents a **medical condition**.
+- Fields:
+    - `name`: Condition name (e.g., Diabetes).
+    - `diagnosed`: Boolean indicating whether it has been officially diagnosed.
+
+### 6. Medication Model
+
+```python
+class Medication(BaseModel):
+    name: str
+    dosage: str
+```
+
+- Represents a **current medication** the patient is taking.
+- Fields:
+    - `name`: Medication name.
+    - `dosage`: Dosage information (e.g., "10mg daily").
+
+### 7. Allergy Model
+
+```python
+class Allergy(BaseModel):
+    name: str
+```
+
+- Represents a **known allergy**.
+- Fields:
+    - `name`: Name of the allergen (e.g., peanuts, penicillin).
+
+### 8. Surgery Model
+
+```python
+class Surgery(BaseModel):
+    name: str
+    date: str
+```
+
+- Represents a **surgery or procedure** the patient has undergone.
+- Fields:
+    - `name`: Surgery name (e.g., Appendectomy).
+    - `date`: Surgery date (as a string, ideally ISO format).
+
+### 9. Patient Model
+
+```python
+class Patient(BaseModel):
+    name: str
+    dob: datetime.date
+    gender: str
+    address: Address
+    phone: str
+    email: str
+    preferred_contact_method: str
+    emergency_contact: Contact
+    insurance: Insurance | None = None
+    reason_for_visit: str
+    symptoms_duration: str
+    past_conditions: list[Condition] = Field(default_factory=list)
+    current_medications: list[Medication] = Field(default_factory=list)
+    allergies: list[Allergy] = Field(default_factory=list)
+    surgeries: list[Surgery] = Field(default_factory=list)
+    occupation: str | None = None
+    pharmacy: Pharmacy | None = None
+    consent_given: bool
+    consent_date: str | None = None
+```
+
+- Represents a **complete patient record** with personal, medical, and administrative information.
+- Key fields:
+    - `name`, `dob`, `gender`: Basic personal info.
+    - `address`, `phone`, `email`: Contact info.
+    - `preferred_contact_method`: How the patient prefers to be reached.
+    - `emergency_contact`: Nested `Contact` model.
+    - `insurance`: Optional nested `Insurance` model.
+    - `reason_for_visit`, `symptoms_duration`: Visit details.
+    - `past_conditions`, `current_medications`, `allergies`, `surgeries`: Lists of nested models for comprehensive medical history.
+    - `occupation`: Optional job info.
+    - `pharmacy`: Optional nested `Pharmacy` model.
+    - `consent_given`, `consent_date`: Legal/administrative consent info.
+
+### Why Use Pydantic Here?
+
+1. **Validation:** Ensures all fields are the correct type (e.g., `dob` is a `date`).
+2. **Structured Nested Models:** Patient has nested objects like `Address`, `Contact`, and `Insurance`.
+3. **Default Values & Optional Fields:** Handles optional fields and defaults (`Field(default_factory=list)` ensures empty lists if no data).
+4. **Serialization:** Easily convert models to JSON for APIs or databases.
+5. **Error Checking:** Automatically raises errors if invalid data is provided.
+
+## DSPy Vision Extractor
+
+### DSPy Signature
+
+Let's define `PatientExtractionSignature`. A **Signature** describes what data your module expects and what it will produce. Think of it as a **schema for an AI task**.
+
+`PatientExtractionSignature` is a `dspy.Signature`, which is DSPy's way of declaring *what* the model should do, not *how* it does it.
+
+```python
+# DSPy Signature for patient information extraction from images
+class PatientExtractionSignature(dspy.Signature):
+    """Extract structured patient information from a medical intake form image."""
+
+    form_images: list[dspy.Image] = dspy.InputField(
+        desc="Images of the patient intake form pages"
+    )
+    patient: Patient = dspy.OutputField(
+        desc="Extracted patient information with all available fields filled"
+    )
+```
+
+This signature defines **task contract** for patient information extraction.
+
+- Inputs: `form_images` – a list of images of the intake form.
+- Outputs: `patient` – a structured `Patient` object.
+
+From DSPy's point of view, this Signature is a "spec": a mapping from an image-based context to a structured, Pydantic-backed semantic object that can later be optimized, trained, and composed with other modules.
+
+### PatientExtractor Module
+
+`PatientExtractor` is a `dspy.Module`, which in DSPy is a composable, potentially trainable building block that implements the Signature.
+
+```python
+class PatientExtractor(dspy.Module):
+    """DSPy module for extracting patient information from intake form images."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.extract = dspy.ChainOfThought(PatientExtractionSignature)
+
+    def forward(self, form_images: list[dspy.Image]) -> Patient:
+        """Extract patient information from form images and return as a Pydantic model."""
+        result = self.extract(form_images=form_images)
+        return result.patient  # type: ignore
+```
+
+- In `__init__`, `ChainOfThought` is a DSPy *primitive module* that knows how to call an LLM with reasoning-style prompting to satisfy the given Signature. In other words, it is a default "strategy" for solving the "extract patient from images" task.
+- The `forward` method is DSPy's standard interface for executing a module. You pass `form_images` into `self.extract()`. DSPy then handles converting this call into an LLM interaction (or a trained program) that produces a `patient` field as declared in the Signature.
+
+Conceptually, `PatientExtractor` is an *ETL operator*: the Signature describes the input/output types, and the internal `ChainOfThought` module is the function that fills that contract.
+
+### Single-Step Extraction
+
+Now let's wire the DSPy Module to extract from a single PDF. From high level,
+
+- The extractor receives PDF bytes directly
+- Internally converts PDF pages to DSPy Image objects using PyMuPDF
+- Processes images with vision model
+- Returns Pydantic model directly
+
+```python
+@cocoindex.op.function(cache=True, behavior_version=1)
+def extract_patient(pdf_content: bytes) -> Patient:
+    """Extract patient information from PDF content."""
+
+    # Convert PDF pages to DSPy Image objects
+    pdf_doc = pymupdf.open(stream=pdf_content, filetype="pdf")
+
+    form_images = []
+    for page in pdf_doc:
+        # Render page to pixmap (image) at 2x resolution for better quality
+        pix = page.get_pixmap(matrix=pymupdf.Matrix(2, 2))
+        # Convert to PNG bytes
+        img_bytes = pix.tobytes("png")
+        # Create DSPy Image from bytes
+        form_images.append(dspy.Image(img_bytes))
+
+    pdf_doc.close()
+
+    # Extract patient information using DSPy with vision
+    extractor = PatientExtractor()
+    patient = extractor(form_images=form_images)
+
+    return patient  # type: ignore
+```
+
+This function is a **CocoIndex function** (decorated with `@cocoindex.op.function`) that takes **PDF bytes** as input and returns a fully structured `Patient` Pydantic object.
+
+- `cache=True` allows repeated calls with the same PDF to **reuse results**.
+- `behavior_version=1` ensures versioning of the function for reproducibility.
+
+### Create DSPy Image objects
+
+We open PDF from bytes using **PyMuPDF** (`pymupdf`), then we iterate over each page.
+
+- Useful trick: Render the page as a **high-resolution image** (`2x`) for better OCR/vision performance.
+- Convert the rendered page to **PNG bytes**.
+- Wrap the PNG bytes in a **DSPy `Image` object**.
+
+### DSPy Extraction
+
+The list of `form_images` is passed to the DSPy module:
+
+1. **ChainOfThought reasoning** interprets each image.
+2. **Vision + NLP** extract relevant text fields.
+3. **Populate Pydantic `Patient` object** with structured patient info.
+
+## CocoIndex Flow
+
+![CocoIndex Flow](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/flow.png)
+
+- Loads PDFs from local directory as binary
+- For each document, applies single transform: PDF bytes → Patient data
+- Exports the results in a PostgreSQL table
+
+### Declare Flow
+
+Declare a CocoIndex flow, connect to the source, add a data collector to collect processed data.
+
+```python
+@cocoindex.flow_def(name="PatientIntakeExtractionDSPy")
+def patient_intake_extraction_dspy_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="data/patient_forms", binary=True)
+    )
+
+    patients_index = data_scope.add_collector()
+```
+
+- `@cocoindex.flow_def` tells CocoIndex that this function is a flow definition, not regular runtime code.
+- `add_source()` registers a `LocalFile` source that traverses `data/patient_forms` directory and creates a logical table named `documents`
+
+![Ingesting Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/ingest.png)
+
+You can connect to various sources, or even custom source with CocoIndex if native connectors are not available. CocoIndex is designed to keep your indexes synchronized with your data sources. This is achieved through a feature called **live updates**, which automatically detects changes in your sources and updates your indexes accordingly. This ensures that your search results and data analysis are always based on the most current information. You can read more here [https://cocoindex.io/docs/tutorials/live_updates](https://cocoindex.io/docs/tutorials/live_updates)
+
+### Process documents
+
+```python
+with data_scope["documents"].row() as doc:
+    # Extract patient information directly from PDF using DSPy with vision
+    # (PDF->Image conversion happens inside the extractor)
+    doc["patient_info"] = doc["content"].transform(extract_patient)
+
+    # Collect the extracted patient information
+    patients_index.collect(
+        filename=doc["filename"],
+        patient_info=doc["patient_info"],
+    )
+```
+
+This iterates over each document. We transform `doc["content"]` (the bytes) by our `extract_patient` function. The result is stored in a new field `patient_info`.
+
+Then we collect a row with the `filename` and extracted `patient_info`.
+
+![Transforming Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/transform.png)
+
+![Nested Data](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/nested.png)
+
+### Export to Postgres
+
+```python
+patients_index.export(
+    "patients",
+    cocoindex.storages.Postgres(table_name="patients_info_dspy"),
+    primary_key_fields=["filename"],
+)
+```
+
+We export the collected index to Postgres. This will create/maintain a table `patients` keyed by filename, automatically deleting or updating rows if inputs change.
+
+Because CocoIndex tracks data lineage, it will handle updates/deletions of source files incrementally.
+
+### Configure CocoIndex settings
+
+Define a **CocoIndex settings function** that configures the AI model for DSPy:
+
+```python
+@cocoindex.settings
+def cocoindex_settings() -> cocoindex.Settings:
+    # Configure the model used in DSPy
+    lm = dspy.LM("gemini/gemini-2.5-flash")
+    dspy.configure(lm=lm)
+
+    return cocoindex.Settings.from_env()
+```
+
+It returns a `cocoindex.Settings` object initialized from environment variables, enabling the system to use the configured model and environment settings for all DSPy operations.
+
+## Running the Pipeline
+
+Update the index:
+
+```bash
+cocoindex update main
+```
+
+### CocoInsight
+
+I used CocoInsight (Free beta now) to troubleshoot the index generation and understand the data lineage of the pipeline. It just connects to your local CocoIndex server, with zero pipeline data retention.
+
+```bash
+cocoindex server -ci main
+```
+
+## Scalable Open ecosystem, not a closed box
+
+CocoIndex is intentionally "composable by default": it gives you a fast, incremental data engine and clean flow, abstraction, but never locks you into a specific model, vector DB, processing module or orchestration stack.
+
+CocoIndex treats everything — sources, ops, and storages — as pluggable interfaces rather than proprietary primitives. You can read from local files, S3, APIs, or custom sources, call any data transformation logic (beyond SQL, DSPy modules, any complex Python transformations, generated parsers etc), and export to relational databases, vector databases, search engines, or custom sinks through its storage layer.
+
+### Why DSPy + CocoIndex fits this philosophy
+
+DSPy is itself a compositional framework for LLMs: you define typed Signatures and Modules, and it learns how to implement them, making the LLM layer programmable, testable, and optimizable.
+
+CocoIndex treats these modules as first-class operators in the flow, so you get a clean separation of concerns: DSPy owns "how the model thinks," while CocoIndex owns "how data moves, is cached, and is served" across changing PDFs, code, or APIs.
+
+This pairing is powerful because neither system tries to be the entire stack: CocoIndex does not prescribe a prompt framework, and DSPy does not prescribe a data pipeline engine. Instead, they interlock: DSPy modules become composable building blocks inside CocoIndex flows, and CocoIndex gives those modules a production context with retries, batching, caching, and live updates.
+
+## Connect to other sources
+
+CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more.
+
+[→ Sources](https://cocoindex.io/docs/sources)
+

--- a/docs/src/content/example-posts/patient_form_extraction_dspy.md
+++ b/docs/src/content/example-posts/patient_form_extraction_dspy.md
@@ -462,4 +462,3 @@ This pairing is powerful because neither system tries to be the entire stack: Co
 CocoIndex natively supports Google Drive, Amazon S3, Azure Blob Storage, and more.
 
 [→ Sources](https://cocoindex.io/docs/sources)
-

--- a/docs/src/content/example-posts/pdf_elements.md
+++ b/docs/src/content/example-posts/pdf_elements.md
@@ -1,0 +1,317 @@
+---
+title: Index PDF Elements - Unified Text & Image Embedding with Metadata
+description: 'Extract, embed, and index both text and images from PDFs for advanced multimodal search. Leverage SentenceTransformers and CLIP for unified vector search, complete with metadata linkage, thumbnails, and full traceability.'
+slug: pdf_elements
+image: https://cocoindex.io/blobs/docs/img/examples/pdf_elements/cover.png
+tags: [vector-index, multi-modal]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/pdf_elements_embedding)
+
+![Index PDF Elements](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/cover.png)
+
+
+PDFs contain a wealth of textual and visual elements—from narrative passages to figures, charts, and images. In this guide, you'll learn how to set up a complete pipeline that extracts, embeds, and indexes both text and images from PDFs, ensuring every element is fully linked back with original page metadata.
+
+In this example, we split out both text and images, link them back to page metadata, and enable unified semantic search. We’ll use **[CocoIndex](https://github.com/cocoindex-io/cocoindex)** to define the flow, **SentenceTransformers** for text embeddings, and **CLIP** for image embeddings — all stored in **Qdrant** for retrieval.
+
+:::tip Incremental Indexing
+CocoIndex supports **incremental updates** out of box. You can add new PDFs or update existing ones without reprocessing the entire dataset. Only new or modified elements are embedded and indexed on each run.
+:::
+
+
+<!-- truncate -->
+
+## 🔍 What It Does
+
+![Flow Overview](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/flow.png)
+
+This flow automatically:
+
+- Extracts both page text and images from PDF files
+- Filters out images that are too small or duplicates
+- Generates standardized thumbnails for images (up to 512×512 pixels)
+- Splits and embeds text elements using SentenceTransformers (`all-MiniLM-L6-v2`)
+- Embeds image elements using CLIP (`openai/clip-vit-large-patch14`)
+- Saves all embeddings to Qdrant, along with metadata that traces each embedding back to its source text or image
+- Enables unified semantic search across all extracted text and image content
+
+## 📦 Prerequisite:
+
+### Run Qdrant
+
+If you don’t have Qdrant running locally, start it via Docker:
+
+```sh
+docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+### 📁 Input Data
+
+We’ll use a few sample PDFs (board game manuals). Download them into the `source_files` directory:
+
+```sh
+./pdf_elements/fetch_manual_urls.sh
+```
+
+Or, feel free to drop in any of your own PDFs.
+
+
+## ⚙️ Run the Flow
+
+Install dependencies:
+
+```sh
+pip install -e .
+```
+
+Then build your index (sets up tables automatically on first run):
+
+```sh
+cocoindex update --setup main
+```
+
+Or Run in CocoInsight
+
+```sh
+cocoindex server -ci main
+```
+
+## Define the flow
+
+### Flow definition
+
+
+
+Let’s break down what happens inside the **`PdfElementsEmbedding`** flow
+
+```python
+@cocoindex.flow_def(name="PdfElementsEmbedding")
+def multi_format_indexing_flow(
+    flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope
+) -> None:
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(
+            path="source_files", included_patterns=["*.pdf"], binary=True
+        )
+    )
+    text_output = data_scope.add_collector()
+    image_output = data_scope.add_collector()
+```
+
+We define the flow, add a source, and add data collectors.
+
+For flow definition, the decorator
+
+```
+@cocoindex.flow_def(name="PdfElementsEmbedding")
+```
+
+marks the function as a CocoIndex flow definition, registering it as part of the data indexing system. When executed via CocoIndex runtime, it orchestrates data ingestion, transformation, and collection.
+
+### Process Each Document
+
+#### Extract PDF documents
+
+We iterate through each document row and run a custom transformation that extracts PDF elements.
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["pages"] = doc["content"].transform(extract_pdf_elements)
+```
+
+#### Extract PDF Elements
+
+Define `dataclass` for structured extraction - we want to extract a list of `PdfPage`  each has page number, text, and list of images.
+
+```python
+@dataclass
+class PdfImage:
+    name: str
+    data: bytes
+
+@dataclass
+class PdfPage:
+    page_number: int
+    text: str
+    images: list[PdfImage]
+```
+
+Next, define a **CocoIndex function** called **`extract_pdf_elements`** that **extracts both text and images from a PDF file**, returning them as structured, page-wise data objects.
+
+```python
+@cocoindex.op.function()
+def extract_pdf_elements(content: bytes) -> list[PdfPage]:
+    """
+    Extract texts and images from a PDF file.
+    """
+    reader = PdfReader(io.BytesIO(content))
+    result = []
+    for i, page in enumerate(reader.pages):
+        text = page.extract_text()
+        images = []
+        for image in page.images:
+            img = image.image
+            if img is None:
+                continue
+            # Skip very small images.
+            if img.width < 16 or img.height < 16:
+                continue
+            thumbnail = io.BytesIO()
+            img.thumbnail(IMG_THUMBNAIL_SIZE)
+            img.save(thumbnail, img.format or "PNG")
+            images.append(PdfImage(name=image.name, data=thumbnail.getvalue()))
+        result.append(PdfPage(page_number=i + 1, text=text, images=images))
+    return result
+```
+
+The `extract_pdf_elements` function reads a PDF file from bytes and extracts both text and images from each page in a structured way.
+
+- It parses every page to retrieve text content and any embedded images, skipping empty or very small images to avoid noise.
+
+- Each image is resized to a consistent thumbnail size (up to 512×512) and converted into bytes for downstream use.
+
+The result is a clean, per-page data structure (`PdfPage`) that contains the page number, extracted text, and processed images — making it easy to embed and index PDFs for multimodal search.
+
+![pdf-elements](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/pages.png)
+
+
+#### Process Each Page
+
+Once we have the pages, we process each page.
+
+1. Chunk the text
+
+This takes each PDF page's text and splits it into smaller, overlapping chunks.
+
+```python
+with doc["pages"].row() as page:
+    page["chunks"] = page["text"].transform(
+        cocoindex.functions.SplitRecursively(
+            custom_languages=[
+                cocoindex.functions.CustomLanguageSpec(
+                    language_name="text",
+                    separators_regex=[
+                        r"\n(\s*\n)+",
+                        r"[\.!\?]\s+",
+                        r"\n",
+                        r"\s+",
+                    ],
+                )
+            ]
+        ),
+        language="text",
+        chunk_size=600,
+        chunk_overlap=100,
+    )
+```
+
+![Split Recursively](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/split-text.png)
+
+2. Process each chunk
+
+Embed and collect the metadata we need. Each chunk includes its embedding, original text, and references to the `filename` and `page` where it originated.
+
+```python
+with page["chunks"].row() as chunk:
+    chunk["embedding"] = chunk["text"].call(embed_text)
+    text_output.collect(
+        id=cocoindex.GeneratedField.UUID,
+        filename=doc["filename"],
+        page=page["page_number"],
+        text=chunk["text"],
+        embedding=chunk["embedding"],
+    )
+```
+![embed-text](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/embed-text.png)
+
+3. Process each image
+
+We use `CLIP` to embed the image and collect the `data`, `embedding`, and metadata `filename`, `page_number`.
+
+
+```python
+with page["images"].row() as image:
+    image["embedding"] = image["data"].transform(clip_embed_image)
+    image_output.collect(
+        id=cocoindex.GeneratedField.UUID,
+        filename=doc["filename"],
+        page=page["page_number"],
+        image_data=image["data"],
+        embedding=image["embedding"],
+    )
+```
+![embed-image](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/embed-image.png)
+
+When we collect image outputs, we also want to preserve relevant metadata alongside the embeddings.
+
+For each image, we store not only its embedding and raw image data, but also important metadata like the source file name and page number. This metadata ensures you can always identify which document and page an embedded image came from when retrieving or analyzing results.
+
+
+
+### Export to Qdrant
+
+Finally, we export the collected data to the target store.
+
+```python
+text_output.export(
+    "text_embeddings",
+    cocoindex.targets.Qdrant(
+        connection=qdrant_connection,
+        collection_name=QDRANT_COLLECTION_TEXT,
+    ),
+    primary_key_fields=["id"],
+)
+image_output.export(
+    "image_embeddings",
+    cocoindex.targets.Qdrant(
+        connection=qdrant_connection,
+        collection_name=QDRANT_COLLECTION_IMAGE,
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+## 🧭 Explore with CocoInsight (Free Beta)
+
+Use **CocoInsight** to visually trace your data lineage and debug the flow.
+
+It connects locally with **zero data retention**.
+
+Start your local server:
+
+```sh
+cocoindex server -ci main
+```
+
+Then open the UI 👉 `https://cocoindex.io/cocoinsight`
+
+## 💡 Why This Matters
+
+Traditional document search only scratches the surface — it’s text-only and often brittle across document layouts.
+This flow gives you **multimodal recall**, meaning you can:
+
+- Search PDFs by text *or* image similarity
+- Retrieve related figures, diagrams, or captions
+- Build next-generation retrieval systems across rich content formats
+
+## Compare with ColPali Vision Model (OCR Free)
+We also have an [example for ColPali](https://cocoindex.io/examples/image_search)
+
+To compare two approaches:
+
+| **Aspect** | **ColPali Multi-Vector Image Grids** | **Separate Text and Image Embeddings** |
+| --- | --- | --- |
+| Input | Whole page as an image grid (multi-vector patches) | Text extracted via OCR + images processed separately |
+| Embedding | Multi-vector patch-level embeddings preserving spatial context | Independent text and image vectors |
+| Query Matching | Late interaction between text token embeddings and image patches | Separate embedding similarity / fusion |
+| Document Structure Handling | Maintains layout and visual cues implicitly | Layout structure inferred by heuristics |
+| OCR Dependence | Minimal to none; model reads text visually | Heavy dependence on OCR (for scanned PDFs) and text extraction |
+| Use Case Strength | Document-heavy, visual-rich formats  | General image and text data, simpler layouts |
+| Complexity | Higher computational cost, more complex storage | Simpler architecture; fewer compute resources needed |
+
+ColPali offers superior vision-text integration for complex documents, while separate text and image embeddings are simpler but may lose important context. Choose based on document type and precision needs.
+
+## Support us
+⭐ Star [CocoIndex on GitHub](https://github.com/cocoindex-io/cocoindex) and share with your community if you find it useful!

--- a/docs/src/content/example-posts/photo_search.md
+++ b/docs/src/content/example-posts/photo_search.md
@@ -1,0 +1,207 @@
+---
+title: Photo Search with Face Detection
+description: 'Covers extracting and embedding faces from images, structuring data for visual search, and exporting to a vector database for face similarity queries.'
+slug: photo_search
+image: https://cocoindex.io/blobs/docs/img/examples/photo_search/cover.png
+tags: [vector-index, multi-modal]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/face_recognition)
+
+![Photo Search](https://cocoindex.io/blobs/docs/img/examples/photo_search/cover.png)
+
+## Overview
+We’ll walk through a comprehensive example of building a scalable face recognition pipeline. We’ll
+- Detect all faces in the image and extract their bounding boxes
+- Crop and encode each face image into a 128-dimensional face embedding
+- Store metadata and vectors in a structured index to support queries like:
+“Find all similar faces to this one” or “Search images that include this person”
+
+With this, you can build your own photo search app with face detection and search.
+
+## Flow Overview
+![Flow Overview](https://cocoindex.io/blobs/docs/img/examples/photo_search/flow.png)
+
+1. Ingest the images.
+2. For each image,
+    - Extract faces from the image.
+    - Compute embeddings for each face.
+3. Export following fields to a table in Postgres with PGVector:
+    - Filename, rect, embedding for each face.
+
+## Setup
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+
+- Install Qdrant
+    ```sh
+    docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
+    ```
+
+- Install dependencies:
+    ```sh
+    pip install -e .
+    ```
+
+## Add source
+
+We monitor an `images/` directory using the built-in `LocalFile` source. All newly added files are automatically processed and indexed.
+
+```python
+@cocoindex.flow_def(name="FaceRecognition")
+def face_recognition_flow(flow_builder, data_scope):
+    data_scope["images"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="images", binary=True),
+        refresh_interval=datetime.timedelta(seconds=10),
+    )
+```
+
+This creates a table with `filename` and `content` fields. 📂
+
+
+You can connect it to your [S3 Buckets](https://cocoindex.io/docs/sources/amazons3) (with SQS integration, [example](https://cocoindex.io/blogs/s3-incremental-etl))
+or [Azure Blob store](https://cocoindex.io/docs/sources/azureblob).
+
+## Detect and Extract Faces
+
+We use the `face_recognition` library under the hood, powered by dlib’s CNN-based face detector. Since the model is slow on large images, we downscale wide images before detection.
+
+```python
+@cocoindex.op.function(
+    cache=True,
+    behavior_version=1,
+    gpu=True,
+    arg_relationship=(cocoindex.op.ArgRelationship.RECTS_BASE_IMAGE, "content"),
+)
+def extract_faces(content: bytes) -> list[FaceBase]:
+    orig_img = Image.open(io.BytesIO(content)).convert("RGB")
+
+    # The model is too slow on large images, so we resize them if too large.
+    if orig_img.width > MAX_IMAGE_WIDTH:
+        ratio = orig_img.width * 1.0 / MAX_IMAGE_WIDTH
+        img = orig_img.resize(
+            (MAX_IMAGE_WIDTH, int(orig_img.height / ratio)),
+            resample=Image.Resampling.BICUBIC,
+        )
+    else:
+        ratio = 1.0
+        img = orig_img
+
+    # Extract face locations.
+    locs = face_recognition.face_locations(np.array(img), model="cnn")
+
+    faces: list[FaceBase] = []
+    for min_y, max_x, max_y, min_x in locs:
+        rect = ImageRect(
+            min_x=int(min_x * ratio),
+            min_y=int(min_y * ratio),
+            max_x=int(max_x * ratio),
+            max_y=int(max_y * ratio),
+        )
+
+        # Crop the face and save it as a PNG.
+        buf = io.BytesIO()
+        orig_img.crop((rect.min_x, rect.min_y, rect.max_x, rect.max_y)).save(
+            buf, format="PNG"
+        )
+        face = buf.getvalue()
+        faces.append(FaceBase(rect, face))
+
+    return faces
+```
+
+We transform the image content:
+
+```python
+with data_scope["images"].row() as image:
+    image["faces"] = image["content"].transform(extract_faces)
+```
+
+After this step, each image has a list of detected faces and bounding boxes.
+Each detected face is cropped from the original image and stored as a PNG.
+
+![Extracted Faces](https://cocoindex.io/blobs/docs/img/examples/photo_search/extraction.png)
+
+## Compute Face Embeddings
+
+We encode each cropped face using the same library. This generates a 128-dimensional vector representation per face.
+
+```python
+@cocoindex.op.function(cache=True, behavior_version=1, gpu=True)
+def extract_face_embedding(
+    face: bytes,
+) -> cocoindex.Vector[cocoindex.Float32, typing.Literal[128]]:
+    """Extract the embedding of a face."""
+    img = Image.open(io.BytesIO(face)).convert("RGB")
+    embedding = face_recognition.face_encodings(
+        np.array(img),
+        known_face_locations=[(0, img.width - 1, img.height - 1, 0)],
+    )[0]
+    return embedding
+```
+
+We plug the embedding function into the flow:
+
+```python
+with image["faces"].row() as face:
+    face["embedding"] = face["image"].transform(extract_face_embedding)
+```
+
+After this step, we have embeddings ready to be indexed!
+
+
+## Collect and Export Embeddings
+
+We now collect structured data for each face: filename, bounding box, and embedding.
+
+```python
+face_embeddings = data_scope.add_collector()
+
+face_embeddings.collect(
+    id=cocoindex.GeneratedField.UUID,
+    filename=image["filename"],
+    rect=face["rect"],
+    embedding=face["embedding"],
+)
+```
+
+We export to a Qdrant collection:
+
+```python
+face_embeddings.export(
+    QDRANT_COLLECTION,
+    cocoindex.targets.Qdrant(
+        collection_name=QDRANT_COLLECTION
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+Now you can run cosine similarity queries over facial vectors.
+
+CocoIndex supports 1-line switch with other vector databases.
+[→ Postgres](https://cocoindex.io/docs/targets/postgres)
+
+## Query the Index
+
+You can now build facial search apps or dashboards. For example:
+- Given a new face embedding, find the most similar faces
+- Find all face images that appear in a set of photos
+- Cluster embeddings to group visually similar people
+
+
+For querying embeddings, check out [Image Search project](https://cocoindex.io/blogs/live-image-search).
+
+If you’d like to see a full example on the query path with image match, give it a shout at
+[our group](https://discord.com/invite/zpA9S2DR7s).
+
+## CocoInsight
+CocoInsight is a tool to help you understand your data pipeline and data index. It can now visualize identified sections of an image based on the bounding boxes and makes it easier to understand and evaluate AI extractions - seamlessly attaching computed features in the context of unstructured visual data.
+
+You can walk through the project step by step in [CocoInsight](https://www.youtube.com/watch?v=MMrpUfUcZPk) to see exactly how each field is constructed and what happens behind the scenes.
+
+```sh
+cocoindex server -ci main
+```
+
+Follow the url `https://cocoindex.io/cocoinsight`.  It connects to your local CocoIndex server, with zero pipeline data retention.

--- a/docs/src/content/example-posts/postgres_source.md
+++ b/docs/src/content/example-posts/postgres_source.md
@@ -1,0 +1,297 @@
+---
+title: Transform Data From Structured Source in PostgreSQL
+description: 'Transform data from PostgreSQL table as source, transform with both AI models and non-AI data mappings, and write them into PostgreSQL/PgVector for semantic + structured search.'
+slug: postgres_source
+image: https://cocoindex.io/blobs/docs/img/examples/postgres_source/cover.png
+tags: [data-mapping, vector-index]
+last_reviewed: 2026-01-18
+---
+
+<GitHubButton url="https://github.com/cocoindex-io/cocoindex/tree/main/examples/postgres_source" margin="0 0 24px 0" /
+>
+![PostgreSQL Product Indexing Flow](https://cocoindex.io/blobs/docs/img/examples/postgres_source/cover.png)
+
+[CocoIndex](https://github.com/cocoindex-io/cocoindex) is one framework for building **incremental** data flows across **structured and unstructured** sources. This tutorial shows how to take data from PostgreSQL table as source, transform with both AI and non-AI data mappings, and write them into a new PostgreSQL table with PgVector for semantic + structured search.
+
+## PostgreSQL Product Indexing Flow
+
+![PostgreSQL Product Indexing Flow](https://cocoindex.io/blobs/docs/img/examples/postgres_source/flow.png)
+
+- Reading data from a PostgreSQL table `source_products`.
+- Computing additional fields (`total_value`, `full_description`).
+- Generating embeddings for semantic search.
+- Storing the results in another PostgreSQL table with a vector index using pgvector
+
+### Connect to source
+
+`flow_builder.add_source` reads rows from `source_products`.
+
+```python
+@cocoindex.flow_def(name="PostgresProductIndexing")
+def postgres_product_indexing_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope) -> None:
+
+    data_scope["products"] = flow_builder.add_source(
+        cocoindex.sources.Postgres(
+            table_name="source_products",
+            # Optional. Use the default CocoIndex database if not specified.
+            database=cocoindex.add_transient_auth_entry(
+                cocoindex.DatabaseConnectionSpec(
+                    url=os.environ["SOURCE_DATABASE_URL"],
+                )
+            ),
+            # Optional.
+            ordinal_column="modified_time",
+            notification=cocoindex.sources.PostgresNotification(),
+        ),
+    )
+```
+
+This step adds source data from PostgreSQL table `source_products` to the flow as a `KTable`.
+
+![Add PostgreSQL Source](https://cocoindex.io/blobs/docs/img/examples/postgres_source/source.png)
+
+CocoIndex incrementally sync data from Postgres. When new or updated rows are found, only those rows run through the pipeline, so downstream indexes and search results reflect the latest data while unchanged rows are untouched. The following two arguments (both are optional) make this more efficient:
+
+- `notification` enables change capture based on Postgres LISTEN/NOTIFY. Each change triggers an incremental processing on the specific row immediately.
+- Regardless if `notification` is provided or not, CocoIndex still needs to scan the full table to detect changes in some scenarios (e.g. between two `update` invocation), and the `ordinal_column` provides a field that CocoIndex can use to quickly detect which row has changed without reading value columns.
+
+Check [Postgres source](https://cocoindex.io/docs/sources/postgres) for more details.
+
+If you use the Postgres database hosted by Supabase, please click Connect on your project dashboard and find the URL there. Check [DatabaseConnectionSpec](https://cocoindex.io/docs/core/settings#databaseconnectionspec)
+for more details.
+
+## Simple Data Mapping / Transformation
+
+Create a simple transformation to calculate the total price.
+
+```python
+@cocoindex.op.function()
+def calculate_total_value(price: float, amount: int) -> float:
+    """Compute total value for each product."""
+    return price * amount
+```
+
+Plug into the flow:
+
+```python
+with data_scope["products"].row() as product:
+     # Compute total value
+    product["total_value"] = flow_builder.transform(
+        calculate_total_value,
+        product["price"],
+        product["amount"],
+    )
+```
+
+![Calculate Total Value](https://cocoindex.io/blobs/docs/img/examples/postgres_source/price.png)
+
+### Data Transformation & AI Transformation
+
+Create a custom function creates a `full_description` field by combining the product’s category, name, and description.
+
+```python
+@cocoindex.op.function()
+def make_full_description(category: str, name: str, description: str) -> str:
+    """Create a detailed product description for embedding."
+    return f"Category: {category}\nName: {name}\n\n{description}"
+
+```
+
+Embeddings often perform better with more context. By combining fields into a single text string, we ensure that the semantic meaning of the product is captured fully.
+
+Now plug into the flow:
+
+```python
+with data_scope["products"].row() as product:
+    #.. other transformations
+
+    # Compute full description
+    product["full_description"] = flow_builder.transform(
+        make_full_description,
+        product["product_category"],
+        product["product_name"],
+        product["description"],
+    )
+
+    # Generate embeddings
+    product["embedding"] = product["full_description"].transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"
+        )
+    )
+
+    # Collect data
+    indexed_product.collect(
+        product_category=product["product_category"],
+        product_name=product["product_name"],
+        description=product["description"],
+        price=product["price"],
+        amount=product["amount"],
+        total_value=product["total_value"],
+        embedding=product["embedding"],
+    )
+```
+
+This takes each product row, and does the following:
+
+1. builds a rich description.
+
+    ![Make Full Description](https://cocoindex.io/blobs/docs/img/examples/postgres_source/description.png)
+
+2. turns it into an embedding
+
+    ![Embed Full Description](https://cocoindex.io/blobs/docs/img/examples/postgres_source/embed.png)
+
+3. collects the embedding along with structured fields (category, name, price, etc.).
+
+    ![Collect Embedding](https://cocoindex.io/blobs/docs/img/examples/postgres_source/collector.png)
+
+## Export
+
+```python
+indexed_product.export(
+    "output",
+    cocoindex.targets.Postgres(),
+    primary_key_fields=["product_category", "product_name"],
+    vector_indexes=[
+        cocoindex.VectorIndexDef(
+            field_name="embedding",
+            metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
+        )
+    ],
+)
+```
+
+All transformed rows are collected and exported to a new PostgreSQL table with a vector index, ready for semantic search.
+
+## Field lineage
+
+When the transform flow starts to getting complex, it's hard to understand how each field is derived.
+CocoIndex provides a way to visualize the lineage of each field, to make it easier to trace and troubleshoot field origins and downstream dependencies.
+
+For example, the following image shows the lineage of the `embedding` field, you can click from the final output backward all the way to the source fields, step by step.
+
+![Field Lineage](https://cocoindex.io/blobs/docs/img/examples/postgres_source/lineage.png)
+
+## Running the Pipeline
+
+1. Set up dependencies:
+
+    ```sh
+    pip install -e .
+    ```
+
+2. Create the source table with sample data:
+
+    ```sh
+    psql "postgres://cocoindex:cocoindex@localhost/cocoindex" -f ./prepare_source_data.sql
+    ```
+
+3. Setup tables and update the index:
+
+    ```sh
+    cocoindex update main
+    ```
+
+4. Run CocoInsight:
+
+    ```sh
+    cocoindex server -ci main
+    ```
+
+    You can walk through the project step by step in CocoInsight to see exactly how each field is constructed and what happens behind the scenes. It connects to your local CocoIndex server, with zero pipeline data retention.
+
+## Continuous Updating
+
+For continuous updating when the source changes, add `-L`:
+
+```sh
+cocoindex update -L main
+```
+
+Check [live updates](https://cocoindex.io/docs/tutorials/live_updates) for more details.
+
+## Search and Query the Index
+
+### Query
+
+Runs a semantic similarity search over the indexed products table, returning the top matches for a given query.
+
+```python
+def search(pool: ConnectionPool, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+    # Get the table name, for the export target in the text_embedding_flow above.
+    table_name = cocoindex.utils.get_target_default_name(
+        postgres_product_indexing_flow, "output"
+    )
+    # Evaluate the transform flow defined above with the input query, to get the embedding.
+    query_vector = text_to_embedding.eval(query)
+    # Run the query and get the results.
+    with pool.connection() as conn:
+        register_vector(conn)
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT
+                    product_category,
+                    product_name,
+                    description,
+                    amount,
+                    total_value,
+                    (embedding <=> %s) AS distance
+                FROM {table_name}
+                ORDER BY distance ASC
+                LIMIT %s
+            """,
+                (query_vector, top_k),
+            )
+            return cur.fetchall()
+```
+
+This function
+
+- Converts the query text into an embedding (`query_vector`).
+- Compares it with each product’s stored embedding (`embedding`) using vector distance.
+- Returns the closest matches, including both metadata and the similarity score (`distance`).
+
+### Create an command-line interactive loop
+
+```python
+def _main() -> None:
+    # Initialize the database connection pool.
+    pool = ConnectionPool(os.environ["COCOINDEX_DATABASE_URL"])
+    # Run queries in a loop to demonstrate the query capabilities.
+    while True:
+        query = input("Enter search query (or Enter to quit): ")
+        if query == "":
+            break
+        # Run the query function with the database connection pool and the query.
+        results = search(pool, query)
+        print("\nSearch results:")
+        for result in results:
+            score = 1.0 - result["distance"]
+            print(
+                f"[{score:.3f}] {result['product_category']} | {result['product_name']} | {result['amount']} | {result['total_value']}"
+            )
+            print(f"    {result['description']}")
+            print("---")
+        print()
+
+if __name__ == "__main__":
+    load_dotenv()
+    cocoindex.init()
+    _main()
+```
+
+### Run as a Service
+
+This [example](https://cocoindex.io/examples/image_search#fast-api-application) runs as a service using Fast API.
+
+## Why One Framework for Structured + Unstructured?
+
+- Unified workflow: All data— files, APIs, or databases—is processed through a single, consistent system, and AI operations are handled alongside standard data transformations.
+
+- True incremental processing with live updates: Out-of-box incremental support from the framework, process only what’s changed, avoiding redundant computation and ensuring faster updates to downstream indexes.
+
+- Reliable consistency: Embeddings and derived data always reflect the accurate, transformed state of each row, ensuring results are dependable and current in a single flow.
+
+- Streamlined operations: A single deployment manages everything, providing clear data lineage and reducing the complexity of the data stack.

--- a/docs/src/content/example-posts/product_recommendation.md
+++ b/docs/src/content/example-posts/product_recommendation.md
@@ -1,0 +1,392 @@
+---
+title: Real-Time Product Recommendation Engine with LLM and Graph Database
+description: 'Build a real-time product recommendation engine with LLM and graph database, from the aspect of product category (taxonomy) understanding.'
+slug: product_recommendation
+image: https://cocoindex.io/blobs/docs/img/examples/product_recommendation/cover.png
+tags: [knowledge-graph]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/product_recommendation)
+
+![Product Recommendation](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/cover.png)
+
+## Overview
+
+We will build a real-time product recommendation engine with LLM and graph database. In particular, we will:
+
+- Use LLM to understand the category (taxonomy) of a product.
+- Use LLM to enumerate the complementary products - users are likely to buy together with the current product (pencil and notebook).
+- Use Graph to explore the relationships between products that can be further used for product recommendations or labeling.
+
+Product taxonomy is a way to organize product catalogs in a logical and hierarchical structure; a great detailed explanation can be found [here](https://help.shopify.com/en/manual/products/details/product-category). In practice, it is a complicated problem: a product can be part of multiple categories, and a category can have multiple parents.
+
+## Prerequisites
+
+- [Install PostgreSQL](https://cocoindex.io/docs/getting_started/installation#-install-postgres). CocoIndex uses PostgreSQL internally for incremental processing.
+- [Install Neo4j](https://cocoindex.io/docs/targets/neo4j), a graph database.
+- [Configure your OpenAI API key](https://cocoindex.io/docs/ai/llm#openai). Create a `.env` file from `.env.example`, and fill `OPENAI_API_KEY`.
+
+Alternatively, we have native support for Gemini, Ollama, LiteLLM. You can choose your favorite LLM provider and work completely on-premises.
+
+[→ LLM](https://cocoindex.io/docs/ai/llm)
+
+## Documentation
+
+[→ Property Graph Targets](https://cocoindex.io/docs/targets#property-graph-targets)
+
+## Flow Overview
+
+The core flow is about [~100 lines of python code](https://github.com/cocoindex-io/cocoindex/blob/1d42ab31692c73743425f7712c9af395ef98c80e/examples/product_taxonomy_knowledge_graph/main.py#L75-L177)
+
+We are going to declare a data flow
+
+1. ingest products (in JSON)
+2. for each product,
+    - parse JSON
+    - map & clean up data
+    - extract taxonomy from the mapped data
+3. collect data
+4. export data to neo4j
+
+## Add source
+
+```python
+@cocoindex.flow_def(name="StoreProduct")
+def store_product_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["products"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="products",
+                                    included_patterns=["*.json"]),
+        refresh_interval=datetime.timedelta(seconds=5))
+```
+
+Here `flow_builder.add_source` creates a [KTable](https://cocoindex.io/docs/core/data_types#KTable).
+`filename` is the key of the KTable.
+
+## Add data collectors
+
+Add collectors at the root scope to collect the product, taxonomy and complementary taxonomy.
+
+```python
+product_node = data_scope.add_collector()
+product_taxonomy = data_scope.add_collector()
+product_complementary_taxonomy = data_scope.add_collector()
+```
+
+## Process each product
+
+We will parse the JSON file for each product, and transform the data to the format that we need for downstream processing.
+
+### Data mapping
+
+```python
+@cocoindex.op.function(behavior_version=2)
+def extract_product_info(product: cocoindex.typing.Json, filename: str) -> ProductInfo:
+    return ProductInfo(
+        id=f"{filename.removesuffix('.json')}",
+        url=product["source"],
+        title=product["title"],
+        price=float(product["price"].lstrip("$").replace(",", "")),
+        detail=Template(PRODUCT_TEMPLATE).render(**product),
+    )
+```
+
+Here we define a function for data mapping, e.g.,
+
+- clean up the `id` field
+- map `title` -> `title`
+- clean up the `price` field
+- generate a markdown string for the product detail based on all the fields (for LLM to extract taxonomy and complementary taxonomy, we find that markdown works best as context for LLM).
+
+### Process product JSON in the flow
+
+Within the flow, we plug in the data mapping transformation to process each product JSON.
+
+```python
+with data_scope["products"].row() as product:
+    data = (product["content"]
+            .transform(cocoindex.functions.ParseJson(), language="json")
+            .transform(extract_product_info, filename=product["filename"]))
+    product_node.collect(id=data["id"], url=data["url"], title=data["title"], price=data["price"])
+```
+
+It performs the following transformations:
+
+1. The first `transform()` parses the JSON file.
+
+    [→ ParseJson](https://cocoindex.io/docs/ops/functions#parsejson)
+    ![ParseJson](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/parse_json.png)
+
+2. The second `transform()` performs the defined data mapping.
+    ![Extract product info and data mapping](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/extract_product.png)
+
+3. We collect the fields we need for the product node in Neo4j.
+
+## Extract taxonomy and complementary taxonomy
+
+![Product Taxonomy Info](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/taxonomy.png)
+
+### Product Taxonomy Definition
+
+Since we are using LLM to extract product taxonomy, we need to provide a detailed instruction at the field-level description.
+
+```python
+class ProductTaxonomy(BaseModel):
+   """
+   Taxonomy for the product.
+   """
+
+   name: str = Field(
+      description="A taxonomy is a concise noun (or short noun phrase), based on its core functionality, "
+                  "without specific details such as branding, style, etc. Always use the most common words in US "
+                  "English. Use lowercase without punctuation, unless it's a proper noun or acronym. A product may "
+                  "have multiple taxonomies. Avoid large categories like 'office supplies' or 'electronics'. Use "
+                  "specific ones, like 'pen' or 'printer'."
+   )
+```
+
+### Define Product Taxonomy Info
+
+Basically, we want to extract all possible taxonomies for a product and think about what other products are likely to be bought together with the current product.
+
+```python
+class ProductTaxonomyInfo(BaseModel):
+   """
+   Taxonomy information for the product.
+   """
+
+   taxonomies: list[ProductTaxonomy] = Field(
+      description="Taxonomies for the current product."
+   )
+   complementary_taxonomies: list[ProductTaxonomy] = Field(
+      "Think about when customers buy this product, what else they might need as complementary products. Put labels "
+      "for these complementary products."
+   )
+```
+
+For each product, we want some insight about its taxonomy and complementary taxonomy, and we could use that as a bridge to find a related product using the knowledge graph.
+
+### LLM Extraction
+
+Finally, we will use `cocoindex.functions.ExtractByLlm` to extract the taxonomy and complementary taxonomy from the product detail.
+
+```python
+taxonomy = data["detail"].transform(cocoindex.functions.ExtractByLlm(
+            llm_spec=cocoindex.LlmSpec(
+                api_type=cocoindex.LlmApiType.OPENAI, model="gpt-4.1"),
+                output_type=ProductTaxonomyInfo))
+```
+
+[→ ExtractByLlm](https://cocoindex.io/docs/ops/functions#extractbyllm)
+
+For example, LLM takes the description of the *gel pen*, and extracts taxonomy to be *gel pen*.
+Meanwhile, it suggests that when people buy *gel pen*, they may also be interested in *notebook* etc as complimentary taxonomy.
+
+![Extract taxonomy and complementary taxonomy](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/extract_taxonomy.png)
+
+### Collect taxonomy and complementary taxonomy
+
+And then we will collect the taxonomy and complementary taxonomy to the collector.
+
+```python
+with taxonomy['taxonomies'].row() as t:
+    product_taxonomy.collect(id=cocoindex.GeneratedField.UUID, product_id=data["id"], taxonomy=t["name"])
+with taxonomy['complementary_taxonomies'].row() as t:
+    product_complementary_taxonomy.collect(id=cocoindex.GeneratedField.UUID, product_id=data["id"], taxonomy=t["name"])
+```
+
+## Build knowledge graph
+
+### Basic concepts
+
+All nodes for Neo4j need two things:
+
+1. Label: The type of the node. E.g., `Product`, `Taxonomy`.
+2. Primary key field: The field that uniquely identifies the node. E.g., `id` for `Product` nodes.
+
+CocoIndex uses the primary key field to match the nodes and deduplicate them. If you have multiple nodes with the same primary key, CocoIndex keeps only one of them.
+
+![Deduplication](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/dedupe.png)
+
+There are two ways to map nodes:
+
+1. When you have a collector just for the node, you can directly export it to Neo4j. For example `Product`. We've collected each product explicitly.
+2. When you have a collector for relationships connecting to the node, you can map nodes from selected fields in the relationship collector. You must declare a node label and primary key field.
+
+For example,
+
+```python
+product_taxonomy.collect(id=cocoindex.GeneratedField.UUID, product_id=data["id"], taxonomy=t["name"])
+```
+
+Collects a relationship, and taxonomy node is created from the relationship.
+
+### Configure Neo4j connection
+
+```python
+conn_spec = cocoindex.add_auth_entry(
+    "Neo4jConnection",
+    cocoindex.storages.Neo4jConnection(
+        uri="bolt://localhost:7687",
+        user="neo4j",
+        password="cocoindex",
+))
+```
+
+### Export `Product` nodes to Neo4j
+
+```python
+product_node.export(
+    "product_node",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Nodes(label="Product")
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+![Export Product](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/export_product.png)
+
+This exports Neo4j nodes with label `Product` from the `product_node` collector.
+
+- It declares Neo4j node label `Product`. It specifies `id` as the primary key field.
+- It carries all the fields from `product_node` collector to Neo4j nodes with label `Product`.
+
+### Export `Taxonomy` nodes to Neo4j
+
+We don't have explicit collector for `Taxonomy` nodes.
+They are part of the `product_taxonomy` and `product_complementary_taxonomy` collectors and fields are collected during the taxonomy extraction.
+
+To export them as Neo4j nodes, we need to first declare `Taxonomy` nodes.
+
+```python
+flow_builder.declare(
+    cocoindex.storages.Neo4jDeclaration(
+        connection=conn_spec,
+        nodes_label="Taxonomy",
+        primary_key_fields=["value"],
+    )
+)
+```
+
+Next, export the `product_taxonomy` as relationship to Neo4j.
+
+```python
+product_taxonomy.export(
+    "product_taxonomy",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Relationships(
+            rel_type="PRODUCT_TAXONOMY",
+            source=cocoindex.storages.NodeFromFields(
+                label="Product",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="product_id", target="id"),
+                ]
+            ),
+            target=cocoindex.storages.NodeFromFields(
+                label="Taxonomy",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="taxonomy", target="value"),
+                ]
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+![Export Taxonomy](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/export_taxonomy.png)
+
+Similarly, we can export the `product_complementary_taxonomy` as relationship to Neo4j.
+
+```python
+product_complementary_taxonomy.export(
+    "product_complementary_taxonomy",
+    cocoindex.storages.Neo4j(
+        connection=conn_spec,
+        mapping=cocoindex.storages.Relationships(
+            rel_type="PRODUCT_COMPLEMENTARY_TAXONOMY",
+            source=cocoindex.storages.NodeFromFields(
+                label="Product",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="product_id", target="id"),
+                ]
+            ),
+            target=cocoindex.storages.NodeFromFields(
+                label="Taxonomy",
+                fields=[
+                    cocoindex.storages.TargetFieldMapping(
+                        source="taxonomy", target="value"),
+                ]
+            ),
+        ),
+    ),
+    primary_key_fields=["id"],
+)
+```
+
+![Export Complementary Taxonomy](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/export_all.png)
+
+The `cocoindex.storages.Relationships` declares how to map relationships in Neo4j.
+
+In a relationship, there's:
+
+1. A source node and a target node.
+2. A relationship connecting the source and target.
+Note that different relationships may share the same source and target nodes.
+
+`NodeFromFields` takes the fields from the `entity_relationship` collector and creates `Taxonomy` nodes.
+
+## Run the flow
+
+1. Install the dependencies:
+
+    ```
+    pip install -e .
+    ```
+
+2. Run the following command to setup and update the index.
+
+    ```sh
+    cocoindex update main
+    ```
+
+    You'll see the index updates state in the terminal. For example, you'll see the following output:
+
+    ```
+    documents: 9 added, 0 removed, 0 updated
+    ```
+
+## Browse the knowledge graph
+
+After the knowledge graph is built, you can explore the knowledge graph you built in Neo4j Browser.
+
+For the dev environment, you can connect to Neo4j browser using credentials:
+
+- username: `Neo4j`
+- password: `cocoindex`
+
+which is pre-configured in our docker compose [config.yaml](https://raw.githubusercontent.com/cocoindex-io/cocoindex/refs/heads/main/dev/Neo4j.yaml).
+
+You can open it at [http://localhost:7474](http://localhost:7474), and run the following Cypher query to get all relationships:
+
+```cypher
+MATCH p=()-->() RETURN p
+```
+
+![Neo4j Browser](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/neo4j.png)
+
+## CocoInsight
+
+I used CocoInsight to troubleshoot the index generation and understand the data lineage of the pipeline. It is in free beta now, you can give it a try. Run following command to start CocoInsight:
+
+```sh
+cocoindex server -ci main
+```
+
+And then open the url `https://cocoindex.io/cocoinsight`.  It just connects to your local CocoIndex server, with Zero pipeline data retention.

--- a/docs/src/content/example-posts/simple_vector_index.md
+++ b/docs/src/content/example-posts/simple_vector_index.md
@@ -1,0 +1,216 @@
+---
+title: Simple Vector Index with Text Embedding
+description: 'Indexing text with CocoIndex and text embeddings, and query it with natural language.'
+slug: simple_vector_index
+image: https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/cover.png
+tags: [vector-index]
+last_reviewed: 2026-01-18
+---
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding)
+
+![Simple Vector Index](https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/cover.png)
+
+## Overview
+
+In this tutorial, we will build index with text embeddings and query it with natural language.
+We try to keep it minimalistic and focus on the gist of the indexing flow.
+
+## Flow Overview
+
+![Flow](https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/flow.png)
+
+1. Read text files from the local filesystem
+2. Chunk each document
+3. For each chunk, embed it with a text embedding model
+4. Store the embeddings in a vector database for retrieval
+
+## Prerequisites
+
+- [Install Postgres](https://cocoindex.io/docs/getting_started/installation).
+CocoIndex uses Postgres to keep track of data lineage for incremental processing.
+
+## Add Source
+
+```python
+@cocoindex.flow_def(name="TextEmbedding")
+def text_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    """
+    Define an example flow that embeds text into a vector database.
+    """
+    data_scope["documents"] = flow_builder.add_source(
+        cocoindex.sources.LocalFile(path="markdown_files"))
+
+    doc_embeddings = data_scope.add_collector()
+```
+
+`flow_builder.add_source` will create a table with sub fields (`filename`, `content`)
+[→ Source](https://cocoindex.io/docs/sources)
+
+## Process each file and collect the embeddings
+
+### Chunk the file
+
+```python
+with data_scope["documents"].row() as doc:
+    doc["chunks"] = doc["content"].transform(
+        cocoindex.functions.SplitRecursively(),
+        language="markdown", chunk_size=2000, chunk_overlap=500)
+```
+
+![Chunking](https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/chunk.png)
+
+[→ SplitRecursively](https://cocoindex.io/docs/ops/functions#splitrecursively)
+
+### Embed each chunk
+
+```python
+with doc["chunks"].row() as chunk:
+    chunk["embedding"] = chunk["text"].transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"
+        )
+    )
+    doc_embeddings.collect(filename=doc["filename"], location=chunk["location"],
+                            text=chunk["text"], embedding=chunk["embedding"])
+```
+
+The `MiniLM-L6-v2` model is a good balance of speed and quality for text embeddings, though you can swap in other SentenceTransformer models as needed.
+
+[→ SentenceTransformerEmbed](https://cocoindex.io/docs/ops/functions#sentencetransformerembed)
+
+![Embedding](https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/embed.png)
+
+## Export the embeddings
+
+Export the embeddings to a table in Postgres.
+
+```python
+doc_embeddings.export(
+    "doc_embeddings",
+    cocoindex.storages.Postgres(),
+    primary_key_fields=["filename", "location"],
+    vector_indexes=[
+        cocoindex.VectorIndexDef(
+            field_name="embedding",
+            metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY)])
+```
+
+CocoIndex supports other vector databases as well, with 1-line switch.
+[→ Targets](https://cocoindex.io/docs/targets)
+
+Need IVFFlat or custom HNSW parameters? Pass a method, for example:
+
+```python
+cocoindex.VectorIndexDef(
+    field_name="embedding",
+    metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
+    method=cocoindex.IvfFlatVectorIndexMethod(lists=200),
+)
+```
+
+## Query the index
+
+### Define a shared flow for both indexing and querying
+
+```python
+@cocoindex.transform_flow()
+def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[list[float]]:
+    """
+    Embed the text using a SentenceTransformer model.
+    This is a shared logic between indexing and querying, so extract it as a function.
+    """
+    return text.transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"))
+```
+
+This code defines a transformation function that converts text into vector embeddings using the SentenceTransformer model.
+`@cocoindex.transform_flow()` is needed to share the transformation across indexing and query.
+
+This decorator marks this as a reusable transformation flow that can be called on specific input data from user code using `eval()`, as shown in the search function below.
+
+### Write query
+
+CocoIndex doesn't provide additional query interface at the moment. We can write SQL or rely on the query engine by the target storage, if any.
+
+[→ Postgres](https://cocoindex.io/docs/targets/postgres)
+
+```python
+def search(pool: ConnectionPool, query: str, top_k: int = 5):
+    table_name = cocoindex.utils.get_target_storage_default_name(text_embedding_flow, "doc_embeddings")
+    query_vector = text_to_embedding.eval(query)
+
+    with pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"""
+                SELECT filename, text, embedding <=> %s::vector AS distance
+                FROM {table_name} ORDER BY distance LIMIT %s
+            """, (query_vector, top_k))
+            return [
+                {"filename": row[0], "text": row[1], "score": 1.0 - row[2]}
+                for row in cur.fetchall()
+            ]
+```
+
+Setup `main()` for interactive query in terminal.
+
+```python
+def _main():
+    # Initialize the database connection pool.
+    pool = ConnectionPool(os.getenv("COCOINDEX_DATABASE_URL"))
+    # Run queries in a loop to demonstrate the query capabilities.
+    while True:
+        query = input("Enter search query (or Enter to quit): ")
+        if query == '':
+            break
+        # Run the query function with the database connection pool and the query.
+        results = search(pool, query)
+        print("\nSearch results:")
+        for result in results:
+            print(f"[{result['score']:.3f}] {result['filename']}")
+            print(f"    {result['text']}")
+            print("---")
+        print()
+
+if __name__ == "__main__":
+    load_dotenv()
+    cocoindex.init()
+    _main()
+```
+
+In the function above, most parts are standard query logic - you can use any libraries you like.
+There're two CocoIndex-specific logic:
+
+1. Get the table name from the export target in the `text_embedding_flow` above.
+    Since the table name for the `Postgres` target is not explicitly specified in the `export()` call,
+    CocoIndex uses a default name.
+    `cocoindex.utils.get_target_default_name()` is a utility function to get the default table name for this case.
+
+2. Evaluate the transform flow defined above with the input query, to get the embedding.
+    It's done by the `eval()` method of the transform flow `text_to_embedding`.
+    The return type of this method is `NDArray[np.float32]` as declared in the `text_to_embedding()` function (`cocoindex.DataSlice[NDArray[np.float32]]`).
+
+## Time to have fun
+
+- Run the following command to setup and update the index.
+
+    ```sh
+    cocoindex update main
+    ```
+
+- Start the interactive query in terminal.
+
+    ```sh
+    python main.py
+    ```
+
+## CocoInsight
+
+You can walk through the project step by step in [CocoInsight](https://www.youtube.com/watch?v=MMrpUfUcZPk) to see exactly how each field is constructed and what happens behind the scenes.
+
+```sh
+cocoindex server -ci main
+```
+
+Follow the url `https://cocoindex.io/cocoinsight`.  It connects to your local CocoIndex server, with zero pipeline data retention.

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -1,0 +1,399 @@
+// Metadata for the /docs/examples listing and per-example pages.
+//
+// Data is mirrored from github.com/cocoindex-io/examples — the markdown
+// bodies live in src/content/example-posts/<slug>.md and are rendered by
+// src/pages/examples/[slug].astro beneath the shared hero. Titles may use
+// *asterisks* to mark the italic-coral accent — see consts.titleMarkup.
+
+export type Category = 'search' | 'ingest' | 'llm' | 'agents' | 'image';
+
+export const CATEGORY_META: Record<Category, { label: string; em?: string; lead: string; thumbClass: string }> = {
+  search:  { label: 'Vector ',        em: 'Indexes',     lead: 'Embed your documents, store vectors, answer by meaning.',         thumbClass: 'search' },
+  ingest:  { label: 'Custom ',        em: 'Building Blocks', lead: 'Bring your own source, target, or parser. Same declarative flow.', thumbClass: 'ingest' },
+  llm:     { label: 'Structured ',    em: 'Extraction',  lead: 'Turn loose prose into structured data with LLMs, BAML, DSPy, or Ollama.', thumbClass: 'llm' },
+  agents:  { label: 'Knowledge ',     em: 'Graphs',      lead: 'Give agents a persistent, graph-shaped memory from conversations, meetings, products.', thumbClass: 'agents' },
+  image:   { label: 'Multimodal',                         lead: 'Images, PDFs, slides, faces — same flow, different encoder.',     thumbClass: 'pink' },
+};
+
+export type ExampleCard = {
+  slug: string;                      // becomes /docs/examples/<slug>
+  title: string;                     // asterisks → italic-coral, e.g. 'HN Trending *Topics*'
+  index: string;                     // e.g. '07 / 20' — shown top-right of thumb
+  category: Category;
+  thumbClass?: string;               // override (e.g. agents shown as multimodal pink card)
+  thumbLabel: string;                // small pill top-left of the thumb
+  motif?: string;                    // raw inner SVG markup for the thumb illustration
+  description: string;
+  tags: Array<{ kind: 'src' | 'tgt' | 'llm' | 'ops' | 'lvl'; label: string }>;
+  footMeta: string;                  // e.g. '~10 min · ~80 loc'
+  sourceSlug?: string;               // override GitHub path when the slug differs from the repo dir
+  featured?: boolean;
+};
+
+const MOTIFS = {
+  nodeGraph: `<svg class="m-node" viewBox="0 0 120 70"><rect x="10" y="20" width="28" height="28" rx="4"/><rect x="82" y="6" width="28" height="28" rx="4"/><rect x="82" y="34" width="28" height="28" rx="4"/><path d="M38 34 L82 20 M38 34 L82 48" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="24" cy="34" r="3"/><circle cx="96" cy="20" r="3"/><circle cx="96" cy="48" r="3"/></svg>`,
+  dots: `<svg class="m-dots" viewBox="0 0 120 70"><circle cx="16" cy="20" r="4"/><circle cx="36" cy="20" r="4"/><circle cx="56" cy="20" r="4"/><circle cx="76" cy="20" r="4" opacity="0.6"/><circle cx="96" cy="20" r="4" opacity="0.35"/><circle cx="16" cy="40" r="4"/><circle cx="36" cy="40" r="4"/><circle cx="56" cy="40" r="4" opacity="0.6"/><circle cx="16" cy="60" r="4"/><circle cx="36" cy="60" r="4" opacity="0.35"/></svg>`,
+  pdf: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="32" y="10" width="42" height="52" rx="2"/><path d="M32 20 L74 20 M40 30 L66 30 M40 38 L66 38 M40 46 L56 46"/><rect x="78" y="14" width="22" height="28" rx="1" opacity="0.5"/><circle cx="89" cy="56" r="8" fill="currentColor"/></svg>`,
+  hnArrow: `<svg viewBox="0 0 120 70" fill="none"><rect x="36" y="14" width="48" height="42" fill="currentColor" opacity="0.12"/><path d="M46 26 L60 40 L60 48 M60 40 L74 26" stroke="currentColor" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+  image: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="22" y="14" width="76" height="42" rx="3"/><circle cx="38" cy="26" r="4" fill="currentColor"/><path d="M22 46 L44 34 L64 44 L80 32 L98 40" stroke-linejoin="round"/></svg>`,
+  postgres: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><ellipse cx="60" cy="18" rx="28" ry="8"/><path d="M32 18 L32 52 Q32 60 60 60 T88 52 L88 18 M32 35 Q32 43 60 43 T88 35"/></svg>`,
+  filesTransform: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="16" y="18" width="32" height="34" rx="2"/><path d="M52 35 L72 35 M64 29 L72 35 L64 41" stroke-linecap="round" stroke-linejoin="round"/><rect x="76" y="18" width="32" height="34" rx="2"/><path d="M22 28 L42 28 M22 36 L42 36 M82 28 L102 28 M82 36 L96 36 M82 44 L102 44"/></svg>`,
+  forms: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="28" y="12" width="40" height="50" rx="2"/><path d="M36 22 L60 22 M36 30 L60 30 M36 38 L54 38"/><rect x="72" y="22" width="28" height="40" rx="2" fill="currentColor" opacity="0.14" stroke="none"/><path d="M76 32 L96 32 M76 40 L96 40 M76 48 L90 48" stroke="currentColor" stroke-width="1.2"/></svg>`,
+  cross: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M60 18 L60 52 M43 35 L77 35" stroke-linecap="round"/><circle cx="60" cy="35" r="22"/></svg>`,
+  dspy: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="30" cy="35" r="10"/><circle cx="60" cy="20" r="8"/><circle cx="60" cy="50" r="8"/><circle cx="90" cy="35" r="10"/><path d="M40 35 L52 22 M40 35 L52 48 M68 22 L80 35 M68 48 L80 35"/></svg>`,
+  slides: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="14" y="12" width="22" height="46" rx="2"/><rect x="40" y="12" width="22" height="46" rx="2"/><rect x="66" y="12" width="22" height="46" rx="2"/><rect x="92" y="12" width="14" height="46" rx="2" opacity="0.5"/></svg>`,
+  face: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="60" cy="35" r="22"/><circle cx="52" cy="30" r="2" fill="currentColor"/><circle cx="68" cy="30" r="2" fill="currentColor"/><path d="M52 42 Q60 48 68 42" stroke-linecap="round"/></svg>`,
+  knowledgeChat: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="16" y="16" width="40" height="24" rx="4"/><path d="M22 44 L32 36 L50 36" stroke-linecap="round"/><rect x="64" y="30" width="40" height="24" rx="4" fill="currentColor" opacity="0.14" stroke="currentColor"/><path d="M70 58 L80 50 L98 50" stroke-linecap="round"/></svg>`,
+  graphTree: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="60" cy="16" r="6" fill="currentColor"/><circle cx="28" cy="42" r="6" fill="currentColor"/><circle cx="60" cy="42" r="6" fill="currentColor"/><circle cx="92" cy="42" r="6" fill="currentColor"/><circle cx="44" cy="60" r="4" fill="currentColor" opacity="0.6"/><circle cx="76" cy="60" r="4" fill="currentColor" opacity="0.6"/><path d="M60 22 L30 38 M60 22 L60 38 M60 22 L90 38 M32 46 L42 58 M60 46 L48 58 M60 46 L74 58 M88 46 L78 58"/></svg>`,
+  boxArrows: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="14" y="14" width="92" height="42" rx="3"/><path d="M14 26 L106 26 M14 38 L106 38 M50 14 L50 56 M78 14 L78 56"/></svg>`,
+  hnStory: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="20" y="14" width="80" height="42" rx="3"/><path d="M26 26 L86 26 M26 34 L72 34 M26 42 L80 42"/><circle cx="92" cy="34" r="3" fill="currentColor"/></svg>`,
+  parser: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="18" y="14" width="30" height="42" rx="2"/><path d="M24 24 L42 24 M24 32 L42 32 M24 40 L36 40"/><path d="M52 35 L68 35 M60 29 L68 35 L60 41" stroke-linecap="round" stroke-linejoin="round"/><rect x="72" y="14" width="30" height="42" rx="2" fill="currentColor" opacity="0.14"/><path d="M78 24 L96 24 M78 32 L96 32 M78 40 L90 40 M78 48 L96 48" stroke-width="1.2"/></svg>`,
+  taxonomy: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="48" y="10" width="24" height="14" rx="2"/><rect x="20" y="34" width="24" height="14" rx="2"/><rect x="48" y="34" width="24" height="14" rx="2"/><rect x="76" y="34" width="24" height="14" rx="2"/><path d="M60 24 L32 34 M60 24 L60 34 M60 24 L88 34"/><rect x="20" y="54" width="16" height="10" rx="1.5" opacity="0.6"/><rect x="52" y="54" width="16" height="10" rx="1.5" opacity="0.6"/></svg>`,
+} as const;
+
+// The full catalog. Order determines display sequence within each category.
+export const examples: ExampleCard[] = [
+  // ── Vector Indexes ──
+  {
+    slug: 'simple_vector_index',
+    title: 'Simple Vector *Index*',
+    index: '01 / 20',
+    category: 'search',
+    thumbLabel: 'Text · Postgres',
+    motif: MOTIFS.dots,
+    description: 'The cleanest "hello world" for CocoIndex + embeddings — index markdown, query it with natural language.',
+    tags: [
+      { kind: 'src', label: 'Local FS' },
+      { kind: 'tgt', label: 'Postgres' },
+      { kind: 'lvl', label: 'Starter' },
+    ],
+    footMeta: '~6 min · starter',
+    sourceSlug: 'text_embedding',
+  },
+  {
+    slug: 'code_index',
+    title: 'Codebase *Indexing*',
+    index: '02 / 20',
+    category: 'search',
+    thumbLabel: 'Code · Tree-sitter',
+    motif: MOTIFS.nodeGraph,
+    description: 'Walk a repo, split by syntax, embed, and query your codebase in English. Real-time RAG for code.',
+    tags: [
+      { kind: 'src', label: 'Local FS' },
+      { kind: 'ops', label: 'Tree-sitter' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~10 min',
+    sourceSlug: 'code_embedding',
+  },
+  {
+    slug: 'academic_papers_index',
+    title: 'Academic *Papers*',
+    index: '03 / 20',
+    category: 'search',
+    thumbLabel: 'PDFs · metadata',
+    motif: MOTIFS.pdf,
+    description: 'Extract metadata, chunk and embed abstracts, enable semantic + author-based search over academic PDFs.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~20 min',
+    sourceSlug: 'paper_metadata',
+  },
+
+  // ── Custom Building Blocks ──
+  {
+    slug: 'postgres_source',
+    title: 'Postgres as a *Source*',
+    index: '04 / 20',
+    category: 'ingest',
+    thumbLabel: 'Postgres · CDC',
+    motif: MOTIFS.postgres,
+    description: 'Use an existing Postgres table as a CocoIndex source. AI transforms + data mappings flow into pgvector.',
+    tags: [
+      { kind: 'src', label: 'Postgres' },
+      { kind: 'tgt', label: 'pgvector' },
+      { kind: 'ops', label: 'Data mapping' },
+    ],
+    footMeta: '~12 min',
+  },
+  {
+    slug: 'custom_source_hackernews',
+    title: 'Custom Source *HN*',
+    index: '05 / 20',
+    category: 'ingest',
+    thumbLabel: 'HN · Algolia API',
+    motif: MOTIFS.hnStory,
+    description: 'Treat any API as a first-class incremental source. A custom HN connector that stays in sync with Postgres.',
+    tags: [
+      { kind: 'src', label: 'HN API' },
+      { kind: 'ops', label: 'Custom source' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~30 min',
+    sourceSlug: 'custom_source_hn',
+  },
+  {
+    slug: 'custom_targets',
+    title: 'Custom *Targets*',
+    index: '06 / 20',
+    category: 'ingest',
+    thumbLabel: 'Markdown → HTML',
+    motif: MOTIFS.filesTransform,
+    description: 'Export markdown files to local HTML using a custom target. The simplest file-to-file pipeline shape.',
+    tags: [
+      { kind: 'src', label: 'Local FS' },
+      { kind: 'tgt', label: 'Local FS' },
+      { kind: 'lvl', label: 'Starter' },
+    ],
+    footMeta: '~8 min',
+    sourceSlug: 'custom_output_files',
+  },
+
+  // ── Structured Extraction (HN is featured) ──
+  {
+    slug: 'hackernews-trending-topics',
+    title: 'HN Trending *Topics*',
+    index: '07 / 20',
+    category: 'llm',
+    thumbLabel: '★ HackerNews',
+    motif: MOTIFS.hnArrow,
+    description: 'Custom source + LLM extraction + live SQL. The showcase multi-stage example with 92% fewer API calls after the first sync.',
+    tags: [
+      { kind: 'src', label: 'HN API' },
+      { kind: 'llm', label: 'Gemini 2.5' },
+      { kind: 'tgt', label: 'Postgres' },
+      { kind: 'lvl', label: 'Advanced' },
+    ],
+    footMeta: '~45 min · featured',
+    sourceSlug: 'hn_trending_topics',
+    featured: true,
+  },
+  {
+    slug: 'manual_extraction',
+    title: 'Python Manual *Extraction*',
+    index: '08 / 20',
+    category: 'llm',
+    thumbLabel: 'Ollama · local',
+    motif: MOTIFS.forms,
+    description: 'Extract structured data from the Python manual markdowns with a local Ollama model.',
+    tags: [
+      { kind: 'src', label: 'Markdown' },
+      { kind: 'llm', label: 'Ollama' },
+      { kind: 'ops', label: 'Structured' },
+    ],
+    footMeta: '~18 min',
+  },
+  {
+    slug: 'patient_form_extraction',
+    title: 'Patient *Form* Extraction',
+    index: '09 / 20',
+    category: 'llm',
+    thumbLabel: 'Nested · typed',
+    motif: MOTIFS.forms,
+    description: 'Extract nested structured data from patient intake forms with field-level transformation and data mapping.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'ops', label: 'Data mapping' },
+    ],
+    footMeta: '~22 min',
+  },
+  {
+    slug: 'patient_form_extraction_baml',
+    title: 'Patient Intake *(BAML)*',
+    index: '10 / 20',
+    category: 'llm',
+    thumbLabel: 'BAML · typed',
+    motif: MOTIFS.cross,
+    description: 'BAML as the typed contract between LLM and code. Same intake problem, stronger guarantees.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'llm', label: 'BAML' },
+      { kind: 'ops', label: 'Structured' },
+    ],
+    footMeta: '~25 min',
+  },
+  {
+    slug: 'patient_form_extraction_dspy',
+    title: 'Patient Intake *(DSPy)*',
+    index: '11 / 20',
+    category: 'llm',
+    thumbLabel: 'DSPy · vision',
+    motif: MOTIFS.dspy,
+    description: 'DSPy-style prompt programming on vision models. Compare the ergonomics to the BAML variant side by side.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'llm', label: 'DSPy' },
+      { kind: 'ops', label: 'Vision models' },
+    ],
+    footMeta: '~28 min',
+  },
+  {
+    slug: 'document_ai',
+    title: 'Document AI *Parser*',
+    index: '12 / 20',
+    category: 'llm',
+    thumbLabel: 'Google · parse',
+    motif: MOTIFS.parser,
+    description: 'Bring your own parser. Google Document AI extracts, CocoIndex embeds and stores for semantic search.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'ops', label: 'Custom parser' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~20 min',
+  },
+
+  // ── Knowledge Graphs ──
+  {
+    slug: 'knowledge-graph-for-docs',
+    title: 'Knowledge Graph for *Docs*',
+    index: '13 / 20',
+    category: 'agents',
+    thumbLabel: 'Docs · Neo4j',
+    motif: MOTIFS.graphTree,
+    description: 'Build live knowledge for agents from documentation — incremental triple extraction with LLMs.',
+    tags: [
+      { kind: 'src', label: 'Markdown' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'tgt', label: 'Neo4j' },
+    ],
+    footMeta: '~30 min',
+    sourceSlug: 'docs_to_knowledge_graph',
+  },
+  {
+    slug: 'meeting_notes_graph',
+    title: 'Meeting Notes *Graph*',
+    index: '14 / 20',
+    category: 'agents',
+    thumbLabel: 'Drive · Neo4j',
+    motif: MOTIFS.knowledgeChat,
+    description: 'Turn Google Drive meeting notes into an automatically updating Neo4j knowledge graph.',
+    tags: [
+      { kind: 'src', label: 'Drive' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'tgt', label: 'Neo4j' },
+    ],
+    footMeta: '~32 min',
+  },
+  {
+    slug: 'product_recommendation',
+    title: 'Product *Recommendation*',
+    index: '15 / 20',
+    category: 'agents',
+    thumbLabel: 'Taxonomy · graph',
+    motif: MOTIFS.taxonomy,
+    description: 'Real-time recommendation engine — product taxonomy understanding via LLM, stored in a graph database.',
+    tags: [
+      { kind: 'src', label: 'Catalog' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'tgt', label: 'Graph DB' },
+    ],
+    footMeta: '~35 min',
+  },
+
+  // ── Multimodal ──
+  {
+    slug: 'image_search',
+    title: 'Image Search *(ColPali)*',
+    index: '16 / 20',
+    category: 'image',
+    thumbLabel: 'ColPali · FastAPI',
+    motif: MOTIFS.image,
+    description: 'ColPali embeddings served behind a FastAPI endpoint. Page-level multi-vector image search.',
+    tags: [
+      { kind: 'src', label: 'Images' },
+      { kind: 'llm', label: 'ColPali' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~22 min',
+  },
+  {
+    slug: 'image_search_clip',
+    title: 'Image Search *(CLIP)*',
+    index: '17 / 20',
+    category: 'image',
+    thumbLabel: 'CLIP · query',
+    motif: MOTIFS.image,
+    description: 'CLIP embeddings over a folder of images. Query by text or reference image.',
+    tags: [
+      { kind: 'src', label: 'Images' },
+      { kind: 'llm', label: 'CLIP' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~15 min',
+    sourceSlug: 'image_search',
+  },
+  {
+    slug: 'multi_format_index',
+    title: 'Multi-format *Index*',
+    index: '18 / 20',
+    category: 'image',
+    thumbLabel: 'PDF · slides · images',
+    motif: MOTIFS.slides,
+    description: 'ColPali over PDFs, images, academic papers, and slides — mixed together in the same vector space, no OCR.',
+    tags: [
+      { kind: 'src', label: 'Mixed' },
+      { kind: 'llm', label: 'ColPali' },
+      { kind: 'ops', label: 'No OCR' },
+    ],
+    footMeta: '~25 min',
+    sourceSlug: 'multi_format_indexing',
+  },
+  {
+    slug: 'pdf_elements',
+    title: 'PDF *Elements*',
+    index: '19 / 20',
+    category: 'image',
+    thumbLabel: 'PDF · unified',
+    motif: MOTIFS.pdf,
+    description: 'Extract, embed, and index both text and images from PDFs — SentenceTransformers + CLIP in one vector space.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'llm', label: 'CLIP + ST' },
+      { kind: 'ops', label: 'Unified' },
+    ],
+    footMeta: '~20 min',
+    sourceSlug: 'pdf_elements_embedding',
+  },
+  {
+    slug: 'photo_search',
+    title: 'Photo Search *(Faces)*',
+    index: '20 / 20',
+    category: 'image',
+    thumbLabel: 'Faces · similarity',
+    motif: MOTIFS.face,
+    description: 'Detect, extract, and embed faces from photos. Export to a vector DB for face similarity queries.',
+    tags: [
+      { kind: 'src', label: 'Images' },
+      { kind: 'ops', label: 'Face detect' },
+      { kind: 'tgt', label: 'Postgres' },
+    ],
+    footMeta: '~18 min',
+    sourceSlug: 'face_recognition',
+  },
+];
+
+// Featured example (rendered as the big hero card on the listing).
+export const featuredSlug = 'hackernews-trending-topics';
+
+// Helper lookups
+export const byCategory = (cat: Category): ExampleCard[] =>
+  examples.filter((e) => e.category === cat && !e.featured);
+
+export const findExample = (slug: string): ExampleCard | undefined =>
+  examples.find((e) => e.slug === slug);
+
+// Sidebar groupings on the listing page — derived from the catalog.
+export const SIDEBAR_TARGETS = ['Postgres', 'Neo4j', 'LanceDB', 'Graph DB', 'Local FS'];
+export const SIDEBAR_SOURCES = ['Local FS', 'PDF', 'Drive', 'Postgres', 'HN API', 'Images'];
+export const SIDEBAR_LLMS    = ['OpenAI', 'Gemini', 'Anthropic', 'Ollama', 'BAML', 'DSPy', 'CLIP', 'ColPali'];
+export const POPULAR: Array<{ slug: string; label: string; count: string }> = [
+  { slug: 'hackernews-trending-topics', label: 'HN Trending',        count: '★'  },
+  { slug: 'code_index',                 label: 'Codebase Indexing',  count: '★'  },
+  { slug: 'simple_vector_index',        label: 'Simple Vector Index', count: '★' },
+  { slug: 'image_search_clip',          label: 'Image Search (CLIP)', count: '★' },
+];

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -1,0 +1,575 @@
+---
+// Per-example detail page at /docs/examples/<slug>. The hero (eyebrow,
+// title, at-a-glance card) is driven by src/data/examples.ts; the body
+// is the MDX entry in the `examplePosts` content collection, ported
+// from github.com/cocoindex-io/examples. Add a new example by dropping a
+// markdown file into src/content/example-posts and a card into
+// examples.ts — the slugs must match.
+import '../../styles/globals.css';
+import Topbar from '../../components/Topbar.astro';
+import { GITHUB_REPO, SITE_URL, titleMarkup, titleText } from '../../consts';
+import { examples, findExample, CATEGORY_META, type Category } from '../../data/examples';
+import { getEntry, render } from 'astro:content';
+
+// Group examples by category for the left sidebar, in the same order as
+// the listing page. Featured examples stay in their home category — we're
+// showing them in a flat nav here, not as a separate "star" bucket.
+const CAT_ORDER: Category[] = ['search', 'ingest', 'llm', 'agents', 'image'];
+const grouped = CAT_ORDER.map((c) => ({
+  cat: c,
+  meta: CATEGORY_META[c],
+  items: examples.filter((e) => e.category === c),
+}));
+
+export async function getStaticPaths() {
+  return examples.map((e) => ({ params: { slug: e.slug } }));
+}
+
+const { slug } = Astro.params;
+const ex = findExample(slug!);
+if (!ex) throw new Error(`Unknown example slug: ${slug}`);
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '';
+const plainTitle = titleText(ex.title);
+const fullTitle = `${plainTitle} · CocoIndex Examples`;
+const canonical = new URL(`${base}/examples/${slug}`, SITE_URL).toString();
+// The repo directory usually matches the slug; override via sourceSlug when
+// it doesn't (e.g. listing slug `code_index` vs repo dir `code_embedding`).
+const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/main/examples/${ex.sourceSlug ?? slug}`;
+
+// Pull the ported markdown body. Every listed example should have a
+// matching entry, but we tolerate a missing one so we can ship the
+// listing + design even before a walkthrough lands.
+const entry = await getEntry('examplePosts', slug!);
+const rendered = entry ? await render(entry) : null;
+const Content = rendered?.Content;
+// Only h2 headings feed the TOC — h3/h4 add noise at this section count.
+const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#FBF6E8" />
+    <title>{fullTitle}</title>
+    <meta name="description" content={ex.description} />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" href={`${base}/img/favicon.ico`} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
+    />
+  </head>
+  <body class="ex-detail">
+    <Topbar />
+
+    <div class="ex-layout">
+      <!-- ─────────── LEFT: EXAMPLE NAV ─────────── -->
+      <aside class="ex-side" aria-label="All examples">
+        <div class="side-head">
+          <a href={`${base}/examples`}>← All examples</a>
+          <span class="ct">{examples.length}</span>
+        </div>
+        {grouped.map((g) => (
+          <div class="side-group">
+            <h6 data-cat={g.cat}>
+              <span class="cat-dot"></span>
+              {g.meta.label}{g.meta.em ?? ''}
+            </h6>
+            <ol>
+              {g.items.map((it) => (
+                <li class={it.slug === slug ? 'on' : ''}>
+                  <a href={`${base}/examples/${it.slug}`}>
+                    <span class="n">{it.index.split(' ')[0]}</span>
+                    <span class="ttl">{titleText(it.title)}</span>
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        ))}
+      </aside>
+
+      <main class="ex-main">
+      <!-- Local breadcrumb sits just below the sticky Topbar. -->
+      <nav class="ex-crumb" aria-label="Breadcrumb">
+        <a href={`${base}/examples`}>Examples</a>
+        <span class="sep">/</span>
+        <span class="cur">{plainTitle}</span>
+      </nav>
+
+      <!-- ─────────── HERO ─────────── -->
+      <section class="hero">
+        <div class="hero-eyebrow">
+          <span class="num">Example · {ex.index.split(' ')[0]}</span>
+          {ex.tags.map((t) => <span class="tag">{t.label}</span>)}
+          <span class="time">{ex.footMeta}</span>
+        </div>
+
+        <div class="hero-grid">
+          <div>
+            <h1 class="hero-h" set:html={titleMarkup(ex.title + (ex.title.endsWith('.') ? '' : '.'))} />
+            <p class="hero-sub">{ex.description}</p>
+            <div class="hero-cta">
+              <a class="btn btn-coral" href={sourceUrl}>View source
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </a>
+              {tocHeadings[0] && <a class="btn btn-outline-muted" href={`#${tocHeadings[0].slug}`}>Start reading</a>}
+              <a class="btn btn-outline-muted" href={`${base}/examples`}>All examples</a>
+            </div>
+            <div class="pill-row">
+              {ex.tags.slice(0, 4).map((t) => <span class="pill"><span class="dot"></span>{t.label}</span>)}
+              <span class="pill dark"><span class="dot"></span>Production ready</span>
+            </div>
+          </div>
+
+          <aside class="hero-card">
+            <div><div class="tl">At a glance</div></div>
+            <h2 class="big" set:html={titleMarkup('Built to *ship.* Clone and run.')} />
+            <div class="meta">
+              {ex.tags.find((t) => t.kind === 'src') && <div><span>Source</span><b>{ex.tags.find((t) => t.kind === 'src')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'llm') && <div><span>LLM</span><b>{ex.tags.find((t) => t.kind === 'llm')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'tgt') && <div><span>Target</span><b>{ex.tags.find((t) => t.kind === 'tgt')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'ops') && <div><span>Mode</span><b>{ex.tags.find((t) => t.kind === 'ops')!.label}</b></div>}
+              <div><span>Time</span><b>{ex.footMeta.split('·')[0].trim()}</b></div>
+              <div><span>Category</span><b>{ex.category}</b></div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ─────────── CONTENT ─────────── -->
+      {Content ? (
+        <article class="ex-prose">
+          <Content />
+        </article>
+      ) : (
+        <section class="blk">
+          <div class="sec-head">
+            <div class="sec-idx"><span class="n">00</span> · Overview</div>
+            <h2 set:html={titleMarkup('Write-up *on the way.*')} />
+            <p class="sec-lead">
+              The step-by-step walkthrough for this example is still being written. The code itself is live on GitHub — clone it to try it today.
+            </p>
+          </div>
+          <div class="callout" style="max-width:780px;">
+            <div class="hd tip"><span class="dt"></span>What this example shows</div>
+            <p>{ex.description}</p>
+          </div>
+        </section>
+      )}
+      </main>
+
+      <!-- ─────────── RIGHT: ON THIS PAGE ─────────── -->
+      <aside class="ex-toc toc" aria-label="On this page">
+        <div class="toc-head">
+          <span>On this page</span>
+          <span class="prog" id="tocProg">0 / {tocHeadings.length}</span>
+        </div>
+        <ol id="tocList">
+          {tocHeadings.map((h) => (
+            <li data-target={`#${h.slug}`}>
+              <a href={`#${h.slug}`}>{h.text}</a>
+            </li>
+          ))}
+        </ol>
+        <div class="toc-aside">
+          <a href={sourceUrl}>↗ Source on GitHub</a>
+          <a href={base || '/'}>↗ Full docs</a>
+          <a href={`${base}/examples`}>↗ All examples</a>
+        </div>
+      </aside>
+    </div>
+
+    <script is:inline>
+      (function(){
+        const tocItems = document.querySelectorAll('#tocList [data-target]');
+        const map = new Map();
+        tocItems.forEach((li) => {
+          const sel = li.getAttribute('data-target');
+          const el = document.querySelector(sel);
+          if (el) map.set(el, li);
+        });
+        const prog = document.getElementById('tocProg');
+        const total = map.size;
+        const active = new Set();
+        const io = new IntersectionObserver((entries) => {
+          entries.forEach((e) => {
+            const li = map.get(e.target);
+            if (!li) return;
+            if (e.isIntersecting) { li.classList.add('active'); active.add(li); }
+            else { li.classList.remove('active'); active.delete(li); }
+          });
+          if (prog) prog.textContent = `${active.size} / ${total}`;
+        }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+        map.forEach((_, el) => io.observe(el));
+      })();
+    </script>
+
+    <style is:global>
+      /* ═══════════ Detail-page styles ═══════════
+         Scoped to body.ex-detail. Palette inherited from globals.css. */
+      body.ex-detail { font-size: 17px; line-height: 1.55; }
+      /* ═══════════ 3-col layout (mirrors docs) ═══════════
+         Left: sticky example nav. Middle: breadcrumb + hero + content.
+         Right: sticky TOC. `--ex-side` / `--ex-toc` match the rail widths
+         used by globals.css on regular docs pages. */
+      body.ex-detail { --ex-side: 280px; --ex-toc: 240px; }
+      body.ex-detail .ex-layout {
+        display: grid;
+        grid-template-columns: var(--ex-side) 1fr var(--ex-toc);
+        max-width: 1480px;
+        margin: 0 auto;
+      }
+      body.ex-detail .ex-main { padding: 28px 48px 96px; min-width: 0; }
+
+      body.ex-detail .ex-side {
+        position: sticky; top: 57px; align-self: start;
+        height: calc(100vh - 57px);
+        overflow-y: auto;
+        padding: 28px 20px 40px 28px;
+        border-right: 1px solid var(--rule);
+        font-family: var(--sans);
+      }
+      body.ex-detail .ex-side .side-head {
+        display: flex; justify-content: space-between; align-items: baseline;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--muted);
+        padding-bottom: 10px; margin-bottom: 16px;
+        border-bottom: 1px solid var(--rule-strong);
+      }
+      body.ex-detail .ex-side .side-head a { color: var(--maroon-ink); text-decoration: none; }
+      body.ex-detail .ex-side .side-head a:hover { color: var(--coral); }
+      body.ex-detail .ex-side .side-head .ct { color: var(--coral); }
+      body.ex-detail .ex-side .side-group { margin-bottom: 18px; }
+      body.ex-detail .ex-side .side-group h6 {
+        display: flex; align-items: center; gap: 8px;
+        font-family: var(--sans); font-size: 12px; font-weight: 600; letter-spacing: -0.01em;
+        color: var(--maroon-ink); margin: 0 0 6px; padding: 0 6px;
+      }
+      body.ex-detail .ex-side .side-group h6 .cat-dot { width: 8px; height: 8px; border-radius: 2px; flex: none; background: var(--maroon); }
+      body.ex-detail .ex-side .side-group h6[data-cat="search"] .cat-dot { background: var(--maroon); }
+      body.ex-detail .ex-side .side-group h6[data-cat="ingest"] .cat-dot { background: var(--peach); }
+      body.ex-detail .ex-side .side-group h6[data-cat="llm"]    .cat-dot { background: var(--coral); }
+      body.ex-detail .ex-side .side-group h6[data-cat="agents"] .cat-dot { background: var(--maroon-ink); }
+      body.ex-detail .ex-side .side-group h6[data-cat="image"]  .cat-dot { background: var(--pink); }
+
+      body.ex-detail .ex-side ol { list-style: none; margin: 0 0 0 6px; padding: 0; }
+      body.ex-detail .ex-side ol li { margin: 0; }
+      body.ex-detail .ex-side ol li a {
+        display: grid; grid-template-columns: 24px 1fr; gap: 8px; align-items: baseline;
+        text-decoration: none; color: var(--muted);
+        font-size: 13px; line-height: 1.35;
+        padding: 5px 8px; border-radius: 5px;
+        transition: color .12s, background .12s;
+      }
+      body.ex-detail .ex-side ol li a .n { font-family: var(--mono); font-size: 11px; color: var(--rule-strong); }
+      body.ex-detail .ex-side ol li a .ttl { color: inherit; }
+      body.ex-detail .ex-side ol li a:hover { color: var(--coral); background: var(--cream); }
+      body.ex-detail .ex-side ol li.on a { color: var(--maroon); background: var(--cream); font-weight: 500; }
+      body.ex-detail .ex-side ol li.on a .n { color: var(--coral); }
+
+      body.ex-detail .ex-toc {
+        position: sticky; top: 57px; align-self: start;
+        height: calc(100vh - 57px);
+        overflow-y: auto;
+        padding: 28px 28px 40px 20px;
+        border-left: 1px solid var(--rule);
+        font-family: var(--sans);
+      }
+
+      body.ex-detail .ex-crumb {
+        font-family: var(--mono); font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase;
+        color: var(--muted); display: flex; gap: 10px; align-items: center;
+        padding: 20px 0 8px;
+      }
+      body.ex-detail .ex-crumb a { text-decoration: none; color: var(--muted); }
+      body.ex-detail .ex-crumb a:hover { color: var(--coral); }
+      body.ex-detail .ex-crumb .sep { opacity: 0.5; }
+      body.ex-detail .ex-crumb .cur { color: var(--maroon); }
+
+      /* Local button styles — scoped rather than leaking into prose/docs. */
+      body.ex-detail .btn {
+        display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+        padding: 10px 18px; border-radius: 999px;
+        font-family: var(--sans); font-size: 14px; font-weight: 500; line-height: 1.2;
+        text-decoration: none; white-space: nowrap;
+        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
+        transition: background .16s, color .16s, border-color .16s, transform .12s;
+      }
+      body.ex-detail .btn:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-detail .btn-primary { background: var(--maroon); color: var(--cream); }
+      body.ex-detail .btn-primary:hover { background: var(--maroon-deep); border-color: var(--maroon-deep); }
+      body.ex-detail .btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
+      body.ex-detail .btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
+      body.ex-detail .btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
+      body.ex-detail .btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+
+      /* ── HERO ── */
+      body.ex-detail .hero { padding: 32px 0 32px; position: relative; }
+      body.ex-detail .hero-eyebrow { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 28px; padding-bottom: 24px; border-bottom: 1px solid var(--rule); }
+      body.ex-detail .hero-eyebrow .num { font-family: var(--mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--coral); font-weight: 500; }
+      body.ex-detail .hero-eyebrow .tag { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); padding: 5px 12px; border: 1px solid var(--rule-strong); border-radius: 999px; }
+      body.ex-detail .hero-eyebrow .time { margin-left: auto; color: var(--muted); font-family: var(--mono); font-size: 12px; }
+
+      body.ex-detail .hero-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: 64px; align-items: end; }
+      body.ex-detail h1.hero-h { font-family: var(--serif); font-weight: 400; font-size: clamp(40px, 4.6vw, 60px); line-height: 0.98; letter-spacing: -0.03em; margin: 0 0 24px; max-width: 18ch; }
+      body.ex-detail h1.hero-h em { font-style: italic; color: var(--coral); }
+      body.ex-detail .hero-sub { font-family: var(--sans); font-size: clamp(17px, 1.4vw, 21px); font-weight: 400; line-height: 1.5; letter-spacing: -0.01em; color: var(--maroon-ink); max-width: 56ch; margin: 0 0 32px; }
+      body.ex-detail .hero-sub b { font-weight: 600; color: var(--maroon); }
+      body.ex-detail .hero-cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+      body.ex-detail .hero-card { background: var(--maroon); color: var(--cream); border-radius: 10px; padding: 32px; position: relative; overflow: hidden; min-height: 320px; display: flex; flex-direction: column; justify-content: space-between; }
+      body.ex-detail .hero-card::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.6px, transparent 2px); background-size: 20px 20px; }
+      body.ex-detail .hero-card > * { position: relative; z-index: 2; }
+      body.ex-detail .hero-card .tl { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .hero-card .big { font-family: var(--sans); font-size: clamp(40px, 4.6vw, 58px); font-weight: 600; letter-spacing: -0.035em; line-height: 0.98; margin: 0; color: var(--cream); }
+      body.ex-detail .hero-card .big em { color: var(--peach); font-style: italic; }
+      body.ex-detail .hero-card .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 28px; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.18); font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .hero-card .meta b { display: block; color: var(--cream); font-weight: 400; margin-top: 3px; letter-spacing: 0.02em; text-transform: none; font-size: 13px; }
+
+      body.ex-detail .pill-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 32px; padding-top: 24px; border-top: 1px solid var(--rule); }
+      body.ex-detail .pill { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 7px 14px; border-radius: 999px; background: var(--cream); border: 1px solid var(--rule); color: var(--maroon); }
+      body.ex-detail .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); }
+      body.ex-detail .pill.dark { background: var(--maroon-ink); color: var(--cream); border-color: var(--maroon-ink); }
+      body.ex-detail .pill.dark .dot { background: var(--palm); }
+
+      /* ── DOC LAYOUT ── */
+      /* (doc/toc 2-col rules removed — new .ex-layout handles positioning) */
+      body.ex-detail .toc-head { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); padding-bottom: 10px; margin-bottom: 14px; border-bottom: 1px solid var(--rule-strong); display: flex; justify-content: space-between; align-items: baseline; }
+      body.ex-detail .toc-head .prog { color: var(--coral); font-family: var(--mono); }
+      body.ex-detail .toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc-part; }
+      body.ex-detail .toc > ol > li { counter-increment: toc-part; margin-bottom: 18px; }
+      body.ex-detail .toc > ol > li > a { display: flex; align-items: baseline; gap: 10px; text-decoration: none; color: var(--maroon-ink); font-size: 14px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.3; padding: 6px 0; transition: color .15s; }
+      body.ex-detail .toc > ol > li > a::before { content: counter(toc-part, decimal-leading-zero); font-family: var(--mono); font-weight: 500; font-size: 11px; letter-spacing: 0.06em; color: var(--muted); flex: none; }
+      body.ex-detail .toc > ol > li > a:hover { color: var(--coral); }
+      body.ex-detail .toc > ol > li.active > a { color: var(--coral); }
+      body.ex-detail .toc ul { list-style: none; padding: 0; margin: 6px 0 4px 26px; counter-reset: toc-step; }
+      body.ex-detail .toc ul li { counter-increment: toc-step; }
+      body.ex-detail .toc ul li a { display: flex; align-items: baseline; gap: 8px; text-decoration: none; color: var(--muted); font-size: 13px; font-weight: 400; line-height: 1.4; padding: 4px 0; transition: color .15s; }
+      body.ex-detail .toc ul li a::before { content: counter(toc-part) "." counter(toc-step); font-family: var(--mono); font-size: 10px; color: var(--rule-strong); flex: none; min-width: 22px; }
+      body.ex-detail .toc ul li a:hover { color: var(--coral); }
+      body.ex-detail .toc ul li.active a { color: var(--maroon); }
+      body.ex-detail .toc ul li.active a::before { color: var(--coral); }
+      body.ex-detail .toc .toc-aside { margin-top: 28px; padding-top: 16px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: flex; flex-direction: column; gap: 8px; }
+      body.ex-detail .toc .toc-aside a { text-decoration: none; color: var(--maroon-ink); display: flex; align-items: center; gap: 6px; }
+      body.ex-detail .toc .toc-aside a:hover { color: var(--coral); }
+
+      body.ex-detail .doc .col-main { min-width: 0; }
+      body.ex-detail section.blk { padding: 72px 0; border-top: 1px solid var(--rule); position: relative; scroll-margin-top: 84px; }
+      body.ex-detail section.blk:first-of-type { border-top: none; padding-top: 24px; }
+      body.ex-detail .sec-head { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 40px; }
+      body.ex-detail .sec-idx { display: inline-flex; gap: 10px; align-items: baseline; font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .sec-idx .n { color: var(--coral); font-weight: 500; }
+      body.ex-detail .sec-head h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(28px, 3.2vw, 44px); line-height: 1.05; letter-spacing: -0.03em; margin: 0; max-width: 22ch; }
+      body.ex-detail .sec-head h2 em { font-style: normal; color: var(--coral); }
+      body.ex-detail .sec-lead { font-family: var(--sans); font-size: clamp(15px, 1.2vw, 17px); font-weight: 400; line-height: 1.55; color: var(--maroon-ink); max-width: 64ch; margin: 8px 0 0; }
+      body.ex-detail .sec-lead a { color: var(--coral); }
+
+      /* Architecture (HN flow) */
+      body.ex-detail .arch { background: var(--cream); border: 1px solid var(--rule); border-radius: 12px; padding: 36px; display: grid; grid-template-columns: 0.9fr auto 1.2fr auto 1fr; gap: 18px; align-items: stretch; }
+      body.ex-detail .arch-col { display: flex; flex-direction: column; gap: 10px; padding: 20px; border-radius: 8px; background: var(--paper); border: 1px solid var(--rule); min-height: 320px; }
+      body.ex-detail .arch-col h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin: 0 0 4px; padding-bottom: 10px; border-bottom: 1px solid var(--rule); display: flex; justify-content: space-between; align-items: center; }
+      body.ex-detail .arch-col h4 .n { color: var(--coral); font-weight: 500; }
+      body.ex-detail .chip { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-radius: 6px; background: var(--cream); border: 1px solid var(--rule); font-size: 13px; font-weight: 500; }
+      body.ex-detail .chip .ico { width: 22px; height: 22px; flex: none; display: grid; place-items: center; border-radius: 4px; background: var(--peach); color: var(--maroon); font-family: var(--mono); font-size: 10px; font-weight: 600; }
+      body.ex-detail .chip .ico.hn { background: #FF6600; color: #fff; }
+      body.ex-detail .chip .ico.pg { background: #336791; color: #fff; }
+      body.ex-detail .chip .ico.llm { background: var(--maroon-ink); color: var(--peach); }
+      body.ex-detail .chip .tail { margin-left: auto; font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+
+      body.ex-detail .arch-core { background: var(--maroon); color: var(--cream); border-radius: 8px; padding: 22px; position: relative; overflow: hidden; display: flex; flex-direction: column; gap: 12px; }
+      body.ex-detail .arch-core::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.4px, transparent 1.8px); background-size: 16px 16px; }
+      body.ex-detail .arch-core > * { position: relative; z-index: 2; }
+      body.ex-detail .arch-core h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); display: flex; justify-content: space-between; padding-bottom: 10px; border-bottom: 1px solid rgba(252, 243, 216, 0.18); margin: 0; }
+      body.ex-detail .arch-core h4 .n { color: var(--peach); }
+      body.ex-detail .arch-core .title { font-family: var(--sans); font-weight: 600; font-size: 21px; line-height: 1.2; letter-spacing: -0.02em; margin: 0; color: var(--cream); }
+      body.ex-detail .arch-core .title em { font-style: normal; color: var(--peach); }
+      body.ex-detail .arch-core .sub { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.6); }
+      body.ex-detail .arch-core .rows { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+      body.ex-detail .arch-core .rows .r { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 5px; background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.1); font-family: var(--mono); font-size: 12px; }
+      body.ex-detail .arch-core .rows .r .k { color: var(--peach); }
+      body.ex-detail .arch-core .rows .r .v { color: rgba(252, 243, 216, 0.9); }
+      body.ex-detail .arch-core .stamp { margin-top: auto; display: flex; gap: 8px; flex-wrap: wrap; font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.65); }
+      body.ex-detail .arch-core .stamp span { padding: 4px 10px; border: 1px solid rgba(252, 243, 216, 0.2); border-radius: 999px; }
+
+      body.ex-detail .arrow { align-self: center; display: flex; flex-direction: column; align-items: center; gap: 6px; min-width: 48px; }
+      body.ex-detail .arrow svg { width: 48px; height: 18px; }
+      body.ex-detail .arrow .lab { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+
+      body.ex-detail .trending-preview { margin-top: 20px; background: var(--paper); border: 1px solid var(--rule); border-radius: 8px; padding: 22px; display: grid; grid-template-columns: 1fr 2fr; gap: 24px; align-items: start; }
+      body.ex-detail .trending-preview h5 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--coral); margin: 0 0 6px; }
+      body.ex-detail .trending-preview p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.5; }
+      body.ex-detail .trending-preview .inline-code { font-family: var(--mono); font-size: 12px; background: var(--cream); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--rule); color: var(--berry); }
+      body.ex-detail .trending-list { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .trending-row { display: grid; grid-template-columns: 28px 1fr auto auto; gap: 14px; align-items: baseline; padding: 7px 12px; border-radius: 5px; font-family: var(--mono); font-size: 13px; border: 1px solid transparent; }
+      body.ex-detail .trending-row:hover { background: var(--cream); border-color: var(--rule); }
+      body.ex-detail .trending-row .rk { color: var(--muted); font-size: 11px; }
+      body.ex-detail .trending-row .tp { color: var(--maroon); font-weight: 500; }
+      body.ex-detail .trending-row .tp em { color: var(--coral); font-style: normal; }
+      body.ex-detail .trending-row .sc { color: var(--coral); font-weight: 600; }
+      body.ex-detail .trending-row .th { color: var(--muted); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; }
+
+      /* Part banner */
+      body.ex-detail .part-banner { display: grid; grid-template-columns: 72px 1fr auto; gap: 24px; align-items: center; margin: 0 0 32px; padding: 24px 28px; background: linear-gradient(90deg, var(--cream) 0%, var(--paper) 100%); border: 1px solid var(--rule); border-left: 4px solid var(--coral); border-radius: 8px; position: relative; }
+      body.ex-detail .part-banner .pn { font-family: var(--mono); font-size: 34px; font-weight: 500; letter-spacing: -0.02em; color: var(--coral); line-height: 1; }
+      body.ex-detail .part-banner .pc { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .part-banner .pc .plabel { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .part-banner .pc h3 { font-family: var(--sans); font-weight: 600; font-size: 26px; letter-spacing: -0.025em; line-height: 1.15; margin: 0; }
+      body.ex-detail .part-banner .pc h3 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .part-banner .pc p { margin: 4px 0 0; color: var(--muted); font-size: 14px; line-height: 1.5; max-width: 60ch; }
+      body.ex-detail .part-banner .pm { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); text-align: right; display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .part-banner .pm b { color: var(--maroon); font-weight: 500; }
+
+      /* Steps */
+      body.ex-detail .steps-wrap { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 48px; }
+      body.ex-detail .step { display: grid; grid-template-columns: 72px 1fr; grid-template-rows: auto auto; column-gap: 24px; row-gap: 20px; align-items: start; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); padding: 28px 30px; position: relative; scroll-margin-top: 90px; }
+      body.ex-detail .step-num { grid-row: 1 / 3; display: flex; flex-direction: column; align-items: flex-start; gap: 10px; align-self: stretch; }
+      body.ex-detail .step-num .chip-num { width: 46px; height: 46px; border-radius: 50%; display: grid; place-items: center; background: var(--maroon); color: var(--cream); font-family: var(--mono); font-weight: 500; font-size: 14px; letter-spacing: 0; }
+      body.ex-detail .step.coral .step-num .chip-num { background: var(--coral); }
+      body.ex-detail .step-num .rail { width: 2px; flex: 1; background: var(--rule-strong); opacity: 0.4; }
+      body.ex-detail .step-num .tag { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .step-head { grid-column: 2; grid-row: 1; max-width: 72ch; }
+      body.ex-detail .step-head h4 { font-family: var(--sans); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; line-height: 1.2; margin: 0 0 10px; }
+      body.ex-detail .step-head h4 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .step-head p { margin: 0 0 14px; color: var(--maroon-ink); max-width: 64ch; font-size: 15px; line-height: 1.55; }
+      body.ex-detail .step-head code,
+      body.ex-detail .step-head p code,
+      body.ex-detail .callout code,
+      body.ex-detail .step-bullets code { font-family: var(--mono); font-size: 13px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 1px 6px; border-radius: 3px; }
+      body.ex-detail .step-bullets { list-style: none; padding: 0; margin: 0 0 6px; display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .step-bullets li { display: flex; gap: 10px; align-items: flex-start; font-size: 13.5px; color: var(--muted); padding: 6px 0; border-top: 1px solid var(--rule); }
+      body.ex-detail .step-bullets li::before { content: ""; width: 6px; height: 6px; margin-top: 7px; flex: none; background: var(--coral); border-radius: 50%; }
+      body.ex-detail .step-bullets li b { color: var(--maroon); font-weight: 500; }
+      body.ex-detail .step-side { grid-column: 2; grid-row: 2; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+
+      /* Code block — matches cocoindex-dark shiki theme. */
+      body.ex-detail .code { background: var(--maroon-ink); color: var(--cream); border-radius: 8px; font-family: var(--mono); font-size: 12.5px; line-height: 1.65; padding: 0; overflow: hidden; }
+      body.ex-detail .code-bar { display: flex; align-items: center; gap: 10px; padding: 11px 16px; border-bottom: 1px solid rgba(252, 243, 216, 0.1); font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.65); }
+      body.ex-detail .code-bar .dots { display: flex; gap: 6px; }
+      body.ex-detail .code-bar .dots span { width: 9px; height: 9px; border-radius: 50%; background: rgba(252, 243, 216, 0.22); }
+      body.ex-detail .code-bar .dots span:first-child { background: var(--pink); }
+      body.ex-detail .code-bar .dots span:nth-child(2) { background: var(--peach); }
+      body.ex-detail .code-bar .dots span:nth-child(3) { background: var(--palm); }
+      body.ex-detail .code-bar .name { margin-left: 8px; }
+      body.ex-detail .code-bar .lang { margin-left: auto; opacity: 0.65; }
+      body.ex-detail .code pre { margin: 0; padding: 16px 18px 20px; overflow-x: auto; white-space: pre; tab-size: 4; color: var(--cream); }
+      body.ex-detail .code .kw { color: var(--peach); }
+      body.ex-detail .code .dec { color: var(--peach); }
+      body.ex-detail .code .fn { color: var(--pink); }
+      body.ex-detail .code .str { color: #8ef09e; }
+      body.ex-detail .code .num { color: #F5D76E; }
+      body.ex-detail .code .tp { color: #C9B8F5; }
+      body.ex-detail .code .dim { opacity: 0.48; }
+      body.ex-detail .code .comment { color: #978A74; font-style: italic; opacity: 0.75; }
+      body.ex-detail .code.terminal .prompt::before { content: "$ "; color: var(--peach); }
+
+      body.ex-detail .callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }
+      body.ex-detail .callout .hd { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .callout .hd .dt { width: 8px; height: 8px; border-radius: 50%; background: var(--coral); }
+      body.ex-detail .callout .hd.tip .dt { background: var(--palm); }
+      body.ex-detail .callout .hd.note .dt { background: var(--peach); }
+      body.ex-detail .callout .hd.warn .dt { background: var(--pink); }
+      body.ex-detail .callout p { margin: 0; color: var(--maroon-ink); }
+
+      /* Variations */
+      body.ex-detail .var-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+      body.ex-detail .var-card { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 26px 24px 20px; background: var(--paper); display: flex; flex-direction: column; gap: 10px; min-height: 200px; transition: background-image .18s ease; text-decoration: none; color: inherit; position: relative; overflow: hidden; }
+      body.ex-detail .var-card:hover { background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px); background-size: 14px 14px; }
+      body.ex-detail .var-card.dark:hover { background-image: radial-gradient(circle, rgba(252, 243, 216, 0.1) 1.2px, transparent 1.6px); }
+      body.ex-detail .var-card .cap { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); display: flex; justify-content: space-between; }
+      body.ex-detail .var-card .cap .num { color: var(--coral); }
+      body.ex-detail .var-card h4 { font-family: var(--sans); font-weight: 600; font-size: 19px; letter-spacing: -0.02em; line-height: 1.2; margin: 0; }
+      body.ex-detail .var-card h4 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .var-card p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; flex: 1; }
+      body.ex-detail .var-card .foot { padding-top: 14px; margin-top: 6px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--coral); display: flex; justify-content: space-between; align-items: center; }
+      body.ex-detail .var-card.dark { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-detail .var-card.dark .cap, body.ex-detail .var-card.dark p { color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .var-card.dark .cap .num { color: var(--peach); }
+      body.ex-detail .var-card.dark .foot { color: var(--peach); border-color: rgba(252, 243, 216, 0.15); }
+      body.ex-detail .var-card.dark h4 em { color: var(--peach); }
+
+      /* Try-it */
+      body.ex-detail .tryit { background: var(--maroon); color: var(--cream); border-radius: 12px; padding: 40px; display: grid; grid-template-columns: 1fr 1.4fr; gap: 40px; align-items: stretch; position: relative; overflow: hidden; }
+      body.ex-detail .tryit::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.07) 1.4px, transparent 1.8px); background-size: 20px 20px; }
+      body.ex-detail .tryit > * { position: relative; z-index: 2; }
+      body.ex-detail .tryit h3 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.8vw, 36px); line-height: 1.08; letter-spacing: -0.03em; margin: 0 0 16px; max-width: 14ch; color: var(--cream); }
+      body.ex-detail .tryit h3 em { color: var(--peach); font-style: normal; }
+      body.ex-detail .tryit p { color: rgba(252, 243, 216, 0.85); max-width: 38ch; margin: 0 0 22px; }
+      body.ex-detail .tryit .tags { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
+      body.ex-detail .tryit .tags span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; padding: 5px 12px; border: 1px solid rgba(252, 243, 216, 0.22); border-radius: 999px; color: rgba(252, 243, 216, 0.75); }
+      body.ex-detail .tryit .queries { display: flex; flex-direction: column; gap: 12px; }
+      body.ex-detail .q-card { background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.15); border-radius: 8px; padding: 16px 18px; }
+      body.ex-detail .q-card .q { font-family: var(--mono); font-size: 13px; color: var(--cream); padding-bottom: 12px; margin-bottom: 12px; border-bottom: 1px solid rgba(252, 243, 216, 0.12); }
+      body.ex-detail .q-card .q::before { content: "query "; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--peach); margin-right: 8px; font-weight: 500; }
+      body.ex-detail .q-card .q em { color: var(--palm); font-style: normal; }
+      body.ex-detail .q-card .hits { display: flex; flex-direction: column; gap: 6px; font-family: var(--mono); font-size: 12px; line-height: 1.55; }
+      body.ex-detail .q-card .hit { display: grid; grid-template-columns: 52px 1fr auto; gap: 12px; align-items: baseline; padding: 3px 0; }
+      body.ex-detail .q-card .hit .sc { color: var(--palm); font-weight: 600; }
+      body.ex-detail .q-card .hit .pth { color: rgba(252, 243, 216, 0.9); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      body.ex-detail .q-card .hit .rng { color: rgba(252, 243, 216, 0.6); }
+
+      /* CTA end */
+      body.ex-detail .cta-end { border-radius: 12px; background: var(--cream); border: 1px solid var(--rule); padding: 60px 44px; text-align: center; position: relative; overflow: hidden; }
+      body.ex-detail .cta-end h3 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 3vw, 38px); line-height: 1.08; letter-spacing: -0.03em; margin: 0 auto 18px; max-width: 20ch; }
+      body.ex-detail .cta-end h3 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .cta-end p { color: var(--muted); max-width: 46ch; margin: 0 auto 26px; font-size: 17px; }
+      body.ex-detail .cta-end .btns { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+
+      @media (max-width: 1100px) {
+        body.ex-detail .ex-layout { grid-template-columns: 1fr; }
+        body.ex-detail .ex-side,
+        body.ex-detail .ex-toc { position: static; height: auto; border: none; padding: 18px 20px; }
+        body.ex-detail .ex-side { border-bottom: 1px solid var(--rule); }
+        body.ex-detail .ex-toc { border-top: 1px solid var(--rule); }
+        body.ex-detail .ex-main { padding: 24px 28px 64px; }
+        body.ex-detail .arch { grid-template-columns: 1fr; gap: 12px; padding: 24px; }
+        body.ex-detail .arrow { transform: rotate(90deg); align-self: center; margin: 4px 0; }
+        body.ex-detail .hero-grid { grid-template-columns: 1fr; gap: 36px; }
+        body.ex-detail .step { grid-template-columns: 56px 1fr; column-gap: 16px; row-gap: 16px; padding: 24px; }
+        body.ex-detail .step-head, body.ex-detail .step-side { grid-column: 2; }
+        body.ex-detail .tryit { grid-template-columns: 1fr; padding: 32px; }
+        body.ex-detail .var-grid { grid-template-columns: 1fr 1fr; }
+        body.ex-detail .part-banner { grid-template-columns: 54px 1fr; gap: 18px; padding: 18px 20px; }
+        body.ex-detail .part-banner .pm { grid-column: 1 / -1; text-align: left; }
+        body.ex-detail .trending-preview { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 640px) { body.ex-detail .var-grid { grid-template-columns: 1fr; } }
+
+      /* ═══════════ Prose (rendered MDX body) ═══════════
+         The ported markdown drops into `.ex-prose`. Keep the typography
+         anchored on the same palette as the docs prose, without pulling
+         in the docs `.prose` container itself — that one's tuned for a
+         narrower column and a different heading scale. */
+      body.ex-detail .ex-prose { padding-top: 40px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
+      body.ex-detail .ex-prose > :first-child { margin-top: 0; }
+      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; padding-top: 28px; border-top: 1px solid var(--rule); }
+      body.ex-detail .ex-prose > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 24px; }
+      body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: 84px; }
+      body.ex-detail .ex-prose h4 { font-family: var(--sans); font-weight: 600; font-size: 17px; letter-spacing: -0.01em; margin: 28px 0 10px; }
+      body.ex-detail .ex-prose p { margin: 0 0 18px; }
+      body.ex-detail .ex-prose a { color: var(--coral); text-decoration: none; border-bottom: 1px solid rgba(190, 81, 51, 0.35); transition: border-color .15s, color .15s; }
+      body.ex-detail .ex-prose a:hover { color: var(--maroon); border-color: var(--maroon); }
+      body.ex-detail .ex-prose ul, body.ex-detail .ex-prose ol { margin: 0 0 18px; padding-left: 22px; }
+      body.ex-detail .ex-prose li { margin-bottom: 6px; }
+      body.ex-detail .ex-prose li > p { margin-bottom: 6px; }
+      body.ex-detail .ex-prose strong, body.ex-detail .ex-prose b { color: var(--maroon); font-weight: 600; }
+      body.ex-detail .ex-prose em, body.ex-detail .ex-prose i { font-style: italic; }
+      body.ex-detail .ex-prose img { max-width: 100%; height: auto; border-radius: 8px; margin: 20px 0; border: 1px solid var(--rule); }
+      body.ex-detail .ex-prose blockquote { margin: 20px 0; padding: 10px 18px; border-left: 3px solid var(--coral); background: var(--cream); border-radius: 0 6px 6px 0; color: var(--muted); }
+      body.ex-detail .ex-prose blockquote p { margin: 0; }
+      body.ex-detail .ex-prose :not(pre) > code { font-family: var(--mono); font-size: 13.5px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 2px 7px; border-radius: 4px; }
+      body.ex-detail .ex-prose pre { background: var(--maroon-ink); color: var(--cream); border-radius: 8px; padding: 18px 20px; overflow-x: auto; font-family: var(--mono); font-size: 13px; line-height: 1.6; margin: 20px 0; border: none; }
+      body.ex-detail .ex-prose pre code { background: transparent; color: inherit; padding: 0; font-size: inherit; border-radius: 0; }
+      body.ex-detail .ex-prose hr { border: none; border-top: 1px solid var(--rule); margin: 40px 0; }
+      body.ex-detail .ex-prose table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 14px; }
+      body.ex-detail .ex-prose th, body.ex-detail .ex-prose td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--rule); }
+      body.ex-detail .ex-prose th { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); border-bottom-color: var(--rule-strong); }
+      body.ex-detail .ex-prose kbd { font-family: var(--mono); font-size: 12px; padding: 2px 6px; border: 1px solid var(--rule-strong); border-radius: 4px; background: var(--cream); }
+    </style>
+  </body>
+</html>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -1,0 +1,714 @@
+---
+// Ports design_guidelines/CocoIndex Examples Listing.html into an Astro page
+// at /docs/examples. Reuses the shared Topbar from the docs site so the
+// header is identical across /docs and /docs/examples. All example cards
+// come from src/data/examples.ts — when you add a new example, update that
+// file and the card appears in its category automatically.
+import '../../styles/globals.css';
+import Topbar from '../../components/Topbar.astro';
+import { GITHUB_REPO, DISCORD_URL, SITE_URL, titleMarkup } from '../../consts';
+import {
+  examples,
+  byCategory,
+  findExample,
+  CATEGORY_META,
+  SIDEBAR_TARGETS,
+  SIDEBAR_SOURCES,
+  SIDEBAR_LLMS,
+  POPULAR,
+  featuredSlug,
+  type Category,
+} from '../../data/examples';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '';
+const exampleHref = (slug: string) => `${base}/examples/${slug}`;
+const featured = findExample(featuredSlug)!;
+
+// Category order and counts, computed from the data.
+const CAT_ORDER: Category[] = ['search', 'ingest', 'llm', 'agents', 'image'];
+const catCount = (c: Category) => examples.filter((e) => e.category === c).length;
+
+const total = examples.length;
+const fullTitle = `Examples · CocoIndex Docs`;
+const description = 'Real pipelines you can clone, run, and bend to your data — custom sources, LLM extraction, vector search, streaming ingest.';
+const canonical = new URL(`${base}/examples`, SITE_URL).toString();
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#FBF6E8" />
+    <title>{fullTitle}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" href={`${base}/img/favicon.ico`} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
+    />
+  </head>
+  <body class="ex-listing">
+    <Topbar />
+
+    <div class="ex-wrap">
+      <!-- ═══════════ HERO ═══════════ -->
+      <section class="ex-hero">
+        <div class="hero-top">
+          <span class="eyb"><span class="dot" aria-hidden="true"></span>{total} live examples · updated weekly</span>
+          <div class="stats">
+            <span><b>{total}</b> examples</span>
+            <span><b>9</b> sources</span>
+            <span><b>6</b> targets</span>
+            <span><b>5</b> LLM providers</span>
+          </div>
+        </div>
+
+        <div class="hero-grid">
+          <div>
+            <h1 class="hero-h">Examples<em>.</em></h1>
+            <p class="hero-sub">
+              Real pipelines you can <b>clone, run, and bend</b> to your data. Each example is production-wired — one source, a declarative flow, a live target. Pick the one closest to what you need and change the parts that don't fit.
+            </p>
+
+            <div class="hero-filters" id="filters">
+              <button class="filter-chip on" data-filter="all">All <span class="cnt">{total}</span></button>
+              {CAT_ORDER.map((c) => (
+                <button class="filter-chip" data-filter={c}>
+                  {CATEGORY_META[c].label}{CATEGORY_META[c].em ?? ''} <span class="cnt">{catCount(c)}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div class="hero-viz" aria-hidden="true">
+            <div class="t search"><span class="lb">Search · RAG</span><span class="ct">{catCount('search')} <em>examples</em></span></div>
+            <div class="t ingest"><span class="lb">Ingest</span><span class="ct">{catCount('ingest')} <em>examples</em></span></div>
+            <div class="t llm"><span class="lb">LLM · Extract</span><span class="ct">{catCount('llm')} <em>examples</em></span></div>
+            <div class="t agents"><span class="lb">Agents</span><span class="ct">{catCount('agents')} <em>examples</em></span></div>
+            <div class="t multi"><span class="lb">Multimodal</span><span class="ct">{catCount('image')} <em>examples</em></span></div>
+            <div class="t custom"><span class="lb">Custom source</span><span class="ct">4 <em>examples</em></span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════ DOC LAYOUT ═══════════ -->
+      <div class="doc">
+        <aside class="side-nav" aria-label="Browse examples">
+          <div class="side-head">
+            <span>Browse</span>
+            <span class="ct">{total} examples</span>
+          </div>
+          <ol id="sideList">
+            <li data-target="section.feat"><a href="#feat-scroll" data-cat="featured"><span class="cat-dot"></span>Featured<span class="count">★</span></a></li>
+            {CAT_ORDER.map((c) => (
+              <li data-target={`#cat-${c}`}>
+                <a href={`#cat-${c}`} data-cat={c}>
+                  <span class="cat-dot"></span>
+                  {CATEGORY_META[c].label}{CATEGORY_META[c].em ?? ''}
+                  <span class="count">{catCount(c)}</span>
+                </a>
+              </li>
+            ))}
+          </ol>
+
+          <div class="side-group">
+            <h6>By target</h6>
+            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>By source</h6>
+            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>By LLM</h6>
+            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>Popular</h6>
+            <div class="links">
+              {POPULAR.map((p) => (
+                <a href={exampleHref(p.slug)}>{p.label}<span class="c">{p.count}</span></a>
+              ))}
+            </div>
+          </div>
+
+          <div class="side-group">
+            <h6>Resources</h6>
+            <div class="links">
+              <a href={`${GITHUB_REPO}/tree/v1/examples`}>↗ Source on GitHub</a>
+              <a href={base || '/'}>↗ Documentation</a>
+              <a href={DISCORD_URL}>↗ Discord</a>
+            </div>
+          </div>
+        </aside>
+
+        <div class="col-main">
+          <!-- ═══════════ FEATURED ═══════════ -->
+          <section class="feat" id="feat-scroll">
+            <div class="sec-head">
+              <h2><span class="idx">★ Featured</span>Start here</h2>
+              <p class="lead">The most complete end-to-end example — a custom source, LLM extraction, and a queryable target.</p>
+            </div>
+
+            <a class="feat-card" href={exampleHref(featured.slug)}>
+              <div class="feat-body">
+                <span class="ribbon"><span class="tick"></span>Multi-stage · custom source · <span class="idx">07 / {total}</span></span>
+                <h3 set:html={titleMarkup('HN Trending *Topics.*')} />
+                <p>
+                  Pulls every new HackerNews thread, extracts topics with an LLM, and keeps a Postgres index continuously fresh. Custom source + live mode = 92% fewer API calls after the first sync.
+                </p>
+                <div class="chips">
+                  <span class="chip">Custom source</span>
+                  <span class="chip">Gemini 2.5 Flash</span>
+                  <span class="chip">Postgres</span>
+                  <span class="chip">Live 30s</span>
+                  <span class="chip">Structured output</span>
+                </div>
+                <div class="foot">
+                  <span>45 min · 6 parts · 12 steps</span>
+                  <span class="go">Open example
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                  </span>
+                </div>
+              </div>
+
+              <div class="feat-viz" aria-hidden="true">
+                <div class="qlabel">
+                  <span>get_trending_topics(limit = 5)</span>
+                  <span class="pulse"><span class="d"></span>live</span>
+                </div>
+                <div class="qrow"><span class="rk">01</span><span class="tp"><em>Claude</em></span><span class="sc">142</span><span class="th">12 threads</span></div>
+                <div class="qrow"><span class="rk">02</span><span class="tp">Rust</span><span class="sc">118</span><span class="th">9 threads</span></div>
+                <div class="qrow"><span class="rk">03</span><span class="tp">OpenAI</span><span class="sc">96</span><span class="th">8 threads</span></div>
+                <div class="qrow"><span class="rk">04</span><span class="tp">Postgres</span><span class="sc">81</span><span class="th">7 threads</span></div>
+                <div class="qrow"><span class="rk">05</span><span class="tp"><em>MCP</em></span><span class="sc">73</span><span class="th">5 threads</span></div>
+              </div>
+            </a>
+          </section>
+
+          <!-- ═══════════ CATEGORY SECTIONS ═══════════ -->
+          {CAT_ORDER.map((cat, ci) => {
+            const items = byCategory(cat);
+            return items.length === 0 ? null : (
+              <section class="cat" id={`cat-${cat}`} data-cat={cat}>
+                <div class="sec-head">
+                  <span class="idx">{String(ci + 1).padStart(2, '0')}</span>
+                  <h2>
+                    {CATEGORY_META[cat].label}
+                    {CATEGORY_META[cat].em ? <em>{CATEGORY_META[cat].em}</em> : null}
+                  </h2>
+                  <p class="lead">{CATEGORY_META[cat].lead}</p>
+                  <a class="all" href={`#cat-${cat}`}>See all {items.length} →</a>
+                </div>
+
+                <div class="cat-grid">
+                  {items.map((ex) => (
+                    <a class="ex-card" href={exampleHref(ex.slug)}>
+                      <div class={`ex-thumb ${ex.thumbClass ?? CATEGORY_META[ex.category].thumbClass}`}>
+                        <span class="tl">{ex.thumbLabel}</span>
+                        <span class="tr">{ex.index}</span>
+                        <div class="motif" set:html={ex.motif ?? ''} />
+                      </div>
+                      <div class="ex-body">
+                        <h3 set:html={titleMarkup(ex.title)} />
+                        <p>{ex.description}</p>
+                        <div class="ex-tags">
+                          {ex.tags.map((t) => (
+                            <span class={`tag ${t.kind}`}><span class="dt"></span>{t.label}</span>
+                          ))}
+                        </div>
+                        <div class="ex-foot">
+                          <span>{ex.footMeta}</span>
+                          <span class="go">Open →</span>
+                        </div>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+
+          <!-- ═══════════ CTA ═══════════ -->
+          <section class="cta-end">
+            <div>
+              <h3 set:html={titleMarkup("Can't find the *shape* you need?")} />
+              <p>Clone the closest example, swap the source or the target, and keep the rest. Or request a new example — we ship the ones developers ask for.</p>
+              <div class="btns">
+                <a class="btn btn-coral" href={GITHUB_REPO}>Request on GitHub</a>
+                <a class="btn btn-primary" href={base || '/'}>Build your own</a>
+                <a class="btn btn-outline-muted" href={DISCORD_URL}>Ask on Discord</a>
+              </div>
+            </div>
+            <aside class="side">
+              <h5>Popular this week</h5>
+              <ul>
+                {POPULAR.map((p) => (
+                  <li><span class="k">{p.label}</span><span class="v">{p.count}</span></li>
+                ))}
+              </ul>
+            </aside>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <script is:inline>
+      // Category filter chips — toggle visibility of category sections.
+      (function(){
+        const chips = document.querySelectorAll('#filters .filter-chip');
+        const sections = document.querySelectorAll('section.cat[data-cat]');
+        const feat = document.querySelector('section.feat');
+
+        chips.forEach((chip) => chip.addEventListener('click', () => {
+          const f = chip.dataset.filter;
+          chips.forEach((c) => c.classList.toggle('on', c === chip));
+          if (f === 'all') {
+            sections.forEach((s) => s.style.display = '');
+            if (feat) feat.style.display = '';
+            return;
+          }
+          sections.forEach((s) => s.style.display = (s.dataset.cat === f ? '' : 'none'));
+          // The featured card is an LLM-extraction example — keep it visible
+          // when that filter is active, hide otherwise.
+          if (feat) feat.style.display = (f === 'llm' ? '' : 'none');
+        }));
+      })();
+
+      // Highlight the active category in the side nav based on scroll.
+      (function(){
+        const items = document.querySelectorAll('#sideList li[data-target]');
+        const map = new Map();
+        items.forEach((li) => {
+          const sel = li.getAttribute('data-target');
+          const el = document.querySelector(sel);
+          if (el) map.set(el, li);
+        });
+        if (!map.size) return;
+        const io = new IntersectionObserver((entries) => {
+          entries.forEach((e) => {
+            const li = map.get(e.target);
+            if (!li) return;
+            li.classList.toggle('active', e.isIntersecting);
+          });
+        }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+        map.forEach((_, el) => io.observe(el));
+      })();
+    </script>
+
+    <style is:global>
+      /* ═══════════ Listing-specific styles ═══════════
+         Scoped to body.ex-listing so they don't leak into the rest of the
+         docs site. Values are lifted verbatim from the design guide. */
+      body.ex-listing { font-size: 17px; line-height: 1.55; }
+
+      body.ex-listing .ex-wrap {
+        max-width: 1440px; margin: 0 auto; padding: 0 40px;
+      }
+
+      /* ── HERO ── */
+      body.ex-listing .ex-hero { padding: 72px 0 48px; border-bottom: 1px solid var(--rule); }
+      body.ex-listing .hero-top { display: flex; align-items: center; gap: 18px; margin-bottom: 32px; flex-wrap: wrap; }
+      body.ex-listing .hero-top .eyb {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--coral); padding: 6px 14px; border: 1px solid var(--coral); border-radius: 999px;
+        display: inline-flex; align-items: center; gap: 10px;
+      }
+      body.ex-listing .hero-top .eyb .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); animation: ex-pulse 2s ease-in-out infinite; }
+      @keyframes ex-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+      body.ex-listing .hero-top .stats { margin-left: auto; display: flex; gap: 20px; font-family: var(--mono); font-size: 12px; color: var(--muted); letter-spacing: 0.06em; flex-wrap: wrap; }
+      body.ex-listing .hero-top .stats b { color: var(--maroon); font-weight: 500; font-size: 14px; }
+
+      body.ex-listing .hero-grid { display: grid; grid-template-columns: 1.35fr 1fr; gap: 48px; align-items: end; }
+      body.ex-listing h1.hero-h {
+        font-family: var(--serif); font-weight: 400;
+        font-size: clamp(40px, 4.6vw, 60px); line-height: 0.98; letter-spacing: -0.03em;
+        margin: 0 0 24px;
+      }
+      body.ex-listing h1.hero-h em { font-style: italic; color: var(--coral); }
+      body.ex-listing .hero-sub {
+        font-family: var(--sans); font-size: clamp(18px, 1.6vw, 24px);
+        font-weight: 400; line-height: 1.45; letter-spacing: -0.01em;
+        color: var(--maroon-ink); max-width: 48ch; margin: 0 0 24px;
+      }
+      body.ex-listing .hero-sub b { font-weight: 600; color: var(--maroon); }
+
+      body.ex-listing .hero-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+      body.ex-listing .filter-chip {
+        font-family: var(--sans); font-size: 13px; font-weight: 500;
+        padding: 8px 14px; border-radius: 999px;
+        background: var(--cream); color: var(--maroon-ink);
+        border: 1px solid var(--rule); cursor: pointer;
+        transition: background .15s, color .15s, border-color .15s;
+        display: inline-flex; gap: 6px; align-items: center;
+      }
+      body.ex-listing .filter-chip:hover { background: var(--paper); border-color: var(--rule-strong); }
+      body.ex-listing .filter-chip.on { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-listing .filter-chip .cnt { font-family: var(--mono); font-size: 11px; opacity: 0.6; letter-spacing: 0; }
+      body.ex-listing .filter-chip.on .cnt { opacity: 0.8; }
+
+      body.ex-listing .hero-viz { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; aspect-ratio: 3/2; }
+      body.ex-listing .hero-viz .t {
+        border-radius: 8px; position: relative; overflow: hidden;
+        padding: 16px; display: flex; flex-direction: column; justify-content: space-between;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+      }
+      body.ex-listing .hero-viz .t .lb { opacity: 0.85; }
+      body.ex-listing .hero-viz .t .ct { font-family: var(--sans); font-size: 20px; font-weight: 600; letter-spacing: -0.02em; line-height: 1; text-transform: none; }
+      body.ex-listing .hero-viz .t .ct em { color: inherit; font-style: normal; }
+      body.ex-listing .hero-viz .t.search { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .hero-viz .t.ingest { background: var(--peach); color: var(--maroon-ink); }
+      body.ex-listing .hero-viz .t.llm { background: var(--coral); color: var(--cream); }
+      body.ex-listing .hero-viz .t.agents { background: var(--cream); color: var(--maroon); border: 1px solid var(--rule-strong); }
+      body.ex-listing .hero-viz .t.multi { background: var(--pink); color: var(--maroon-ink); }
+      body.ex-listing .hero-viz .t.custom { background: var(--maroon-ink); color: var(--cream); }
+      body.ex-listing .hero-viz .t::after {
+        content: ""; position: absolute; inset: 0; pointer-events: none;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.2px, transparent 1.6px);
+        background-size: 14px 14px; opacity: 0.6;
+      }
+      body.ex-listing .hero-viz .t.agents::after,
+      body.ex-listing .hero-viz .t.ingest::after,
+      body.ex-listing .hero-viz .t.multi::after {
+        background-image: radial-gradient(circle, rgba(42, 18, 27, 0.08) 1.2px, transparent 1.6px);
+      }
+
+      /* ── SIDEBAR + MAIN ── */
+      body.ex-listing .doc { display: grid; grid-template-columns: 260px 1fr; gap: 56px; align-items: start; padding-top: 32px; }
+      body.ex-listing .side-nav { position: sticky; top: 84px; align-self: start; max-height: calc(100vh - 100px); overflow-y: auto; padding: 0 0 40px; font-family: var(--sans); }
+      body.ex-listing .side-head {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--muted); padding-bottom: 10px; margin-bottom: 14px;
+        border-bottom: 1px solid var(--rule-strong);
+        display: flex; justify-content: space-between; align-items: baseline;
+      }
+      body.ex-listing .side-head .ct { color: var(--coral); font-family: var(--mono); }
+      body.ex-listing .side-nav ol { list-style: none; padding: 0; margin: 0 0 24px; }
+      body.ex-listing .side-nav ol li { margin-bottom: 2px; }
+      body.ex-listing .side-nav ol li a {
+        display: flex; align-items: center; gap: 10px;
+        text-decoration: none; color: var(--maroon-ink);
+        font-size: 14px; font-weight: 500; letter-spacing: -0.01em; line-height: 1.3;
+        padding: 9px 12px; border-radius: 6px;
+        border-left: 2px solid transparent;
+        margin-left: -14px; padding-left: 12px;
+        transition: color .15s, background .15s, border-color .15s;
+      }
+      body.ex-listing .side-nav ol li a .cat-dot { width: 10px; height: 10px; border-radius: 3px; flex: none; background: var(--maroon); }
+      body.ex-listing .side-nav ol li a[data-cat="search"]  .cat-dot { background: var(--maroon); }
+      body.ex-listing .side-nav ol li a[data-cat="ingest"]  .cat-dot { background: var(--peach); }
+      body.ex-listing .side-nav ol li a[data-cat="llm"]     .cat-dot { background: var(--coral); }
+      body.ex-listing .side-nav ol li a[data-cat="agents"]  .cat-dot { background: var(--maroon-ink); }
+      body.ex-listing .side-nav ol li a[data-cat="image"]   .cat-dot { background: var(--pink); }
+      body.ex-listing .side-nav ol li a[data-cat="featured"] .cat-dot { background: var(--coral); border-radius: 50%; }
+      body.ex-listing .side-nav ol li a .count {
+        margin-left: auto;
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; color: var(--muted);
+        padding: 2px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--rule);
+      }
+      body.ex-listing .side-nav ol li a:hover { color: var(--coral); background: var(--cream); }
+      body.ex-listing .side-nav ol li.active a { color: var(--maroon); background: var(--cream); border-left-color: var(--coral); }
+      body.ex-listing .side-nav ol li.active a .count { color: var(--coral); border-color: var(--coral); }
+
+      body.ex-listing .side-group { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--rule); }
+      body.ex-listing .side-group h6 {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--muted); margin: 0 0 10px;
+      }
+      body.ex-listing .side-group .tags-row { display: flex; flex-wrap: wrap; gap: 5px; }
+      body.ex-listing .side-group .mini-tag {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+        color: var(--maroon-ink);
+        padding: 4px 9px; border-radius: 999px;
+        background: var(--cream); border: 1px solid var(--rule);
+      }
+      body.ex-listing .side-group .links { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-listing .side-group .links a {
+        text-decoration: none; color: var(--maroon-ink);
+        font-size: 13px; padding: 4px 0;
+        display: flex; justify-content: space-between; align-items: center;
+      }
+      body.ex-listing .side-group .links a:hover { color: var(--coral); }
+      body.ex-listing .side-group .links a .c { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+
+      body.ex-listing .col-main { min-width: 0; }
+
+      /* ── FEATURED ── */
+      body.ex-listing section.feat { padding: 0 0 40px; scroll-margin-top: 84px; }
+      body.ex-listing .sec-head { display: flex; align-items: baseline; gap: 18px; margin-bottom: 28px; padding-bottom: 18px; border-bottom: 1px solid var(--rule); flex-wrap: wrap; }
+      body.ex-listing .sec-head h2 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(28px, 3.2vw, 44px); letter-spacing: -0.03em; line-height: 1.05;
+        margin: 0;
+      }
+      body.ex-listing .sec-head h2 em { font-style: normal; color: var(--coral); }
+      body.ex-listing .sec-head .lead { color: var(--muted); font-size: 15px; max-width: 40ch; margin: 0; }
+      body.ex-listing .sec-head .idx { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); margin-right: 8px; }
+      body.ex-listing .sec-head .all {
+        margin-left: auto;
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+        color: var(--maroon); text-decoration: none;
+        padding-bottom: 2px; border-bottom: 1px solid var(--maroon);
+      }
+      body.ex-listing .sec-head .all:hover { color: var(--coral); border-color: var(--coral); }
+
+      body.ex-listing .feat-card {
+        display: grid; grid-template-columns: 1.2fr 1fr; gap: 0;
+        border-radius: 12px; overflow: hidden;
+        background: var(--maroon); color: var(--cream);
+        min-height: 440px; position: relative;
+        text-decoration: none;
+        transition: transform .2s, box-shadow .2s;
+      }
+      body.ex-listing .feat-card:hover { transform: translateY(-3px); box-shadow: 0 24px 60px -24px rgba(42, 18, 27, 0.4); }
+      body.ex-listing .feat-card::before {
+        content: ""; position: absolute; inset: 0;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.07) 1.6px, transparent 2px);
+        background-size: 20px 20px; opacity: 0.7; pointer-events: none;
+      }
+      body.ex-listing .feat-body { position: relative; z-index: 2; padding: 48px; display: flex; flex-direction: column; gap: 22px; }
+      body.ex-listing .feat-body .ribbon { display: inline-flex; gap: 10px; align-items: center; font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--peach); }
+      body.ex-listing .feat-body .ribbon .tick { width: 6px; height: 6px; background: var(--peach); border-radius: 50%; }
+      body.ex-listing .feat-body .ribbon .idx { color: rgba(252, 243, 216, 0.6); }
+      body.ex-listing .feat-body h3 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(30px, 3.6vw, 48px); line-height: 1.02; letter-spacing: -0.035em;
+        margin: 0; max-width: 16ch; color: var(--cream);
+      }
+      body.ex-listing .feat-body h3 em { color: var(--peach); font-style: italic; }
+      body.ex-listing .feat-body p { color: rgba(252, 243, 216, 0.85); margin: 0; max-width: 44ch; font-size: 16px; line-height: 1.55; }
+      body.ex-listing .feat-body .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+      body.ex-listing .feat-body .chip {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+        padding: 5px 12px; border-radius: 999px;
+        border: 1px solid rgba(252, 243, 216, 0.25);
+        color: rgba(252, 243, 216, 0.85);
+      }
+      body.ex-listing .feat-body .foot { margin-top: auto; display: flex; justify-content: space-between; align-items: flex-end; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.15); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-listing .feat-body .foot .go {
+        font-family: var(--sans); font-size: 13px; font-weight: 500; letter-spacing: 0;
+        color: var(--cream); text-transform: none;
+        display: inline-flex; gap: 8px; align-items: center;
+        padding: 10px 18px; border-radius: 999px; background: var(--coral); border: 1px solid var(--coral);
+        transition: background .15s;
+      }
+      body.ex-listing .feat-card:hover .feat-body .foot .go { background: var(--peach); border-color: var(--peach); color: var(--maroon-ink); }
+
+      body.ex-listing .feat-viz {
+        position: relative; z-index: 2;
+        background: linear-gradient(135deg, rgba(252, 243, 216, 0.08), rgba(252, 243, 216, 0.02));
+        border-left: 1px solid rgba(252, 243, 216, 0.12);
+        padding: 40px;
+        display: flex; flex-direction: column; gap: 14px; justify-content: center;
+      }
+      body.ex-listing .feat-viz .qrow {
+        display: grid; grid-template-columns: 28px 1fr auto 60px;
+        gap: 14px; align-items: baseline;
+        padding: 10px 14px; border-radius: 6px;
+        background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.12);
+        font-family: var(--mono); font-size: 13px;
+      }
+      body.ex-listing .feat-viz .qrow .rk { color: rgba(252, 243, 216, 0.5); font-size: 11px; }
+      body.ex-listing .feat-viz .qrow .tp { color: var(--cream); font-weight: 500; }
+      body.ex-listing .feat-viz .qrow .tp em { color: var(--peach); font-style: normal; }
+      body.ex-listing .feat-viz .qrow .sc { color: var(--palm); font-weight: 600; }
+      body.ex-listing .feat-viz .qrow .th { color: rgba(252, 243, 216, 0.55); font-size: 11px; text-align: right; }
+      body.ex-listing .feat-viz .qlabel {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: rgba(252, 243, 216, 0.55); padding-bottom: 8px;
+        border-bottom: 1px solid rgba(252, 243, 216, 0.12);
+        display: flex; justify-content: space-between;
+      }
+      body.ex-listing .feat-viz .qlabel .pulse { display: inline-flex; gap: 5px; align-items: center; color: var(--palm); }
+      body.ex-listing .feat-viz .qlabel .pulse .d { width: 6px; height: 6px; border-radius: 50%; background: var(--palm); box-shadow: 0 0 0 3px rgba(39, 230, 43, 0.15); }
+
+      /* ── CATEGORY SECTIONS ── */
+      body.ex-listing section.cat { padding: 64px 0; scroll-margin-top: 84px; }
+      body.ex-listing .cat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+      body.ex-listing .ex-card {
+        display: flex; flex-direction: column;
+        border: 1px solid var(--rule); border-radius: 10px;
+        background: var(--paper);
+        min-height: 280px;
+        text-decoration: none; color: inherit;
+        overflow: hidden;
+        position: relative;
+        transition: background-image .18s ease;
+      }
+      body.ex-listing .ex-card:hover {
+        background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px);
+        background-size: 14px 14px;
+      }
+      body.ex-listing .ex-thumb {
+        aspect-ratio: 16/7;
+        position: relative; overflow: hidden;
+        border-bottom: 1px solid var(--rule);
+      }
+      body.ex-listing .ex-thumb .motif { position: absolute; inset: 0; display: grid; place-items: center; color: var(--cream); }
+      body.ex-listing .ex-thumb .motif svg { width: 70%; height: 70%; }
+      body.ex-listing .ex-thumb .tl {
+        position: absolute; top: 12px; left: 14px; z-index: 3;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        padding: 4px 10px; border-radius: 999px;
+        background: rgba(252, 243, 216, 0.2); color: var(--cream);
+        backdrop-filter: blur(6px);
+        border: 1px solid rgba(252, 243, 216, 0.2);
+      }
+      body.ex-listing .ex-thumb .tr {
+        position: absolute; top: 12px; right: 14px; z-index: 3;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+        color: rgba(252, 243, 216, 0.8);
+      }
+      body.ex-listing .ex-thumb.search { background: var(--maroon); }
+      body.ex-listing .ex-thumb.ingest { background: var(--peach); color: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.ingest .motif { color: var(--maroon); }
+      body.ex-listing .ex-thumb.ingest .tl { background: rgba(42, 18, 27, 0.1); color: var(--maroon); border-color: rgba(42, 18, 27, 0.15); }
+      body.ex-listing .ex-thumb.ingest .tr { color: rgba(42, 18, 27, 0.6); }
+      body.ex-listing .ex-thumb.llm { background: var(--coral); }
+      body.ex-listing .ex-thumb.agents { background: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.pink { background: var(--pink); color: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.pink .motif { color: var(--maroon); }
+      body.ex-listing .ex-thumb.pink .tl { background: rgba(42, 18, 27, 0.1); color: var(--maroon); border-color: rgba(42, 18, 27, 0.15); }
+      body.ex-listing .ex-thumb.pink .tr { color: rgba(42, 18, 27, 0.55); }
+      body.ex-listing .ex-thumb.search::after,
+      body.ex-listing .ex-thumb.llm::after,
+      body.ex-listing .ex-thumb.agents::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.1) 1.2px, transparent 1.6px);
+        background-size: 14px 14px;
+      }
+      body.ex-listing .ex-thumb.ingest::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: repeating-linear-gradient(135deg, transparent 0 8px, rgba(42, 18, 27, 0.06) 8px 9px);
+      }
+      body.ex-listing .ex-thumb.pink::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: linear-gradient(to right, rgba(42, 18, 27, 0.04) 1px, transparent 1px),
+                          linear-gradient(to bottom, rgba(42, 18, 27, 0.04) 1px, transparent 1px);
+        background-size: 18px 18px;
+      }
+
+      body.ex-listing .ex-body { padding: 20px 22px 22px; display: flex; flex-direction: column; gap: 10px; flex: 1; }
+      body.ex-listing .ex-body h3 { font-family: var(--sans); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; line-height: 1.2; margin: 0; color: var(--maroon-ink); }
+      body.ex-listing .ex-body h3 em { color: var(--coral); font-style: normal; }
+      body.ex-listing .ex-body p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; flex: 1; }
+
+      body.ex-listing .ex-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+      body.ex-listing .ex-tags .tag {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+        padding: 4px 10px; border-radius: 999px;
+        background: var(--paper); color: var(--maroon);
+        border: 1px solid var(--rule);
+        display: inline-flex; gap: 6px; align-items: center;
+      }
+      body.ex-listing .ex-tags .tag .dt { width: 5px; height: 5px; border-radius: 50%; background: var(--coral); }
+      body.ex-listing .ex-tags .tag.src .dt { background: var(--peach); }
+      body.ex-listing .ex-tags .tag.tgt .dt { background: var(--pink); }
+      body.ex-listing .ex-tags .tag.llm .dt { background: var(--palm); }
+      body.ex-listing .ex-tags .tag.ops .dt { background: var(--coral); }
+      body.ex-listing .ex-tags .tag.lvl .dt { background: var(--maroon); }
+
+      body.ex-listing .ex-foot {
+        display: flex; justify-content: space-between; align-items: center;
+        padding-top: 14px; margin-top: 6px; border-top: 1px solid var(--rule);
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+        color: var(--muted);
+      }
+      body.ex-listing .ex-foot .go { color: var(--coral); display: inline-flex; gap: 6px; align-items: center; }
+
+      body.ex-listing .m-dots circle { fill: currentColor; }
+      body.ex-listing .m-grid rect { fill: none; stroke: currentColor; stroke-width: 1; }
+      body.ex-listing .m-flow path { stroke: currentColor; stroke-width: 1.5; fill: none; stroke-linecap: round; }
+      body.ex-listing .m-node rect { fill: none; stroke: currentColor; stroke-width: 1.5; }
+      body.ex-listing .m-node circle { fill: currentColor; }
+
+      /* ── BOTTOM CTA ── */
+      body.ex-listing .cta-end {
+        margin: 72px 0 96px;
+        border-radius: 12px;
+        background: var(--cream);
+        border: 1px solid var(--rule);
+        padding: 64px 48px;
+        display: grid; grid-template-columns: 1.4fr 1fr; gap: 48px;
+        align-items: center;
+        position: relative; overflow: hidden;
+      }
+      body.ex-listing .cta-end::before {
+        content: ""; position: absolute; right: -40px; bottom: -60px;
+        width: 260px; height: 260px; border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, rgba(190, 81, 51, 0.2), transparent 60%);
+        pointer-events: none;
+      }
+      body.ex-listing .cta-end h3 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(28px, 3.4vw, 44px); line-height: 1.05; letter-spacing: -0.03em;
+        margin: 0 0 16px; max-width: 22ch;
+      }
+      body.ex-listing .cta-end h3 em { color: var(--coral); font-style: normal; }
+      body.ex-listing .cta-end p { color: var(--muted); max-width: 48ch; margin: 0 0 24px; font-size: 17px; }
+      body.ex-listing .cta-end .btns { display: flex; gap: 12px; flex-wrap: wrap; }
+      body.ex-listing .cta-end .btn {
+        display: inline-flex; align-items: center; gap: 8px;
+        padding: 10px 18px; border-radius: 999px;
+        font-family: var(--sans); font-size: 14px; font-weight: 500; text-decoration: none;
+        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
+        transition: background .16s, color .16s, border-color .16s;
+      }
+      body.ex-listing .cta-end .btn:hover { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .cta-end .btn.btn-primary { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .cta-end .btn.btn-primary:hover { background: var(--maroon-deep); }
+      body.ex-listing .cta-end .btn.btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
+      body.ex-listing .cta-end .btn.btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
+      body.ex-listing .cta-end .btn.btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
+      body.ex-listing .cta-end .btn.btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-listing .cta-end .side {
+        display: flex; flex-direction: column; gap: 10px;
+        padding: 24px; border-radius: 10px;
+        background: var(--paper); border: 1px solid var(--rule);
+      }
+      body.ex-listing .cta-end .side h5 {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--muted); margin: 0;
+      }
+      body.ex-listing .cta-end .side ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+      body.ex-listing .cta-end .side ul li {
+        display: flex; justify-content: space-between; align-items: center;
+        padding: 8px 10px; border-radius: 5px; font-size: 14px;
+      }
+      body.ex-listing .cta-end .side ul li:hover { background: var(--cream); }
+      body.ex-listing .cta-end .side ul li .k { color: var(--maroon-ink); font-weight: 500; }
+      body.ex-listing .cta-end .side ul li .v { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+
+      @media (max-width: 1180px) {
+        body.ex-listing .doc { grid-template-columns: 1fr; gap: 0; }
+        body.ex-listing .side-nav {
+          position: static; top: auto; max-height: none;
+          padding: 16px; border: 1px solid var(--rule); border-radius: 10px;
+          background: var(--cream); margin-bottom: 32px;
+        }
+        body.ex-listing .side-nav ol { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+        body.ex-listing .side-nav ol li { margin-bottom: 0; }
+        body.ex-listing .side-nav ol li a { padding: 8px 12px; margin-left: 0; border-left: none; border: 1px solid var(--rule); }
+        body.ex-listing .side-nav ol li.active a { border-color: var(--coral); }
+        body.ex-listing .side-group { margin-top: 10px; padding-top: 10px; }
+        body.ex-listing .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+        body.ex-listing .feat-card { grid-template-columns: 1fr; }
+        body.ex-listing .feat-viz { border-left: none; border-top: 1px solid rgba(252, 243, 216, 0.12); }
+        body.ex-listing .cat-grid { grid-template-columns: repeat(2, 1fr); }
+        body.ex-listing .cta-end { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 640px) {
+        body.ex-listing .cat-grid { grid-template-columns: 1fr; }
+        body.ex-listing .hero-top { flex-wrap: wrap; }
+        body.ex-listing .hero-top .stats { order: 3; width: 100%; }
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
…/examples

Adds a dedicated examples section to the Astro docs site, ported 1:1 from the design mocks in `cocoindex-io.github.io/design_guidelines/`:

* Listing page at `/docs/examples` — 5 categories (vector indexes, custom building blocks, structured extraction, knowledge graphs, multimodal), sticky sidebar, filter chips, featured card for HN trending topics, and hover-dotted category cards. Built from a single `src/data/examples.ts` catalog — add a card there and it appears automatically.
* Detail pages at `/docs/examples/<slug>` — three-column layout mirroring the docs layout (left: per-category example nav, middle: hero + MDX body, right: sticky TOC). The current slug lights up in the left rail.
* New `examplePosts` content collection. All 20 walkthroughs from the upstream `cocoindex-io/examples` repo ported into `src/content/example-posts/`, Docusaurus-only imports stripped and `<GitHubButton>` / `<DocumentationButton>` / `<YouTubeButton>` calls replaced with plain markdown links.
* Image URLs rewritten to the `cocoindex-io/blobs` static origin (`https://cocoindex.io/blobs/docs/img/examples/...`) so the docs bundle doesn't ship 22 MB of example images.

To add a new example: drop a `src/content/example-posts/<slug>.md` file and a card in `examples.ts` with the matching slug.