### PR TITLE
docs(v1): align styles with design system, polish example pages

### DIFF
--- a/docs/scripts/remark-admonitions.mjs
+++ b/docs/scripts/remark-admonitions.mjs
@@ -1,5 +1,5 @@
-// Turn Docusaurus-style admonition blocks into the design mock's `.callout`
-// layout. Shape:
+// Turn Docusaurus-style admonition blocks into the design system's `.co`
+// layout (see design_guidelines/ui/admonitions.html). Shape:
 //
 //   :::info Prerequisite
 //   Make sure your Postgres server is running.
@@ -7,34 +7,28 @@
 //
 // …becomes:
 //
-//   <div class="callout note">
+//   <div class="co info">
 //     <div class="ico">i</div>
 //     <div class="body"><b>Prerequisite</b> Make sure your …</div>
 //   </div>
 //
 // Pair with `remark-directive` (it's what parses the `:::name [label]`
-// block into a containerDirective node). The CSS for `.callout`, `.tip`,
-// `.warn`, `.note` lives in src/styles/globals.css.
+// block into a containerDirective node). The CSS for `.co` + variants
+// lives in src/styles/globals.css and matches
+// design_guidelines/ui/admonitions.html verbatim.
 import { visit } from 'unist-util-visit';
 import { toString } from 'mdast-util-to-string';
 
