### PR TITLE
docs: move concurrency control to advanced topics

### DIFF
--- a/docs/src/content/docs/advanced_topics/concurrency_control.mdx
+++ b/docs/src/content/docs/advanced_topics/concurrency_control.mdx
@@ -1,0 +1,37 @@
+---
+title: "*Concurrency* control"
+description: >
+  Tune how many processing components can run at the same time with
+  `max_inflight_components` or the `COCOINDEX_MAX_INFLIGHT_COMPONENTS`
+  environment variable, and understand how CocoIndex avoids deadlocks in
+  nested mount scenarios.
+---
+CocoIndex executes each [processing component](../programming_guide/processing_component.md) as a unit of concurrent work. By default, up to **1024** processing components can be in flight per app. When components perform resource-intensive work (e.g., calling external APIs, running ML models), you may want a tighter limit.
+
+## Setting the limit
+
+Set `max_inflight_components` in `AppConfig`:
+
+```python
+app = coco.App(
+    coco.AppConfig(name="MyPipeline", max_inflight_components=4),
+    app_main,
+    sourcedir=pathlib.Path("./data"),
+)
+```
+
+With `max_inflight_components=4`, at most 4 processing components execute at the same time. When a component finishes, the next pending one starts.
+
+Setting `max_inflight_components=1` serializes all components — only one runs at a time.
+
+You can also set the limit via the `COCOINDEX_MAX_INFLIGHT_COMPONENTS` environment variable:
+
+```bash
+export COCOINDEX_MAX_INFLIGHT_COMPONENTS=4
+```
+
+**Precedence:** `AppConfig` value > environment variable > default (1024).
+
+## Deadlock prevention
+
+When a parent component mounts a child, the parent releases its concurrency slot so the child can make progress. This prevents deadlocks in nested mount scenarios — even with `max_inflight_components=1`, a parent mounting a child will not block forever.

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -2,8 +2,8 @@
 title: The CocoIndex *App*
 description: >
   Apps are the top-level runnable unit in CocoIndex. Learn how to create an App,
-  trigger updates, configure concurrency and database paths, and wire up
-  lifespan-managed resources.
+  trigger updates, configure the database path, and wire up lifespan-managed
+  resources.
 ---
 An **App** is the top-level runnable unit in CocoIndex.
 It names your pipeline and binds a main function with its parameters. When you call `app.update()`, CocoIndex runs that main function as the root [processing component](./processing_component.md) which can mount child processing components to do work and declare target states.
@@ -116,36 +116,6 @@ For example, an app that processes files might mount one component per file:
 ```
 
 See [Processing Component](./processing_component.md) for how mounting and component paths define these boundaries.
-
-## Concurrency control
-
-By default, CocoIndex limits the number of concurrently executing processing components to **1024** per app. When components perform resource-intensive work (e.g., calling external APIs, running ML models), you may want to lower this limit.
-
-Set `max_inflight_components` in `AppConfig` to control the limit:
-
-```python
-app = coco.App(
-    coco.AppConfig(name="MyPipeline", max_inflight_components=4),
-    app_main,
-    sourcedir=pathlib.Path("./data"),
-)
-```
-
-With `max_inflight_components=4`, at most 4 processing components execute at the same time. When a component finishes, the next pending one starts.
-
-Setting `max_inflight_components=1` serializes all components — only one runs at a time.
-
-You can also set the limit via the `COCOINDEX_MAX_INFLIGHT_COMPONENTS` environment variable:
-
-```bash
-export COCOINDEX_MAX_INFLIGHT_COMPONENTS=4
-```
-
-**Precedence:** `AppConfig` value > environment variable > default (1024).
-
-:::info[Deadlock Prevention]
-When a parent component mounts a child, the parent releases its concurrency slot so the child can make progress. This prevents deadlocks in nested mount scenarios — even with `max_inflight_components=1`, a parent mounting a child will not block forever.
-:::
 
 ## Database path
 

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -83,6 +83,7 @@ export const sidebar: SidebarItem[] = [
     type: 'category',
     label: 'Advanced Topics',
     items: [
+      { type: 'doc', slug: 'advanced_topics/concurrency_control', label: 'Concurrency control' },
       { type: 'doc', slug: 'advanced_topics/memoization_keys', label: 'Memoization keys' },
       { type: 'doc', slug: 'advanced_topics/exception_handlers', label: 'Error handling' },
       { type: 'doc', slug: 'advanced_topics/internal_storage', label: 'Internal storage' },


### PR DESCRIPTION
## Summary
- Move `## Concurrency control` out of `programming_guide/app.mdx` into a new `advanced_topics/concurrency_control.mdx`. It's an optimization knob that presumes the Processing Component mental model, so it's a better fit for Advanced Topics than the App primer.
- Promote the deadlock-prevention note from an `:::info` callout to a proper subsection on the standalone page, and add a short intro that links back to Processing Component for readers who land there directly.
- Register the new page in `docs-sidebar.ts` and trim the `app.mdx` frontmatter description.

## Test plan
CI
