### PR TITLE
docs(v1): point v0 links to /docs-v0 paths

### DIFF
--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -8,8 +8,9 @@ import { SITE_MAIN, SITE_BLOG, GITHUB_REPO } from '../consts';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 const CODE = `${SITE_MAIN}/cocoindex-code`;
 const DOCS = base;
+const DOCS_V0 = `${SITE_MAIN}/docs-v0`;
 const EXAMPLES_V1 = `${base}/examples`;
-const EXAMPLES_V0 = 'https://cocoindex.io/docs/examples/';
+const EXAMPLES_V0 = `${SITE_MAIN}/docs-v0/examples/`;
 const ENTERPRISE = `${SITE_MAIN}/enterprise`;
 ---
 
@@ -51,7 +52,7 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
             <span class="ver">v1</span>
             <span class="tag">preview</span>
           </a>
-          <a href="https://cocoindex.io/docs/" role="menuitem">
+          <a href={DOCS_V0} role="menuitem">
             <span class="ver">v0</span>
             <span class="tag legacy">stable</span>
           </a>

--- a/docs/src/consts.ts
+++ b/docs/src/consts.ts
@@ -3,7 +3,8 @@ export const GITHUB_REPO = 'https://github.com/cocoindex-io/cocoindex';
 export const DISCORD_URL = 'https://discord.com/invite/zpA9S2DR7s';
 export const SITE_MAIN = 'https://cocoindex.io';
 export const SITE_BLOG = 'https://cocoindex.io/blogs';
-export const SITE_EXAMPLES = 'https://cocoindex.io/examples';
+// `import.meta.env.BASE_URL` reflects `base` in astro.config.mjs (e.g. `/docs-v0/`).
+export const SITE_EXAMPLES = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/examples`;
 // GitHub web-editor URL prefix for the "Edit this page" link.
 export const DOCS_EDIT_BASE = 'https://github.com/cocoindex-io/cocoindex/edit/main/docs/docs';
 


### PR DESCRIPTION
## Summary
- Point Topbar v0 docs/examples menu links to `${SITE_MAIN}/docs-v0` instead of the legacy `cocoindex.io/docs/` URLs.
- Update `SITE_EXAMPLES` to derive from `import.meta.env.BASE_URL` so it resolves to the current docs site's examples path.

## Test plan
CI
