### PR TITLE
docs: fix trailing whitespace in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 
-<p align="center">CocoIndex turns codebases, meeting notes, inboxes, Slack, PDFs, and videos into live, continuously fresh context for your AI agents and LLM apps to reason over effectively — with minimal incremental processing.  Get your production AI agent ready in 10 minutes with reliable, continuously fresh data — no stale batches, no context gap 
+<p align="center">CocoIndex turns codebases, meeting notes, inboxes, Slack, PDFs, and videos into live, continuously fresh context for your AI agents and LLM apps to reason over effectively — with minimal incremental processing.  Get your production AI agent ready in 10 minutes with reliable, continuously fresh data — no stale batches, no context gap
 </p>
 <p align="center">
   <b>Incremental</b> · only the delta &nbsp;·&nbsp; <b>Any scale</b> · parallel by default &nbsp;·&nbsp; <b>Declarative</b> · Python, 5 min


### PR DESCRIPTION
## Summary
- Strip the trailing space on the README intro paragraph (line 18) introduced in #1877
- Resolves the prek `trailing-whitespace` hook failure that is currently tripping CI for PRs against `v1`

## Test plan
- [x] `grep -n ' $' README.md` returns no matches locally
- [ ] CI prek run passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)