### PR TITLE
fix(litellm): explicitly pass encoding_format="float"

### DIFF
--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -72,6 +72,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
             response = await litellm.aembedding(
                 model=self._model,
                 input=["hello"],
+                encoding_format="float",
                 **self._kwargs,
             )
             embedding = response.data[0]["embedding"]
@@ -103,6 +104,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         response = await litellm.aembedding(
             model=self._model,
             input=texts,
+            encoding_format="float",
             **kwargs,
         )
         return [


### PR DESCRIPTION
## Summary
- LiteLLM documents `encoding_format` as defaulting to `"float"`, but some providers (e.g. `nvidia_nim`) error out when it is omitted.
- Pass `encoding_format="float"` explicitly in `LiteLLMEmbedder` as a workaround.

## Test plan
CI
