### PR TITLE
docs: accept both /examples and /examples/ (trailingSlash: ignore)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,7 +48,7 @@ const cocoindexCodeTheme = {
 export default defineConfig({
   site: 'https://cocoindex.io',
   base: '/docs',
-  trailingSlash: 'never',
+  trailingSlash: 'ignore',
   build: { format: 'file' },
   integrations: [
     mdx({


### PR DESCRIPTION
## Summary
- Switches Astro config from `trailingSlash: 'never'` to `'ignore'` so `/docs/examples` and `/docs/examples/` resolve to the same page instead of returning the trailing-slash warning.

## Test plan
- [x] `npm run dev` — server starts cleanly with new config
- [x] Both `/docs/examples` and `/docs/examples/` return HTTP 200 with identical bodies (verified via curl + sha)

🤖 Generated with [Claude Code](https://claude.com/claude-code)