### PR TITLE
docs(topbar): label v0 entries as legacy

### DIFF
--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -35,7 +35,7 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
           </a>
           <a href={EXAMPLES_V0} role="menuitem">
             <span class="ver">v0</span>
-            <span class="tag legacy">stable</span>
+            <span class="tag legacy">legacy</span>
           </a>
         </div>
       </div>
@@ -52,7 +52,7 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
           </a>
           <a href={DOCS_V0} role="menuitem">
             <span class="ver">v0</span>
-            <span class="tag legacy">stable</span>
+            <span class="tag legacy">legacy</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Change the v0 topbar dropdown tag from "stable" to "legacy" in both the examples and docs menus.

## Test plan
CI
