### PR TITLE
docs(topbar): drop preview tag from v1 entries

### DIFF
--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -32,7 +32,6 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
         <div class="nav-dd-menu" role="menu">
           <a class="on" href={EXAMPLES_V1} role="menuitem">
             <span class="ver">v1</span>
-            <span class="tag">preview</span>
           </a>
           <a href={EXAMPLES_V0} role="menuitem">
             <span class="ver">v0</span>
@@ -50,7 +49,6 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
         <div class="nav-dd-menu" role="menu">
           <a class="on" href={DOCS} role="menuitem">
             <span class="ver">v1</span>
-            <span class="tag">preview</span>
           </a>
           <a href={DOCS_V0} role="menuitem">
             <span class="ver">v0</span>


### PR DESCRIPTION
## Summary
- Remove the "preview" tag from the v1 entries in the examples and docs dropdowns now that v1 is no longer a preview.

## Test plan
CI
