### PR TITLE
docs(v1): restore missing tab blocks in core_concepts

### DIFF
--- a/docs/src/components/Tabs.astro
+++ b/docs/src/components/Tabs.astro
@@ -1,0 +1,175 @@
+---
+// CSS-only tabs. Radios are direct children of .coco-tabs so they can
+// be general siblings of the bar + panels; labels reference them by
+// `for=`. No JS required. Each instance gets a unique radio-group name.
+interface Props {
+  labels: string[];
+  initial?: number;
+}
+const { labels, initial = 0 } = Astro.props;
+const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
+---
+<div class="coco-tabs">
+  {labels.map((_, i) => (
+    <input
+      type="radio"
+      class="coco-tabs-radio"
+      name={id}
+      id={`${id}-${i}`}
+      checked={i === initial}
+    />
+  ))}
+  <div class="coco-tabs-bar" role="tablist">
+    {labels.map((label, i) => (
+      <label for={`${id}-${i}`} class="coco-tabs-label" role="tab">
+        <span>{label}</span>
+      </label>
+    ))}
+  </div>
+  <div class="coco-tabs-panels">
+    {labels[0] && (
+      <section class="coco-tabs-panel" data-tab-index="0" role="tabpanel"><slot name="tab-0" /></section>
+    )}
+    {labels[1] && (
+      <section class="coco-tabs-panel" data-tab-index="1" role="tabpanel"><slot name="tab-1" /></section>
+    )}
+    {labels[2] && (
+      <section class="coco-tabs-panel" data-tab-index="2" role="tabpanel"><slot name="tab-2" /></section>
+    )}
+    {labels[3] && (
+      <section class="coco-tabs-panel" data-tab-index="3" role="tabpanel"><slot name="tab-3" /></section>
+    )}
+    {labels[4] && (
+      <section class="coco-tabs-panel" data-tab-index="4" role="tabpanel"><slot name="tab-4" /></section>
+    )}
+  </div>
+</div>
+
+<style>
+.coco-tabs {
+  position: relative;
+  margin: 1.75rem 0;
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  background: var(--cream-soft);
+  overflow: hidden;
+  box-shadow: 0 1px 0 rgba(42, 18, 27, 0.03), 0 6px 20px -12px rgba(42, 18, 27, 0.18);
+}
+
+.coco-tabs-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.coco-tabs-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 10px 10px 0;
+  background: linear-gradient(to bottom, var(--paper), var(--cream-soft));
+  border-bottom: 1px solid var(--rule);
+}
+
+.coco-tabs-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 16px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 8px 8px 0 0;
+  border: 1px solid transparent;
+  border-bottom: none;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  user-select: none;
+  position: relative;
+}
+
+.coco-tabs-label:hover { color: var(--maroon-ink); background: rgba(251, 246, 232, 0.6); }
+
+.coco-tabs-label::after {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 0;
+  height: 2px;
+  background: transparent;
+  border-radius: 2px 2px 0 0;
+  transition: background 0.15s ease;
+}
+
+.coco-tabs-radio:focus-visible + .coco-tabs-bar,
+.coco-tabs-radio:focus-visible ~ .coco-tabs-bar .coco-tabs-label {
+  /* no-op: focus outline handled below per active label */
+}
+
+.coco-tabs-panels {
+  background: var(--paper);
+  padding: 24px 28px;
+}
+
+.coco-tabs-panel { display: none; }
+
+/* Active label + panel, one rule per position.
+   Supports up to 5 tabs; extend if a page ever needs more. */
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1),
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2),
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3),
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4),
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5) {
+  color: var(--maroon-ink);
+  background: var(--paper);
+  border-color: var(--rule);
+  font-weight: 600;
+}
+
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1)::after,
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2)::after,
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3)::after,
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4)::after,
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5)::after {
+  background: var(--coral);
+}
+
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="0"],
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="1"],
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="2"],
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="3"],
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="4"] {
+  display: block;
+}
+
+.coco-tabs-radio:focus-visible ~ .coco-tabs-bar .coco-tabs-label:hover { outline: none; }
+.coco-tabs-radio:nth-of-type(1):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1),
+.coco-tabs-radio:nth-of-type(2):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2),
+.coco-tabs-radio:nth-of-type(3):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3),
+.coco-tabs-radio:nth-of-type(4):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4),
+.coco-tabs-radio:nth-of-type(5):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5) {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+}
+
+.coco-tabs-panel :global(img) {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 4px auto 18px;
+}
+
+.coco-tabs-panel :global(p:first-child) { margin-top: 0; }
+.coco-tabs-panel :global(p:last-child),
+.coco-tabs-panel :global(ul:last-child) { margin-bottom: 0; }
+
+@media (max-width: 640px) {
+  .coco-tabs-panels { padding: 18px; }
+  .coco-tabs-label { padding: 8px 12px; font-size: 13px; }
+}
+</style>

