### PR TITLE
docs(topbar): phone-mode menu drawer with sidebar + on-page TOC

### DIFF
--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -1,0 +1,236 @@
+---
+// Phone-only off-canvas drawer. Two segmented tabs:
+//   - On this page : the current doc's H2/H3 headings (numbered like Toc)
+//   - Pages        : the full sidebar tree (mirrors Sidebar.astro)
+//
+// Token discipline matches design_guidelines/ui/hamburger-toc.html:
+//   · ghost-at-rest burger + star pill in the topbar
+//   · scrim + hairline border for elevation (no drop shadows)
+//   · one coral accent at a time — the active row, or the burger glyph
+//     while open. Never both.
+//
+// Scoped via `@media (max-width: 820px)` in globals.css, so desktop is
+// unaffected — the sheet sits at `display: none` until phone width.
+import type { MarkdownHeading } from 'astro';
+import { sidebar, type SidebarItem } from '../data/docs-sidebar';
+
+export interface Props {
+  /** Slug of the currently-rendered doc. Drives the `aria-current` row in the Pages tab. */
+  currentSlug: string;
+  /** Page headings (already filtered to H2/H3 by the layout, or raw — we re-filter here). */
+  headings: MarkdownHeading[];
+  /** Optional override of the sidebar tree. Defaults to docs-sidebar. */
+  sidebarItems?: SidebarItem[];
+}
+
+const { currentSlug, headings, sidebarItems = sidebar } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+// Same H2/H3 filter + numbering as Toc.astro so the phone "On this page"
+// list matches the desktop rail one-for-one.
+const tocItems = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+let h2Count = 0;
+const tocRows = tocItems.map((h) => {
+  if (h.depth === 2) h2Count++;
+  return { ...h, n: h.depth === 2 ? h2Count : null };
+});
+
+function href(slug: string): string {
+  return `${base}/${slug}`;
+}
+---
+
+<div class="mobile-scrim" id="mobileScrim" aria-hidden="true"></div>
+
+<aside
+  class="mobile-sheet"
+  id="mobileSheet"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="mobileSheetTtl"
+  hidden
+>
+  <header class="mobile-sheet-head">
+    <span class="ttl" id="mobileSheetTtl">Menu</span>
+    <button class="mobile-close" id="mobileClose" type="button" aria-label="Close menu">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <path d="M3 3l10 10M13 3L3 13"/>
+      </svg>
+    </button>
+  </header>
+
+  <div class="mobile-tabs" role="tablist" aria-label="Menu sections">
+    <button
+      id="tabPages"
+      type="button"
+      role="tab"
+      aria-selected="true"
+      aria-controls="panePages"
+    >
+      Pages
+    </button>
+    <button
+      id="tabToc"
+      type="button"
+      role="tab"
+      aria-selected="false"
+      aria-controls="paneToc"
+      disabled={tocRows.length === 0}
+    >
+      On this page
+    </button>
+  </div>
+
+  <div
+    class="mobile-pane"
+    id="paneToc"
+    role="tabpanel"
+    aria-labelledby="tabToc"
+    hidden
+  >
+    {tocRows.length === 0 ? (
+      <p class="mobile-empty">No headings on this page.</p>
+    ) : (
+      <nav class="mobile-list" aria-label="On this page">
+        {tocRows.map((h) => (
+          <a
+            href={`#${h.slug}`}
+            data-mobile-toc-link={h.slug}
+            class={h.depth === 3 ? 'sub' : ''}
+          >
+            {h.n != null && <span class="num">{h.n}</span>}
+            <span class="lbl">{h.text}</span>
+          </a>
+        ))}
+      </nav>
+    )}
+  </div>
+
+  <div
+    class="mobile-pane"
+    id="panePages"
+    role="tabpanel"
+    aria-labelledby="tabPages"
+  >
+    {sidebarItems.map((item) => (
+      item.type === 'doc' ? (
+        <div class="mobile-group">
+          <nav class="mobile-list" aria-label={item.label ?? item.slug}>
+            <a
+              href={href(item.slug)}
+              aria-current={currentSlug === item.slug ? 'page' : undefined}
+            >
+              <span class="lbl">{item.label ?? item.slug}</span>
+            </a>
+          </nav>
+        </div>
+      ) : (
+        <div class="mobile-group">
+          <h6>
+            {item.slug ? (
+              <a href={href(item.slug)}>{item.label}</a>
+            ) : (
+              <span>{item.label}</span>
+            )}
+          </h6>
+          <nav class="mobile-list" aria-label={item.label}>
+            {item.items.map((child) => (
+              child.type === 'doc' ? (
+                <a
+                  href={href(child.slug)}
+                  aria-current={currentSlug === child.slug ? 'page' : undefined}
+                >
+                  <span class="lbl">{child.label ?? child.slug}</span>
+                </a>
+              ) : null
+            ))}
+          </nav>
+        </div>
+      )
+    ))}
+  </div>
+</aside>
+
+<script>
+  // Phone drawer controller. Same logic shape as the design-system spec
+  // at design_guidelines/ui/hamburger-toc.html: open/close, tab switch,
+  // Esc, scrim-tap, body scroll-lock. The burger lives in Topbar; the
+  // sheet lives in this component; they connect by id via aria-controls.
+  (() => {
+    const burger = document.getElementById('menuBtn') as HTMLButtonElement | null;
+    const sheet  = document.getElementById('mobileSheet') as HTMLElement | null;
+    const scrim  = document.getElementById('mobileScrim') as HTMLElement | null;
+    const close  = document.getElementById('mobileClose') as HTMLButtonElement | null;
+    const tabToc   = document.getElementById('tabToc')   as HTMLButtonElement | null;
+    const tabPages = document.getElementById('tabPages') as HTMLButtonElement | null;
+    const paneToc   = document.getElementById('paneToc')   as HTMLElement | null;
+    const panePages = document.getElementById('panePages') as HTMLElement | null;
+    if (!burger || !sheet || !scrim || !close || !tabToc || !tabPages || !paneToc || !panePages) return;
+
+    const setOpen = (open: boolean) => {
+      burger.classList.toggle('open', open);
+      sheet.classList.toggle('open', open);
+      scrim.classList.toggle('open', open);
+      sheet.hidden = !open;
+      scrim.setAttribute('aria-hidden', open ? 'false' : 'true');
+      burger.setAttribute('aria-expanded', open ? 'true' : 'false');
+      burger.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+      // Prevent the page beneath from scrolling when the sheet is open;
+      // restoring `''` keeps any user-set inline overflow intact.
+      document.body.style.overflow = open ? 'hidden' : '';
+      if (open) {
+        const active = sheet.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
+        active?.focus();
+      }
+    };
+
+    const setTab = (which: 'toc' | 'pages') => {
+      const onToc = which === 'toc' && !tabToc.disabled;
+      tabToc.setAttribute('aria-selected', onToc ? 'true' : 'false');
+      tabPages.setAttribute('aria-selected', onToc ? 'false' : 'true');
+      paneToc.hidden = !onToc;
+      panePages.hidden = onToc;
+    };
+
+    burger.addEventListener('click', () => setOpen(!sheet.classList.contains('open')));
+    close .addEventListener('click', () => setOpen(false));
+    scrim .addEventListener('click', () => setOpen(false));
+
+    tabToc  .addEventListener('click', () => setTab('toc'));
+    tabPages.addEventListener('click', () => setTab('pages'));
+
+    // Arrow-key tab navigation (a11y).
+    [tabToc, tabPages].forEach((t, i, arr) => {
+      t.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const target = arr[(i + (e.key === 'ArrowRight' ? 1 : -1) + arr.length) % arr.length];
+          target.focus();
+          setTab(target === tabToc ? 'toc' : 'pages');
+        }
+      });
+    });
+
+    // Tapping a TOC link closes the sheet so the user lands on the heading
+    // without an open drawer obscuring it.
+    paneToc.addEventListener('click', (e) => {
+      const a = (e.target as HTMLElement | null)?.closest('a[data-mobile-toc-link]');
+      if (a) setOpen(false);
+    });
+
+    // Esc closes the sheet — only listen at the document level when open
+    // so we don't sit on every keystroke.
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && sheet.classList.contains('open')) setOpen(false);
+    });
+
+    // If the viewport widens past phone breakpoint while the sheet is
+    // open, close it — the desktop rails take over the same job.
+    const mq = window.matchMedia('(min-width: 821px)');
+    const onMq = (ev: MediaQueryListEvent | MediaQueryList) => {
+      if ((ev as MediaQueryList).matches) setOpen(false);
+    };
+    if (mq.addEventListener) mq.addEventListener('change', onMq as (ev: MediaQueryListEvent) => void);
+    else mq.addListener(onMq as (ev: MediaQueryListEvent) => void);
+  })();
+</script>

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -5,6 +5,16 @@
 // React + a client bundle just to render one number.
 import { SITE_MAIN, SITE_BLOG, GITHUB_REPO } from '../consts';
 
