### PR TITLE
feat(telemetry): add anonymous usage tracking via Scarf gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ version = "999.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bytes",
  "cocoindex_utils",
  "env_logger",

--- a/docs/src/content/docs/about/telemetry.mdx
+++ b/docs/src/content/docs/about/telemetry.mdx
@@ -1,0 +1,71 @@
+---
+title: Anonymous *usage telemetry*
+description: >
+  What CocoIndex's anonymous usage tracking collects, what it doesn't, and how
+  to opt out.
+---
+
+CocoIndex sends a small number of anonymous events to help us understand how
+the library is used across platforms and runtimes. Tracking is strictly
+anonymous, release-only, and opt-out.
+
+## What we collect
+
+On release builds, CocoIndex POSTs a JSON event to our telemetry endpoint
+(the [Scarf](https://about.scarf.sh/) gateway) at four points in the library's
+lifecycle:
+
+- `init` — once per process, when CocoIndex is imported.
+- `app_create` — when a `cocoindex.App` is constructed.
+- `app_update` — each time `app.update()` is called.
+- `app_drop` — each time `app.drop()` is called.
+
+Each event body contains exactly three fields:
+
+```json
+{ "event": "app_update", "platform": "aarch64-macos", "lang": "python3.11" }
+```
+
+The package identity and version travel in the request URL, for example
+`https://cocoindex.gateway.scarf.sh/python-1.0.0a1`.
+
+## What we don't collect
+
+CocoIndex telemetry never sends:
+
+- Your data, flow definitions, or function code.
+- Source/target connector configuration, credentials, URLs, or database names.
+- App names, component names, file paths, or any user-provided identifiers.
+- Stats about row counts, processing times, or memory usage.
+- A persistent machine or user identifier. Requests are not tagged; the gateway
+  only sees whatever an HTTP request normally carries (IP address, which Scarf
+  uses for coarse geolocation and then discards).
+
+## When telemetry is active
+
+Telemetry runs only in **release builds** of the native extension (the
+wheels published to PyPI). Local development installs via `maturin develop`
+produce a debug build and never send any events — the check is compile-time,
+so the code path doesn't exist in debug binaries.
+
+Delivery is non-blocking: each event is dispatched on a background task with a
+5-second timeout. Failures are logged at INFO level and never affect your app.
+
+## Opting out
+
+Set the `COCOINDEX_DISABLE_USAGE_TRACKING` environment variable to any non-empty
+value other than `0` before starting your program:
+
+```bash
+export COCOINDEX_DISABLE_USAGE_TRACKING=1
+```
+
+When this variable is set, CocoIndex skips all telemetry initialization — no
+events are ever constructed or dispatched.
+
+## Why we collect this
+
+Knowing which platforms and Python versions are in active use helps us prioritize
+wheel builds, platform support, and compatibility testing. If you have feedback
+about what we track, please [open an issue](https://github.com/cocoindex-io/cocoindex/issues)
+or reach out in our [Discord](https://discord.com/invite/zpA9S2DR7s).

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -105,7 +105,10 @@ export const sidebar: SidebarItem[] = [
   {
     type: 'category',
     label: 'About',
-    items: [{ type: 'doc', slug: 'about/community', label: 'Community' }],
+    items: [
+      { type: 'doc', slug: 'about/community', label: 'Community' },
+      { type: 'doc', slug: 'about/telemetry', label: 'Anonymous usage telemetry' },
+    ],
   },
 ];
 

--- a/python/cocoindex/_internal/__init__.py
+++ b/python/cocoindex/_internal/__init__.py
@@ -2,14 +2,24 @@
 Library level functions and states.
 """
 
+import sys as _sys
+import sysconfig as _sysconfig
+
 from . import core as _core
 from . import serde as _serde
 from . import typing as _typing
+from .._version import __version__ as _package_version
 from .memo_fingerprint import register_memo_key_function as _register_memo_key_function
 from .target_state import _TypedTargetHandlerWrapper as _TypedTargetHandlerWrapper
 
 
+_package_id = f"python-{_package_version}"
+_gil_suffix = "t" if _sysconfig.get_config_var("Py_GIL_DISABLED") else ""
+_lang = f"python{_sys.version_info.major}.{_sys.version_info.minor}{_gil_suffix}"
+
 _core.init_runtime(
+    package_id=_package_id,
+    lang=_lang,
     serialize_fn=_serde.serialize,
     handler_wrapper_fn=_TypedTargetHandlerWrapper,
     non_existence=_typing.NON_EXISTENCE,

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -265,6 +265,8 @@ class TargetStateProvider:
 
 def init_runtime(
     *,
+    package_id: str,
+    lang: str,
     serialize_fn: Callable[[Any], bytes],
     handler_wrapper_fn: Callable[[Any], Any],
     non_existence: Any,

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-cocoindex_utils = { path = "../utils" }
+cocoindex_utils = { path = "../utils", features = ["reqwest"] }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }
@@ -32,3 +32,4 @@ async-trait = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+axum = { workspace = true }

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -80,6 +80,7 @@ impl<Prof: EngineProfile> App<Prof> {
 
         let app_ctx = AppContext::new(env, db, app_reg, max_inflight_components);
         let root_component = Component::new(app_ctx, StablePath::root(), None);
+        crate::telemetry::track("app_create");
         Ok(Self { root_component })
     }
 }
@@ -98,6 +99,7 @@ impl<Prof: EngineProfile> App<Prof> {
         options: AppUpdateOptions,
         host_ctx: Arc<Prof::HostCtx>,
     ) -> Result<AppOpHandle<Prof::FunctionData>> {
+        crate::telemetry::track("app_update");
         let processing_stats = ProcessingStats::new();
         let version_rx = processing_stats.subscribe();
         let context = self.root_component.new_processor_context_for_build(
@@ -152,6 +154,7 @@ impl<Prof: EngineProfile> App<Prof> {
     /// Synchronous setup (cancellation, context construction) happens before the spawn.
     #[instrument(name = "app.drop", skip_all, fields(app_name = %self.app_ctx().app_reg().name()))]
     pub fn drop_app(&self, host_ctx: Arc<Prof::HostCtx>) -> Result<AppOpHandle<()>> {
+        crate::telemetry::track("app_drop");
         self.app_ctx().cancellation_token().cancel();
 
         let processing_stats = ProcessingStats::default();

--- a/rust/core/src/engine/runtime.rs
+++ b/rust/core/src/engine/runtime.rs
@@ -33,6 +33,15 @@ pub fn get_runtime() -> &'static Runtime {
     &**TOKIO_RUNTIME
 }
 
+/// Returns `true` if the global Tokio runtime has been shut down.
+///
+/// Use this as a guard before `get_runtime().spawn(...)` in background paths
+/// that may be invoked after `shutdown_runtime()` (e.g. telemetry on `drop_app`
+/// called during Python finalization) — spawning on a shut-down runtime panics.
+pub fn is_runtime_shutdown() -> bool {
+    RUNTIME_SHUTDOWN.load(Ordering::SeqCst)
+}
+
 /// Return a clone of the current global cancellation token.
 ///
 /// The returned token stays valid even if the global slot is later replaced

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -3,3 +3,4 @@ mod prelude;
 pub mod engine;
 pub mod inspect;
 pub mod state;
+pub mod telemetry;

--- a/rust/core/src/telemetry/mod.rs
+++ b/rust/core/src/telemetry/mod.rs
@@ -1,0 +1,287 @@
+//! Anonymous usage telemetry.
+//!
+//! See `specs/telemetry/design.md` for rationale. Events are POSTed to the
+//! Scarf gateway as fire-and-forget HTTP requests. Tracking is opt-out via
+//! `COCOINDEX_DISABLE_USAGE_TRACKING`, only active in release builds, and never
+//! blocks or fails user operations.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::info;
+
+use cocoindex_utils::reqwest;
+
+use crate::engine::runtime::{get_runtime, is_runtime_shutdown};
+
+const SCARF_BASE: &str = "https://cocoindex.gateway.scarf.sh";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const DISABLE_ENV: &str = "COCOINDEX_DISABLE_USAGE_TRACKING";
+
+static TELEMETRY: OnceLock<TelemetryContext> = OnceLock::new();
+
+struct TelemetryContext {
+    client: reqwest::Client,
+    base_url: String,
+    platform: String,
+    lang: String,
+}
+
+#[derive(Serialize)]
+struct EventPayload<'a> {
+    event: &'a str,
+    platform: &'a str,
+    lang: &'a str,
+}
+
+/// Initialize telemetry. No-op in debug builds, no-op if
+/// `COCOINDEX_DISABLE_USAGE_TRACKING` is set (to any value other than empty or
+/// `"0"`). Safe to call multiple times; only the first successful call
+/// installs the global context. On installation, fires the `init` event.
+///
+/// `package_id` takes the form `"{name}-{version}"`, e.g. `"python-1.0.0a1"`.
+pub fn init(package_id: String, lang: String) {
+    if cfg!(debug_assertions) {
+        return;
+    }
+    if is_disabled_by_env() {
+        return;
+    }
+    let Some(ctx) = build_context(package_id, lang) else {
+        return;
+    };
+    if TELEMETRY.set(ctx).is_err() {
+        return;
+    }
+    track("init");
+}
+
+/// Fire a telemetry event. No-op if `init` never installed a global context,
+/// or if the global Tokio runtime has been shut down. Non-blocking: spawns a
+/// background task and returns immediately.
+pub fn track(event: &'static str) {
+    if is_runtime_shutdown() {
+        return;
+    }
+    let Some(ctx) = TELEMETRY.get() else {
+        return;
+    };
+    get_runtime().spawn(async move { send_event(ctx, event).await });
+}
+
+fn build_context(package_id: String, lang: String) -> Option<TelemetryContext> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .ok()?;
+    Some(TelemetryContext {
+        client,
+        base_url: format!("{SCARF_BASE}/{package_id}"),
+        platform: current_platform(),
+        lang,
+    })
+}
+
+fn current_platform() -> String {
+    format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
+}
+
+fn is_disabled_by_env() -> bool {
+    match std::env::var(DISABLE_ENV) {
+        Ok(v) => parse_disable_value(&v),
+        Err(_) => false,
+    }
+}
+
+fn parse_disable_value(v: &str) -> bool {
+    !v.is_empty() && v != "0"
+}
+
+async fn send_event(ctx: &TelemetryContext, event: &'static str) {
+    let payload = EventPayload {
+        event,
+        platform: &ctx.platform,
+        lang: &ctx.lang,
+    };
+    let result = ctx
+        .client
+        .post(&ctx.base_url)
+        .json(&payload)
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status());
+    if let Err(err) = result {
+        info!("usage tracking event {event} failed: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    use axum::Router;
+    use axum::body::Bytes;
+    use axum::extract::State;
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::post;
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Debug)]
+    struct Recorded {
+        path: String,
+        content_type: Option<String>,
+        body: Value,
+    }
+
+    #[derive(Clone)]
+    struct MockState {
+        recorded: Arc<Mutex<Vec<Recorded>>>,
+        response_status: StatusCode,
+    }
+
+    async fn handle_any(
+        State(state): State<MockState>,
+        headers: HeaderMap,
+        axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+        body: Bytes,
+    ) -> StatusCode {
+        let content_type = headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        state.recorded.lock().unwrap().push(Recorded {
+            path: uri.path().to_string(),
+            content_type,
+            body: parsed,
+        });
+        state.response_status
+    }
+
+    async fn spawn_mock_server(
+        response_status: StatusCode,
+    ) -> (SocketAddr, Arc<Mutex<Vec<Recorded>>>) {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = MockState {
+            recorded: recorded.clone(),
+            response_status,
+        };
+        let app = Router::new()
+            .route("/{*any}", post(handle_any))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (addr, recorded)
+    }
+
+    fn make_test_ctx(base_url: String, lang: String, timeout: Duration) -> TelemetryContext {
+        TelemetryContext {
+            client: reqwest::Client::builder().timeout(timeout).build().unwrap(),
+            base_url,
+            platform: current_platform(),
+            lang,
+        }
+    }
+
+    #[tokio::test]
+    async fn send_event_posts_expected_payload() {
+        let (addr, recorded) = spawn_mock_server(StatusCode::OK).await;
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-1.0.0a1"),
+            "python3.11".to_string(),
+            Duration::from_secs(5),
+        );
+
+        send_event(&ctx, "app_create").await;
+
+        let recs = recorded.lock().unwrap().clone();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].path, "/python-1.0.0a1");
+        assert_eq!(recs[0].content_type.as_deref(), Some("application/json"));
+        let body = &recs[0].body;
+        assert_eq!(body["event"], "app_create");
+        assert_eq!(body["lang"], "python3.11");
+        assert_eq!(body["platform"], current_platform());
+    }
+
+    #[tokio::test]
+    async fn send_event_handles_non_2xx_without_panic() {
+        let (addr, recorded) = spawn_mock_server(StatusCode::INTERNAL_SERVER_ERROR).await;
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-1.0.0a1"),
+            "python3.11".to_string(),
+            Duration::from_secs(5),
+        );
+        send_event(&ctx, "app_update").await;
+        assert_eq!(recorded.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_event_handles_transport_error() {
+        // Port 1 is almost never bound; connection should fail promptly.
+        let ctx = make_test_ctx(
+            "http://127.0.0.1:1/python-1.0.0a1".to_string(),
+            "python3.11".to_string(),
+            Duration::from_millis(500),
+        );
+        send_event(&ctx, "init").await;
+    }
+
+    #[tokio::test]
+    async fn send_event_respects_timeout() {
+        // Mock server that accepts connections but never routes a response for GETs;
+        // Axum with our router returns 405 quickly for unmatched methods, so we need
+        // a raw listener that accepts and holds the socket open.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let _ = listener.accept().await;
+                // Hold the accepted socket by not dropping it; sleep forever.
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        });
+
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-1.0.0a1"),
+            "python3.11".to_string(),
+            Duration::from_millis(300),
+        );
+        let start = std::time::Instant::now();
+        send_event(&ctx, "app_update").await;
+        let elapsed = start.elapsed();
+        assert!(elapsed < Duration::from_secs(2), "elapsed = {elapsed:?}");
+    }
+
+    #[test]
+    fn parse_disable_value_matrix() {
+        assert!(!parse_disable_value(""));
+        assert!(!parse_disable_value("0"));
+        assert!(parse_disable_value("1"));
+        assert!(parse_disable_value("true"));
+        assert!(parse_disable_value("yes"));
+        assert!(parse_disable_value("anything"));
+    }
+
+    #[test]
+    fn track_noops_when_telemetry_not_initialized() {
+        // In debug builds (cargo test), TELEMETRY is never installed.
+        // This must not panic regardless of whether a mock server has been spawned.
+        track("app_create");
+    }
+
+    #[test]
+    fn init_short_circuits_in_debug_build() {
+        // Under `cargo test` we are always in debug mode.
+        init("python-1.0.0a1".to_string(), "python3.11".to_string());
+        assert!(TELEMETRY.get().is_none());
+    }
+}

--- a/rust/core/tests/telemetry_shutdown.rs
+++ b/rust/core/tests/telemetry_shutdown.rs
@@ -1,0 +1,14 @@
+//! Integration test for the post-shutdown safety guard in `track()`.
+//!
+//! Runs as its own binary so `shutdown_runtime` (which consumes the global
+//! static Tokio runtime) can be called without affecting other tests.
+
+use cocoindex_core::engine::runtime::shutdown_runtime;
+use cocoindex_core::telemetry;
+
+#[test]
+fn track_noops_after_runtime_shutdown() {
+    shutdown_runtime();
+    telemetry::track("app_drop");
+    telemetry::track("app_update");
+}

--- a/rust/py/src/runtime.rs
+++ b/rust/py/src/runtime.rs
@@ -38,6 +38,8 @@ static PY_OBJECTS: OnceLock<std::mem::ManuallyDrop<PythonObjects>> = OnceLock::n
 
 #[pyfunction]
 pub fn init_runtime(
+    package_id: String,
+    lang: String,
     serialize_fn: Py<PyAny>,
     handler_wrapper_fn: Py<PyAny>,
     non_existence: Py<PyAny>,
@@ -48,6 +50,7 @@ pub fn init_runtime(
             "Failed to initialize Tokio runtime: already initialized",
         ));
     }
+    cocoindex_core::telemetry::init(package_id, lang);
     PY_OBJECTS
         .set(std::mem::ManuallyDrop::new(PythonObjects {
             serialize_fn,

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -14,6 +14,8 @@ pub mod prelude;
 pub mod bytes_decode;
 #[cfg(feature = "reqwest")]
 pub mod http;
+#[cfg(feature = "reqwest")]
+pub use reqwest;
 #[cfg(feature = "sqlx")]
 pub mod str_sanitize;
 #[cfg(feature = "yaml")]


### PR DESCRIPTION
## Summary

- Add anonymous usage telemetry in `cocoindex_core`: fire-and-forget HTTP POSTs to `cocoindex.gateway.scarf.sh/{package_id}` for `init`, `app_create`, `app_update`, `app_drop` events with `{event, platform, lang}` payload.
- Release-build only (compile-time `cfg!(debug_assertions)` gate), opt-out via `COCOINDEX_DISABLE_USAGE_TRACKING` env var, non-blocking with 5s timeout, INFO-level logging on failure, and a post-shutdown guard so `track()` on a torn-down runtime no-ops instead of panicking.
- Add a user-facing docs page under **About → Anonymous usage telemetry** covering what's collected, what isn't, and how to opt out.

## Test plan

- CI (`cargo test`, `pytest`, `mypy` — all green locally; pre-commit hooks also ran on commit).
- 7 telemetry unit tests (payload shape against axum mock server, non-2xx handling, transport error, timeout, env-disable matrix, debug-build short-circuit, uninitialized no-op) and 1 integration test (`track_noops_after_runtime_shutdown`).
