### PR TITLE
docs: backport admonition `danger` variant from main

### DIFF
--- a/docs/scripts/remark-admonitions.mjs
+++ b/docs/scripts/remark-admonitions.mjs
@@ -19,16 +19,21 @@
 import { visit } from 'unist-util-visit';
 import { toString } from 'mdast-util-to-string';
 
-// Four canonical variants per the design spec. `caution` and `danger` are
-// legacy aliases that collapse to `warn` — the design system explicitly
-// forbids a fifth variant.
+// Each admonition kind gets a distinct icon + class so readers can
+// distinguish at a glance. Colors are defined in src/styles/globals.css.
+//   note    — neutral annotation (berry pin, plain cream bg)
+//   info    — important context (coral i, peach-tinted cream)
+//   tip     — helpful suggestion (palm ✓, green-tinted cream)
+//   warning — heads up (pink !, pink-tinted cream)
+//   caution — alias for warning
+//   danger  — critical (coral !, deeper pink-tinted cream)
 const SPECS = {
-  note:    { defaultLabel: 'Note',         cls: 'note', icon: 'i' },
-  info:    { defaultLabel: 'Prerequisite', cls: 'info', icon: 'i' },
-  tip:     { defaultLabel: 'Tip',          cls: 'tip',  icon: '\u2713' },
-  warning: { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
-  caution: { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
-  danger:  { defaultLabel: 'Warning',      cls: 'warn', icon: '!' },
+  note: { defaultLabel: 'Note', cls: 'note', icon: 'i' },
+  info: { defaultLabel: 'Info', cls: 'info', icon: 'i' },
+  tip: { defaultLabel: 'Tip', cls: 'tip', icon: '\u2713' },
+  warning: { defaultLabel: 'Warning', cls: 'warn', icon: '!' },
+  caution: { defaultLabel: 'Caution', cls: 'warn', icon: '!' },
+  danger: { defaultLabel: 'Danger', cls: 'danger', icon: '!' },
 };
 
 export default function remarkAdmonitions() {

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -576,6 +576,13 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
 }
 .prose .co.warn .ico { background: var(--pink); color: var(--maroon-ink); }
 
+/* Danger — critical / breaking: deeper pink wash, coral icon. */
+.prose .co.danger {
+  border-color: var(--coral);
+  background: color-mix(in oklab, var(--pink) 20%, var(--cream));
+}
+.prose .co.danger .ico { background: var(--coral); color: var(--cream); }
+
 /* Block quotes — plain markdown `> …` surfaces that aren't admonitions. */
 .prose blockquote {
   margin: 20px 0;


### PR DESCRIPTION
## Summary
- Brings the admonition `danger` variant from `main` into `v1`: distinct `.co.danger` class (vs. collapsing into `warn`), updated default labels (`Info`, `Caution`, `Danger`).
- Adds matching `.co.danger` CSS (deeper pink wash + coral icon), mirroring `.callout.danger` on `main`.
- Replaces the stale "design system forbids a fifth variant" comment with the per-variant rationale from `main`.

## Test plan
CI
