### PR TITLE
docs: adopt github-landing-draft homepage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,49 @@
 <p align="center">
-    <img src="https://cocoindex.io/images/github.svg" alt="CocoIndex">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/enterprise-hero-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/enterprise-hero-light.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/enterprise-hero-light.svg" alt="Enterprise corpus — codebase, Slack, meeting notes, and documentation — flowing continuously through the CocoIndex incremental sync engine into a production AI agent with always-fresh context. Only the Δ (delta) is reprocessed on every change. Keywords: RAG pipeline, agent memory, enterprise retrieval, AI agent context, live indexing, retrieval-augmented generation, production LLM apps, streaming ETL, incremental ingestion." width="100%" draggable="false"/>
+  </picture>
+</p>
+<h1 align="center">Your agents deserve <em>fresh context.</em></h1>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub — open-source incremental indexing framework for AI agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub — open-source Python framework for RAG, vector search, and live agent context" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io" title="Visit cocoindex.io — the CocoIndex homepage"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/coco-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/coco-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/coco-inline-light.svg" alt="cocoindex.io — the CocoIndex homepage: incremental data pipelines for AI agents" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs" title="Read the CocoIndex documentation — guides, quickstart, connectors, transformations, and API reference"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation — quickstart, connectors, ops, transformations, target stores, RAG and knowledge graph recipes" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord — community chat, showcase, release notes, help and support"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord community — help, showcase, release notes, and live chat with maintainers" height="36" align="absmiddle"/></picture></a>
 </p>
 