+interface Props {
+  /** When set, renders the phone hamburger and wires `aria-controls` to
+   *  the given sheet id. Layouts that ship a phone drawer (DocsLayout)
+   *  set this; pages that have no off-canvas sheet (404, listing pages)
+   *  leave it off so no orphan burger appears on phones. */
+  mobileSheetId?: string;
+}
+
+const { mobileSheetId } = Astro.props as Props;
+
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 const CODE = `${SITE_MAIN}/cocoindex-code`;
 const DOCS = base;
@@ -66,6 +76,19 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
         </svg>
         <span class="count" aria-label="GitHub stars">—</span>
       </a>
+      {mobileSheetId && (
+        <button
+          class="menu-btn"
+          id="menuBtn"
+          type="button"
+          aria-label="Open menu"
+          aria-expanded="false"
+          aria-controls={mobileSheetId}
+          data-mobile-toggle={mobileSheetId}
+        >
+          <span class="bar"></span>
+        </button>
+      )}
     </div>
   </div>
 </nav>

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -4,6 +4,7 @@ import type { MarkdownHeading } from 'astro';
 import Topbar from '../components/Topbar.astro';
 import Sidebar from '../components/Sidebar.astro';
 import Toc from '../components/Toc.astro';
+import MobileSheet from '../components/MobileSheet.astro';
 import { SITE_URL, titleMarkup, DOCS_EDIT_BASE } from '../consts';
 import { flatten, sidebar, type SidebarItem } from '../data/docs-sidebar';
 import docsMeta from '../data/docs-meta.json';