-// Each admonition kind gets a distinct class + default label. The icon
-// glyph itself is drawn in CSS via a per-kind mask-image data URI — that
-// way the icon colour stays in sync with the bubble (currentColor) and we
-// don't need to inject raw SVG through the MDX pipeline.
-//   note    — neutral annotation (document-with-lines, berry bubble)
-//   info    — important context (info-circle, coral bubble)
-//   tip     — helpful suggestion (lightbulb, palm bubble)
-//   warning — heads up (triangle !, pink bubble)
-//   caution — alias for warning
-//   danger  — critical (octagon !, coral bubble, deep pink bg)
+// Four canonical variants per the design spec. `caution` and `danger` are
+// legacy aliases that collapse to `warn` — the design system explicitly
+// forbids a fifth variant.
 const SPECS = {
-  note:    { defaultLabel: 'Note',    cls: 'note'   },
-  info:    { defaultLabel: 'Info',    cls: 'info'   },
-  tip:     { defaultLabel: 'Tip',     cls: 'tip'    },
-  warning: { defaultLabel: 'Warning', cls: 'warn'   },
-  caution: { defaultLabel: 'Caution', cls: 'warn'   },
-  danger:  { defaultLabel: 'Danger',  cls: 'danger' },
+  note:    { defaultLabel: 'Note',         cls: 'note', icon: 'i' },
+  info:    { defaultLabel: 'Prerequisite', cls: 'info', icon: 'i' },
+  tip:     { defaultLabel: 'Tip',          cls: 'tip',  icon: '\u2713' },
+  warning: { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
+  caution: { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
+  danger:  { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
 };
 
 export default function remarkAdmonitions() {
@@ -58,15 +52,13 @@ export default function remarkAdmonitions() {
       const body = node.children;
       const data = node.data || (node.data = {});
       data.hName = 'div';
-      data.hProperties = { className: ['callout', spec.cls] };
+      data.hProperties = { className: ['co', spec.cls] };
 
       node.children = [
         {
-          // Empty by design — `.ico::before` draws the SVG via mask-image
-          // so we can react to variant-specific colours via CSS only.
           type: 'paragraph',
           data: { hName: 'div', hProperties: { className: ['ico'], 'aria-hidden': 'true' } },
-          children: [],
+          children: [{ type: 'text', value: spec.icon }],
         },
         {
           type: 'paragraph',

--- a/docs/src/components/Tabs.astro
+++ b/docs/src/components/Tabs.astro
@@ -53,7 +53,6 @@ const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
   border-radius: 14px;
   background: var(--cream-soft);
   overflow: hidden;
-  box-shadow: 0 1px 0 rgba(42, 18, 27, 0.03), 0 6px 20px -12px rgba(42, 18, 27, 0.18);
 }
 
 .coco-tabs-radio {

--- a/docs/src/components/Toc.astro
+++ b/docs/src/components/Toc.astro
@@ -1,15 +1,18 @@
 ---
 import type { MarkdownHeading } from 'astro';
 import { GITHUB_REPO, DISCORD_URL } from '../consts';
-import docsMeta from '../docs-meta.json';
 
 export interface Props {
   headings: MarkdownHeading[];
-  /** Slug of the current doc — keys into src/docs-meta.json for edit time. */
+  /** Slug of the current doc — retained for callers; not used internally. */
   slug: string;
+  /** Formatted "Last reviewed" date (e.g. "Apr 20, 2026"). When provided,
+   *  renders as a row in the meta block. Pass the absolute date rather
+   *  than a relative "Xd ago" so the rail matches the intro-meta above. */
+  lastReviewed?: string | null;
 }
 
-const { headings, slug } = Astro.props;
+const { headings, lastReviewed } = Astro.props;
 
 // Only H2 and H3 in the right rail — deeper nesting makes noise. H2s get
 // numbered ("1 · Install") to match the design mock.
@@ -19,29 +22,6 @@ const rows = items.map((h) => {
   if (h.depth === 2) h2Count++;
   return { ...h, n: h.depth === 2 ? h2Count : null };
 });
-
-const metaMap = (docsMeta as {
-  _version?: string | null;
-  files: Record<string, { sourcePath: string; editTs: number }>;
-}).files ?? {};
-const meta = metaMap[slug];
-const editTs = meta?.editTs ?? 0;
-
-// "Last reviewed · Xd ago" — coarse relative time suitable for the rail.
-// Timestamp comes from the last git commit touching the source doc, which
-// is the best proxy we have for when a human last reviewed it.
-function relativeReview(ts: number): string | null {
-  if (!ts) return null;
-  const now = Math.floor(Date.now() / 1000);
-  const delta = Math.max(0, now - ts);
-  const pick = (n: number, unit: string) => `${n}${unit} ago`;
-  if (delta < 3600) return pick(Math.max(1, Math.round(delta / 60)), 'm');
-  if (delta < 86400) return pick(Math.round(delta / 3600), 'h');
-  if (delta < 86400 * 30) return pick(Math.round(delta / 86400), 'd');
-  if (delta < 86400 * 365) return pick(Math.round(delta / (86400 * 30)), 'mo');
-  return pick(Math.round(delta / (86400 * 365)), 'y');
-}
-const reviewedAgo = relativeReview(editTs);
 ---
 
 <aside class="toc">
@@ -64,7 +44,7 @@ const reviewedAgo = relativeReview(editTs);
       </svg>
       View CocoIndex
     </a>
-    {reviewedAgo && (
+    {lastReviewed && (
       <span class="edited">
         <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden>
           <circle cx="8" cy="8" r="7" fill="var(--palm)" />
@@ -72,7 +52,7 @@ const reviewedAgo = relativeReview(editTs);
                 fill="none" stroke="var(--maroon-ink)"
                 stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        Last reviewed · {reviewedAgo}
+        Last reviewed · {lastReviewed}
       </span>
     )}
     <a href={DISCORD_URL} target="_blank" rel="noopener">

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -4,12 +4,8 @@ description: 'Generate documentation for multiple Python projects using LLM-powe
 slug: multi-codebase-summarization
 image: https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png
 tags: [llm, structured-data-extraction]
-last_reviewed: 2026-02-04
+last_reviewed: 2026-04-20
 ---
-
-# Multi-Codebase Summarization
-
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/multi_codebase_summarization)
 
 ![Multi-Codebase Summarization](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png)
 

--- a/docs/src/content/example-posts/pdf-to-markdown.md
+++ b/docs/src/content/example-posts/pdf-to-markdown.md
@@ -4,22 +4,17 @@ description: 'Convert PDF files to Markdown with incremental processing'
 slug: pdf-to-markdown
 image: https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/cover.png
 tags: [pdf, custom-building-blocks]
-last_reviewed: 2026-02-04
+last_reviewed: 2026-04-20
 ---
 
-# PDF to Markdown
-
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_to_markdown)
-
 ![PDF to Markdown](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/cover.png)
-
 
 In this tutorial, we'll build a simple app that converts PDF files to Markdown and saves them to a local directory.
 
 
 ## Overview
 
-![App example showing PDF to Markdown conversion](/img/concept/app-example.svg)
+![App example showing PDF to Markdown conversion](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/app-example.svg)
 
 
 1. Read PDF files from a local directory

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -188,7 +188,7 @@ const next = i >= 0 && i < flat.length - 1 ? flat[i + 1] : null;
         </div>
       </main>
 
-      <Toc headings={headings} slug={slug} />
+      <Toc headings={headings} slug={slug} lastReviewed={lastReviewed} />
     </div>
   </body>
 </html>

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -56,9 +56,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
                 </svg>
                 Back to cocoindex.io
               </a>
-              <a href={base} class="btn nf-btn-ghost">Read the docs</a>
-              <a href={SITE_BLOG} class="btn nf-btn-ghost">Visit the blog</a>
-              <a href={SITE_EXAMPLES} class="btn nf-btn-ghost">Browse examples</a>
+              <a href={base} class="btn btn-outline-muted">Read the docs</a>
+              <a href={SITE_BLOG} class="btn btn-outline-muted">Visit the blog</a>
+              <a href={SITE_EXAMPLES} class="btn btn-outline-muted">Browse examples</a>
             </div>
 
             <div class="nf-tip">
@@ -137,29 +137,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
         display: flex; flex-wrap: wrap; gap: 12px;
         margin-bottom: 28px;
       }
-      .nf .btn {
-        display: inline-flex; align-items: center; gap: 8px;
-        padding: 10px 18px; border-radius: 999px;
-        font-size: 14px; font-weight: 500; text-decoration: none;
-        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
-        transition: background .15s, color .15s;
-        cursor: pointer;
-      }
-      .nf .btn:hover { background: var(--maroon); color: var(--cream); }
-      .nf .btn-primary { background: var(--maroon); color: var(--cream); }
-      .nf .btn-primary:hover { background: var(--maroon-deep); color: var(--cream); }
-      .nf .btn-xl { padding: 13px 22px; font-size: 15px; }
+      /* Buttons — see `.btn` + variants in globals.css. No local overrides. */
       .nf .btn-xl svg { flex: none; }
-      .nf .nf-btn-ghost {
-        background: transparent;
-        border-color: var(--rule-strong);
-        color: var(--maroon-ink);
-      }
-      .nf .nf-btn-ghost:hover {
-        background: var(--maroon);
-        color: var(--cream);
-        border-color: var(--maroon);
-      }
 
       .nf .nf-tip {
         display: inline-flex; align-items: center; gap: 12px;

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -478,8 +478,9 @@ const introItems = [
          anchored on the same palette as the docs prose, without pulling
          in the docs `.prose` container itself — that one's tuned for a
          narrower column and a different heading scale. */
-      body.ex-detail .ex-prose { padding-top: 40px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
+      body.ex-detail .ex-prose { padding-top: 8px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
       body.ex-detail .ex-prose > :first-child { margin-top: 0; }
+      body.ex-detail .ex-prose > p:first-child img { margin-top: 0; }
       body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; }
       body.ex-detail .ex-prose > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 24px; }
       body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: 84px; }

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -7,6 +7,7 @@
 // examples.ts — the slugs must match.
 import '../../styles/globals.css';
 import Topbar from '../../components/Topbar.astro';
+import Toc from '../../components/Toc.astro';
 import { GITHUB_REPO, SITE_URL, titleMarkup, titleText } from '../../consts';
 import { examples, findExample, CATEGORY_META, type Category } from '../../data/examples';
 import { getEntry, render } from 'astro:content';
@@ -43,8 +44,29 @@ const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/main/examples/
 const entry = await getEntry('examplePosts', slug!);
 const rendered = entry ? await render(entry) : null;
 const Content = rendered?.Content;
-// Only h2 headings feed the TOC — h3/h4 add noise at this section count.
-const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
+
+// Intro-meta strip under the hero — mirrors the docs-page layout
+// (DocsLayout.astro), so example pages carry the same typographic rhythm.
+const tagOf = (kind: 'src' | 'tgt' | 'llm' | 'ops') =>
+  ex.tags.find((t) => t.kind === kind)?.label ?? null;
+const lastReviewedRaw = (entry?.data as { last_reviewed?: string | Date })?.last_reviewed;
+// Format YYYY-MM-DD as a local-calendar date — `new Date('2026-04-20')`
+// parses as UTC midnight and drifts a day west of UTC when rendered.
+const formatLocalDate = (raw: string | Date): string => {
+  const iso = raw instanceof Date ? raw.toISOString().slice(0, 10) : String(raw).slice(0, 10);
+  const [y, m, d] = iso.split('-').map((n) => parseInt(n, 10));
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+const lastReviewed = lastReviewedRaw ? formatLocalDate(lastReviewedRaw) : null;
+const introItems = [
+  { k: 'Time',          v: ex.footMeta.split('·')[0].trim(),                       reviewed: false },
+  { k: 'Source',        v: tagOf('src'),                                           reviewed: false },
+  { k: 'Target',        v: tagOf('tgt'),                                           reviewed: false },
+  { k: 'LLM',           v: tagOf('llm'),                                           reviewed: false },
+  { k: 'Mode',          v: tagOf('ops'),                                           reviewed: false },
+  { k: 'Category',      v: ex.category,                                            reviewed: false },
+  { k: 'Last reviewed', v: lastReviewed,                                           reviewed: true  },
+].filter((m) => m.v);
 ---
 <!doctype html>
 <html lang="en">
@@ -102,43 +124,40 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
         <span class="cur">{plainTitle}</span>
       </nav>
 
-      <!-- ─────────── HERO ─────────── -->
+      <!-- ─────────── HERO ─────────── Mirrors DocsLayout so example pages
+           carry the same rhythm as the rest of the docs: serif h1 with a
+           coral italic accent, a `.lede` description, then an intro-meta
+           strip under a hairline rule. -->
       <section class="hero">
-        <div class="hero-eyebrow">
-          <span class="num">Example · {ex.index.split(' ')[0]}</span>
-          {ex.tags.map((t) => <span class="tag">{t.label}</span>)}
-          <span class="time">{ex.footMeta}</span>
+        <div class="pill-row">
+          {ex.tags.slice(0, 4).map((t) => <span class="pill"><span class="dot"></span>{t.label}</span>)}
+          <span class="pill dark"><span class="dot"></span>Production ready</span>
         </div>
 
-        <div class="hero-grid">
-          <div>
-            <h1 class="hero-h" set:html={titleMarkup(ex.title + (ex.title.endsWith('.') ? '' : '.'))} />
-            <p class="hero-sub">{ex.description}</p>
-            <div class="hero-cta">
-              <a class="btn btn-coral" href={sourceUrl}>View source
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              </a>
-              {tocHeadings[0] && <a class="btn btn-outline-muted" href={`#${tocHeadings[0].slug}`}>Start reading</a>}
-              <a class="btn btn-outline-muted" href={`${base}/examples`}>All examples</a>
+        <h1 class="hero-h" set:html={titleMarkup(ex.title + (ex.title.endsWith('.') ? '' : '.'))} />
+        <p class="lede">{ex.description}</p>
+        <dl class="intro-meta">
+          {introItems.map((m) => (
+            <div class={`m${m.reviewed ? ' m-reviewed' : ''}`}>
+              <dt class="k">{m.k}</dt>
+              <dd class="v">
+                {m.reviewed && (
+                  <svg class="check" width="14" height="14" viewBox="0 0 16 16" aria-hidden>
+                    <circle cx="8" cy="8" r="7" fill="var(--palm)" />
+                    <path d="M4.5 8.3l2.3 2.2L11.5 5.8"
+                          fill="none" stroke="var(--maroon-ink)"
+                          stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                )}
+                <span>{m.v}</span>
+              </dd>
             </div>
-            <div class="pill-row">
-              {ex.tags.slice(0, 4).map((t) => <span class="pill"><span class="dot"></span>{t.label}</span>)}
-              <span class="pill dark"><span class="dot"></span>Production ready</span>
-            </div>
-          </div>
-
-          <aside class="hero-card">
-            <div><div class="tl">At a glance</div></div>
-            <h2 class="big" set:html={titleMarkup('Built to *ship.* Clone and run.')} />
-            <div class="meta">
-              {ex.tags.find((t) => t.kind === 'src') && <div><span>Source</span><b>{ex.tags.find((t) => t.kind === 'src')!.label}</b></div>}
-              {ex.tags.find((t) => t.kind === 'llm') && <div><span>LLM</span><b>{ex.tags.find((t) => t.kind === 'llm')!.label}</b></div>}
-              {ex.tags.find((t) => t.kind === 'tgt') && <div><span>Target</span><b>{ex.tags.find((t) => t.kind === 'tgt')!.label}</b></div>}
-              {ex.tags.find((t) => t.kind === 'ops') && <div><span>Mode</span><b>{ex.tags.find((t) => t.kind === 'ops')!.label}</b></div>}
-              <div><span>Time</span><b>{ex.footMeta.split('·')[0].trim()}</b></div>
-              <div><span>Category</span><b>{ex.category}</b></div>
-            </div>
-          </aside>
+          ))}
+        </dl>
+        <div class="hero-cta">
+          <a class="btn btn-coral" href={sourceUrl}>View source
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </a>
         </div>
       </section>
 
@@ -164,51 +183,11 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       )}
       </main>
 
-      <!-- ─────────── RIGHT: ON THIS PAGE ─────────── -->
-      <aside class="ex-toc toc" aria-label="On this page">
-        <div class="toc-head">
-          <span>On this page</span>
-          <span class="prog" id="tocProg">0 / {tocHeadings.length}</span>
-        </div>
-        <ol id="tocList">
-          {tocHeadings.map((h) => (
-            <li data-target={`#${h.slug}`}>
-              <a href={`#${h.slug}`}>{h.text}</a>
-            </li>
-          ))}
-        </ol>
-        <div class="toc-aside">
-          <a href={sourceUrl}>↗ Source on GitHub</a>
-          <a href={base || '/'}>↗ Full docs</a>
-          <a href={`${base}/examples`}>↗ All examples</a>
-        </div>
-      </aside>
+      <!-- ─────────── RIGHT: ON THIS PAGE ─────────── Reuses the shared
+           Toc component so scroll-spy + visual styling match the regular
+           docs pages (globals.css `aside.toc`). -->
+      <Toc headings={rendered?.headings ?? []} slug={slug!} lastReviewed={lastReviewed} />
     </div>
-
-    <script is:inline>
-      (function(){
-        const tocItems = document.querySelectorAll('#tocList [data-target]');
-        const map = new Map();
-        tocItems.forEach((li) => {
-          const sel = li.getAttribute('data-target');
-          const el = document.querySelector(sel);
-          if (el) map.set(el, li);
-        });
-        const prog = document.getElementById('tocProg');
-        const total = map.size;
-        const active = new Set();
-        const io = new IntersectionObserver((entries) => {
-          entries.forEach((e) => {
-            const li = map.get(e.target);
-            if (!li) return;
-            if (e.isIntersecting) { li.classList.add('active'); active.add(li); }
-            else { li.classList.remove('active'); active.delete(li); }
-          });
-          if (prog) prog.textContent = `${active.size} / ${total}`;
-        }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
-        map.forEach((_, el) => io.observe(el));
-      })();
-    </script>
 
     <style is:global>
       /* ═══════════ Detail-page styles ═══════════
@@ -273,14 +252,8 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .ex-side ol li.on a { color: var(--maroon); background: var(--cream); font-weight: 500; }
       body.ex-detail .ex-side ol li.on a .n { color: var(--coral); }
 
-      body.ex-detail .ex-toc {
-        position: sticky; top: 57px; align-self: start;
-        height: calc(100vh - 57px);
-        overflow-y: auto;
-        padding: 28px 28px 40px 20px;
-        border-left: 1px solid var(--rule);
-        font-family: var(--sans);
-      }
+      /* Right-side TOC — rendered via the shared <Toc> component; styles
+         live in globals.css `aside.toc`. No local overrides. */
 
       body.ex-detail .ex-crumb {
         font-family: var(--mono); font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase;
@@ -292,72 +265,36 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .ex-crumb .sep { opacity: 0.5; }
       body.ex-detail .ex-crumb .cur { color: var(--maroon); }
 
-      /* Local button styles — scoped rather than leaking into prose/docs. */
-      body.ex-detail .btn {
-        display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-        padding: 10px 18px; border-radius: 999px;
-        font-family: var(--sans); font-size: 14px; font-weight: 500; line-height: 1.2;
-        text-decoration: none; white-space: nowrap;
-        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
-        transition: background .16s, color .16s, border-color .16s, transform .12s;
-      }
-      body.ex-detail .btn:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
-      body.ex-detail .btn-primary { background: var(--maroon); color: var(--cream); }
-      body.ex-detail .btn-primary:hover { background: var(--maroon-deep); border-color: var(--maroon-deep); }
-      body.ex-detail .btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
-      body.ex-detail .btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
-      body.ex-detail .btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
-      body.ex-detail .btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      /* Buttons — see `.btn` + variants in globals.css (ported from
+         design_guidelines/ui/buttons.html). No local overrides here. */
 
-      /* ── HERO ── */
+      /* ── HERO ── Typography mirrors `.prose h1 / .lede / .intro-meta`
+         from globals.css so example pages carry the same rhythm as docs. */
       body.ex-detail .hero { padding: 32px 0 32px; position: relative; }
-      body.ex-detail .hero-eyebrow { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 28px; padding-bottom: 24px; border-bottom: 1px solid var(--rule); }
-      body.ex-detail .hero-eyebrow .num { font-family: var(--mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--coral); font-weight: 500; }
-      body.ex-detail .hero-eyebrow .tag { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); padding: 5px 12px; border: 1px solid var(--rule-strong); border-radius: 999px; }
-      body.ex-detail .hero-eyebrow .time { margin-left: auto; color: var(--muted); font-family: var(--mono); font-size: 12px; }
-
-      body.ex-detail .hero-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: 64px; align-items: end; }
-      body.ex-detail h1.hero-h { font-family: var(--serif); font-weight: 400; font-size: clamp(40px, 4.6vw, 60px); line-height: 0.98; letter-spacing: -0.03em; margin: 0 0 24px; max-width: 18ch; }
+      body.ex-detail .hero .pill-row { display: flex; gap: 10px; flex-wrap: wrap; margin: 0 0 20px; }
+      body.ex-detail .hero .pill { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 7px 14px; border-radius: 999px; background: var(--cream); border: 1px solid var(--rule); color: var(--maroon); }
+      body.ex-detail .hero .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); flex: none; }
+      body.ex-detail .hero .pill.dark { background: var(--maroon-ink); color: var(--cream); border-color: var(--maroon-ink); }
+      body.ex-detail .hero .pill.dark .dot { background: var(--palm); }
+      body.ex-detail h1.hero-h { font-family: var(--serif); font-weight: 400; font-size: clamp(40px, 4.6vw, 60px); line-height: 1.02; letter-spacing: -0.03em; margin: 0 0 18px; }
       body.ex-detail h1.hero-h em { font-style: italic; color: var(--coral); }
-      body.ex-detail .hero-sub { font-family: var(--sans); font-size: clamp(17px, 1.4vw, 21px); font-weight: 400; line-height: 1.5; letter-spacing: -0.01em; color: var(--maroon-ink); max-width: 56ch; margin: 0 0 32px; }
-      body.ex-detail .hero-sub b { font-weight: 600; color: var(--maroon); }
+      body.ex-detail .hero .lede { font-family: var(--sans); font-size: clamp(17px, 1.4vw, 20px); font-weight: 400; line-height: 1.5; letter-spacing: -0.005em; color: var(--maroon-ink); max-width: 62ch; margin: 0 0 14px; }
+      body.ex-detail .hero .intro-meta {
+        display: flex; flex-wrap: wrap; gap: 22px;
+        margin: 20px 0 28px; padding: 14px 0 18px;
+        border-top: 1px solid var(--rule);
+        border-bottom: 1px solid var(--rule);
+      }
+      body.ex-detail .hero .intro-meta .m { display: flex; flex-direction: column; gap: 2px; margin: 0; }
+      body.ex-detail .hero .intro-meta .k { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin: 0; }
+      body.ex-detail .hero .intro-meta .v { font-size: 13px; font-weight: 500; margin: 0; display: inline-flex; align-items: center; gap: 6px; }
+      body.ex-detail .hero .intro-meta .check { flex: none; }
       body.ex-detail .hero-cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 
-      body.ex-detail .hero-card { background: var(--maroon); color: var(--cream); border-radius: 10px; padding: 32px; position: relative; overflow: hidden; min-height: 320px; display: flex; flex-direction: column; justify-content: space-between; }
-      body.ex-detail .hero-card::before { content: ""; position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(252, 243, 216, 0.08) 1.6px, transparent 2px); background-size: 20px 20px; }
-      body.ex-detail .hero-card > * { position: relative; z-index: 2; }
-      body.ex-detail .hero-card .tl { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
-      body.ex-detail .hero-card .big { font-family: var(--sans); font-size: clamp(40px, 4.6vw, 58px); font-weight: 600; letter-spacing: -0.035em; line-height: 0.98; margin: 0; color: var(--cream); }
-      body.ex-detail .hero-card .big em { color: var(--peach); font-style: italic; }
-      body.ex-detail .hero-card .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 28px; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.18); font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
-      body.ex-detail .hero-card .meta b { display: block; color: var(--cream); font-weight: 400; margin-top: 3px; letter-spacing: 0.02em; text-transform: none; font-size: 13px; }
-
-      body.ex-detail .pill-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 32px; padding-top: 24px; border-top: 1px solid var(--rule); }
-      body.ex-detail .pill { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 7px 14px; border-radius: 999px; background: var(--cream); border: 1px solid var(--rule); color: var(--maroon); }
-      body.ex-detail .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); }
-      body.ex-detail .pill.dark { background: var(--maroon-ink); color: var(--cream); border-color: var(--maroon-ink); }
-      body.ex-detail .pill.dark .dot { background: var(--palm); }
-
-      /* ── DOC LAYOUT ── */
-      /* (doc/toc 2-col rules removed — new .ex-layout handles positioning) */
-      body.ex-detail .toc-head { font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--muted); padding-bottom: 10px; margin-bottom: 14px; border-bottom: 1px solid var(--rule-strong); display: flex; justify-content: space-between; align-items: baseline; }
-      body.ex-detail .toc-head .prog { color: var(--coral); font-family: var(--mono); }
-      body.ex-detail .toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc-part; }
-      body.ex-detail .toc > ol > li { counter-increment: toc-part; margin-bottom: 18px; }
-      body.ex-detail .toc > ol > li > a { display: flex; align-items: baseline; gap: 10px; text-decoration: none; color: var(--maroon-ink); font-size: 14px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.3; padding: 6px 0; transition: color .15s; }
-      body.ex-detail .toc > ol > li > a::before { content: counter(toc-part, decimal-leading-zero); font-family: var(--mono); font-weight: 500; font-size: 11px; letter-spacing: 0.06em; color: var(--muted); flex: none; }
-      body.ex-detail .toc > ol > li > a:hover { color: var(--coral); }
-      body.ex-detail .toc > ol > li.active > a { color: var(--coral); }
-      body.ex-detail .toc ul { list-style: none; padding: 0; margin: 6px 0 4px 26px; counter-reset: toc-step; }
-      body.ex-detail .toc ul li { counter-increment: toc-step; }
-      body.ex-detail .toc ul li a { display: flex; align-items: baseline; gap: 8px; text-decoration: none; color: var(--muted); font-size: 13px; font-weight: 400; line-height: 1.4; padding: 4px 0; transition: color .15s; }
-      body.ex-detail .toc ul li a::before { content: counter(toc-part) "." counter(toc-step); font-family: var(--mono); font-size: 10px; color: var(--rule-strong); flex: none; min-width: 22px; }
-      body.ex-detail .toc ul li a:hover { color: var(--coral); }
-      body.ex-detail .toc ul li.active a { color: var(--maroon); }
-      body.ex-detail .toc ul li.active a::before { color: var(--coral); }
-      body.ex-detail .toc .toc-aside { margin-top: 28px; padding-top: 16px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: flex; flex-direction: column; gap: 8px; }
-      body.ex-detail .toc .toc-aside a { text-decoration: none; color: var(--maroon-ink); display: flex; align-items: center; gap: 6px; }
-      body.ex-detail .toc .toc-aside a:hover { color: var(--coral); }
+      /* Right-rail `<Toc>` visuals come straight from globals.css —
+         no body.ex-detail overrides here (leftover `.toc ol` / `.toc ul`
+         counters were clobbering the shared aside.toc rules and
+         injecting "0.1 / 0.2" prefixes). */
 
       body.ex-detail .doc .col-main { min-width: 0; }
       body.ex-detail section.blk { padding: 72px 0; border-top: 1px solid var(--rule); position: relative; scroll-margin-top: 84px; }