-<h1 align="center">Data transformation for AI</h1>
+
+<p align="center">CocoIndex turns codebases, meeting notes, inboxes, Slack, PDFs, and videos into live, continuously fresh context for your AI agents and LLM apps to reason over effectively — with minimal incremental processing.  Get your production AI agent ready in 10 minutes with reliable, continuously fresh data — no stale batches, no context gap 
+</p>
+<p align="center">
+  <b>Incremental</b> · only the delta &nbsp;·&nbsp; <b>Any scale</b> · parallel by default &nbsp;·&nbsp; <b>Declarative</b> · Python, 5 min
+</p>
+
 
 <div align="center">
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
-[![Documentation](https://img.shields.io/badge/Documentation-394e79?logo=readthedocs&logoColor=00B9FF)](https://cocoindex.io/docs/getting_started/quickstart)
-[![License](https://img.shields.io/badge/license-Apache%202.0-5B5BD6?logoColor=white)](https://opensource.org/licenses/Apache-2.0)
-[![PyPI version](https://img.shields.io/pypi/v/cocoindex?color=5B5BD6)](https://pypi.org/project/cocoindex/)
-<!--[![PyPI - Downloads](https://img.shields.io/pypi/dm/cocoindex)](https://pypistats.org/packages/cocoindex) -->
-[![PyPI Downloads](https://static.pepy.tech/badge/cocoindex/month)](https://pepy.tech/projects/cocoindex)
-[![CI](https://github.com/cocoindex-io/cocoindex/actions/workflows/CI.yml/badge.svg?event=push&color=5B5BD6)](https://github.com/cocoindex-io/cocoindex/actions/workflows/CI.yml)
-[![release](https://github.com/cocoindex-io/cocoindex/actions/workflows/release.yml/badge.svg?event=push&color=5B5BD6)](https://github.com/cocoindex-io/cocoindex/actions/workflows/release.yml)
-[![Link Check](https://github.com/cocoindex-io/cocoindex/actions/workflows/links.yml/badge.svg)](https://github.com/cocoindex-io/cocoindex/actions/workflows/links.yml)
-[![prek](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json)](https://github.com/j178/prek)
-[![Discord](https://img.shields.io/discord/1314801574169673738?logo=discord&color=5B5BD6&logoColor=white)](https://discord.com/invite/zpA9S2DR7s)
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![downloads](https://img.shields.io/pepy/dt/cocoindex?style=flat-square&label=downloads&color=16A534)](https://pepy.tech/projects/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![python](https://img.shields.io/badge/python-3.10--3.13-3572A5?style=flat-square)](https://www.python.org/)
+[![rust](https://img.shields.io/badge/rust-core-db6d28?style=flat-square)](https://www.rust-lang.org/)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/cocoindex-io/cocoindex/CI.yml?event=push&style=flat-square&label=CI)](https://github.com/cocoindex-io/cocoindex/actions/workflows/CI.yml)
+[![release](https://img.shields.io/github/actions/workflow/status/cocoindex-io/cocoindex/release.yml?event=push&style=flat-square&label=release)](https://github.com/cocoindex-io/cocoindex/actions/workflows/release.yml)
+[![links](https://img.shields.io/github/actions/workflow/status/cocoindex-io/cocoindex/links.yml?event=push&style=flat-square&label=link%20check)](https://github.com/cocoindex-io/cocoindex/actions/workflows/links.yml)
 
 </div>
 
-<div align="center">
-    <a href="https://trendshift.io/repositories/13939" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13939" alt="cocoindex-io%2Fcocoindex | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</div>
+<p align="center"><a href="https://trendshift.io/repositories/13939" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13939" alt="cocoindex-io/cocoindex | Trendshift" width="250" height="55"/></a></p>
 
-Ultra performant data transformation framework for AI, with core engine written in Rust. Support incremental processing and data lineage out-of-box.  Exceptional developer velocity. Production-ready at day 0.
-
-⭐ Drop a star to help us grow!
+<br/>
 
 <div align="center">
 
-<!-- Keep these links. Translations will automatically update with the README. -->
 [Deutsch](https://readme-i18n.com/cocoindex-io/cocoindex?lang=de) |
 [English](https://readme-i18n.com/cocoindex-io/cocoindex?lang=en) |
 [Español](https://readme-i18n.com/cocoindex-io/cocoindex?lang=es) |
@@ -43,119 +56,251 @@ Ultra performant data transformation framework for AI, with core engine written 
 
 </div>
 
-</br>
 
+<br/><br/>
+
+<h2 align="center">Built with CocoIndex ❤️</h2>
+
+<!-- Flagship: CocoIndex-code — full-bleed clickable hero -->
 <p align="center">
-    <img src="https://cocoindex.io/images/transformation.svg" alt="CocoIndex Transformation">
+  <a href="https://cocoindex.io/cocoindex-code" title="CocoIndex-code — flagship MCP server for AI coding agents: AST-aware, incremental, semantic code index. Claude Code and Cursor see your whole repo instantly."><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg" alt="CocoIndex-code — flagship MCP server for AI coding agents. AST-aware incremental semantic code index that keeps live call graphs, symbols, vectors, and chunks fresh on every commit. 70% fewer tokens per turn, 80-90% cache hits on re-index, sub-second freshness. Supports Python, TypeScript, Rust, and Go. Features: Δ-only incremental processing, semantic search by meaning (not grep), call graphs and blast-radius analysis, global repo view for duplicates and architecture. Build coding agents (generate, refactor) and code-review agents (catch, approve). One install — Claude Code, Cursor, and other MCP-aware agents see your whole repository instantly. Keywords: MCP server, coding agent, code intelligence, AST chunking, semantic code search, call graph, vector embedding, repository context, Claude Code, Cursor, incremental indexing, blast radius." width="100%"/></picture></a>
 </p>
 
-</br>
+<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples"><b>See all 20+ examples · updated every week →</b></a></p>
 
-CocoIndex makes it effortless to transform data with AI, and keep source data and target in sync. Whether you’re building a vector index, creating knowledge graphs for context engineering or performing any custom data transformations — goes beyond SQL.
+<br/>
 
-</br>
-
-<p align="center">
-<img alt="CocoIndex Features" src="https://cocoindex.io/images/venn2.svg" />
-</p>
-
-</br>
-
-## Exceptional velocity
-
-Just declare transformation in dataflow with ~100 lines of python
-
-```python
-# import
-data['content'] = flow_builder.add_source(...)
-
-# transform
-data['out'] = data['content']
-    .transform(...)
-    .transform(...)
-
-# collect data
-collector.collect(...)
-
-# export to db, vector db, graph db ...
-collector.export(...)
-```
-
-CocoIndex follows the idea of [Dataflow](https://en.wikipedia.org/wiki/Dataflow_programming) programming model. Each transformation creates a new field solely based on input fields, without hidden states and value mutation. All data before/after each transformation is observable, with lineage out of the box.
-
-**Particularly**, developers don't explicitly mutate data by creating, updating and deleting. They just need to define transformation/formula for a set of source data.
-
-## Plug-and-Play Building Blocks
-
-Native builtins for different source, targets and transformations. Standardize interface, make it 1-line code switch between different components - as easy as assembling building blocks.
-
-<p align="center">
-    <img src="https://cocoindex.io/images/components.svg" alt="CocoIndex Features">
-</p>
-
-## Data Freshness
-
-CocoIndex keep source data and target in sync effortlessly.
-
-<p align="center">
-    <img src="https://github.com/user-attachments/assets/f4eb29b3-84ee-4fa0-a1e2-80eedeeabde6" alt="Incremental Processing" width="700">
-</p>
-
-It has out-of-box support for incremental indexing:
-
-- minimal recomputation on source or logic change.
-- (re-)processing necessary portions; reuse cache when possible
-
-## Quick Start
-
-If you're new to CocoIndex, we recommend checking out
-
-- 📖 [Documentation](https://cocoindex.io/docs)
-- ⚡  [Quick Start Guide](https://cocoindex.io/docs/getting_started/quickstart)
-- 🎬 [Quick Start Video Tutorial](https://youtu.be/gv5R8nOXsWU?si=9ioeKYkMEnYevTXT)
-
-### Setup
-
-1. Install CocoIndex Python library
-
-> **Note**: CocoIndex v1 is currently in preview (pre-release). Use the `--pre` flag with pip, or configure your package manager to allow pre-releases.
+<h3 align="center">Get started</h3>
 
 ```sh
-pip install -U --pre cocoindex
+pip install -U --pre cocoindex     # v1 is in preview — the --pre flag is required
 ```
 
-1. [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one. CocoIndex uses it for incremental processing.
+Declare *what* should be in your target — CocoIndex keeps it in sync forever, recomputing only the Δ.
 
-2. (Optional) Install Claude Code skill for enhanced development experience. Run these commands in [Claude Code](https://claude.com/claude-code):
+```python
+import cocoindex as coco
+from cocoindex.connectors import localfs, postgres
+from cocoindex.ops.text import RecursiveSplitter
 
+@coco.fn(memo=True)                          # ← cached by hash(input) + hash(code)
+async def index_file(file, table):
+    for chunk in RecursiveSplitter().split(await file.read_text()):
+        table.declare_row(text=chunk.text, embedding=embed(chunk.text))
+
+@coco.fn
+async def main(src):
+    table = await postgres.mount_table_target(PG, table_name="docs")
+    table.declare_vector_index(column="embedding")
+    await coco.mount_each(index_file, localfs.walk_dir(src).items(), table)
+
+coco.App(coco.AppConfig(name="docs"), main, src="./docs").update_blocking()
 ```
-/plugin marketplace add cocoindex-io/cocoindex-claude
-/plugin install cocoindex-skills@cocoindex
-```
 
-## 📖 Documentation
+<p align="center">Run once to backfill. Re-run anytime — only the changed files re-embed.</p>
 
-For detailed documentation, visit [CocoIndex Documentation](https://cocoindex.io/docs), including a [Quickstart guide](https://cocoindex.io/docs/getting_started/quickstart).
+<p align="center">
+  <a href="https://cocoindex.io/docs/getting_started/quickstart" title="Full CocoIndex quickstart — install, declare sources and targets, run the incremental engine, set up vector search or knowledge graph in 5 minutes"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/quickstart-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/quickstart-btn-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/quickstart-btn-light.svg" alt="Full quickstart — open-book icon linking to the CocoIndex documentation quickstart: pip install, declare sources and targets, run the incremental engine" height="36" align="absmiddle"/></picture></a>
+  &nbsp;&nbsp;
+  <a href="https://cocoindex.io/docs-v1/programming_guide/core_concepts" title="Learn the CocoIndex core concepts — sources, targets, flows, incremental engine, lineage"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg" alt="Learn the concept — lightbulb icon linking to the CocoIndex core-concepts guide: sources, targets, flows, incremental engine, and data lineage" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## 🤝 Contributing
 
-We love contributions from our community ❤️. For details on contributing or running the project for development, check out our [contributing guide](https://cocoindex.io/docs/about/contributing).
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub — open-source Python framework for live agent context"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/comm-github-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/comm-github-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/comm-github-light.svg" alt="Animated GitHub Star button for the cocoindex-io/cocoindex repository: a cursor clicks the star, it fills yellow, confetti bursts, the star count ticks up 6.9k → 7.0k, and an 'Appreciate a star if you like it!' caption with a beating heart shows below the button" width="620"/></picture></a>
+</p>
 
-## 👥 Community
+<br/><br/>
 
-Welcome with a huge coconut hug 🥥⋆｡˚🤗. We are super excited for community contributions of all kinds - whether it's code improvements, documentation updates, issue reports, feature requests, and discussions in our Discord.
+<h2 align="center">React — <em>for data engineering</em></h2>
 
-Join our community here:
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/react4de-hero-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/react4de-hero-light.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/react4de-hero-light.svg" alt="React — for data engineering. The CocoIndex mental model: Target = F(Source). A persistent-state-driven dataflow where you declare the desired target state and the engine keeps it in sync with the latest source data and code, forever, at low latency and low cost. Source files (.py, .md, .pdf, .ts) flow through your Python transformation F into a live target dots-matrix index; only the Δ is reprocessed on every change, and every target dot traces back to its exact source byte. Four core properties: Python not a DAG (sky), declare target state (yellow bullseye), lineage end-to-end (coral connected dots), and incremental at any scale (mint Δ+1). Your code is as simple as the one-off version — the engine does the rest. Keywords: React for data engineering, declarative ETL, persistent state, data lineage, dataflow, Δ only, incremental indexing, CocoIndex." width="100%"/>
+  </picture>
+</p>
 
-- 🌟 [Star us on GitHub](https://github.com/cocoindex-io/cocoindex)
-- 👋 [Join our Discord community](https://discord.com/invite/zpA9S2DR7s)
-- ▶️ [Subscribe to our YouTube channel](https://www.youtube.com/@cocoindex-io)
-- 📜 [Read our blog posts](https://cocoindex.io/blogs/)
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/either-side-change-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/either-side-change-light.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/either-side-change-light.svg" alt="What happens when either side changes — CocoIndex tracks per-row provenance so the Δ propagates at minimum cost. Two scenarios shown in one illustration: (top) Source change — one file (b.md) is edited and only one target dot re-syncs (coral pulse). (bottom) Code change — the transformation function F is rewritten from v1 to v2 and only the dots whose outputs depend on the changed code re-run (amber/yellow pulses). Source on the left, F in the center (Python code block), target dots-matrix on the right. Keywords: incremental indexing, change data capture, delta processing, fine-grained invalidation, code-aware caching, hash-of-code invalidation, memoization, reproducible pipelines, incremental recomputation." width="100%"/>
+  </picture>
+</p>
 
-## Support us
+<p align="center"><a href="https://cocoindex.io/react-cocoindex"><b>See the React ↔ CocoIndex mental model →</b></a></p>
 
-We are constantly improving, and more features and examples are coming soon. If you love this project, please drop us a star ⭐ at GitHub repo [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex) to stay tuned and help us grow.
 
-## License
+<br/><br/>
 
-CocoIndex is Apache 2.0 licensed.
+<h2 align="center"><em>Incremental engine</em> for long-horizon agents</h2>
+
+<p align="center">
+  Data transformation for any engineer, designed for AI workloads —<br/>
+  with a smart incremental engine for <em>always-fresh, explainable data.</em>
+</p>
+
+<p align="center">
+  <a href="https://cocoindex.io/docs-v1/programming_guide/core_concepts" title="Learn the CocoIndex core concepts — sources, targets, flows, incremental engine, lineage"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg" alt="Learn the concept — purple button with a lightbulb icon linking to the CocoIndex core-concepts guide: sources, targets, flows, incremental engine, and data lineage" height="44" align="absmiddle"/></picture></a>
+</p>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/incremental-engine-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/incremental-engine-light.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/incremental-engine-light.svg" alt="CocoIndex's Python-native transformation flows connect 8 source categories (Codebases, Meeting Notes, Web · APIs, File System · Blob Stores, Databases, Message Queues, Images · Video, Voice · Transcripts) through the incremental engine out to 6 target stores (Relational DB, Data Warehouse, Vector DB, Graph DB, Message Queue, Feature Store). A flow.py code block (@coco.fn · def f(src): · chunks = split(src) · target.row(embed(chunks))) shows the shared pipeline; only the Δ is reprocessed — unchanged src hits the cache, changed src re-runs split() and Δ → re-embed. The persistent data-pipeline control plane runs eight always-on subsystems: live caching, pipeline catalog, version tracking, continuously learning, lineage, task scheduling, metrics collection, and failure management. Keywords: data pipeline, ETL, source connectors, vector database, graph database, incremental engine, streaming ingestion, caching, lineage, versioning, scheduling, metrics, retries." width="100%"/>
+  </picture>
+</p>
+
+
+<br/><br/>
+
+<h2 align="center">Why <em>incremental?</em></h2>
+
+<p align="center">Your agents are only as good as the data they see.<br/>Batch pipelines drift stale. CocoIndex stays live — and only runs the Δ.</p>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/why-incremental-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/why-incremental-dark.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/why-incremental-dark.svg" alt="Why incremental? — one illustration combining the four core benefits of CocoIndex's incremental engine. Sub-second fresh (mint): a stopwatch ticking under a second, source changes propagate to the target in under a second so agents see the world as it is, not as it was yesterday. 10× cheaper at scale (yellow): a 10,000-row corpus block where only a thin Δ 0.1% column re-runs and 99.9% stays cached — you skip the other 99.9% of your corpus and pay a fraction of the compute, embedding, and LLM bill. Explainable by default (coral): a lineage thread links a source byte (handbook.md L42) to a target vector — every vector, row, or graph node in the target traces back to its exact source byte for debuggable, auditable, regulator-friendly AI pipelines. Production-grade (purple): a shield stamped with the Rust crab surrounded by retry loops, back-off dots, a DLQ tray, and a no-data-loss check — Rust core with retries, exponential back-off, dead-letter queues, and no-data-loss guarantees, production-ready for long-horizon AI agents. Keywords: incremental indexing, Δ-only reprocessing, sub-second freshness, low-latency RAG, cost-efficient embeddings, data lineage, retrieval-augmented generation, Rust core, retries, back-off, dead letters, no data loss, long-horizon agents." width="100%"/>
+  </picture>
+</p>
+
+
+<br/><br/>
+
+<h2 align="center">What can you <em>build?</em></h2>
+
+<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples" title="Browse all 20+ CocoIndex examples on GitHub — code, PDF, HN, knowledge graph, podcast, CSV-to-Kafka, image, and more"><b>See all 20+ examples · updated every week →</b></a></p>
+
+<p align="center"><b>Working starters from <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples">the examples tree</a> — clone, plug your source, ship.</b></p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding" title="Real-time code index — walk a git repo, chunk source files with an AST-aware splitter, embed with sentence-transformers, and upsert to pgvector / LanceDB. Fully incremental: only files touched by the latest commit re-embed. Good for coding agents, code review, semantic find-by-meaning."><img src="https://cocoindex.io/blobs/github/homepage/example-code.svg" alt="Real-time code index — walk a git repo, AST-chunk source files, embed with sentence-transformers, upsert to pgvector / LanceDB, incremental on every commit. Keywords: code search, code embedding, semantic code retrieval, Python." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_embedding" title="PDF → RAG index — ingest PDFs from local / S3 / Google Drive, extract text, chunk with a recursive splitter, embed each chunk, and upsert into pgvector / LanceDB with a vector index. Classic RAG stack, incremental — only edited PDFs re-embed."><img src="https://cocoindex.io/blobs/github/homepage/example-pdf.svg" alt="PDF → RAG index — ingest PDFs from local, S3, or GDrive, extract + chunk text, embed chunks, upsert to pgvector / LanceDB. Classic retrieval-augmented-generation stack, incremental. Keywords: RAG, document Q&A, PDF search, vector database." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/hn_trending_topics" title="HN trending topics — fetch Hacker News threads via the Algolia API, recursively pull nested comments, LLM-extract typed topic lists per message with Gemini 2.5 Flash, and rank topics by weighted mention count (thread = 5 points, comment = 1 point)."><img src="https://cocoindex.io/blobs/github/homepage/example-hn-trending.svg" alt="HN trending topics — pull Hacker News threads via Algolia, recursively parse comments, LLM-extract topics with Gemini 2.5 Flash, rank by weighted hit count (thread=5, comment=1), store in Postgres. Incremental. Keywords: Hacker News, trending topics, LLM extraction, Gemini, Postgres, news intelligence, topic ranking." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/conversation_to_knowledge" title="Conversation → knowledge graph — pull people, topics, decisions, and action items out of meeting transcripts, Slack, podcasts, or support calls with an LLM extractor, and upsert into Neo4j or Kuzu. Incremental: only changed turns re-extract."><img src="https://cocoindex.io/blobs/github/homepage/example-kg.svg" alt="Conversation → knowledge graph — LLM extracts people, topics, decisions, action items from transcripts and upserts into Neo4j / Kuzu. Live graph, incremental. Keywords: knowledge graph, entity extraction, meeting intelligence, agent memory." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/multi_codebase_summarization" title="Multi-repo summarization — walk N git repositories, extract READMEs / public APIs / modules, LLM-summarize each one, and roll up into a single top-level summary. Incremental: only repos with new commits re-run."><img src="https://cocoindex.io/blobs/github/homepage/example-multicode.svg" alt="Multi-repo summarization — walk N git repos, extract structure, LLM-summarize per-repo + a rolled-up org summary, refresh on every push. Keywords: internal platform, developer experience, monorepo, SDK docs." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/patient_intake_extraction_baml" title="Structured extraction — read messy forms, PDFs, invoices, or free-text and extract typed, schema-validated fields with BAML or DSPy, then write rows into Postgres or a warehouse. Incremental: only changed documents re-extract."><img src="https://cocoindex.io/blobs/github/homepage/example-intake.svg" alt="Structured extraction — BAML / DSPy typed schema extraction from forms, PDFs, intakes, invoices into Postgres / warehouse. Incremental. Keywords: ETL, LLM extraction, schema-first, patient intake, invoice processing, KYC, contracts." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/conversation_to_knowledge" title="Podcast → knowledge graph — download YouTube podcast audio, transcribe with speaker diarization (Whisper / AssemblyAI), LLM-extract structured statements and entities per speaker, resolve duplicates across episodes with embeddings, and store the whole graph (speakers, statements, topics) in SurrealDB or Neo4j. Incremental."><img src="https://cocoindex.io/blobs/github/homepage/example-podcast.svg" alt="Podcast → knowledge graph — transcribe YouTube / Spotify audio with speaker diarization, LLM-extract speakers and statements, resolve entities across episodes, store in SurrealDB / Neo4j. Keywords: podcast, diarization, YouTube, Whisper, SurrealDB, knowledge graph, entity resolution." width="70%"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/csv_to_kafka" title="CSV → Kafka live — watch a folder of CSV files (local or S3) and publish each row as a JSON message keyed by its primary key to a Kafka topic on StreamNative / Confluent / self-hosted. Sub-second incremental — only changed rows publish."><img src="https://cocoindex.io/blobs/github/homepage/example-csv-kafka.svg" alt="CSV → Kafka live — watch a folder of CSV files, publish each row as a JSON message to a Kafka topic via CocoIndex's Kafka target connector. Incremental, sub-second, no producer loop. Keywords: Kafka, CDC, streaming, StreamNative, Confluent, CSV ingestion, event streaming." width="70%"/></a>
+</p>
+
+<br/>
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/share-build-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/share-build-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/share-build-light.svg" alt="Share what you build — a banner with a trail of tiny hearts rising from the bottom behind the text, inviting the CocoIndex community to share projects built with the framework" height="36" draggable="false"/></picture></p>
+
+<p align="center">Building something with CocoIndex? <b>We want to see it.</b><br/>Tag <a href="https://x.com/cocoindex_io" title="Tag @cocoindex_io on X to showcase your CocoIndex project">@cocoindex_io</a> on X or drop a link in <a href="https://discord.com/invite/zpA9S2DR7s" title="Share your project in the CocoIndex Discord #showcase channel">#showcase</a> on Discord. We'll boost it. 🥥</p>
+
+
+<br/><br/>
+
+<h2 align="center">Community</h2>
+
+<table width="100%" border="0" cellspacing="0" role="presentation">
+  <tr>
+    <td align="center" valign="middle" width="25%">
+      <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord — community chat, showcase, help, release notes"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/comm-discord-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/comm-discord-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/comm-discord-light.svg" alt="Join the CocoIndex Discord community — live chat with maintainers and users, showcase your projects, get help building RAG pipelines and knowledge graphs" width="100%"/></picture></a>
+    </td>
+    <td align="center" valign="middle" width="25%">
+      <a href="https://www.youtube.com/@cocoindex-io" title="Subscribe to the CocoIndex YouTube channel — live demos, tutorials, and deep dives"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/comm-youtube-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/comm-youtube-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/comm-youtube-light.svg" alt="Subscribe to the CocoIndex YouTube channel — video tutorials, live demos, architecture deep dives, and AI agent recipes" width="100%" draggable="false"/></picture></a>
+    </td>
+    <td align="center" valign="middle" width="25%">
+      <a href="https://cocoindex.io/blogs/" title="Read the CocoIndex blog — engineering posts, release notes, and tutorials"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/comm-blog-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/comm-blog-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/comm-blog-light.svg" alt="Read the CocoIndex blog — engineering deep dives, release notes, RAG and knowledge graph tutorials, and case studies" width="100%"/></picture></a>
+    </td>
+    <td align="center" valign="middle" width="25%">
+      <a href="https://x.com/cocoindex_io" title="Follow @cocoindex_io on X (Twitter) for release notes, demos, and updates"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/comm-x-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/comm-x-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/comm-x-light.svg" alt="Follow @cocoindex_io on X (formerly Twitter) for release notes, demos, launches, and AI data pipeline updates" width="100%" draggable="false"/></picture></a>
+    </td>
+  </tr>
+</table>
+
+<br/><br/>
+
+<p align="center">
+  <img src="https://cocoindex.io/blobs/github/homepage/we-love-contributors.svg" alt="We love Contributors — section title banner with a pulsing coral heart badge and cream twinkle sparkles. Every typo fix, new connector, and doc tweak makes CocoIndex better. Keywords: open-source contribution, pull request, typo fix, new connector, good first issue, Hacktoberfest, community, coconut heart." width="620"/>
+</p>
+
+<p align="center">
+  <b>We are <em>so</em> excited to meet you.</b><br/>
+  Every typo fix, new connector, doc tweak, or full-on rewrite makes CocoIndex better.<br/>
+  Come hang out — big PRs and small ones, both welcome.
+</p>
+
+<p align="center">
+  📝 <a href="https://cocoindex.io/docs/about/contributing"><b>Read the contributing guide</b></a> &nbsp;·&nbsp;
+  🐛 <a href="https://github.com/cocoindex-io/cocoindex/labels/good%20first%20issue"><b>good first issues</b></a> &nbsp;·&nbsp;
+  💬 <a href="https://discord.com/invite/zpA9S2DR7s"><b>Say hi on Discord</b></a>
+</p>
+
+<br/><br/>
+
+<h2 align="center">CocoIndex <em>Enterprise</em></h2>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/enterprise-scale-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/enterprise-scale-light.svg">
+    <img src="https://cocoindex.io/blobs/github/homepage/enterprise-scale-light.svg" alt="CocoIndex Enterprise — built for enterprise scale. Four headline stats for PB-scale incremental indexing: PB corpus scale incrementally indexed (coral), 10× fewer LLM embedding calls vs. full recompute (yellow), 100% lineage coverage with every byte traceable (mint), Δ only the delta always (sky). Below, a wide 50×8 corpus matrix of 400 dim tiles represents a petabyte-scale store where a single coral Δ slice of 8 tiles re-runs while the other 99.9% stays cached. Keywords: enterprise RAG, petabyte-scale indexing, incremental compute, delta-only, lineage, parallel chunking, zero-copy, failure isolation." width="100%"/>
+  </picture>
+</p>
+
+<h3 align="center">Large corpus — <em>built for enterprise scale.</em></h3>
+
+<p align="center">
+  Incremental compute is the only way to keep large corpora fresh without re-embedding them every cycle.<br/>
+  CocoIndex scales from a single repo to petabyte-scale stores — parallel by default, delta-only by design.
+</p>
+
+<br/>
+
+<h3 align="center">Process once. <em>Reconcile forever.</em></h3>
+
+<p align="center">
+  When a source changes, CocoIndex identifies the affected records, propagates the change<br/>
+  across joins and lookups, updates the target, and retires stale rows —<br/>
+  without touching anything that didn't change.
+</p>
+
+<br/>
+
+<h3 align="center">Built on a <em>Rust engine.</em></h3>
+
+<p align="center">
+  The core is Rust — production-grade from day zero.<br/>
+  Parallel chunking, zero-copy transforms where possible, and failure isolation<br/>
+  so one bad record doesn't stall the flow.
+</p>
+
+<br/><br/>
+
+<p align="center">
+  <a href="https://cocoindex.io/enterprise/" title="Explore CocoIndex Enterprise — PB-scale incremental data pipelines for AI agents"><img src="https://cocoindex.io/blobs/github/homepage/enterprise-btn.svg" alt="Explore CocoIndex Enterprise — bright blue pill button linking to cocoindex.io/enterprise, the PB-scale incremental data pipeline for AI agents" height="44" align="absmiddle"/></a>
+</p>
+
+<br/><br/>
+
+<p align="center"><sub>Apache 2.0 · © CocoIndex contributors 🥥</sub></p>


### PR DESCRIPTION
## Summary
- Replaces README with polished landing page from github-landing-draft
- Rewrites `./assets/` paths to `https://cocoindex.io/blobs/github/homepage/` so SVGs are served from the cocoindex.io/blobs CDN (`public/github/homepage/` in the blobs repo)

## Test plan
- [ ] Render README on GitHub and verify all images load from the blobs CDN
- [ ] Check dark/light variant SVGs display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)