@@ -113,7 +114,8 @@ const next = i >= 0 && i < flat.length - 1 ? flat[i + 1] : null;
     />
   </head>
   <body>
-    <Topbar />
+    <Topbar mobileSheetId="mobileSheet" />
+    <MobileSheet currentSlug={slug} headings={headings} />
 
     <div class="layout">
       <Sidebar currentSlug={slug} />

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -235,6 +235,200 @@ nav.top {
   font-variant-numeric: tabular-nums;
 }
 
+/* ─── phone hamburger ───
+   Hidden on desktop; phone-mode rules quiet both this and `.stars` so
+   the topbar doesn't read as three competing controls (logo + stars +
+   burger). See @media (max-width: 820px) below for the ghost treatment. */
+.menu-btn {
+  display: none; /* desktop default; flipped on at phone width */
+  width: 32px; height: 32px; flex: none;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  align-items: center; justify-content: center;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+  transition: background .16s ease, border-color .16s ease, color .16s ease;
+}
+.menu-btn:hover {
+  border-color: var(--rule);
+  background: color-mix(in oklab, var(--peach) 10%, transparent);
+  color: var(--maroon-ink);
+}
+.menu-btn:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+.menu-btn .bar,
+.menu-btn::before,
+.menu-btn::after {
+  content: "";
+  position: absolute; left: 8px; right: 8px;
+  height: 1.4px; border-radius: 1px;
+  background: currentColor;
+  transition: transform .22s cubic-bezier(.2,.8,.2,1), opacity .14s ease, top .22s cubic-bezier(.2,.8,.2,1);
+}
+.menu-btn::before { top: 10px; }
+.menu-btn .bar    { top: 15px; }
+.menu-btn::after  { top: 20px; }
+.menu-btn.open {
+  color: var(--coral);
+  border-color: var(--rule);
+  background: color-mix(in oklab, var(--peach) 10%, transparent);
+}
+.menu-btn.open::before { top: 15px; transform: rotate(45deg); }
+.menu-btn.open::after  { top: 15px; transform: rotate(-45deg); }
+.menu-btn.open .bar    { opacity: 0; }
+
+/* ─── phone drawer (scrim + sheet + tabs + lists) ───
+   Lives at `display: none` on desktop and only materializes at phone
+   width. Tokens mirror design_guidelines/ui/hamburger-toc.html: no drop
+   shadow (elevation reads from the maroon scrim), one coral accent at a
+   time, animation ≤ 220ms. */
+.mobile-scrim,
+.mobile-sheet { display: none; }
+.mobile-scrim {
+  position: fixed; inset: 0;
+  background: color-mix(in oklab, var(--maroon-ink) 38%, transparent);
+  opacity: 0; pointer-events: none;
+  transition: opacity .22s ease;
+  z-index: 60;
+}
+.mobile-scrim.open { opacity: 1; pointer-events: auto; }
+
+.mobile-sheet {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: min(86%, 360px);
+  background: var(--paper);
+  border-left: 1px solid var(--rule-strong);
+  transform: translateX(100%);
+  transition: transform .22s cubic-bezier(.2,.8,.2,1);
+  flex-direction: column;
+  z-index: 70;
+  overflow: hidden;
+}
+.mobile-sheet.open { transform: translateX(0); }
+.mobile-sheet[hidden] { display: none !important; }
+
+.mobile-sheet-head {
+  display: flex; align-items: center; gap: 10px;
+  /* y-padding mirrors `.nav-in`'s phone-mode 10px so the sheet's
+     border-bottom lines up exactly with the topbar's, even though the
+     sheet sits in its own stacking context. With a 32px close button
+     this resolves to 52px content + 1px rule = 53px total height,
+     identical to the topbar at ≤820px. */
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--rule);
+  flex: none;
+}
+.mobile-sheet-head .ttl {
+  font-family: var(--mono); font-weight: 500;
+  font-size: 11px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+  flex: 1;
+}
+.mobile-close {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid transparent; background: transparent;
+  color: var(--muted);
+  display: grid; place-items: center;
+  cursor: pointer; padding: 0;
+  transition: color .16s ease, border-color .16s ease, background .16s ease;
+}
+.mobile-close:hover {
+  color: var(--coral);
+  border-color: var(--rule);
+  background: color-mix(in oklab, var(--peach) 10%, transparent);
+}
+.mobile-close:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+
+.mobile-tabs {
+  display: grid; grid-template-columns: 1fr 1fr;
+  margin: 12px 14px 0;
+  padding: 3px;
+  background: color-mix(in oklab, var(--maroon-ink) 6%, var(--cream));
+  border-radius: 10px;
+  flex: none;
+}
+.mobile-tabs button {
+  appearance: none;
+  border: none; background: transparent; cursor: pointer;
+  padding: 8px 10px;
+  font-family: var(--sans); font-weight: 500;
+  font-size: 13px; letter-spacing: -0.005em;
+  color: var(--maroon-ink); opacity: .7;
+  border-radius: 7px;
+  transition: opacity .16s ease, color .16s ease, background .16s ease;
+}
+.mobile-tabs button[aria-selected="true"] {
+  opacity: 1; color: var(--maroon-ink);
+  background: var(--paper);
+  box-shadow: inset 0 0 0 1px var(--rule);
+}
+.mobile-tabs button[disabled] { opacity: .35; cursor: not-allowed; }
+.mobile-tabs button:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+
+.mobile-pane {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 6px 24px;
+  -webkit-overflow-scrolling: touch;
+}
+.mobile-pane[hidden] { display: none; }
+.mobile-empty {
+  margin: 16px 14px; color: var(--muted);
+  font-size: 13.5px; line-height: 1.55;
+}
+
+.mobile-group { margin: 0 8px 14px; }
+.mobile-group h6 {
+  margin: 14px 8px 6px;
+  font-family: var(--mono); font-weight: 500;
+  font-size: 10px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+}
+.mobile-group h6 a { color: inherit; text-decoration: none; }
+.mobile-group h6 a:hover { color: var(--coral); }
+
+.mobile-list { display: flex; flex-direction: column; }
+.mobile-list a {
+  display: flex; align-items: center; gap: 10px;
+  min-height: 44px;
+  padding: 10px 10px;
+  border-radius: 8px;
+  font-family: var(--sans); font-weight: 500;
+  font-size: 14px; letter-spacing: -0.005em;
+  color: var(--maroon-ink); text-decoration: none;
+  transition: background .14s ease, color .14s ease;
+}
+.mobile-list a:hover { background: color-mix(in oklab, var(--coral) 8%, transparent); color: var(--maroon-ink); }
+.mobile-list a[aria-current] {
+  background: color-mix(in oklab, var(--coral) 14%, transparent);
+  color: var(--coral);
+}
+.mobile-list a .num {
+  width: 22px; height: 22px; border-radius: 5px;
+  flex: none; display: grid; place-items: center;
+  font-family: var(--mono); font-size: 10px; font-weight: 500;
+  background: color-mix(in oklab, var(--maroon-ink) 6%, transparent);
+  color: var(--maroon-ink);
+  font-variant-numeric: tabular-nums;
+}
+.mobile-list a[aria-current] .num { background: var(--coral); color: var(--cream); }
+.mobile-list a.sub {
+  padding-left: 36px; min-height: 38px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.mobile-list a.sub:hover { color: var(--maroon-ink); }
+.mobile-list .lbl { flex: 1; min-width: 0; line-height: 1.3; }
+
+@media (prefers-reduced-motion: reduce) {
+  .menu-btn::before, .menu-btn::after, .menu-btn .bar,
+  .mobile-sheet, .mobile-scrim {
+    transition: none !important;
+  }
+}
+
 /* ─── layout ─── */
 .layout {
   display: grid;
@@ -679,4 +873,34 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
   aside.side { display: none; }
   main.content { padding: 32px 24px 64px; }
   .nav-links { display: none; }
+
+  /* Topbar tightens up: less side padding, smaller gap, and the .stars
+     pill loses its cream fill + heavy border. At rest the star is just
+     a glyph + count in muted-ink; the pill chrome only fades in on
+     hover or focus. The burger is the rightmost element and shares the
+     same ghost discipline (see .menu-btn above). */
+  .nav-in { padding: 10px 18px; gap: 12px; }
+  .nav-cta { gap: 4px; }
+  .stars {
+    height: 28px; padding: 0 8px;
+    border-color: transparent;
+    background: transparent;
+    color: var(--muted);
+    min-width: 0;
+    font-size: 11px;
+  }
+  .stars:hover {
+    border-color: var(--rule);
+    background: color-mix(in oklab, var(--peach) 10%, transparent);
+    color: var(--coral);
+  }
+  .stars svg { width: 12px; height: 12px; opacity: .85; }
+  .stars:hover svg { opacity: 1; }
+  .stars .count { width: auto; min-width: 3ch; }
+
+  .menu-btn { display: inline-flex; }
+
+  /* Sheet + scrim only exist on phones. */
+  .mobile-scrim { display: block; }
+  .mobile-sheet { display: flex; }
 }


### PR DESCRIPTION
## Summary

- Adds a ghosted hamburger to the docs topbar that opens a right-anchored sheet on phone widths (≤820px), with two segmented tabs:
  - **Pages** (default) — the full sidebar tree, active doc highlighted
  - **On this page** — the doc's H2/H3 headings, numbered/indented to match the desktop TOC rail
- Quietens both the new burger and the existing GitHub `.stars` pill at rest on phones (transparent border + bg, muted color); pill chrome only fades in on hover/focus/open. Stops the topbar reading as three competing controls.
- Aligns the sheet header's bottom rule with the topbar's by matching y-padding and control sizes (53px each at phone width).
- Sheet behavior mirrors the internal design spec at [design_guidelines/ui/hamburger-toc.html](https://github.com/cocoindex-io/cocoindex-io.github.io/blob/main/design_guidelines/ui/hamburger-toc.html): scrim-tap dismiss, Esc-to-close, body scroll-lock, arrow-key tab nav, auto-close when the viewport widens past 820px.

Desktop is untouched — the burger sits at \`display: none\` and the sheet/scrim never mount above phone width.

## Files

- \`docs/src/components/Topbar.astro\` — optional \`mobileSheetId\` prop; renders the hamburger only when set.
- \`docs/src/components/MobileSheet.astro\` *(new)* — sheet markup + controller.
- \`docs/src/layouts/DocsLayout.astro\` — passes \`mobileSheetId=\"mobileSheet\"\` and renders the sheet once per page.
- \`docs/src/styles/globals.css\` — ghost styles for \`.menu-btn\`/\`.stars\` at phone width, full sheet/scrim/tab styles, reduced-motion fallback.

## Test plan

- [ ] Resize the docs site to ≤820px (or DevTools mobile preview): hamburger appears, star pill goes ghost, no chrome fights for attention at rest.
- [ ] Tap the hamburger → sheet slides in, scrim dims the page, body stops scrolling.
- [ ] Default tab is **Pages**; sidebar tree renders with the current doc highlighted in coral.
- [ ] Switch to **On this page**; H2 numbers + H3 indents match the desktop TOC.
- [ ] Tap a TOC link → sheet closes, page scrolls to the heading.
- [ ] Esc closes the sheet; scrim-tap closes the sheet; resizing past 820px closes the sheet.
- [ ] Pages with no headings: **On this page** tab is disabled and the drawer opens directly to Pages.
- [ ] Desktop ≥821px: no hamburger, no sheet markup visible, existing nav-links + .stars pill render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)