### PR TITLE
docs(examples): migrate cocoindex-io/examples-v1 walkthroughs into /docs-v1/examples

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -7,8 +7,19 @@ const docs = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/docs' }),
   schema: z
     .object({
+      // Title may include *asterisks* to mark italic-coral segments — see
+      // titleMarkup/titleText in src/consts.ts. Plain metadata strips them.
       title: z.string().optional(),
+      // Lede paragraph rendered under the H1 and used as <meta description>.
       description: z.string().optional(),
+      // Intro-meta strip (Time / Language / Requires) shown above the body.
+      meta: z
+        .object({
+          time: z.string().optional(),
+          language: z.string().optional(),
+          requires: z.string().optional(),
+        })
+        .optional(),
       sidebar_label: z.string().optional(),
       sidebar_position: z.number().optional(),
       toc_max_heading_level: z.number().optional(),
@@ -17,4 +28,23 @@ const docs = defineCollection({
     .passthrough(),
 });
 
-export const collections = { docs };
+// Example walkthroughs — ported from github.com/cocoindex-io/examples.
+// One .md file per slug in src/content/example-posts, rendered by
+// src/pages/examples/[slug].astro beneath the shared hero.
+const examplePosts = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/example-posts' }),
+  schema: z
+    .object({
+      title: z.string(),
+      description: z.string().optional(),
+      slug: z.string(),
+      image: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      // YAML parses ISO dates into Date; accept either so hand-edited
+      // string dates also work.
+      last_reviewed: z.union([z.string(), z.date()]).optional(),
+    })
+    .passthrough(),
+});
+
+export const collections = { docs, examplePosts };

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -1,0 +1,491 @@
+---
+title: Multi-Codebase Summarization
+description: 'Generate documentation for multiple Python projects using LLM-powered code analysis'
+slug: multi-codebase-summarization
+image: https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png
+tags: [llm, structured-data-extraction]
+last_reviewed: 2026-02-04
+---
+
+# Multi-Codebase Summarization
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/multi_codebase_summarization)
+
+![Multi-Codebase Summarization](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png)
+
+Your code is the source of truth. In this tutorial, we'll build a pipeline that automatically generates a one-pager wiki for each project in a list, that never goes out-of-date with incremental processing. Think about building your own deep wiki that is always fresh.
+
+For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/v1/examples), we can have an auto-one-pager like this:
+
+
+![markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.png)
+
+
+## Overview
+
+This example uses structured LLM outputs to analyze code and generate documentation at scale with LLMs.
+
+1. Scan top-level subdirectories, treating each as a separate project
+2. Extract structured information from each file using an LLM (classes, functions, relationships)
+3. Aggregate file-level data into project-level summaries
+4. Generate Markdown documentation with Mermaid diagrams
+
+You declare the transformation logic with native Python without worrying about changes.
+
+Think:
+**target_state = transformation(source_state)**
+
+When your source data is updated, or your processing logic is changed (for example, switching to a different model, updating your LLM extraction logic), CocoIndex performs smart incremental processing that only reprocesses the minimum. And it keeps your wikis always up to date in production.
+
+
+
+## Setup
+
+1. Install CocoIndex and dependencies:
+
+    ```bash
+    pip install --pre 'cocoindex>=1.0.0a6' instructor litellm pydantic
+    ```
+
+2. Create a new directory for your project:
+
+    ```bash
+    mkdir multi-codebase-summarization
+    cd multi-codebase-summarization
+    ```
+
+3. Set up your LLM environment variables:
+
+    ```bash
+    export GEMINI_API_KEY="your-api-key"
+    export LLM_MODEL="gemini/gemini-2.5-flash"  # Or any LiteLLM-supported model
+    ```
+
+4. Create a `.env` file to configure the database path:
+
+    ```bash
+    echo "COCOINDEX_DB=./cocoindex.db" > .env
+    ```
+
+5. Create a `projects/` directory with subdirectories for each Python project:
+
+    ```bash
+    mkdir projects
+    ```
+    ```bash
+    projects/
+    ├── my_project_1/
+    │   ├── main.py
+    │   └── utils.py
+    ├── my_project_2/
+    │   └── app.py
+    └── ...
+    ```
+
+## Define the app
+
+Define a CocoIndex App — the top-level runnable unit in CocoIndex.
+
+
+![App Definition](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/app.svg)
+
+```python title="main.py"
+from __future__ import annotations
+
+from typing import Collection
+
+from litellm import acompletion
+from pydantic import BaseModel, Field
+
+from cocoindex.connectors import localfs
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
+LLM_MODEL = os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash")
+
+
+app = coco.App(
+    "MultiCodebaseSummarization",
+    app_main,
+    root_dir=pathlib.Path("./projects"),
+    output_dir=pathlib.Path("./output"),
+)
+```
+
+- The app scans `projects/` and outputs documentation to `output/`
+
+[→ App](/docs-v1/programming_guide/app)
+
+## Define the main function
+
+![App Definition](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/main.svg)
+
+In the main function, we walk through each project in the subdirectories and process it.
+
+It is up to you to declare the process granularity. It can be
+- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding) is a project, each containing multiple files,
+- or at file level,
+- or at even smaller units (e.g., page level, or semantic unit level).
+
+In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
+
+```python title="main.py"
+@coco.function
+def app_main(
+    root_dir: pathlib.Path,
+    output_dir: pathlib.Path,
+) -> None:
+    """Scan subdirectories and generate documentation for each project."""
+    for entry in root_dir.resolve().iterdir():
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        project_name = entry.name
+
+        files = list(
+            localfs.walk_dir(
+                entry,
+                recursive=True,
+                path_matcher=PatternFilePathMatcher(
+                    included_patterns=["*.py"],
+                    excluded_patterns=[".*", "__pycache__"],
+                ),
+            )
+        )
+
+        if files:
+            coco.mount(
+                coco.component_subpath("project", project_name),
+                process_project,
+                project_name,
+                files,
+                output_dir,
+            )
+```
+
+The main function does two things:
+
+1. **Find all projects** — Loop through each subdirectory in `root_dir`, treating each as a separate project.
+
+2. **Mount a processing component for each project** — For each project with Python files, `coco.mount()` sets up a processing component. CocoIndex handles the execution and tracks dependencies automatically.
+
+**Why processing components?** A processing component groups an item's processing together with its target states. Each component runs independently and in parallel. In this case, when `project_a` finishes, its results are applied to the external system immediately, without waiting for `project_b` or any other project.
+
+To learn more about processing components, you can read the documentation:
+[→ Processing Component](/docs-v1/programming_guide/processing_component)
+
+## Process each project
+For each project, we will
+1. use LLM to extract info
+2. aggregate all the extraction into a project-level summary
+3. output the extraction to a nice documentation with a Mermaid diagram.
+
+![Process Project](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/project.svg)
+
+```python title="main.py"
+@coco.function(memo=True)
+async def process_project(
+    project_name: str,
+    files: Collection[localfs.File],
+    output_dir: pathlib.Path,
+) -> None:
+    """Process a project: extract, aggregate, and output markdown."""
+    # Extract info from each file concurrently using asyncio.gather
+    file_infos = await asyncio.gather(*[extract_file_info(f) for f in files])
+
+    # Aggregate into project-level summary
+    project_info = await aggregate_project_info(project_name, file_infos)
+
+    # Generate and output markdown
+    markdown = generate_markdown(project_name, project_info, file_infos)
+    localfs.declare_file(
+        output_dir / f"{project_name}.md", markdown, create_parent_dirs=True
+    )
+```
+**Concurrent processing with async** — By using `asyncio.gather()`, all file extractions run concurrently. This is significantly faster than sequential processing, especially when making LLM API calls.
+
+[→ Function](/docs-v1/programming_guide/function)
+
+
+## Extract file information with LLM
+
+Now let's take a look at the details for each transformation.
+For file extraction, we define a structure using Pydantic and use [Instructor](https://github.com/jxnl/instructor) to extract with LLMs.
+
+![Extract files](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/extraction.svg)
+
+### Define the data models
+
+The key to structured LLM outputs is defining clear Pydantic models.
+![Define Models](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/extraction-models.svg)
+
+```python title="models.py"
+class FunctionInfo(BaseModel):
+    """Information about a public function."""
+    name: str = Field(description="Function name")
+    signature: str = Field(
+        description="Function signature, e.g. 'async def foo(x: int) -> str'"
+    )
+    is_coco_function: bool = Field(
+        description="Whether decorated with @coco.function"
+    )
+    summary: str = Field(description="Brief summary of what the function does")
+
+
+class ClassInfo(BaseModel):
+    """Information about a public class."""
+    name: str = Field(description="Class name")
+    summary: str = Field(description="Brief summary of what the class represents")
+
+
+class CodebaseInfo(BaseModel):
+    """Extracted information from Python code."""
+    name: str = Field(description="File path or project name")
+    summary: str = Field(description="Brief summary of purpose and functionality")
+    public_classes: list[ClassInfo] = Field(default_factory=list)
+    public_functions: list[FunctionInfo] = Field(default_factory=list)
+    mermaid_graphs: list[str] = Field(
+        default_factory=list,
+        description="Mermaid graphs showing function relationships"
+    )
+```
+
+### Extract file info
+
+The core extraction function uses memoization to cache LLM results:
+
+````python title="main.py"
+_instructor_client = instructor.from_litellm(acompletion, mode=instructor.Mode.JSON)
+
+@coco.function(memo=True)
+async def extract_file_info(file: FileLike) -> CodebaseInfo:
+    """Extract structured information from a single Python file using LLM."""
+    content = file.read_text()
+    file_path = str(file.file_path.path)
+
+    prompt = f"""Analyze the following Python file and extract structured information.
+
+File path: {file_path}
+
+```python
+{content}
+```
+
+Instructions:
+1. Identify all PUBLIC classes (not starting with _) and summarize their purpose
+2. Identify all PUBLIC functions (not starting with _) and summarize their purpose
+3. If this file contains CocoIndex apps (coco.App), create Mermaid graphs showing the
+   function call relationships (see the mermaid_graphs field description for format)
+4. Provide a brief summary of the file's purpose
+"""
+
+    result = await _instructor_client.chat.completions.create(
+        model=LLM_MODEL,
+        response_model=CodebaseInfo,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return CodebaseInfo.model_validate(result.model_dump())
+````
+
+**Why `memo=True` matters:** LLM calls are expensive. With memoization, CocoIndex caches the result keyed by the file content. If you run the pipeline again without changing a file, the cached result is used—no LLM call needed.
+
+[→ Function](/docs-v1/programming_guide/function)
+
+
+
+## Aggregate project information
+
+For projects with multiple files, we aggregate into a unified summary:
+
+![Aggregate files](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/aggregate.svg)
+
+```python title="main.py"
+@coco.function
+async def aggregate_project_info(
+    project_name: str,
+    file_infos: list[CodebaseInfo],
+) -> CodebaseInfo:
+    """Aggregate multiple file extractions into a project-level summary."""
+    if not file_infos:
+        return CodebaseInfo(
+            name=project_name, summary="Empty project with no Python files."
+        )
+
+    # Single file - just update the name
+    if len(file_infos) == 1:
+        info = file_infos[0]
+        return CodebaseInfo(
+            name=project_name,
+            summary=info.summary,
+            public_classes=info.public_classes,
+            public_functions=info.public_functions,
+            mermaid_graphs=info.mermaid_graphs,
+        )
+
+    # Multiple files - use LLM to create unified summary
+    files_text = "\n\n".join(
+        f"### {info.name}\n"
+        f"Summary: {info.summary}\n"
+        f"Classes: {', '.join(c.name for c in info.public_classes) or 'None'}\n"
+        f"Functions: {', '.join(f.name for f in info.public_functions) or 'None'}"
+        for info in file_infos
+    )
+
+    # Collect all mermaid graphs from files
+    all_graphs = [g for info in file_infos for g in info.mermaid_graphs]
+
+    prompt = f"""Aggregate the following Python files into a project-level summary.
+
+Project name: {project_name}
+
+Files:
+{files_text}
+
+Create a unified CodebaseInfo that:
+1. Summarizes the overall project purpose (not individual files)
+2. Lists the most important public classes across all files
+3. Lists the most important public functions across all files
+4. For mermaid_graphs: create a single unified graph showing how the CocoIndex
+   components connect across the project (if applicable)
+"""
+
+    result = await _instructor_client.chat.completions.create(
+        model=LLM_MODEL,
+        response_model=CodebaseInfo,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    result = CodebaseInfo.model_validate(result.model_dump())
+
+    # Keep original file-level graphs if LLM didn't generate a unified one
+    if not result.mermaid_graphs and all_graphs:
+        result.mermaid_graphs = all_graphs
+
+    return result
+```
+
+This function combines file-level extractions into a single project summary:
+
+- **Single file project** — Just use that file's info directly (no extra LLM call needed)
+- **Multi-file project** — Ask the LLM to synthesize all file summaries into one cohesive project overview
+
+The result is a unified `CodebaseInfo` that represents the entire project, not individual files.
+
+[→ Function](/docs-v1/programming_guide/function)
+
+## Generate markdown output
+
+Create output markdown for each project.
+![Create Markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.svg)
+
+```python title="main.py"
+@coco.function
+def generate_markdown(
+    project_name: str, info: CodebaseInfo, file_infos: list[CodebaseInfo]
+) -> str:
+    """Generate markdown documentation from project info."""
+    lines = [
+        f"# {project_name}",
+        "",
+        "## Overview",
+        "",
+        info.summary,
+        "",
+    ]
+
+    if info.public_classes or info.public_functions:
+        lines.extend(["## Components", ""])
+
+        if info.public_classes:
+            lines.append("**Classes:**")
+            for cls in info.public_classes:
+                lines.append(f"- `{cls.name}`: {cls.summary}")
+            lines.append("")
+
+        if info.public_functions:
+            lines.append("**Functions:**")
+            for fn in info.public_functions:
+                marker = " ★" if fn.is_coco_function else ""
+                lines.append(f"- `{fn.signature}`{marker}: {fn.summary}")
+            lines.append("")
+
+    if info.mermaid_graphs:
+        lines.extend(["## CocoIndex Pipeline", ""])
+        for graph in info.mermaid_graphs:
+            graph_content = graph.strip()
+            if not graph_content.startswith("```"):
+                lines.append("```mermaid")
+                lines.append(graph_content)
+                lines.append("```")
+            else:
+                lines.append(graph_content)
+            lines.append("")
+
+    if len(file_infos) > 1:
+        lines.extend(["## File Details", ""])
+        for fi in file_infos:
+            lines.extend([f"### {fi.name}", "", fi.summary, ""])
+
+    lines.extend(["---", "", "*★ = CocoIndex function*"])
+    return "\n".join(lines)
+```
+
+This function converts the structured `CodebaseInfo` into readable documentation:
+
+- **Overview** — Project summary at the top
+- **Components** — Lists classes and functions with descriptions (★ marks CocoIndex functions)
+- **Pipeline diagram** — Mermaid graphs showing how functions connect
+- **File details** — For multi-file projects, includes per-file summaries
+
+## Run the pipeline
+
+```bash
+cocoindex update main.py
+```
+
+CocoIndex will:
+
+1. Scan each subdirectory in `projects/`
+2. Extract structured information from Python files using the LLM
+3. Aggregate file summaries into project summaries
+4. Generate Markdown files in `output/`
+
+Check the output:
+
+```bash
+ls output/
+# project1.md project2.md ...
+```
+
+## Incremental updates
+
+The real power shows when you make changes:
+
+**Modify a file:**
+
+Edit a Python file in one of your projects, then run:
+
+```bash
+cocoindex update main.py
+```
+
+Only the modified file is re-analyzed by the LLM. Unchanged files use cached results.
+
+**Add a new project:**
+
+Add a new subdirectory with Python files:
+
+```bash
+mkdir projects/new_project
+# add .py files
+cocoindex update main.py
+```
+
+Only the new project is processed.
+
+## Key patterns demonstrated
+
+This example showcases several powerful patterns:
+
+1. **Structured LLM outputs** with Instructor + Pydantic models
+2. **Memoized LLM calls** to avoid redundant API costs
+3. **Async concurrent processing** with `asyncio.gather()`
+4. **Hierarchical aggregation** (file → project)
+5. **Incremental processing** for efficient updates

--- a/docs/src/content/example-posts/pdf-to-markdown.md
+++ b/docs/src/content/example-posts/pdf-to-markdown.md
@@ -1,0 +1,194 @@
+---
+title: PDF to Markdown
+description: 'Convert PDF files to Markdown with incremental processing'
+slug: pdf-to-markdown
+image: https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/cover.png
+tags: [pdf, custom-building-blocks]
+last_reviewed: 2026-02-04
+---
+
+# PDF to Markdown
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_to_markdown)
+
+![PDF to Markdown](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/cover.png)
+
+
+In this tutorial, we'll build a simple app that converts PDF files to Markdown and saves them to a local directory.
+
+
+## Overview
+
+![App example showing PDF to Markdown conversion](/img/concept/app-example.svg)
+
+
+1. Read PDF files from a local directory
+2. Convert each file to Markdown using Docling
+3. Save the Markdown files to an output directory (as **target states**)
+
+You declare the transformation logic with native Python without worrying about changes.
+
+Think:
+**target_state = transformation(source_state)**
+
+When your source data is updated, or your processing logic is changed (for example, switching parsers or tweaking conversion settings), CocoIndex performs smart incremental processing that only reprocesses the minimum. And it keeps your Markdown files always up to date in production.
+
+## Setup
+
+1. Install CocoIndex and dependencies:
+
+    ```bash
+    pip install 'cocoindex>=1.0.0a1' docling
+    ```
+
+2. Create a new directory for your project:
+
+    ```bash
+    mkdir pdf-to-markdown
+    cd pdf-to-markdown
+    ```
+
+3. Create a `pdf_files/` directory and add your PDF files:
+
+    ```bash
+    mkdir pdf_files
+    ```
+    You can download sample PDF files from the [git repo](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_to_markdown).
+
+4. Create a `.env` file to configure the database path:
+
+    ```bash
+    echo "COCOINDEX_DB=./cocoindex.db" > .env
+    ```
+
+## Define the app
+
+Define a CocoIndex App — the top-level runnable unit in CocoIndex.
+
+![App Definition](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/app-def.svg)
+
+```python title="main.py"
+
+from cocoindex.connectors import localfs
+from cocoindex.resources.file import PatternFilePathMatcher
+from docling.document_converter import DocumentConverter
+
+app = coco.App(
+    coco.AppConfig(name="PdfToMarkdown"),
+    app_main,
+    sourcedir=pathlib.Path("./pdf_files"),
+    outdir=pathlib.Path("./out"),
+)
+```
+
+[→ CocoIndex App](/docs-v1/programming_guide/app)
+
+### Define the main function
+
+![App Definition](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/components.svg)
+
+In the main function, we walk through each file in the source directory and process it.
+
+```python title="main.py"
+@coco.function
+def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
+    files = localfs.walk_dir(
+        sourcedir,
+        recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["*.pdf"]),
+    )
+    for f in files:
+        coco.mount(
+            coco.component_subpath("process", str(f.file_path.path)),
+            process_file,
+            f,
+            outdir,
+        )
+```
+For each file, `coco.mount()` mounts a processing component. It's up to you to pick the process granularity, for example it can be
+- at directory level,
+- at file level,
+- at page level.
+
+In this example, because we want to independently convert each file to Markdown, it is the most natural to pick it at the file level.
+
+[→ Processing Component](/docs-v1/programming_guide/processing_component)
+
+
+### Define file processing
+
+![File Process](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/file-process.svg)
+
+For a file, we use Docling to convert it to Markdown.
+
+```python title="main.py"
+_converter = DocumentConverter()
+
+@coco.function(memo=True)
+def process_file(
+    file: localfs.File,
+    outdir: pathlib.Path,
+) -> None:
+    markdown = _converter.convert(
+        file.file_path.resolve()
+    ).document.export_to_markdown()
+    outname = file.file_path.path.stem + ".md"
+    localfs.declare_file(outdir / outname, markdown, create_parent_dirs=True)
+```
+
+We use `@coco.function` with `memo=True` to create a memoized function that processes each file.
+
+[→ Function](/docs-v1/programming_guide/function)
+
+## Run the pipeline
+
+Run the pipeline:
+
+```bash
+cocoindex update main.py
+```
+
+CocoIndex will:
+
+1. Create the `out/` directory
+2. Convert each PDF in `pdf_files/` to Markdown in `out/`
+
+Check the output:
+
+```bash
+ls out/
+# example.md (one .md file for each input PDF)
+```
+
+## Incremental updates
+
+The power of CocoIndex is **incremental processing**. Try these:
+
+**Add a new file:**
+
+Add a new PDF to `pdf_files/`, then run:
+
+```bash
+cocoindex update main.py
+```
+
+Only the new file is processed.
+
+**Modify a file:**
+
+Replace a PDF in `pdf_files/` with an updated version, then run:
+
+```bash
+cocoindex update main.py
+```
+
+Only the changed file is reprocessed.
+
+**Delete a file:**
+
+```bash
+rm pdf_files/example.pdf
+cocoindex update main.py
+```
+
+The corresponding Markdown file is automatically removed.

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -1,0 +1,95 @@
+// Metadata for the /docs-v1/examples listing and per-example pages.
+//
+// Data is mirrored from github.com/cocoindex-io/examples-v1 — the markdown
+// bodies live in src/content/example-posts/<slug>.md and are rendered by
+// src/pages/examples/[slug].astro beneath the shared hero. Titles may use
+// *asterisks* to mark the italic-coral accent — see consts.titleMarkup.
+//
+// The v1 examples repo currently ships two walkthroughs; this file grows
+// as more land there.
+
+export type Category = 'search' | 'ingest' | 'llm' | 'agents' | 'image';
+
+export const CATEGORY_META: Record<Category, { label: string; em?: string; lead: string; thumbClass: string }> = {
+  search:  { label: 'Vector ',        em: 'Indexes',         lead: 'Embed your documents, store vectors, answer by meaning.',                                thumbClass: 'search' },
+  ingest:  { label: 'Custom ',        em: 'Building Blocks', lead: 'Bring your own source, target, or parser. Same declarative flow.',                        thumbClass: 'ingest' },
+  llm:     { label: 'Structured ',    em: 'Extraction',      lead: 'Turn loose prose into structured data with LLMs, BAML, DSPy, or Ollama.',                  thumbClass: 'llm' },
+  agents:  { label: 'Knowledge ',     em: 'Graphs',          lead: 'Give agents a persistent, graph-shaped memory from conversations, meetings, products.',    thumbClass: 'agents' },
+  image:   { label: 'Multimodal',                             lead: 'Images, PDFs, slides, faces — same flow, different encoder.',                             thumbClass: 'pink' },
+};
+
+export type ExampleCard = {
+  slug: string;                      // becomes /docs-v1/examples/<slug>
+  title: string;                     // asterisks → italic-coral
+  index: string;                     // e.g. '01 / 02' — shown top-right of thumb
+  category: Category;
+  thumbClass?: string;
+  thumbLabel: string;
+  motif?: string;                    // raw inline SVG markup for the thumb
+  description: string;
+  tags: Array<{ kind: 'src' | 'tgt' | 'llm' | 'ops' | 'lvl'; label: string }>;
+  footMeta: string;
+  sourceSlug?: string;               // override GitHub path when the listing slug differs from the repo dir
+  featured?: boolean;
+};
+
+const MOTIFS = {
+  repos: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="14" y="18" width="20" height="34" rx="2"/><rect x="40" y="18" width="20" height="34" rx="2"/><rect x="66" y="18" width="20" height="34" rx="2"/><path d="M92 35 L106 35 M98 30 L106 35 L98 40" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+  pdfToMd: `<svg viewBox="0 0 120 70" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="18" y="14" width="30" height="42" rx="2"/><path d="M54 35 L70 35 M62 29 L70 35 L62 41" stroke-linecap="round" stroke-linejoin="round"/><rect x="74" y="14" width="30" height="42" rx="2"/><path d="M80 24 L98 24 M80 32 L94 32 M80 40 L98 40 M80 48 L88 48"/></svg>`,
+} as const;
+
+export const examples: ExampleCard[] = [
+  {
+    slug: 'multi-codebase-summarization',
+    title: 'Multi-codebase *Summarization*',
+    index: '01 / 02',
+    category: 'llm',
+    thumbLabel: 'Code · LLM summaries',
+    motif: MOTIFS.repos,
+    description: 'Walk many Python repos, chunk by syntax, ask an LLM to write a searchable summary per file. The flagship v1 walkthrough.',
+    tags: [
+      { kind: 'src', label: 'Multi-repo' },
+      { kind: 'llm', label: 'Any LLM' },
+      { kind: 'lvl', label: 'Advanced' },
+    ],
+    footMeta: '~35 min · featured',
+    sourceSlug: 'multi_codebase_summarization',
+    featured: true,
+  },
+  {
+    slug: 'pdf-to-markdown',
+    title: 'PDF → *Markdown*',
+    index: '02 / 02',
+    category: 'ingest',
+    thumbLabel: 'PDF · custom blocks',
+    motif: MOTIFS.pdfToMd,
+    description: 'Incremental PDF → Markdown conversion pipeline. Custom building blocks over a folder of PDFs.',
+    tags: [
+      { kind: 'src', label: 'PDF' },
+      { kind: 'tgt', label: 'Local FS' },
+      { kind: 'ops', label: 'Custom blocks' },
+    ],
+    footMeta: '~18 min',
+    sourceSlug: 'pdf_to_markdown',
+  },
+];
+
+export const featuredSlug = 'multi-codebase-summarization';
+
+// Featured examples still show up in their home category grid — when the
+// catalog is small, hiding them leaves categories visibly empty.
+export const byCategory = (cat: Category): ExampleCard[] =>
+  examples.filter((e) => e.category === cat);
+
+export const findExample = (slug: string): ExampleCard | undefined =>
+  examples.find((e) => e.slug === slug);
+
+// Sidebar facets shown on the listing. Short in v1 — expands as more
+// examples land.
+export const SIDEBAR_TARGETS = ['Local FS', 'Postgres'];
+export const SIDEBAR_SOURCES = ['Local FS', 'PDF', 'Multi-repo'];
+export const SIDEBAR_LLMS    = ['OpenAI', 'Gemini', 'Anthropic'];
+export const POPULAR: Array<{ slug: string; label: string; count: string }> = [
+  { slug: 'multi-codebase-summarization', label: 'Multi-codebase Summarization', count: '★' },
+  { slug: 'pdf-to-markdown',              label: 'PDF → Markdown',               count: '★' },
+];

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -1,0 +1,575 @@
+---
+// Per-example detail page at /docs/examples/<slug>. The hero (eyebrow,
+// title, at-a-glance card) is driven by src/data/examples.ts; the body
+// is the MDX entry in the `examplePosts` content collection, ported
+// from github.com/cocoindex-io/examples. Add a new example by dropping a
+// markdown file into src/content/example-posts and a card into
+// examples.ts — the slugs must match.
+import '../../styles/globals.css';
+import Topbar from '../../components/Topbar.astro';
+import { GITHUB_REPO, SITE_URL, titleMarkup, titleText } from '../../consts';
+import { examples, findExample, CATEGORY_META, type Category } from '../../data/examples';
+import { getEntry, render } from 'astro:content';
+
+// Group examples by category for the left sidebar, in the same order as
+// the listing page. Featured examples stay in their home category — we're
+// showing them in a flat nav here, not as a separate "star" bucket.
+const CAT_ORDER: Category[] = ['search', 'ingest', 'llm', 'agents', 'image'];
+const grouped = CAT_ORDER.map((c) => ({
+  cat: c,
+  meta: CATEGORY_META[c],
+  items: examples.filter((e) => e.category === c),
+}));
+
+export async function getStaticPaths() {
+  return examples.map((e) => ({ params: { slug: e.slug } }));
+}
+
+const { slug } = Astro.params;
+const ex = findExample(slug!);
+if (!ex) throw new Error(`Unknown example slug: ${slug}`);
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '';
+const plainTitle = titleText(ex.title);
+const fullTitle = `${plainTitle} · CocoIndex Examples`;
+const canonical = new URL(`${base}/examples/${slug}`, SITE_URL).toString();
+// The repo directory usually matches the slug; override via sourceSlug when
+// it doesn't (e.g. listing slug `code_index` vs repo dir `code_embedding`).
+const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/main/examples/${ex.sourceSlug ?? slug}`;
+
+// Pull the ported markdown body. Every listed example should have a
+// matching entry, but we tolerate a missing one so we can ship the
+// listing + design even before a walkthrough lands.
+const entry = await getEntry('examplePosts', slug!);
+const rendered = entry ? await render(entry) : null;
+const Content = rendered?.Content;
+// Only h2 headings feed the TOC — h3/h4 add noise at this section count.
+const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#FBF6E8" />
+    <title>{fullTitle}</title>
+    <meta name="description" content={ex.description} />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" href={`${base}/img/favicon.ico`} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
+    />
+  </head>
+  <body class="ex-detail">
+    <Topbar />
+
+    <div class="ex-layout">
+      <!-- ─────────── LEFT: EXAMPLE NAV ─────────── -->
+      <aside class="ex-side" aria-label="All examples">
+        <div class="side-head">
+          <a href={`${base}/examples`}>← All examples</a>
+          <span class="ct">{examples.length}</span>
+        </div>
+        {grouped.map((g) => (
+          <div class="side-group">
+            <h6 data-cat={g.cat}>
+              <span class="cat-dot"></span>
+              {g.meta.label}{g.meta.em ?? ''}
+            </h6>
+            <ol>
+              {g.items.map((it) => (
+                <li class={it.slug === slug ? 'on' : ''}>
+                  <a href={`${base}/examples/${it.slug}`}>
+                    <span class="n">{it.index.split(' ')[0]}</span>
+                    <span class="ttl">{titleText(it.title)}</span>
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        ))}
+      </aside>
+
+      <main class="ex-main">
+      <!-- Local breadcrumb sits just below the sticky Topbar. -->
+      <nav class="ex-crumb" aria-label="Breadcrumb">
+        <a href={`${base}/examples`}>Examples</a>
+        <span class="sep">/</span>
+        <span class="cur">{plainTitle}</span>
+      </nav>
+
+      <!-- ─────────── HERO ─────────── -->
+      <section class="hero">
+        <div class="hero-eyebrow">
+          <span class="num">Example · {ex.index.split(' ')[0]}</span>
+          {ex.tags.map((t) => <span class="tag">{t.label}</span>)}
+          <span class="time">{ex.footMeta}</span>
+        </div>
+
+        <div class="hero-grid">
+          <div>
+            <h1 class="hero-h" set:html={titleMarkup(ex.title + (ex.title.endsWith('.') ? '' : '.'))} />
+            <p class="hero-sub">{ex.description}</p>
+            <div class="hero-cta">
+              <a class="btn btn-coral" href={sourceUrl}>View source
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </a>
+              {tocHeadings[0] && <a class="btn btn-outline-muted" href={`#${tocHeadings[0].slug}`}>Start reading</a>}
+              <a class="btn btn-outline-muted" href={`${base}/examples`}>All examples</a>
+            </div>
+            <div class="pill-row">
+              {ex.tags.slice(0, 4).map((t) => <span class="pill"><span class="dot"></span>{t.label}</span>)}
+              <span class="pill dark"><span class="dot"></span>Production ready</span>
+            </div>
+          </div>
+
+          <aside class="hero-card">
+            <div><div class="tl">At a glance</div></div>
+            <h2 class="big" set:html={titleMarkup('Built to *ship.* Clone and run.')} />
+            <div class="meta">
+              {ex.tags.find((t) => t.kind === 'src') && <div><span>Source</span><b>{ex.tags.find((t) => t.kind === 'src')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'llm') && <div><span>LLM</span><b>{ex.tags.find((t) => t.kind === 'llm')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'tgt') && <div><span>Target</span><b>{ex.tags.find((t) => t.kind === 'tgt')!.label}</b></div>}
+              {ex.tags.find((t) => t.kind === 'ops') && <div><span>Mode</span><b>{ex.tags.find((t) => t.kind === 'ops')!.label}</b></div>}
+              <div><span>Time</span><b>{ex.footMeta.split('·')[0].trim()}</b></div>
+              <div><span>Category</span><b>{ex.category}</b></div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ─────────── CONTENT ─────────── -->
+      {Content ? (
+        <article class="ex-prose">
+          <Content />
+        </article>
+      ) : (
+        <section class="blk">
+          <div class="sec-head">
+            <div class="sec-idx"><span class="n">00</span> · Overview</div>
+            <h2 set:html={titleMarkup('Write-up *on the way.*')} />
+            <p class="sec-lead">
+              The step-by-step walkthrough for this example is still being written. The code itself is live on GitHub — clone it to try it today.
+            </p>
+          </div>
+          <div class="callout" style="max-width:780px;">
+            <div class="hd tip"><span class="dt"></span>What this example shows</div>
+            <p>{ex.description}</p>
+          </div>
+        </section>
+      )}
+      </main>
+
+      <!-- ─────────── RIGHT: ON THIS PAGE ─────────── -->
+      <aside class="ex-toc toc" aria-label="On this page">
+        <div class="toc-head">
+          <span>On this page</span>
+          <span class="prog" id="tocProg">0 / {tocHeadings.length}</span>
+        </div>
+        <ol id="tocList">
+          {tocHeadings.map((h) => (
+            <li data-target={`#${h.slug}`}>
+              <a href={`#${h.slug}`}>{h.text}</a>
+            </li>
+          ))}
+        </ol>
+        <div class="toc-aside">
+          <a href={sourceUrl}>↗ Source on GitHub</a>
+          <a href={base || '/'}>↗ Full docs</a>
+          <a href={`${base}/examples`}>↗ All examples</a>
+        </div>
+      </aside>
+    </div>
+
+    <script is:inline>
+      (function(){
+        const tocItems = document.querySelectorAll('#tocList [data-target]');
+        const map = new Map();
+        tocItems.forEach((li) => {
+          const sel = li.getAttribute('data-target');
+          const el = document.querySelector(sel);
+          if (el) map.set(el, li);
+        });
+        const prog = document.getElementById('tocProg');
+        const total = map.size;
+        const active = new Set();
+        const io = new IntersectionObserver((entries) => {
+          entries.forEach((e) => {
+            const li = map.get(e.target);
+            if (!li) return;
+            if (e.isIntersecting) { li.classList.add('active'); active.add(li); }
+            else { li.classList.remove('active'); active.delete(li); }
+          });
+          if (prog) prog.textContent = `${active.size} / ${total}`;
+        }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+        map.forEach((_, el) => io.observe(el));
+      })();
+    </script>
+
+    <style is:global>
+      /* ═══════════ Detail-page styles ═══════════
+         Scoped to body.ex-detail. Palette inherited from globals.css. */
+      body.ex-detail { font-size: 17px; line-height: 1.55; }
+      /* ═══════════ 3-col layout (mirrors docs) ═══════════
+         Left: sticky example nav. Middle: breadcrumb + hero + content.
+         Right: sticky TOC. `--ex-side` / `--ex-toc` match the rail widths
+         used by globals.css on regular docs pages. */
+      body.ex-detail { --ex-side: 280px; --ex-toc: 240px; }
+      body.ex-detail .ex-layout {
+        display: grid;
+        grid-template-columns: var(--ex-side) 1fr var(--ex-toc);
+        max-width: 1480px;
+        margin: 0 auto;
+      }
+      body.ex-detail .ex-main { padding: 28px 48px 96px; min-width: 0; }
+
+      body.ex-detail .ex-side {
+        position: sticky; top: 57px; align-self: start;
+        height: calc(100vh - 57px);
+        overflow-y: auto;
+        padding: 28px 20px 40px 28px;
+        border-right: 1px solid var(--rule);
+        font-family: var(--sans);
+      }
+      body.ex-detail .ex-side .side-head {
+        display: flex; justify-content: space-between; align-items: baseline;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--muted);
+        padding-bottom: 10px; margin-bottom: 16px;
+        border-bottom: 1px solid var(--rule-strong);
+      }
+      body.ex-detail .ex-side .side-head a { color: var(--maroon-ink); text-decoration: none; }
+      body.ex-detail .ex-side .side-head a:hover { color: var(--coral); }
+      body.ex-detail .ex-side .side-head .ct { color: var(--coral); }
+      body.ex-detail .ex-side .side-group { margin-bottom: 18px; }
+      body.ex-detail .ex-side .side-group h6 {
+        display: flex; align-items: center; gap: 8px;
+        font-family: var(--sans); font-size: 12px; font-weight: 600; letter-spacing: -0.01em;
+        color: var(--maroon-ink); margin: 0 0 6px; padding: 0 6px;
+      }
+      body.ex-detail .ex-side .side-group h6 .cat-dot { width: 8px; height: 8px; border-radius: 2px; flex: none; background: var(--maroon); }
+      body.ex-detail .ex-side .side-group h6[data-cat="search"] .cat-dot { background: var(--maroon); }
+      body.ex-detail .ex-side .side-group h6[data-cat="ingest"] .cat-dot { background: var(--peach); }
+      body.ex-detail .ex-side .side-group h6[data-cat="llm"]    .cat-dot { background: var(--coral); }
+      body.ex-detail .ex-side .side-group h6[data-cat="agents"] .cat-dot { background: var(--maroon-ink); }
+      body.ex-detail .ex-side .side-group h6[data-cat="image"]  .cat-dot { background: var(--pink); }
+
+      body.ex-detail .ex-side ol { list-style: none; margin: 0 0 0 6px; padding: 0; }
+      body.ex-detail .ex-side ol li { margin: 0; }
+      body.ex-detail .ex-side ol li a {
+        display: grid; grid-template-columns: 24px 1fr; gap: 8px; align-items: baseline;
+        text-decoration: none; color: var(--muted);
+        font-size: 13px; line-height: 1.35;
+        padding: 5px 8px; border-radius: 5px;
+        transition: color .12s, background .12s;
+      }
+      body.ex-detail .ex-side ol li a .n { font-family: var(--mono); font-size: 11px; color: var(--rule-strong); }
+      body.ex-detail .ex-side ol li a .ttl { color: inherit; }
+      body.ex-detail .ex-side ol li a:hover { color: var(--coral); background: var(--cream); }
+      body.ex-detail .ex-side ol li.on a { color: var(--maroon); background: var(--cream); font-weight: 500; }
+      body.ex-detail .ex-side ol li.on a .n { color: var(--coral); }
+
+      body.ex-detail .ex-toc {
+        position: sticky; top: 57px; align-self: start;
+        height: calc(100vh - 57px);
+        overflow-y: auto;
+        padding: 28px 28px 40px 20px;
+        border-left: 1px solid var(--rule);
+        font-family: var(--sans);
+      }
+
+      body.ex-detail .ex-crumb {
+        font-family: var(--mono); font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase;
+        color: var(--muted); display: flex; gap: 10px; align-items: center;
+        padding: 20px 0 8px;
+      }
+      body.ex-detail .ex-crumb a { text-decoration: none; color: var(--muted); }
+      body.ex-detail .ex-crumb a:hover { color: var(--coral); }
+      body.ex-detail .ex-crumb .sep { opacity: 0.5; }
+      body.ex-detail .ex-crumb .cur { color: var(--maroon); }
+
+      /* Local button styles — scoped rather than leaking into prose/docs. */
+      body.ex-detail .btn {
+        display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+        padding: 10px 18px; border-radius: 999px;
+        font-family: var(--sans); font-size: 14px; font-weight: 500; line-height: 1.2;
+        text-decoration: none; white-space: nowrap;
+        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
+        transition: background .16s, color .16s, border-color .16s, transform .12s;
+      }
+      body.ex-detail .btn:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-detail .btn-primary { background: var(--maroon); color: var(--cream); }
+      body.ex-detail .btn-primary:hover { background: var(--maroon-deep); border-color: var(--maroon-deep); }
+      body.ex-detail .btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
+      body.ex-detail .btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
+      body.ex-detail .btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
+      body.ex-detail .btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+
+      /* ── HERO ── */
+      body.ex-detail .hero { padding: 32px 0 32px; position: relative; }
+      body.ex-detail .hero-eyebrow { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 28px; padding-bottom: 24px; border-bottom: 1px solid var(--rule); }
+      body.ex-detail .hero-eyebrow .num { font-family: var(--mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--coral); font-weight: 500; }
+      body.ex-detail .hero-eyebrow .tag { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); padding: 5px 12px; border: 1px solid var(--rule-strong); border-radius: 999px; }
+      body.ex-detail .hero-eyebrow .time { margin-left: auto; color: var(--muted); font-family: var(--mono); font-size: 12px; }
+
+      body.ex-detail .hero-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: 64px; align-items: end; }
+      body.ex-detail h1.hero-h { font-family: var(--serif); font-weight: 400; font-size: clamp(40px, 4.6vw, 60px); line-height: 0.98; letter-spacing: -0.03em; margin: 0 0 24px; max-width: 18ch; }
+      body.ex-detail h1.hero-h em { font-style: italic; color: var(--coral); }
+      body.ex-detail .hero-sub { font-family: var(--sans); font-size: clamp(17px, 1.4vw, 21px); font-weight: 400; line-height: 1.5; letter-spacing: -0.01em; color: var(--maroon-ink); max-width: 56ch; margin: 0 0 32px; }
+      body.ex-detail .hero-sub b { font-weight: 600; color: var(--maroon); }
+      body.ex-detail .hero-cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+      body.ex-detail .hero-card { background: var(--maroon); color: var(--cream); border-radius: 10px; padding: 32px; position: relative; overflow: hidden; min-height: 320px; display: flex; flex-direction: column; justify-content: space-between; }
+      body.ex-detail .hero-card::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.6px, transparent 2px); background-size: 20px 20px; }
+      body.ex-detail .hero-card > * { position: relative; z-index: 2; }
+      body.ex-detail .hero-card .tl { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .hero-card .big { font-family: var(--sans); font-size: clamp(40px, 4.6vw, 58px); font-weight: 600; letter-spacing: -0.035em; line-height: 0.98; margin: 0; color: var(--cream); }
+      body.ex-detail .hero-card .big em { color: var(--peach); font-style: italic; }
+      body.ex-detail .hero-card .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 28px; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.18); font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .hero-card .meta b { display: block; color: var(--cream); font-weight: 400; margin-top: 3px; letter-spacing: 0.02em; text-transform: none; font-size: 13px; }
+
+      body.ex-detail .pill-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 32px; padding-top: 24px; border-top: 1px solid var(--rule); }
+      body.ex-detail .pill { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 7px 14px; border-radius: 999px; background: var(--cream); border: 1px solid var(--rule); color: var(--maroon); }
+      body.ex-detail .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); }
+      body.ex-detail .pill.dark { background: var(--maroon-ink); color: var(--cream); border-color: var(--maroon-ink); }
+      body.ex-detail .pill.dark .dot { background: var(--palm); }
+
+      /* ── DOC LAYOUT ── */
+      /* (doc/toc 2-col rules removed — new .ex-layout handles positioning) */
+      body.ex-detail .toc-head { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); padding-bottom: 10px; margin-bottom: 14px; border-bottom: 1px solid var(--rule-strong); display: flex; justify-content: space-between; align-items: baseline; }
+      body.ex-detail .toc-head .prog { color: var(--coral); font-family: var(--mono); }
+      body.ex-detail .toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc-part; }
+      body.ex-detail .toc > ol > li { counter-increment: toc-part; margin-bottom: 18px; }
+      body.ex-detail .toc > ol > li > a { display: flex; align-items: baseline; gap: 10px; text-decoration: none; color: var(--maroon-ink); font-size: 14px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.3; padding: 6px 0; transition: color .15s; }
+      body.ex-detail .toc > ol > li > a::before { content: counter(toc-part, decimal-leading-zero); font-family: var(--mono); font-weight: 500; font-size: 11px; letter-spacing: 0.06em; color: var(--muted); flex: none; }
+      body.ex-detail .toc > ol > li > a:hover { color: var(--coral); }
+      body.ex-detail .toc > ol > li.active > a { color: var(--coral); }
+      body.ex-detail .toc ul { list-style: none; padding: 0; margin: 6px 0 4px 26px; counter-reset: toc-step; }
+      body.ex-detail .toc ul li { counter-increment: toc-step; }
+      body.ex-detail .toc ul li a { display: flex; align-items: baseline; gap: 8px; text-decoration: none; color: var(--muted); font-size: 13px; font-weight: 400; line-height: 1.4; padding: 4px 0; transition: color .15s; }
+      body.ex-detail .toc ul li a::before { content: counter(toc-part) "." counter(toc-step); font-family: var(--mono); font-size: 10px; color: var(--rule-strong); flex: none; min-width: 22px; }
+      body.ex-detail .toc ul li a:hover { color: var(--coral); }
+      body.ex-detail .toc ul li.active a { color: var(--maroon); }
+      body.ex-detail .toc ul li.active a::before { color: var(--coral); }
+      body.ex-detail .toc .toc-aside { margin-top: 28px; padding-top: 16px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: flex; flex-direction: column; gap: 8px; }
+      body.ex-detail .toc .toc-aside a { text-decoration: none; color: var(--maroon-ink); display: flex; align-items: center; gap: 6px; }
+      body.ex-detail .toc .toc-aside a:hover { color: var(--coral); }
+
+      body.ex-detail .doc .col-main { min-width: 0; }
+      body.ex-detail section.blk { padding: 72px 0; border-top: 1px solid var(--rule); position: relative; scroll-margin-top: 84px; }
+      body.ex-detail section.blk:first-of-type { border-top: none; padding-top: 24px; }
+      body.ex-detail .sec-head { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 40px; }
+      body.ex-detail .sec-idx { display: inline-flex; gap: 10px; align-items: baseline; font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .sec-idx .n { color: var(--coral); font-weight: 500; }
+      body.ex-detail .sec-head h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(28px, 3.2vw, 44px); line-height: 1.05; letter-spacing: -0.03em; margin: 0; max-width: 22ch; }
+      body.ex-detail .sec-head h2 em { font-style: normal; color: var(--coral); }
+      body.ex-detail .sec-lead { font-family: var(--sans); font-size: clamp(15px, 1.2vw, 17px); font-weight: 400; line-height: 1.55; color: var(--maroon-ink); max-width: 64ch; margin: 8px 0 0; }
+      body.ex-detail .sec-lead a { color: var(--coral); }
+
+      /* Architecture (HN flow) */
+      body.ex-detail .arch { background: var(--cream); border: 1px solid var(--rule); border-radius: 12px; padding: 36px; display: grid; grid-template-columns: 0.9fr auto 1.2fr auto 1fr; gap: 18px; align-items: stretch; }
+      body.ex-detail .arch-col { display: flex; flex-direction: column; gap: 10px; padding: 20px; border-radius: 8px; background: var(--paper); border: 1px solid var(--rule); min-height: 320px; }
+      body.ex-detail .arch-col h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin: 0 0 4px; padding-bottom: 10px; border-bottom: 1px solid var(--rule); display: flex; justify-content: space-between; align-items: center; }
+      body.ex-detail .arch-col h4 .n { color: var(--coral); font-weight: 500; }
+      body.ex-detail .chip { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-radius: 6px; background: var(--cream); border: 1px solid var(--rule); font-size: 13px; font-weight: 500; }
+      body.ex-detail .chip .ico { width: 22px; height: 22px; flex: none; display: grid; place-items: center; border-radius: 4px; background: var(--peach); color: var(--maroon); font-family: var(--mono); font-size: 10px; font-weight: 600; }
+      body.ex-detail .chip .ico.hn { background: #FF6600; color: #fff; }
+      body.ex-detail .chip .ico.pg { background: #336791; color: #fff; }
+      body.ex-detail .chip .ico.llm { background: var(--maroon-ink); color: var(--peach); }
+      body.ex-detail .chip .tail { margin-left: auto; font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+
+      body.ex-detail .arch-core { background: var(--maroon); color: var(--cream); border-radius: 8px; padding: 22px; position: relative; overflow: hidden; display: flex; flex-direction: column; gap: 12px; }
+      body.ex-detail .arch-core::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.4px, transparent 1.8px); background-size: 16px 16px; }
+      body.ex-detail .arch-core > * { position: relative; z-index: 2; }
+      body.ex-detail .arch-core h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); display: flex; justify-content: space-between; padding-bottom: 10px; border-bottom: 1px solid rgba(252, 243, 216, 0.18); margin: 0; }
+      body.ex-detail .arch-core h4 .n { color: var(--peach); }
+      body.ex-detail .arch-core .title { font-family: var(--sans); font-weight: 600; font-size: 21px; line-height: 1.2; letter-spacing: -0.02em; margin: 0; color: var(--cream); }
+      body.ex-detail .arch-core .title em { font-style: normal; color: var(--peach); }
+      body.ex-detail .arch-core .sub { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.6); }
+      body.ex-detail .arch-core .rows { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+      body.ex-detail .arch-core .rows .r { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 5px; background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.1); font-family: var(--mono); font-size: 12px; }
+      body.ex-detail .arch-core .rows .r .k { color: var(--peach); }
+      body.ex-detail .arch-core .rows .r .v { color: rgba(252, 243, 216, 0.9); }
+      body.ex-detail .arch-core .stamp { margin-top: auto; display: flex; gap: 8px; flex-wrap: wrap; font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.65); }
+      body.ex-detail .arch-core .stamp span { padding: 4px 10px; border: 1px solid rgba(252, 243, 216, 0.2); border-radius: 999px; }
+
+      body.ex-detail .arrow { align-self: center; display: flex; flex-direction: column; align-items: center; gap: 6px; min-width: 48px; }
+      body.ex-detail .arrow svg { width: 48px; height: 18px; }
+      body.ex-detail .arrow .lab { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+
+      body.ex-detail .trending-preview { margin-top: 20px; background: var(--paper); border: 1px solid var(--rule); border-radius: 8px; padding: 22px; display: grid; grid-template-columns: 1fr 2fr; gap: 24px; align-items: start; }
+      body.ex-detail .trending-preview h5 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--coral); margin: 0 0 6px; }
+      body.ex-detail .trending-preview p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.5; }
+      body.ex-detail .trending-preview .inline-code { font-family: var(--mono); font-size: 12px; background: var(--cream); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--rule); color: var(--berry); }
+      body.ex-detail .trending-list { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .trending-row { display: grid; grid-template-columns: 28px 1fr auto auto; gap: 14px; align-items: baseline; padding: 7px 12px; border-radius: 5px; font-family: var(--mono); font-size: 13px; border: 1px solid transparent; }
+      body.ex-detail .trending-row:hover { background: var(--cream); border-color: var(--rule); }
+      body.ex-detail .trending-row .rk { color: var(--muted); font-size: 11px; }
+      body.ex-detail .trending-row .tp { color: var(--maroon); font-weight: 500; }
+      body.ex-detail .trending-row .tp em { color: var(--coral); font-style: normal; }
+      body.ex-detail .trending-row .sc { color: var(--coral); font-weight: 600; }
+      body.ex-detail .trending-row .th { color: var(--muted); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; }
+
+      /* Part banner */
+      body.ex-detail .part-banner { display: grid; grid-template-columns: 72px 1fr auto; gap: 24px; align-items: center; margin: 0 0 32px; padding: 24px 28px; background: linear-gradient(90deg, var(--cream) 0%, var(--paper) 100%); border: 1px solid var(--rule); border-left: 4px solid var(--coral); border-radius: 8px; position: relative; }
+      body.ex-detail .part-banner .pn { font-family: var(--mono); font-size: 34px; font-weight: 500; letter-spacing: -0.02em; color: var(--coral); line-height: 1; }
+      body.ex-detail .part-banner .pc { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .part-banner .pc .plabel { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .part-banner .pc h3 { font-family: var(--sans); font-weight: 600; font-size: 26px; letter-spacing: -0.025em; line-height: 1.15; margin: 0; }
+      body.ex-detail .part-banner .pc h3 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .part-banner .pc p { margin: 4px 0 0; color: var(--muted); font-size: 14px; line-height: 1.5; max-width: 60ch; }
+      body.ex-detail .part-banner .pm { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); text-align: right; display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .part-banner .pm b { color: var(--maroon); font-weight: 500; }
+
+      /* Steps */
+      body.ex-detail .steps-wrap { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 48px; }
+      body.ex-detail .step { display: grid; grid-template-columns: 72px 1fr; grid-template-rows: auto auto; column-gap: 24px; row-gap: 20px; align-items: start; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); padding: 28px 30px; position: relative; scroll-margin-top: 90px; }
+      body.ex-detail .step-num { grid-row: 1 / 3; display: flex; flex-direction: column; align-items: flex-start; gap: 10px; align-self: stretch; }
+      body.ex-detail .step-num .chip-num { width: 46px; height: 46px; border-radius: 50%; display: grid; place-items: center; background: var(--maroon); color: var(--cream); font-family: var(--mono); font-weight: 500; font-size: 14px; letter-spacing: 0; }
+      body.ex-detail .step.coral .step-num .chip-num { background: var(--coral); }
+      body.ex-detail .step-num .rail { width: 2px; flex: 1; background: var(--rule-strong); opacity: 0.4; }
+      body.ex-detail .step-num .tag { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .step-head { grid-column: 2; grid-row: 1; max-width: 72ch; }
+      body.ex-detail .step-head h4 { font-family: var(--sans); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; line-height: 1.2; margin: 0 0 10px; }
+      body.ex-detail .step-head h4 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .step-head p { margin: 0 0 14px; color: var(--maroon-ink); max-width: 64ch; font-size: 15px; line-height: 1.55; }
+      body.ex-detail .step-head code,
+      body.ex-detail .step-head p code,
+      body.ex-detail .callout code,
+      body.ex-detail .step-bullets code { font-family: var(--mono); font-size: 13px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 1px 6px; border-radius: 3px; }
+      body.ex-detail .step-bullets { list-style: none; padding: 0; margin: 0 0 6px; display: flex; flex-direction: column; gap: 4px; }
+      body.ex-detail .step-bullets li { display: flex; gap: 10px; align-items: flex-start; font-size: 13.5px; color: var(--muted); padding: 6px 0; border-top: 1px solid var(--rule); }
+      body.ex-detail .step-bullets li::before { content: ""; width: 6px; height: 6px; margin-top: 7px; flex: none; background: var(--coral); border-radius: 50%; }
+      body.ex-detail .step-bullets li b { color: var(--maroon); font-weight: 500; }
+      body.ex-detail .step-side { grid-column: 2; grid-row: 2; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+
+      /* Code block — matches cocoindex-dark shiki theme. */
+      body.ex-detail .code { background: var(--maroon-ink); color: var(--cream); border-radius: 8px; font-family: var(--mono); font-size: 12.5px; line-height: 1.65; padding: 0; overflow: hidden; }
+      body.ex-detail .code-bar { display: flex; align-items: center; gap: 10px; padding: 11px 16px; border-bottom: 1px solid rgba(252, 243, 216, 0.1); font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.65); }
+      body.ex-detail .code-bar .dots { display: flex; gap: 6px; }
+      body.ex-detail .code-bar .dots span { width: 9px; height: 9px; border-radius: 50%; background: rgba(252, 243, 216, 0.22); }
+      body.ex-detail .code-bar .dots span:first-child { background: var(--pink); }
+      body.ex-detail .code-bar .dots span:nth-child(2) { background: var(--peach); }
+      body.ex-detail .code-bar .dots span:nth-child(3) { background: var(--palm); }
+      body.ex-detail .code-bar .name { margin-left: 8px; }
+      body.ex-detail .code-bar .lang { margin-left: auto; opacity: 0.65; }
+      body.ex-detail .code pre { margin: 0; padding: 16px 18px 20px; overflow-x: auto; white-space: pre; tab-size: 4; color: var(--cream); }
+      body.ex-detail .code .kw { color: var(--peach); }
+      body.ex-detail .code .dec { color: var(--peach); }
+      body.ex-detail .code .fn { color: var(--pink); }
+      body.ex-detail .code .str { color: #8ef09e; }
+      body.ex-detail .code .num { color: #F5D76E; }
+      body.ex-detail .code .tp { color: #C9B8F5; }
+      body.ex-detail .code .dim { opacity: 0.48; }
+      body.ex-detail .code .comment { color: #978A74; font-style: italic; opacity: 0.75; }
+      body.ex-detail .code.terminal .prompt::before { content: "$ "; color: var(--peach); }
+
+      body.ex-detail .callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }
+      body.ex-detail .callout .hd { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .callout .hd .dt { width: 8px; height: 8px; border-radius: 50%; background: var(--coral); }
+      body.ex-detail .callout .hd.tip .dt { background: var(--palm); }
+      body.ex-detail .callout .hd.note .dt { background: var(--peach); }
+      body.ex-detail .callout .hd.warn .dt { background: var(--pink); }
+      body.ex-detail .callout p { margin: 0; color: var(--maroon-ink); }
+
+      /* Variations */
+      body.ex-detail .var-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+      body.ex-detail .var-card { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 26px 24px 20px; background: var(--paper); display: flex; flex-direction: column; gap: 10px; min-height: 200px; transition: background-image .18s ease; text-decoration: none; color: inherit; position: relative; overflow: hidden; }
+      body.ex-detail .var-card:hover { background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px); background-size: 14px 14px; }
+      body.ex-detail .var-card.dark:hover { background-image: radial-gradient(circle, rgba(252, 243, 216, 0.1) 1.2px, transparent 1.6px); }
+      body.ex-detail .var-card .cap { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); display: flex; justify-content: space-between; }
+      body.ex-detail .var-card .cap .num { color: var(--coral); }
+      body.ex-detail .var-card h4 { font-family: var(--sans); font-weight: 600; font-size: 19px; letter-spacing: -0.02em; line-height: 1.2; margin: 0; }
+      body.ex-detail .var-card h4 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .var-card p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; flex: 1; }
+      body.ex-detail .var-card .foot { padding-top: 14px; margin-top: 6px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--coral); display: flex; justify-content: space-between; align-items: center; }
+      body.ex-detail .var-card.dark { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-detail .var-card.dark .cap, body.ex-detail .var-card.dark p { color: rgba(252, 243, 216, 0.7); }
+      body.ex-detail .var-card.dark .cap .num { color: var(--peach); }
+      body.ex-detail .var-card.dark .foot { color: var(--peach); border-color: rgba(252, 243, 216, 0.15); }
+      body.ex-detail .var-card.dark h4 em { color: var(--peach); }
+
+      /* Try-it */
+      body.ex-detail .tryit { background: var(--maroon); color: var(--cream); border-radius: 12px; padding: 40px; display: grid; grid-template-columns: 1fr 1.4fr; gap: 40px; align-items: stretch; position: relative; overflow: hidden; }
+      body.ex-detail .tryit::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.07) 1.4px, transparent 1.8px); background-size: 20px 20px; }
+      body.ex-detail .tryit > * { position: relative; z-index: 2; }
+      body.ex-detail .tryit h3 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.8vw, 36px); line-height: 1.08; letter-spacing: -0.03em; margin: 0 0 16px; max-width: 14ch; color: var(--cream); }
+      body.ex-detail .tryit h3 em { color: var(--peach); font-style: normal; }
+      body.ex-detail .tryit p { color: rgba(252, 243, 216, 0.85); max-width: 38ch; margin: 0 0 22px; }
+      body.ex-detail .tryit .tags { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
+      body.ex-detail .tryit .tags span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; padding: 5px 12px; border: 1px solid rgba(252, 243, 216, 0.22); border-radius: 999px; color: rgba(252, 243, 216, 0.75); }
+      body.ex-detail .tryit .queries { display: flex; flex-direction: column; gap: 12px; }
+      body.ex-detail .q-card { background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.15); border-radius: 8px; padding: 16px 18px; }
+      body.ex-detail .q-card .q { font-family: var(--mono); font-size: 13px; color: var(--cream); padding-bottom: 12px; margin-bottom: 12px; border-bottom: 1px solid rgba(252, 243, 216, 0.12); }
+      body.ex-detail .q-card .q::before { content: "query "; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--peach); margin-right: 8px; font-weight: 500; }
+      body.ex-detail .q-card .q em { color: var(--palm); font-style: normal; }
+      body.ex-detail .q-card .hits { display: flex; flex-direction: column; gap: 6px; font-family: var(--mono); font-size: 12px; line-height: 1.55; }
+      body.ex-detail .q-card .hit { display: grid; grid-template-columns: 52px 1fr auto; gap: 12px; align-items: baseline; padding: 3px 0; }
+      body.ex-detail .q-card .hit .sc { color: var(--palm); font-weight: 600; }
+      body.ex-detail .q-card .hit .pth { color: rgba(252, 243, 216, 0.9); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      body.ex-detail .q-card .hit .rng { color: rgba(252, 243, 216, 0.6); }
+
+      /* CTA end */
+      body.ex-detail .cta-end { border-radius: 12px; background: var(--cream); border: 1px solid var(--rule); padding: 60px 44px; text-align: center; position: relative; overflow: hidden; }
+      body.ex-detail .cta-end h3 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 3vw, 38px); line-height: 1.08; letter-spacing: -0.03em; margin: 0 auto 18px; max-width: 20ch; }
+      body.ex-detail .cta-end h3 em { color: var(--coral); font-style: normal; }
+      body.ex-detail .cta-end p { color: var(--muted); max-width: 46ch; margin: 0 auto 26px; font-size: 17px; }
+      body.ex-detail .cta-end .btns { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+
+      @media (max-width: 1100px) {
+        body.ex-detail .ex-layout { grid-template-columns: 1fr; }
+        body.ex-detail .ex-side,
+        body.ex-detail .ex-toc { position: static; height: auto; border: none; padding: 18px 20px; }
+        body.ex-detail .ex-side { border-bottom: 1px solid var(--rule); }
+        body.ex-detail .ex-toc { border-top: 1px solid var(--rule); }
+        body.ex-detail .ex-main { padding: 24px 28px 64px; }
+        body.ex-detail .arch { grid-template-columns: 1fr; gap: 12px; padding: 24px; }
+        body.ex-detail .arrow { transform: rotate(90deg); align-self: center; margin: 4px 0; }
+        body.ex-detail .hero-grid { grid-template-columns: 1fr; gap: 36px; }
+        body.ex-detail .step { grid-template-columns: 56px 1fr; column-gap: 16px; row-gap: 16px; padding: 24px; }
+        body.ex-detail .step-head, body.ex-detail .step-side { grid-column: 2; }
+        body.ex-detail .tryit { grid-template-columns: 1fr; padding: 32px; }
+        body.ex-detail .var-grid { grid-template-columns: 1fr 1fr; }
+        body.ex-detail .part-banner { grid-template-columns: 54px 1fr; gap: 18px; padding: 18px 20px; }
+        body.ex-detail .part-banner .pm { grid-column: 1 / -1; text-align: left; }
+        body.ex-detail .trending-preview { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 640px) { body.ex-detail .var-grid { grid-template-columns: 1fr; } }
+
+      /* ═══════════ Prose (rendered MDX body) ═══════════
+         The ported markdown drops into `.ex-prose`. Keep the typography
+         anchored on the same palette as the docs prose, without pulling
+         in the docs `.prose` container itself — that one's tuned for a
+         narrower column and a different heading scale. */
+      body.ex-detail .ex-prose { padding-top: 40px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
+      body.ex-detail .ex-prose > :first-child { margin-top: 0; }
+      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; padding-top: 28px; border-top: 1px solid var(--rule); }
+      body.ex-detail .ex-prose > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 24px; }
+      body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: 84px; }
+      body.ex-detail .ex-prose h4 { font-family: var(--sans); font-weight: 600; font-size: 17px; letter-spacing: -0.01em; margin: 28px 0 10px; }
+      body.ex-detail .ex-prose p { margin: 0 0 18px; }
+      body.ex-detail .ex-prose a { color: var(--coral); text-decoration: none; border-bottom: 1px solid rgba(190, 81, 51, 0.35); transition: border-color .15s, color .15s; }
+      body.ex-detail .ex-prose a:hover { color: var(--maroon); border-color: var(--maroon); }
+      body.ex-detail .ex-prose ul, body.ex-detail .ex-prose ol { margin: 0 0 18px; padding-left: 22px; }
+      body.ex-detail .ex-prose li { margin-bottom: 6px; }
+      body.ex-detail .ex-prose li > p { margin-bottom: 6px; }
+      body.ex-detail .ex-prose strong, body.ex-detail .ex-prose b { color: var(--maroon); font-weight: 600; }
+      body.ex-detail .ex-prose em, body.ex-detail .ex-prose i { font-style: italic; }
+      body.ex-detail .ex-prose img { max-width: 100%; height: auto; border-radius: 8px; margin: 20px 0; border: 1px solid var(--rule); }
+      body.ex-detail .ex-prose blockquote { margin: 20px 0; padding: 10px 18px; border-left: 3px solid var(--coral); background: var(--cream); border-radius: 0 6px 6px 0; color: var(--muted); }
+      body.ex-detail .ex-prose blockquote p { margin: 0; }
+      body.ex-detail .ex-prose :not(pre) > code { font-family: var(--mono); font-size: 13.5px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 2px 7px; border-radius: 4px; }
+      body.ex-detail .ex-prose pre { background: var(--maroon-ink); color: var(--cream); border-radius: 8px; padding: 18px 20px; overflow-x: auto; font-family: var(--mono); font-size: 13px; line-height: 1.6; margin: 20px 0; border: none; }
+      body.ex-detail .ex-prose pre code { background: transparent; color: inherit; padding: 0; font-size: inherit; border-radius: 0; }
+      body.ex-detail .ex-prose hr { border: none; border-top: 1px solid var(--rule); margin: 40px 0; }
+      body.ex-detail .ex-prose table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 14px; }
+      body.ex-detail .ex-prose th, body.ex-detail .ex-prose td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--rule); }
+      body.ex-detail .ex-prose th { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); border-bottom-color: var(--rule-strong); }
+      body.ex-detail .ex-prose kbd { font-family: var(--mono); font-size: 12px; padding: 2px 6px; border: 1px solid var(--rule-strong); border-radius: 4px; background: var(--cream); }
+    </style>
+  </body>
+</html>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -1,0 +1,720 @@
+---
+// Ports design_guidelines/CocoIndex Examples Listing.html into an Astro page
+// at /docs/examples. Reuses the shared Topbar from the docs site so the
+// header is identical across /docs and /docs/examples. All example cards
+// come from src/data/examples.ts — when you add a new example, update that
+// file and the card appears in its category automatically.
+import '../../styles/globals.css';
+import Topbar from '../../components/Topbar.astro';
+import { GITHUB_REPO, DISCORD_URL, SITE_URL, titleMarkup } from '../../consts';
+import {
+  examples,
+  byCategory,
+  findExample,
+  CATEGORY_META,
+  SIDEBAR_TARGETS,
+  SIDEBAR_SOURCES,
+  SIDEBAR_LLMS,
+  POPULAR,
+  featuredSlug,
+  type Category,
+} from '../../data/examples';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '';
+const exampleHref = (slug: string) => `${base}/examples/${slug}`;
+const featured = findExample(featuredSlug)!;
+
+// Category order and counts, computed from the data.
+const CAT_ORDER: Category[] = ['search', 'ingest', 'llm', 'agents', 'image'];
+const catCount = (c: Category) => examples.filter((e) => e.category === c).length;
+
+const total = examples.length;
+const fullTitle = `Examples · CocoIndex Docs`;
+const description = 'Real pipelines you can clone, run, and bend to your data — custom sources, LLM extraction, vector search, streaming ingest.';
+const canonical = new URL(`${base}/examples`, SITE_URL).toString();
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#FBF6E8" />
+    <title>{fullTitle}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" href={`${base}/img/favicon.ico`} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
+    />
+  </head>
+  <body class="ex-listing">
+    <Topbar />
+
+    <div class="ex-wrap">
+      <!-- ═══════════ HERO ═══════════ -->
+      <section class="ex-hero">
+        <div class="hero-top">
+          <span class="eyb"><span class="dot" aria-hidden="true"></span>{total} live examples · updated weekly</span>
+          <div class="stats">
+            <span><b>{total}</b> examples</span>
+            <span><b>9</b> sources</span>
+            <span><b>6</b> targets</span>
+            <span><b>5</b> LLM providers</span>
+          </div>
+        </div>
+
+        <div class="hero-grid">
+          <div>
+            <h1 class="hero-h">Examples<em>.</em></h1>
+            <p class="hero-sub">
+              Real pipelines you can <b>clone, run, and bend</b> to your data. Each example is production-wired — one source, a declarative flow, a live target. Pick the one closest to what you need and change the parts that don't fit.
+            </p>
+
+            <div class="hero-filters" id="filters">
+              <button class="filter-chip on" data-filter="all">All <span class="cnt">{total}</span></button>
+              {CAT_ORDER.map((c) => (
+                <button class="filter-chip" data-filter={c}>
+                  {CATEGORY_META[c].label}{CATEGORY_META[c].em ?? ''} <span class="cnt">{catCount(c)}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ═══════════ DOC LAYOUT ═══════════ -->
+      <div class="doc">
+        <aside class="side-nav" aria-label="Browse examples">
+          <div class="side-head">
+            <span>Browse</span>
+            <span class="ct">{total} examples</span>
+          </div>
+          <ol id="sideList">
+            <li data-target="section.feat"><a href="#feat-scroll" data-cat="featured"><span class="cat-dot"></span>Featured<span class="count">★</span></a></li>
+            {CAT_ORDER.map((c) => (
+              <li data-target={`#cat-${c}`}>
+                <a href={`#cat-${c}`} data-cat={c}>
+                  <span class="cat-dot"></span>
+                  {CATEGORY_META[c].label}{CATEGORY_META[c].em ?? ''}
+                  <span class="count">{catCount(c)}</span>
+                </a>
+              </li>
+            ))}
+          </ol>
+
+          <div class="side-group">
+            <h6>By target</h6>
+            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>By source</h6>
+            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>By LLM</h6>
+            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+          </div>
+
+          <div class="side-group">
+            <h6>Popular</h6>
+            <div class="links">
+              {POPULAR.map((p) => (
+                <a href={exampleHref(p.slug)}>{p.label}<span class="c">{p.count}</span></a>
+              ))}
+            </div>
+          </div>
+
+          <div class="side-group">
+            <h6>Resources</h6>
+            <div class="links">
+              <a href={`${GITHUB_REPO}/tree/v1/examples`}>↗ Source on GitHub</a>
+              <a href={base || '/'}>↗ Documentation</a>
+              <a href={DISCORD_URL}>↗ Discord</a>
+            </div>
+          </div>
+        </aside>
+
+        <div class="col-main">
+          <!-- ═══════════ FEATURED ═══════════ -->
+          <section class="feat" id="feat-scroll">
+            <div class="feat-eyebrow">★ Featured</div>
+            <a class="feat-card" href={exampleHref(featured.slug)}>
+              <div class="feat-body">
+                <span class="ribbon"><span class="tick"></span>{featured.thumbLabel} · <span class="idx">{featured.index}</span></span>
+                <h3 set:html={titleMarkup(featured.title + '.')} />
+                <p>{featured.description}</p>
+                <div class="chips">
+                  {featured.tags.map((t) => <span class="chip">{t.label}</span>)}
+                </div>
+                <div class="foot">
+                  <span>{featured.footMeta}</span>
+                  <span class="go">Open example
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                  </span>
+                </div>
+              </div>
+
+              <div class="feat-viz" aria-hidden="true" set:html={featured.motif ?? ''} />
+            </a>
+          </section>
+
+          <!-- ═══════════ CATEGORY SECTIONS ═══════════ -->
+          {CAT_ORDER.map((cat, ci) => {
+            const items = byCategory(cat);
+            return items.length === 0 ? null : (
+              <section class="cat" id={`cat-${cat}`} data-cat={cat}>
+                <div class="sec-head">
+                  <h2>
+                    {CATEGORY_META[cat].label}
+                    {CATEGORY_META[cat].em ? <em>{CATEGORY_META[cat].em}</em> : null}
+                  </h2>
+                  <p class="lead">{CATEGORY_META[cat].lead}</p>
+                </div>
+
+                <div class="cat-grid">
+                  {items.map((ex) => (
+                    <a class="ex-card" href={exampleHref(ex.slug)}>
+                      <div class={`ex-thumb ${ex.thumbClass ?? CATEGORY_META[ex.category].thumbClass}`}>
+                        <span class="tl">{ex.thumbLabel}</span>
+                        <span class="tr">{ex.index}</span>
+                        <div class="motif" set:html={ex.motif ?? ''} />
+                      </div>
+                      <div class="ex-body">
+                        <h3 set:html={titleMarkup(ex.title)} />
+                        <p>{ex.description}</p>
+                        <div class="ex-tags">
+                          {ex.tags.map((t) => (
+                            <span class={`tag ${t.kind}`}><span class="dt"></span>{t.label}</span>
+                          ))}
+                        </div>
+                        <div class="ex-foot">
+                          <span>{ex.footMeta}</span>
+                          <span class="go">Open →</span>
+                        </div>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+
+          <!-- ═══════════ CTA ═══════════ -->
+          <section class="cta-end">
+            <div class="cta-copy">
+              <h3 set:html={titleMarkup("Can't find the *shape* you need?")} />
+              <p>Clone the closest example, swap the source or the target, and keep the rest. Or request a new example — we ship the ones developers ask for.</p>
+              <div class="btns">
+                <a class="btn btn-coral" href={GITHUB_REPO}>Request on GitHub</a>
+                <a class="btn btn-primary" href={base || '/'}>Build your own</a>
+                <a class="btn btn-outline-muted" href={DISCORD_URL}>Ask on Discord</a>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <script is:inline>
+      // Category filter chips — toggle visibility of category sections.
+      (function(){
+        const chips = document.querySelectorAll('#filters .filter-chip');
+        const sections = document.querySelectorAll('section.cat[data-cat]');
+        const feat = document.querySelector('section.feat');
+
+        chips.forEach((chip) => chip.addEventListener('click', () => {
+          const f = chip.dataset.filter;
+          chips.forEach((c) => c.classList.toggle('on', c === chip));
+          if (f === 'all') {
+            sections.forEach((s) => s.style.display = '');
+            if (feat) feat.style.display = '';
+            return;
+          }
+          sections.forEach((s) => s.style.display = (s.dataset.cat === f ? '' : 'none'));
+          // The featured card is an LLM-extraction example — keep it visible
+          // when that filter is active, hide otherwise.
+          if (feat) feat.style.display = (f === 'llm' ? '' : 'none');
+        }));
+      })();
+
+      // Highlight the active category in the side nav based on scroll.
+      (function(){
+        const items = document.querySelectorAll('#sideList li[data-target]');
+        const map = new Map();
+        items.forEach((li) => {
+          const sel = li.getAttribute('data-target');
+          const el = document.querySelector(sel);
+          if (el) map.set(el, li);
+        });
+        if (!map.size) return;
+        const io = new IntersectionObserver((entries) => {
+          entries.forEach((e) => {
+            const li = map.get(e.target);
+            if (!li) return;
+            li.classList.toggle('active', e.isIntersecting);
+          });
+        }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+        map.forEach((_, el) => io.observe(el));
+      })();
+    </script>
+
+    <style is:global>
+      /* ═══════════ Listing-specific styles ═══════════
+         Scoped to body.ex-listing so they don't leak into the rest of the
+         docs site. Values are lifted verbatim from the design guide. */
+      body.ex-listing { font-size: 17px; line-height: 1.55; }
+
+      body.ex-listing .ex-wrap {
+        max-width: 1440px; margin: 0 auto; padding: 0 40px;
+      }
+
+      /* ── HERO ── */
+      body.ex-listing .ex-hero { padding: 72px 0 48px; border-bottom: 1px solid var(--rule); }
+      body.ex-listing .hero-top { display: flex; align-items: center; gap: 18px; margin-bottom: 32px; flex-wrap: wrap; }
+      body.ex-listing .hero-top .eyb {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--coral); padding: 6px 14px; border: 1px solid var(--coral); border-radius: 999px;
+        display: inline-flex; align-items: center; gap: 10px;
+      }
+      body.ex-listing .hero-top .eyb .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); animation: ex-pulse 2s ease-in-out infinite; }
+      @keyframes ex-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+      body.ex-listing .hero-top .stats { margin-left: auto; display: flex; gap: 20px; font-family: var(--mono); font-size: 12px; color: var(--muted); letter-spacing: 0.06em; flex-wrap: wrap; }
+      body.ex-listing .hero-top .stats b { color: var(--maroon); font-weight: 500; font-size: 14px; }
+
+      body.ex-listing .hero-grid { display: grid; grid-template-columns: 1fr; gap: 48px; align-items: end; }
+      body.ex-listing h1.hero-h {
+        font-family: var(--serif); font-weight: 400;
+        font-size: clamp(40px, 4.6vw, 60px); line-height: 0.98; letter-spacing: -0.03em;
+        margin: 0 0 24px;
+      }
+      body.ex-listing h1.hero-h em { font-style: italic; color: var(--coral); }
+      body.ex-listing .hero-sub {
+        font-family: var(--sans); font-size: clamp(18px, 1.6vw, 24px);
+        font-weight: 400; line-height: 1.45; letter-spacing: -0.01em;
+        color: var(--maroon-ink); max-width: 48ch; margin: 0 0 24px;
+      }
+      body.ex-listing .hero-sub b { font-weight: 600; color: var(--maroon); }
+
+      body.ex-listing .hero-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+      body.ex-listing .filter-chip {
+        font-family: var(--sans); font-size: 13px; font-weight: 500;
+        padding: 8px 14px; border-radius: 999px;
+        background: var(--cream); color: var(--maroon-ink);
+        border: 1px solid var(--rule); cursor: pointer;
+        transition: background .15s, color .15s, border-color .15s;
+        display: inline-flex; gap: 6px; align-items: center;
+      }
+      body.ex-listing .filter-chip:hover { background: var(--paper); border-color: var(--rule-strong); }
+      body.ex-listing .filter-chip.on { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-listing .filter-chip .cnt { font-family: var(--mono); font-size: 11px; opacity: 0.6; letter-spacing: 0; }
+      body.ex-listing .filter-chip.on .cnt { opacity: 0.8; }
+
+      body.ex-listing .hero-viz { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; aspect-ratio: 3/2; }
+      body.ex-listing .hero-viz .t {
+        border-radius: 8px; position: relative; overflow: hidden;
+        padding: 16px; display: flex; flex-direction: column; justify-content: space-between;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+      }
+      body.ex-listing .hero-viz .t .lb { opacity: 0.85; }
+      body.ex-listing .hero-viz .t .ct { font-family: var(--sans); font-size: 20px; font-weight: 600; letter-spacing: -0.02em; line-height: 1; text-transform: none; }
+      body.ex-listing .hero-viz .t .ct em { color: inherit; font-style: normal; }
+      body.ex-listing .hero-viz .t.search { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .hero-viz .t.ingest { background: var(--peach); color: var(--maroon-ink); }
+      body.ex-listing .hero-viz .t.llm { background: var(--coral); color: var(--cream); }
+      body.ex-listing .hero-viz .t.agents { background: var(--cream); color: var(--maroon); border: 1px solid var(--rule-strong); }
+      body.ex-listing .hero-viz .t.multi { background: var(--pink); color: var(--maroon-ink); }
+      body.ex-listing .hero-viz .t.custom { background: var(--maroon-ink); color: var(--cream); }
+      body.ex-listing .hero-viz .t::after {
+        content: ""; position: absolute; inset: 0; pointer-events: none;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.2px, transparent 1.6px);
+        background-size: 14px 14px; opacity: 0.6;
+      }
+      body.ex-listing .hero-viz .t.agents::after,
+      body.ex-listing .hero-viz .t.ingest::after,
+      body.ex-listing .hero-viz .t.multi::after {
+        background-image: radial-gradient(circle, rgba(42, 18, 27, 0.08) 1.2px, transparent 1.6px);
+      }
+
+      /* ── SIDEBAR + MAIN ── */
+      body.ex-listing .doc { display: grid; grid-template-columns: 1fr 260px; gap: 56px; align-items: start; padding-top: 32px; }
+      /* Swap visual order so the "Browse" nav sits on the right without
+         moving it in the DOM (keeps it first for keyboard/tab order). */
+      body.ex-listing .doc > .side-nav { grid-column: 2; grid-row: 1; }
+      body.ex-listing .doc > .col-main { grid-column: 1; grid-row: 1; }
+      body.ex-listing .side-nav { position: sticky; top: 84px; align-self: start; max-height: calc(100vh - 100px); overflow-y: auto; padding: 0 0 40px; font-family: var(--sans); }
+      body.ex-listing .side-head {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--muted); padding-bottom: 10px; margin-bottom: 14px;
+        border-bottom: 1px solid var(--rule-strong);
+        display: flex; justify-content: space-between; align-items: baseline;
+      }
+      body.ex-listing .side-head .ct { color: var(--coral); font-family: var(--mono); }
+      body.ex-listing .side-nav ol { list-style: none; padding: 0; margin: 0 0 24px; }
+      body.ex-listing .side-nav ol li { margin-bottom: 2px; }
+      body.ex-listing .side-nav ol li a {
+        display: flex; align-items: center; gap: 10px;
+        text-decoration: none; color: var(--maroon-ink);
+        font-size: 14px; font-weight: 500; letter-spacing: -0.01em; line-height: 1.3;
+        padding: 9px 12px; border-radius: 6px;
+        border-left: 2px solid transparent;
+        margin-left: -14px; padding-left: 12px;
+        transition: color .15s, background .15s, border-color .15s;
+      }
+      body.ex-listing .side-nav ol li a .cat-dot { width: 10px; height: 10px; border-radius: 3px; flex: none; background: var(--maroon); }
+      body.ex-listing .side-nav ol li a[data-cat="search"]  .cat-dot { background: var(--maroon); }
+      body.ex-listing .side-nav ol li a[data-cat="ingest"]  .cat-dot { background: var(--peach); }
+      body.ex-listing .side-nav ol li a[data-cat="llm"]     .cat-dot { background: var(--coral); }
+      body.ex-listing .side-nav ol li a[data-cat="agents"]  .cat-dot { background: var(--maroon-ink); }
+      body.ex-listing .side-nav ol li a[data-cat="image"]   .cat-dot { background: var(--pink); }
+      body.ex-listing .side-nav ol li a[data-cat="featured"] .cat-dot { background: var(--coral); border-radius: 50%; }
+      body.ex-listing .side-nav ol li a .count {
+        margin-left: auto;
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; color: var(--muted);
+        padding: 2px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--rule);
+      }
+      body.ex-listing .side-nav ol li a:hover { color: var(--coral); background: var(--cream); }
+      body.ex-listing .side-nav ol li.active a { color: var(--maroon); background: var(--cream); border-left-color: var(--coral); }
+      body.ex-listing .side-nav ol li.active a .count { color: var(--coral); border-color: var(--coral); }
+
+      body.ex-listing .side-group { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--rule); }
+      body.ex-listing .side-group h6 {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--muted); margin: 0 0 10px;
+      }
+      body.ex-listing .side-group .tags-row { display: flex; flex-wrap: wrap; gap: 5px; }
+      body.ex-listing .side-group .mini-tag {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+        color: var(--maroon-ink);
+        padding: 4px 9px; border-radius: 999px;
+        background: var(--cream); border: 1px solid var(--rule);
+      }
+      body.ex-listing .side-group .links { display: flex; flex-direction: column; gap: 4px; }
+      body.ex-listing .side-group .links a {
+        text-decoration: none; color: var(--maroon-ink);
+        font-size: 13px; padding: 4px 0;
+        display: flex; justify-content: space-between; align-items: center;
+      }
+      body.ex-listing .side-group .links a:hover { color: var(--coral); }
+      body.ex-listing .side-group .links a .c { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+
+      body.ex-listing .col-main { min-width: 0; }
+
+      /* ── FEATURED ── */
+      body.ex-listing section.feat { padding: 0 0 40px; scroll-margin-top: 84px; }
+      body.ex-listing .sec-head {
+        display: flex; flex-direction: column; gap: 8px;
+        margin-bottom: 28px;
+        padding-bottom: 18px;
+        border-bottom: 1px solid var(--rule);
+      }
+      body.ex-listing .sec-head h2 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(28px, 3.2vw, 44px); letter-spacing: -0.03em; line-height: 1.05;
+        margin: 0;
+      }
+      body.ex-listing .sec-head h2 em { font-style: normal; color: var(--coral); }
+      body.ex-listing .sec-head .lead { color: var(--muted); font-size: 15px; max-width: 60ch; margin: 0; }
+      body.ex-listing .sec-head .idx { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); margin-right: 8px; }
+      body.ex-listing .sec-head .all {
+        margin-left: auto;
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+        color: var(--maroon); text-decoration: none;
+        padding-bottom: 2px; border-bottom: 1px solid var(--maroon);
+      }
+      body.ex-listing .sec-head .all:hover { color: var(--coral); border-color: var(--coral); }
+
+      body.ex-listing .feat-card {
+        display: grid; grid-template-columns: 1.2fr 1fr; gap: 0;
+        border-radius: 12px; overflow: hidden;
+        background: var(--maroon); color: var(--cream);
+        min-height: 440px; position: relative;
+        text-decoration: none;
+        transition: transform .2s, box-shadow .2s;
+      }
+      body.ex-listing .feat-eyebrow {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--coral); margin-bottom: 14px;
+      }
+      body.ex-listing .feat-card::before {
+        content: ""; position: absolute; inset: 0;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.07) 1.6px, transparent 2px);
+        background-size: 20px 20px; opacity: 0.7; pointer-events: none;
+      }
+      body.ex-listing .feat-body { position: relative; z-index: 2; padding: 48px; display: flex; flex-direction: column; gap: 22px; }
+      body.ex-listing .feat-body .ribbon { display: inline-flex; gap: 10px; align-items: center; font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--peach); }
+      body.ex-listing .feat-body .ribbon .tick { width: 6px; height: 6px; background: var(--peach); border-radius: 50%; }
+      body.ex-listing .feat-body .ribbon .idx { color: rgba(252, 243, 216, 0.6); }
+      body.ex-listing .feat-body h3 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(30px, 3.6vw, 48px); line-height: 1.02; letter-spacing: -0.035em;
+        margin: 0; max-width: 16ch; color: var(--cream);
+      }
+      body.ex-listing .feat-body h3 em { color: var(--peach); font-style: italic; }
+      body.ex-listing .feat-body p { color: rgba(252, 243, 216, 0.85); margin: 0; max-width: 44ch; font-size: 16px; line-height: 1.55; }
+      body.ex-listing .feat-body .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+      body.ex-listing .feat-body .chip {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+        padding: 5px 12px; border-radius: 999px;
+        border: 1px solid rgba(252, 243, 216, 0.25);
+        color: rgba(252, 243, 216, 0.85);
+      }
+      body.ex-listing .feat-body .foot { margin-top: auto; display: flex; justify-content: space-between; align-items: flex-end; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.15); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
+      body.ex-listing .feat-body .foot .go {
+        font-family: var(--sans); font-size: 13px; font-weight: 500; letter-spacing: 0;
+        color: var(--cream); text-transform: none;
+        display: inline-flex; gap: 8px; align-items: center;
+        padding: 10px 18px; border-radius: 999px; background: var(--coral); border: 1px solid var(--coral);
+        transition: background .15s;
+      }
+      body.ex-listing .feat-card:hover .feat-body .foot .go { background: var(--peach); border-color: var(--peach); color: var(--maroon-ink); }
+
+      body.ex-listing .feat-viz {
+        position: relative; z-index: 2;
+        background: linear-gradient(135deg, rgba(252, 243, 216, 0.08), rgba(252, 243, 216, 0.02));
+        border-left: 1px solid rgba(252, 243, 216, 0.12);
+        padding: 40px;
+        display: flex; flex-direction: column; gap: 14px; justify-content: center; align-items: center;
+        color: var(--cream);
+      }
+      body.ex-listing .feat-viz svg { width: 55%; max-width: 260px; height: auto; }
+      body.ex-listing .feat-viz .qrow {
+        display: grid; grid-template-columns: 28px 1fr auto 60px;
+        gap: 14px; align-items: baseline;
+        padding: 10px 14px; border-radius: 6px;
+        background: rgba(252, 243, 216, 0.06); border: 1px solid rgba(252, 243, 216, 0.12);
+        font-family: var(--mono); font-size: 13px;
+      }
+      body.ex-listing .feat-viz .qrow .rk { color: rgba(252, 243, 216, 0.5); font-size: 11px; }
+      body.ex-listing .feat-viz .qrow .tp { color: var(--cream); font-weight: 500; }
+      body.ex-listing .feat-viz .qrow .tp em { color: var(--peach); font-style: normal; }
+      body.ex-listing .feat-viz .qrow .sc { color: var(--palm); font-weight: 600; }
+      body.ex-listing .feat-viz .qrow .th { color: rgba(252, 243, 216, 0.55); font-size: 11px; text-align: right; }
+      body.ex-listing .feat-viz .qlabel {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: rgba(252, 243, 216, 0.55); padding-bottom: 8px;
+        border-bottom: 1px solid rgba(252, 243, 216, 0.12);
+        display: flex; justify-content: space-between;
+      }
+      body.ex-listing .feat-viz .qlabel .pulse { display: inline-flex; gap: 5px; align-items: center; color: var(--palm); }
+      body.ex-listing .feat-viz .qlabel .pulse .d { width: 6px; height: 6px; border-radius: 50%; background: var(--palm); box-shadow: 0 0 0 3px rgba(39, 230, 43, 0.15); }
+
+      /* ── CATEGORY SECTIONS ── */
+      body.ex-listing section.cat { padding: 64px 0; scroll-margin-top: 84px; }
+      body.ex-listing .cat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+      body.ex-listing .ex-card {
+        display: flex; flex-direction: column;
+        border: 1px solid var(--rule); border-radius: 10px;
+        background: var(--paper);
+        min-height: 280px;
+        text-decoration: none; color: inherit;
+        overflow: hidden;
+        position: relative;
+        transition: background-image .18s ease;
+      }
+      body.ex-listing .ex-card:hover {
+        background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px);
+        background-size: 14px 14px;
+      }
+      body.ex-listing .ex-thumb {
+        aspect-ratio: 16/7;
+        position: relative; overflow: hidden;
+        border-bottom: 1px solid var(--rule);
+      }
+      body.ex-listing .ex-thumb .motif { position: absolute; inset: 0; display: grid; place-items: center; color: var(--cream); }
+      body.ex-listing .ex-thumb .motif svg { width: 70%; height: 70%; }
+      body.ex-listing .ex-thumb .tl {
+        position: absolute; top: 12px; left: 14px; z-index: 3;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+        padding: 4px 10px; border-radius: 999px;
+        background: rgba(252, 243, 216, 0.2); color: var(--cream);
+        backdrop-filter: blur(6px);
+        border: 1px solid rgba(252, 243, 216, 0.2);
+      }
+      body.ex-listing .ex-thumb .tr {
+        position: absolute; top: 12px; right: 14px; z-index: 3;
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+        color: rgba(252, 243, 216, 0.8);
+      }
+      body.ex-listing .ex-thumb.search { background: var(--maroon); }
+      body.ex-listing .ex-thumb.ingest { background: var(--peach); color: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.ingest .motif { color: var(--maroon); }
+      body.ex-listing .ex-thumb.ingest .tl { background: rgba(42, 18, 27, 0.1); color: var(--maroon); border-color: rgba(42, 18, 27, 0.15); }
+      body.ex-listing .ex-thumb.ingest .tr { color: rgba(42, 18, 27, 0.6); }
+      body.ex-listing .ex-thumb.llm { background: var(--coral); }
+      body.ex-listing .ex-thumb.agents { background: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.pink { background: var(--pink); color: var(--maroon-ink); }
+      body.ex-listing .ex-thumb.pink .motif { color: var(--maroon); }
+      body.ex-listing .ex-thumb.pink .tl { background: rgba(42, 18, 27, 0.1); color: var(--maroon); border-color: rgba(42, 18, 27, 0.15); }
+      body.ex-listing .ex-thumb.pink .tr { color: rgba(42, 18, 27, 0.55); }
+      body.ex-listing .ex-thumb.search::after,
+      body.ex-listing .ex-thumb.llm::after,
+      body.ex-listing .ex-thumb.agents::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: radial-gradient(circle, rgba(252, 243, 216, 0.1) 1.2px, transparent 1.6px);
+        background-size: 14px 14px;
+      }
+      body.ex-listing .ex-thumb.ingest::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: repeating-linear-gradient(135deg, transparent 0 8px, rgba(42, 18, 27, 0.06) 8px 9px);
+      }
+      body.ex-listing .ex-thumb.pink::after {
+        content: ""; position: absolute; inset: 0;
+        background-image: linear-gradient(to right, rgba(42, 18, 27, 0.04) 1px, transparent 1px),
+                          linear-gradient(to bottom, rgba(42, 18, 27, 0.04) 1px, transparent 1px);
+        background-size: 18px 18px;
+      }
+
+      body.ex-listing .ex-body { padding: 20px 22px 22px; display: flex; flex-direction: column; gap: 10px; flex: 1; }
+      body.ex-listing .ex-body h3 { font-family: var(--sans); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; line-height: 1.2; margin: 0; color: var(--maroon-ink); }
+      body.ex-listing .ex-body h3 em { color: var(--coral); font-style: normal; }
+      body.ex-listing .ex-body p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; flex: 1; }
+
+      body.ex-listing .ex-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+      body.ex-listing .ex-tags .tag {
+        font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+        padding: 4px 10px; border-radius: 999px;
+        background: var(--paper); color: var(--maroon);
+        border: 1px solid var(--rule);
+        display: inline-flex; gap: 6px; align-items: center;
+      }
+      body.ex-listing .ex-tags .tag .dt { width: 5px; height: 5px; border-radius: 50%; background: var(--coral); }
+      body.ex-listing .ex-tags .tag.src .dt { background: var(--peach); }
+      body.ex-listing .ex-tags .tag.tgt .dt { background: var(--pink); }
+      body.ex-listing .ex-tags .tag.llm .dt { background: var(--palm); }
+      body.ex-listing .ex-tags .tag.ops .dt { background: var(--coral); }
+      body.ex-listing .ex-tags .tag.lvl .dt { background: var(--maroon); }
+
+      body.ex-listing .ex-foot {
+        display: flex; justify-content: space-between; align-items: center;
+        padding-top: 14px; margin-top: 6px; border-top: 1px solid var(--rule);
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+        color: var(--muted);
+      }
+      body.ex-listing .ex-foot .go { color: var(--coral); display: inline-flex; gap: 6px; align-items: center; }
+
+      body.ex-listing .m-dots circle { fill: currentColor; }
+      body.ex-listing .m-grid rect { fill: none; stroke: currentColor; stroke-width: 1; }
+      body.ex-listing .m-flow path { stroke: currentColor; stroke-width: 1.5; fill: none; stroke-linecap: round; }
+      body.ex-listing .m-node rect { fill: none; stroke: currentColor; stroke-width: 1.5; }
+      body.ex-listing .m-node circle { fill: currentColor; }
+
+      /* ── BOTTOM CTA ── */
+      body.ex-listing .cta-end {
+        margin: 72px 0 96px;
+        border-radius: 12px;
+        background: var(--cream);
+        border: 1px solid var(--rule);
+        padding: 64px 48px;
+        position: relative; overflow: hidden;
+      }
+      body.ex-listing .cta-end::before {
+        content: ""; position: absolute; right: -40px; bottom: -60px;
+        width: 260px; height: 260px; border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, rgba(190, 81, 51, 0.2), transparent 60%);
+        pointer-events: none;
+      }
+      body.ex-listing .cta-end h3 {
+        font-family: var(--sans); font-weight: 600;
+        font-size: clamp(28px, 3.4vw, 44px); line-height: 1.05; letter-spacing: -0.03em;
+        margin: 0 0 16px; max-width: 22ch;
+      }
+      body.ex-listing .cta-end h3 em { color: var(--coral); font-style: normal; }
+      body.ex-listing .cta-end p { color: var(--muted); max-width: 48ch; margin: 0 0 24px; font-size: 17px; }
+      body.ex-listing .cta-end .btns { display: flex; gap: 12px; flex-wrap: wrap; }
+      body.ex-listing .cta-end .btn {
+        display: inline-flex; align-items: center; gap: 8px;
+        padding: 10px 18px; border-radius: 999px;
+        font-family: var(--sans); font-size: 14px; font-weight: 500; text-decoration: none;
+        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
+        transition: background .16s, color .16s, border-color .16s;
+      }
+      body.ex-listing .cta-end .btn:hover { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .cta-end .btn.btn-primary { background: var(--maroon); color: var(--cream); }
+      body.ex-listing .cta-end .btn.btn-primary:hover { background: var(--maroon-deep); }
+      body.ex-listing .cta-end .btn.btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
+      body.ex-listing .cta-end .btn.btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
+      body.ex-listing .cta-end .btn.btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
+      body.ex-listing .cta-end .btn.btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      body.ex-listing .cta-end .side {
+        display: flex; flex-direction: column; gap: 18px;
+        padding: 28px 26px; border-radius: 10px;
+        background: var(--paper); border: 1px solid var(--rule);
+      }
+      body.ex-listing .cta-end .side .side-h {
+        display: flex; justify-content: space-between; align-items: baseline;
+      }
+      body.ex-listing .cta-end .side .eyebrow {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--coral);
+      }
+      body.ex-listing .cta-end .side .time {
+        font-family: var(--mono); font-size: 11px; color: var(--muted);
+      }
+      body.ex-listing .cta-end .side h4 {
+        font-family: var(--sans); font-weight: 600; font-size: 22px; letter-spacing: -0.02em;
+        line-height: 1.2; margin: 0;
+      }
+      body.ex-listing .cta-end .side h4 em { color: var(--coral); font-style: normal; }
+      body.ex-listing .cta-end .side .qs-steps {
+        list-style: none; padding: 0; margin: 0;
+        display: flex; flex-direction: column; gap: 14px;
+      }
+      body.ex-listing .cta-end .side .qs-steps li {
+        display: grid; grid-template-columns: 32px 1fr; gap: 10px; align-items: start;
+      }
+      body.ex-listing .cta-end .side .qs-steps li .n {
+        font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+        color: var(--coral); padding-top: 4px;
+      }
+      body.ex-listing .cta-end .side .qs-steps li .t {
+        font-size: 14px; font-weight: 500; color: var(--maroon-ink); margin-bottom: 5px;
+      }
+      body.ex-listing .cta-end .side .qs-steps li .code {
+        font-family: var(--mono); font-size: 12px; color: var(--cream);
+        background: var(--maroon-ink); padding: 7px 10px; border-radius: 5px;
+        overflow-x: auto; white-space: nowrap;
+      }
+      body.ex-listing .cta-end .side .qs-steps li .code .p { color: var(--peach); margin-right: 6px; }
+      body.ex-listing .cta-end .side .side-links {
+        display: flex; flex-direction: column; gap: 4px;
+        padding-top: 12px; border-top: 1px solid var(--rule);
+      }
+      body.ex-listing .cta-end .side .side-links a {
+        font-size: 13px; color: var(--maroon-ink); text-decoration: none;
+        padding: 5px 0;
+      }
+      body.ex-listing .cta-end .side .side-links a:hover { color: var(--coral); }
+
+      @media (max-width: 1180px) {
+        body.ex-listing .doc { grid-template-columns: 1fr; gap: 0; }
+        body.ex-listing .side-nav {
+          position: static; top: auto; max-height: none;
+          padding: 16px; border: 1px solid var(--rule); border-radius: 10px;
+          background: var(--cream); margin-bottom: 32px;
+        }
+        body.ex-listing .side-nav ol { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+        body.ex-listing .side-nav ol li { margin-bottom: 0; }
+        body.ex-listing .side-nav ol li a { padding: 8px 12px; margin-left: 0; border-left: none; border: 1px solid var(--rule); }
+        body.ex-listing .side-nav ol li.active a { border-color: var(--coral); }
+        body.ex-listing .side-group { margin-top: 10px; padding-top: 10px; }
+        body.ex-listing .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+        body.ex-listing .feat-card { grid-template-columns: 1fr; }
+        body.ex-listing .feat-viz { border-left: none; border-top: 1px solid rgba(252, 243, 216, 0.12); }
+        body.ex-listing .cat-grid { grid-template-columns: repeat(2, 1fr); }
+        body.ex-listing .cta-end { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 640px) {
+        body.ex-listing .cat-grid { grid-template-columns: 1fr; }
+        body.ex-listing .hero-top { flex-wrap: wrap; }
+        body.ex-listing .hero-top .stats { order: 3; width: 100%; }
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
Brings the examples section from main (#1857) onto the v1 branch, with walkthrough bodies ported from the dedicated `cocoindex-io/examples-v1` repo. Today it ships two entries — Multi-Codebase Summarization (featured) and PDF → Markdown — and grows automatically as more land upstream.

## Summary
- `src/content/example-posts/multi-codebase-summarization.md`
- `src/content/example-posts/pdf-to-markdown.md`
- `src/data/examples.ts` — trimmed catalog with just these two cards
- `src/pages/examples/index.astro` + `[slug].astro` — unchanged from main (#1857), so a future `v1-merge-main` won't create conflicts in the infra files
- `src/content.config.ts` — adds the `examplePosts` collection

Image URLs point at `cocoindex-io/blobs` under a new `docs-v1/` root so the v0 and v1 docs sites don't collide on the shared blobs origin: `https://cocoindex.io/blobs/docs-v1/img/examples/…`. The blobs repo has already been updated ([cocoindex-io/blobs@97fe7e9](https://github.com/cocoindex-io/blobs/commit/97fe7e9)).

## Test plan
- [ ] `/docs-v1/examples` — listing renders, both cards visible, Multi-Codebase featured
- [ ] `/docs-v1/examples/multi-codebase-summarization` — MDX body renders, left rail highlights current slug, right TOC lists h2 headings
- [ ] `/docs-v1/examples/pdf-to-markdown` — same checks
- [ ] Images resolve from `https://cocoindex.io/blobs/docs-v1/img/examples/…`
- [ ] Adding a new example: drop `<slug>.md` into `src/content/example-posts/` + a card in `examples.ts` and the listing picks it up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)