--- a/docs/src/content/docs/programming_guide/core_concepts.mdx
+++ b/docs/src/content/docs/programming_guide/core_concepts.mdx
@@ -2,6 +2,8 @@
 title: Core Concepts
 description: Briefly introduces the core concepts of CocoIndex, covering state-driven sync, Target States, Apps, Processing Components, and incremental execution across logic and input changes.
 ---
+import Tabs from '../../../components/Tabs.astro';
+
 ## Incremental processing
 
 When processing data and storing results in targets (e.g., a database) for knowledge retrieval by AI agents or search systems, both your data and code evolve over time. Reprocessing everything after every change is expensive, slow, and disruptive. Incremental processing solves this by only processing what's changed, and applying those changes to the target.
@@ -75,7 +77,23 @@ Taking this further, suppose you want to split each file into chunks and create 
 
 Let's see what happens when the source state changes in different ways:
 
+<Tabs labels={["On New File Added", "On Existing File Updated", "On Existing File Deleted"]}>
+  <Fragment slot="tab-0">
+    <img src="/docs-v1/img/concept/add.svg" alt="New file added" />
 
+    When a new file (`c.md`) is added, a new processing component is created for it. Once execution completes, CocoIndex applies the new target states — inserting `vector5` and `vector6` into the vector store.
+  </Fragment>
+  <Fragment slot="tab-1">
+    <img src="/docs-v1/img/concept/update.svg" alt="File updated" />
+
+    When file `b.md` is updated — say its content is reduced to just one chunk instead of two — the processing component's target state changes from `vector3` and `vector4` to just `vector5`. CocoIndex deletes `vector3` and `vector4`, then inserts `vector5` into the vector database, all within a single transaction.
+  </Fragment>
+  <Fragment slot="tab-2">
+    <img src="/docs-v1/img/concept/delete.svg" alt="File deleted" />
+
+    When file `b.md` is deleted from the source folder, CocoIndex deletes its associated target states (`vector3` and `vector4`) from the vector database in a single transaction.
+  </Fragment>
+</Tabs>
 
 ## Function memoization: skip unchanged computations
 
@@ -93,7 +111,34 @@ See [Function Memoization](./function.md#memoization) for more details.
 
 Here's how memoization behaves in different scenarios:
 
+<Tabs labels={["On Input Data Change", "On Code Change"]}>
+  <Fragment slot="tab-0">
+    <img src="/docs-v1/img/concept/memo1.svg" alt="Input data update" />
 
+    When input file `b.md` changes:
+
+    - The input state `a.md` is unchanged, so the 1st processing component is entirely reused without reprocessing.
+
+    - The input state `b.md` changed, so the 2nd processing component must be reprocessed. After splitting, suppose we get two chunks: `chunk3` (identical to before) and `chunk5` (new).
+
+      - `Embed(chunk3)` was memoized previously, so its cached result is reused.
+
+      - `Embed(chunk5)` is new and must be computed.
+  </Fragment>
+  <Fragment slot="tab-1">
+    <img src="/docs-v1/img/concept/memo2.svg" alt="Code update" />
+
+    When the "Split into chunks" logic changes:
+
+    - All processing components must be reprocessed since the logic changed.
+
+    - For the 1st processing component, the new logic produces the same chunks as before. The memoized `Embed` results are reused without recomputation.
+
+    - For the 2nd processing component, the new logic produces different chunks (`chunk5` and `chunk6`), so `Embed` must be invoked on them.
+
+    As these examples show, memoization can save expensive computations even when logic changes — as long as the intermediate results remain the same.
+  </Fragment>
+</Tabs>
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Two tab blocks (source-state-change scenarios + memoization scenarios) in `programming_guide/core_concepts.mdx` were lost in the Docusaurus→Astro port — only the lead-in paragraphs remained. This PR brings them back.
- Adds a new CSS-only `<Tabs>` component at `docs/src/components/Tabs.astro`, styled with the existing brand palette (cream/coral/maroon). No client JS.

## Test plan
- [x] `npm run dev` — page compiles without errors
- [x] `/docs-v1/programming_guide/core_concepts` returns 200 and contains both tab sets with their labels and images
- [ ] Click each tab in a browser and confirm the correct panel is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)