### PR TITLE
docs: accept both /examples and /examples/ (trailingSlash: ignore)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -49,7 +49,7 @@ const cocoindexCodeTheme = {
 export default defineConfig({
   site: 'https://cocoindex.io',
   base: '/docs-v1',
-  trailingSlash: 'never',
+  trailingSlash: 'ignore',
   build: { format: 'file' },
   integrations: [
     mdx({


### PR DESCRIPTION
## Summary
- Switches Astro config from `trailingSlash: 'never'` to `'ignore'` so `/docs-v1/examples` and `/docs-v1/examples/` resolve to the same page instead of returning the trailing-slash warning.

## Test plan
- [x] `npm run dev` — server restarts cleanly with new config
- [ ] Visit `/docs-v1/examples` and `/docs-v1/examples/` — both render the examples index

🤖 Generated with [Claude Code](https://claude.com/claude-code)