@@ -462,16 +399,16 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .code .dec { color: var(--peach); }
       body.ex-detail .code .fn { color: var(--pink); }
       body.ex-detail .code .str { color: #8ef09e; }
-      body.ex-detail .code .num { color: #F5D76E; }
-      body.ex-detail .code .tp { color: #C9B8F5; }
+      body.ex-detail .code .num { color: var(--gold); }
+      body.ex-detail .code .tp { color: var(--lavender); }
       body.ex-detail .code .dim { opacity: 0.48; }
-      body.ex-detail .code .comment { color: #978A74; font-style: italic; opacity: 0.75; }
+      body.ex-detail .code .comment { color: var(--taupe); font-style: italic; opacity: 0.75; }
       body.ex-detail .code.terminal .prompt::before { content: "$ "; color: var(--peach); }
 
       body.ex-detail .callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }
       body.ex-detail .callout .hd { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
       body.ex-detail .callout .hd .dt { width: 8px; height: 8px; border-radius: 50%; background: var(--coral); }
-      body.ex-detail .callout .hd.tip .dt { background: var(--palm); }
+      body.ex-detail .callout .hd.tip .dt { background: var(--palm-ink); }
       body.ex-detail .callout .hd.note .dt { background: var(--peach); }
       body.ex-detail .callout .hd.warn .dt { background: var(--pink); }
       body.ex-detail .callout p { margin: 0; color: var(--maroon-ink); }
@@ -522,14 +459,10 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
 
       @media (max-width: 1100px) {
         body.ex-detail .ex-layout { grid-template-columns: 1fr; }
-        body.ex-detail .ex-side,
-        body.ex-detail .ex-toc { position: static; height: auto; border: none; padding: 18px 20px; }
-        body.ex-detail .ex-side { border-bottom: 1px solid var(--rule); }
-        body.ex-detail .ex-toc { border-top: 1px solid var(--rule); }
+        body.ex-detail .ex-side { position: static; height: auto; border: none; border-bottom: 1px solid var(--rule); padding: 18px 20px; }
         body.ex-detail .ex-main { padding: 24px 28px 64px; }
         body.ex-detail .arch { grid-template-columns: 1fr; gap: 12px; padding: 24px; }
         body.ex-detail .arrow { transform: rotate(90deg); align-self: center; margin: 4px 0; }
-        body.ex-detail .hero-grid { grid-template-columns: 1fr; gap: 36px; }
         body.ex-detail .step { grid-template-columns: 56px 1fr; column-gap: 16px; row-gap: 16px; padding: 24px; }
         body.ex-detail .step-head, body.ex-detail .step-side { grid-column: 2; }
         body.ex-detail .tryit { grid-template-columns: 1fr; padding: 32px; }
@@ -547,7 +480,7 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
          narrower column and a different heading scale. */
       body.ex-detail .ex-prose { padding-top: 40px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
       body.ex-detail .ex-prose > :first-child { margin-top: 0; }
-      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; padding-top: 28px; border-top: 1px solid var(--rule); }
+      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; }
       body.ex-detail .ex-prose > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 24px; }
       body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: 84px; }
       body.ex-detail .ex-prose h4 { font-family: var(--sans); font-weight: 600; font-size: 17px; letter-spacing: -0.01em; margin: 28px 0 10px; }
@@ -559,7 +492,7 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .ex-prose li > p { margin-bottom: 6px; }
       body.ex-detail .ex-prose strong, body.ex-detail .ex-prose b { color: var(--maroon); font-weight: 600; }
       body.ex-detail .ex-prose em, body.ex-detail .ex-prose i { font-style: italic; }
-      body.ex-detail .ex-prose img { max-width: 100%; height: auto; border-radius: 8px; margin: 20px 0; border: 1px solid var(--rule); }
+      body.ex-detail .ex-prose img { max-width: 100%; height: auto; margin: 20px 0; }
       body.ex-detail .ex-prose blockquote { margin: 20px 0; padding: 10px 18px; border-left: 3px solid var(--coral); background: var(--cream); border-radius: 0 6px 6px 0; color: var(--muted); }
       body.ex-detail .ex-prose blockquote p { margin: 0; }
       body.ex-detail .ex-prose :not(pre) > code { font-family: var(--mono); font-size: 13.5px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 2px 7px; border-radius: 4px; }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -436,7 +436,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
         background: var(--maroon); color: var(--cream);
         min-height: 440px; position: relative;
         text-decoration: none;
-        transition: transform .2s, box-shadow .2s;
+        transition: transform .2s;
       }
       body.ex-listing .feat-eyebrow {
         font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
@@ -587,7 +587,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
       body.ex-listing .ex-tags .tag .dt { width: 5px; height: 5px; border-radius: 50%; background: var(--coral); }
       body.ex-listing .ex-tags .tag.src .dt { background: var(--peach); }
       body.ex-listing .ex-tags .tag.tgt .dt { background: var(--pink); }
-      body.ex-listing .ex-tags .tag.llm .dt { background: var(--palm); }
+      body.ex-listing .ex-tags .tag.llm .dt { background: var(--palm-ink); }
       body.ex-listing .ex-tags .tag.ops .dt { background: var(--coral); }
       body.ex-listing .ex-tags .tag.lvl .dt { background: var(--maroon); }
 
@@ -628,20 +628,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
       body.ex-listing .cta-end h3 em { color: var(--coral); font-style: normal; }
       body.ex-listing .cta-end p { color: var(--muted); max-width: 48ch; margin: 0 0 24px; font-size: 17px; }
       body.ex-listing .cta-end .btns { display: flex; gap: 12px; flex-wrap: wrap; }
-      body.ex-listing .cta-end .btn {
-        display: inline-flex; align-items: center; gap: 8px;
-        padding: 10px 18px; border-radius: 999px;
-        font-family: var(--sans); font-size: 14px; font-weight: 500; text-decoration: none;
-        border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
-        transition: background .16s, color .16s, border-color .16s;
-      }
-      body.ex-listing .cta-end .btn:hover { background: var(--maroon); color: var(--cream); }
-      body.ex-listing .cta-end .btn.btn-primary { background: var(--maroon); color: var(--cream); }
-      body.ex-listing .cta-end .btn.btn-primary:hover { background: var(--maroon-deep); }
-      body.ex-listing .cta-end .btn.btn-coral { background: var(--coral); color: var(--cream); border-color: var(--coral); }
-      body.ex-listing .cta-end .btn.btn-coral:hover { background: var(--maroon); border-color: var(--maroon); }
-      body.ex-listing .cta-end .btn.btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); }
-      body.ex-listing .cta-end .btn.btn-outline-muted:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+      /* Buttons — see `.btn` + variants in globals.css. No local overrides. */
       body.ex-listing .cta-end .side {
         display: flex; flex-direction: column; gap: 18px;
         padding: 28px 26px; border-radius: 10px;

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -10,12 +10,19 @@
   --cream: #FCF3D8;
   --cream-soft: #F6F4E9;
   --pink: #FB6A76;
-  --palm: #27E62B;
+  --palm: #27E62B;      /* live signal · dark bg only */
+  --palm-ink: #16A534;  /* live signal · light bg (a11y) */
   --berry: #6A1E23;
   --paper: #FBF6E8;
   --rule: rgba(42, 18, 27, 0.14);
   --rule-strong: rgba(42, 18, 27, 0.35);
   --muted: rgba(42, 18, 27, 0.58);
+  /* Code-block exceptions — only valid inside fenced code on maroon-ink.
+     Single source of truth: design_guidelines/ui/color.html § 04 — Code. */
+  --gold:     #F5D76E;  /* numbers + True/False/None */
+  --lavender: #C9B8F5;  /* types + classes */
+  --taupe:    #978A74;  /* comments (italic) */
+  --stone:    #C5B7A0;  /* punctuation */
 
   --serif: "Source Serif 4", ui-serif, Georgia, serif;
   --sans: "Inter", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -36,6 +43,73 @@ body {
 
 a { color: var(--coral); text-decoration: none; }
 a:hover { text-decoration: underline; }
+
+/* ─── Buttons ─── Single structural base + composable variants.
+   Ported verbatim from design_guidelines/ui/buttons.html — one `.btn` class
+   carries shape, padding, focus ring; variants colour it; sizes tune it.
+   Keep this block as the sole source of truth — per-page overrides have
+   been removed. */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 10px 18px; border-radius: 999px;
+  font-family: var(--sans); font-size: 14px; font-weight: 500; line-height: 1.2;
+  text-decoration: none; white-space: nowrap; cursor: pointer;
+  border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
+  transition: background .16s ease, color .16s ease, border-color .16s ease, transform .12s ease;
+}
+.btn:hover { text-decoration: none; }
+.btn:focus-visible, .btn.is-focus { outline: 2px solid var(--coral); outline-offset: 2px; }
+.btn[disabled], .btn.is-disabled { opacity: 0.45; pointer-events: none; }
+
+/* Variants */
+.btn-coral,
+.btn-coral:hover { color: var(--cream); }
+.btn-coral { background: var(--coral); border-color: var(--coral); }
+.btn-coral:hover, .btn-coral.is-hover { background: var(--maroon); border-color: var(--maroon); }
+
+.btn-primary,
+.btn-primary:hover { color: var(--cream); }
+.btn-primary { background: var(--maroon); border-color: var(--maroon); }
+.btn-primary:hover, .btn-primary.is-hover { background: var(--maroon-deep); border-color: var(--maroon-deep); }
+
+.btn-outline { border-color: var(--maroon); color: var(--maroon); background: transparent; }
+.btn-outline:hover, .btn-outline.is-hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+
+.btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); background: transparent; }
+.btn-outline-muted:hover, .btn-outline-muted.is-hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+
+.btn-ghost { border-color: transparent; color: var(--maroon-ink); background: transparent; }
+.btn-ghost:hover, .btn-ghost.is-hover { color: var(--coral); }
+
+.btn-mono {
+  font-family: var(--mono); font-size: 12px; font-weight: 500;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  border-color: var(--rule-strong); color: var(--maroon-ink);
+}
+.btn-mono:hover, .btn-mono.is-hover { border-color: var(--coral); color: var(--coral); }
+
+/* Sizes — default is medium. `btn-xl` is an alias of `btn-lg`. */
+.btn-sm { padding: 6px 12px; font-size: 13px; }
+.btn-lg, .btn-xl { padding: 13px 22px; font-size: 15px; }
+
+/* Shape — pill is default; `btn-rounded` is the rectangular variant. */
+.btn-rounded { border-radius: 8px; }
+
+/* Icon-only — square 36px at default, 28/44 at sm/lg. `btn-icon-circle`
+   keeps the pill radius; otherwise defaults to `btn-rounded`. */
+.btn-icon { padding: 0; width: 36px; height: 36px; border-radius: 8px; }
+.btn-icon.btn-sm { width: 28px; height: 28px; }
+.btn-icon.btn-lg, .btn-icon.btn-xl { width: 44px; height: 44px; }
+.btn-icon-circle { border-radius: 999px; }
+
+/* Social — 32px hairline square, maroon icon at rest, coral on hover.
+   Always compose as `btn btn-social` with an `aria-label`. */
+.btn-social {
+  width: 32px; height: 32px; padding: 0; border-radius: 6px;
+  border-color: var(--rule); color: var(--maroon);
+  background: transparent;
+}
+.btn-social:hover, .btn-social.is-hover { border-color: var(--coral); color: var(--coral); background: transparent; }
 
 .caps { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
 .mono { font-family: var(--mono); }
@@ -86,7 +160,6 @@ nav.top {
   background: var(--paper);
   border: 1px solid var(--rule-strong);
   border-radius: 10px;
-  box-shadow: 0 10px 32px -12px rgba(42, 18, 27, 0.22);
   opacity: 0;
   visibility: hidden;
   transform: translateY(-4px);
@@ -361,95 +434,63 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
 }
 .prose pre code { background: none; color: inherit; padding: 0; font-size: inherit; }
 
-/* Callouts — rendered from Docusaurus admonition blocks (`:::info`,
-   `:::tip`, `:::warning`, …) via scripts/remark-admonitions.mjs. Each
-   variant has its own icon circle color + subtle bg wash so readers can
-   distinguish at a glance. Shell dimensions match the `.tip` example in
-   design_guidelines/CocoIndex Docs.html. */
-.prose .callout {
-  display: flex; gap: 16px;
-  padding: 18px 22px;
-  border: 1px solid var(--rule-strong); border-radius: 8px;
+/* Admonitions — rendered from Docusaurus-style `:::note`, `:::info`,
+   `:::tip`, `:::warning` blocks via scripts/remark-admonitions.mjs.
+   Ported verbatim from design_guidelines/ui/admonitions.html — four
+   semantic variants, single hairline border + cream fill + circular
+   icon badge. Colour carries semantics; the glyph is a single-character
+   mark (i / ✓ / !). */
+.prose .co {
+  display: flex;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 8px;
   background: var(--cream);
-  margin: 28px 0;
-  max-width: 68ch;
+  font-size: 13.5px;
+  color: var(--maroon-ink);
+  margin: 18px 0;
 }
-/* note — neutral annotation, plain cream, subdued berry icon. */
-.prose .callout.note { background: var(--cream); border-color: var(--rule-strong); }
-/* info — peach-tinted cream, coral icon (matches design `.tip`). */
-.prose .callout.info {
+.prose .co .ico {
+  width: 24px; height: 24px; flex: none;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 12px; font-weight: 500;
+  color: var(--cream);
+  background: var(--coral);
+}
+.prose .co .body { flex: 1; line-height: 1.5; min-width: 0; font-size: inherit; margin: 0; max-width: none; }
+.prose .co .body > b {
+  display: block;
+  font-family: var(--sans); font-weight: 600;
+  font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase;
+  margin-bottom: 2px;
+}
+.prose .co .body > :is(p, ul, ol):first-of-type { margin-top: 0; }
+.prose .co .body > :last-child { margin-bottom: 0; }
+
+/* Note — quietest level: berry disc, no tint. */
+.prose .co.note .ico { background: var(--berry); }
+
+/* Info — prerequisite / setup: peach wash, coral hairline. */
+.prose .co.info {
   border-color: color-mix(in oklab, var(--coral) 45%, transparent);
   background: color-mix(in oklab, var(--peach) 16%, var(--cream));
 }
-/* tip — palm-tinted cream, green icon: a helpful suggestion. */
-.prose .callout.tip {
+
+/* Tip — non-blocking suggestion: palm wash + check glyph. */
+.prose .co.tip {
   border-color: color-mix(in oklab, var(--palm) 50%, var(--rule-strong));
   background: color-mix(in oklab, var(--palm) 7%, var(--cream));
 }
-/* warn / caution — pink-tinted cream (matches design `.warn`). */
-.prose .callout.warn {
+.prose .co.tip .ico { background: var(--palm); color: var(--maroon-ink); }
+
+/* Warn — might break: pink wash + coral border. */
+.prose .co.warn {
   border-color: var(--coral);
   background: color-mix(in oklab, var(--pink) 10%, var(--cream));
 }
-/* danger — deeper pink wash, coral icon. Reserved for breaking things. */
-.prose .callout.danger {
-  border-color: var(--coral);
-  background: color-mix(in oklab, var(--pink) 20%, var(--cream));
-}
-/* The icon bubble. Each variant sets `background` + `color`; the glyph
-   itself is painted in CSS as a mask-image data URI so it inherits the
-   bubble's `color` (=currentColor) and stays in sync with the variant. */
-.prose .callout .ico {
-  width: 28px; height: 28px; flex: none;
-  border-radius: 50%;
-  display: grid; place-items: center;
-  background: var(--coral); color: var(--cream);
-  margin: 0;
-}
-.prose .callout .ico::before {
-  content: "";
-  display: block;
-  width: 15px; height: 15px;
-  background-color: currentColor;
-  -webkit-mask: var(--ico-mask) center / contain no-repeat;
-          mask: var(--ico-mask) center / contain no-repeat;
-}
-
-/* Per-variant bubble colours + icon mask URIs. SVGs are hand-drawn at
-   16×16 on stroke-width 1.6, fill=transparent, stroke+dots=black so the
-   mask picks up the silhouette cleanly. */
-.prose .callout.note .ico {
-  background: var(--berry); color: var(--cream);
-  --ico-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><path d='M4 2h6l3 3v9H4z'/><path d='M10 2v3h3'/><path d='M6 9h4M6 11h4M6 13h3'/></svg>");
-}
-.prose .callout.info .ico {
-  background: var(--coral); color: var(--cream);
-  --ico-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><circle cx='8' cy='8' r='6.5'/><path d='M8 7.5v4.2'/><circle cx='8' cy='4.8' r='0.7' fill='black'/></svg>");
-}
-.prose .callout.tip .ico {
-  background: var(--palm); color: var(--maroon-ink);
-  --ico-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5.2 9.4c-1.3-.9-2.1-2.4-2.1-4A4.9 4.9 0 0 1 8 .5a4.9 4.9 0 0 1 4.9 4.9c0 1.6-.8 3.1-2.1 4'/><path d='M5.8 9.4v2.8h4.4V9.4'/><path d='M6.6 14.2h2.8'/></svg>");
-}
-.prose .callout.warn .ico {
-  background: var(--pink); color: var(--maroon-ink);
-  --ico-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><path d='M8 1.5 1.5 14h13z'/><path d='M8 6.2v3.8'/><circle cx='8' cy='12' r='0.75' fill='black'/></svg>");
-}
-.prose .callout.danger .ico {
-  background: var(--coral); color: var(--cream);
-  --ico-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='black' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5.4 1.5h5.2l3.9 3.9v5.2l-3.9 3.9H5.4l-3.9-3.9V5.4z'/><path d='M8 5.2v4.1'/><circle cx='8' cy='11.5' r='0.75' fill='black'/></svg>");
-}
-
-/* Nested code blocks inside a callout use the same maroon-ink chrome as
-   standalone code blocks — a uniform "chocolate" reads cleaner than
-   tinting per variant. The callout bubble + bg already carry the kind. */
-.prose .callout .body { flex: 1; font-size: 14.5px; margin: 0; max-width: none; }
-.prose .callout .body > b {
-  font-family: var(--sans); font-weight: 600; font-size: 13px;
-  letter-spacing: 0.01em; text-transform: uppercase;
-  display: block; margin-bottom: 4px;
-}
-.prose .callout .body > :is(p, ul, ol):first-of-type { margin-top: 0; }
-.prose .callout .body > :last-child { margin-bottom: 0; }
+.prose .co.warn .ico { background: var(--pink); color: var(--maroon-ink); }
 
 /* Block quotes — plain markdown `> …` surfaces that aren't admonitions. */
 .prose blockquote {


### PR DESCRIPTION
## Summary

Two overlapping cleanups:

- **Design-system conformance.** Port the canonical `.btn` and `.co` (admonition) systems verbatim from [design_guidelines/ui/*.html](https://github.com/cocoindex-io/cocoindex-io.github.io/tree/main/design_guidelines/ui) into [globals.css](docs/src/styles/globals.css). Drop per-page duplicates in 404, examples listing, example detail. Rename the non-spec `nf-btn-ghost` → `btn-outline-muted`. Add `--palm-ink` + `--gold` / `--lavender` / `--taupe` / `--stone` tokens per [color.html](https://github.com/cocoindex-io/cocoindex-io.github.io/blob/main/design_guidelines/ui/color.html); swap raw hex in example code syntax to tokens; palm → palm-ink on light-bg dots. Remove drop-shadows from nav dropdown, Tabs, and examples feat-card hover.
- **Example detail page polish.** Replace the "Built to ship. Clone and run." at-a-glance card with an intro-meta strip that mirrors `DocsLayout` (Time / Source / Target / LLM / Mode / Category / Last reviewed). Hero gets a chip row at the top (`tags` + `Production ready`). Restore cover images via `cocoindex.io/blobs/...` URLs; fix the broken `app-example.svg` path. Drop H1 / GitHub-link duplicates from the two MDX bodies. Drop image borders and the `ex-prose h2` border-top separator.
- **Right rail.** Replace the bespoke `ex-toc` markup + scroll-spy with the shared [`<Toc>`](docs/src/components/Toc.astro) component so scroll-highlight works and the rail visually matches the docs pages. `Toc` now accepts a `lastReviewed` prop — absolute date from frontmatter (examples) or editTs (docs) — instead of a git-editTs relative "Xd ago". Check-circle fill is `var(--palm)` to match prod.

## Test plan

- [ ] `npm run dev` in `docs/`; visit `/docs-v1/examples/pdf-to-markdown` and `/docs-v1/examples/multi-codebase-summarization`
- [ ] Hero shows chip row + serif h1 + lede + intro-meta strip + View source button; no "Example · 01", no at-a-glance card, no pill-row below the title
- [ ] Cover image renders at top of each example body (from `cocoindex.io/blobs/...`)
- [ ] Overview section on pdf-to-markdown shows the app-example.svg (fixed URL)
- [ ] No border around images; no horizontal separator above H2s in example prose
- [ ] Right rail: same visual + scroll-spy highlight as `/docs-v1/getting_started/quickstart`; "Last reviewed · Apr 20, 2026" row with green (palm) check
- [ ] `/docs-v1/getting_started/quickstart` unchanged visually; right-rail `Last reviewed · <date>` uses the editTs-derived absolute date (no "Xd ago")
- [ ] `/docs-v1/examples` listing + `/docs-v1/__nope__` 404 render correct button variants (coral / maroon / outline-muted)
- [ ] Admonitions on any docs page with `:::note` / `:::info` / `:::tip` / `:::warning` render via `.co` + text glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)