### PR TITLE
fix(docs): clean up right-rail TOC rendering

### DIFF
--- a/docs/src/components/Toc.astro
+++ b/docs/src/components/Toc.astro
@@ -11,14 +11,8 @@ export interface Props {
 
 const { headings, slug } = Astro.props;
 
-// Only H2 and H3 in the right rail — deeper nesting makes noise. H2s get
-// numbered ("1 · Install") to match the design mock.
-const items = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
-let h2Count = 0;
-const rows = items.map((h) => {
-  if (h.depth === 2) h2Count++;
-  return { ...h, n: h.depth === 2 ? h2Count : null };
-});
+// Only H2 and H3 in the right rail — deeper nesting makes noise.
+const rows = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
 
 const metaMap = (docsMeta as {
   _version?: string | null;
@@ -50,7 +44,6 @@ const reviewedAgo = relativeReview(editTs);
     {rows.map((h) => (
       <li class={h.depth === 3 ? 'sub' : ''} data-toc-item>
         <a href={`#${h.slug}`} data-toc-link={h.slug}>
-          {h.n != null && <span class="n">{h.n}</span>}
           {h.text}
         </a>
       </li>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -300,7 +300,7 @@ aside.toc h6 {
 }
 aside.toc ul { list-style: none; margin: 0; padding: 0; }
 aside.toc li a {
-  display: flex; align-items: baseline; gap: 8px;
+  display: block;
   padding: 4px 10px;
   color: var(--muted); font-size: 13px;
   text-decoration: none;
@@ -309,14 +309,6 @@ aside.toc li a {
 }
 aside.toc li a:hover { color: var(--coral); text-decoration: none; }
 aside.toc li a.on { color: var(--coral); border-left-color: var(--coral); }
-aside.toc li a.on .n { color: var(--coral); }
-aside.toc li a .n {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--muted);
-  min-width: 12px;
-}
-aside.toc li a .n::after { content: ' ·'; opacity: 0.65; }
 aside.toc li.sub a { padding-left: 22px; font-size: 12.5px; }
 
 aside.toc .meta {
@@ -613,7 +605,6 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--muted);
   border-bottom-color: var(--rule-strong);
 }


### PR DESCRIPTION
## Summary
- Drop the H2 number prefix in the right-rail TOC; it added a wrapping `· ` glyph that broke onto a separate line under tight column widths.
- Switch the TOC link container from flex to block so L2 entries sit flush at the left padding, with L3 cleanly nested at 22px.
- Stop forcing `text-transform: uppercase` on `.prose th` so type names like `LiveMapSubscriber` render in their original casing.

## Test plan
- Visual check on the docs site: open `advanced_topics/live_component` and confirm the TOC renders without numbered prefixes, L2/L3 indent reads correctly, and the table headers preserve identifier casing.
