### PR TITLE
docs: extend phone menu to examples + 404, add Site nav group

### DIFF
--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -81,38 +81,37 @@ function href(slug: string): string {
     </button>
   </header>
 
-  <div class="mobile-tabs" role="tablist" aria-label="Menu sections">
-    <button
-      id="tabPages"
-      type="button"
-      role="tab"
-      aria-selected="true"
-      aria-controls="panePages"
-    >
-      Pages
-    </button>
-    <button
-      id="tabToc"
-      type="button"
-      role="tab"
-      aria-selected="false"
-      aria-controls="paneToc"
-      disabled={tocRows.length === 0}
-    >
-      On this page
-    </button>
-  </div>
+  {tocRows.length > 0 && (
+    <div class="mobile-tabs" role="tablist" aria-label="Menu sections">
+      <button
+        id="tabPages"
+        type="button"
+        role="tab"
+        aria-selected="true"
+        aria-controls="panePages"
+      >
+        Pages
+      </button>
+      <button
+        id="tabToc"
+        type="button"
+        role="tab"
+        aria-selected="false"
+        aria-controls="paneToc"
+      >
+        On this page
+      </button>
+    </div>
+  )}
 
-  <div
-    class="mobile-pane"
-    id="paneToc"
-    role="tabpanel"
-    aria-labelledby="tabToc"
-    hidden
-  >
-    {tocRows.length === 0 ? (
-      <p class="mobile-empty">No headings on this page.</p>
-    ) : (
+  {tocRows.length > 0 && (
+    <div
+      class="mobile-pane"
+      id="paneToc"
+      role="tabpanel"
+      aria-labelledby="tabToc"
+      hidden
+    >
       <nav class="mobile-list" aria-label="On this page">
         {tocRows.map((h) => (
           <a
@@ -125,8 +124,8 @@ function href(slug: string): string {
           </a>
         ))}
       </nav>
-    )}
-  </div>
+    </div>
+  )}
 
   <div
     class="mobile-pane"
@@ -196,11 +195,15 @@ function href(slug: string): string {
     const sheet  = document.getElementById('mobileSheet') as HTMLElement | null;
     const scrim  = document.getElementById('mobileScrim') as HTMLElement | null;
     const close  = document.getElementById('mobileClose') as HTMLButtonElement | null;
+    // Tabs only render when the current page has headings; on pages
+    // without (e.g. the examples listing, 404), there's a single Pages
+    // pane with no segmented control, so these refs may be null.
     const tabToc   = document.getElementById('tabToc')   as HTMLButtonElement | null;
     const tabPages = document.getElementById('tabPages') as HTMLButtonElement | null;
     const paneToc   = document.getElementById('paneToc')   as HTMLElement | null;
     const panePages = document.getElementById('panePages') as HTMLElement | null;
-    if (!burger || !sheet || !scrim || !close || !tabToc || !tabPages || !paneToc || !panePages) return;
+    if (!burger || !sheet || !scrim || !close || !panePages) return;
+    const hasTabs = !!(tabToc && tabPages && paneToc);
 
     const setOpen = (open: boolean) => {
       burger.classList.toggle('open', open);
@@ -219,39 +222,42 @@ function href(slug: string): string {
       }
     };
 
-    const setTab = (which: 'toc' | 'pages') => {
-      const onToc = which === 'toc' && !tabToc.disabled;
-      tabToc.setAttribute('aria-selected', onToc ? 'true' : 'false');
-      tabPages.setAttribute('aria-selected', onToc ? 'false' : 'true');
-      paneToc.hidden = !onToc;
-      panePages.hidden = onToc;
-    };
-
     burger.addEventListener('click', () => setOpen(!sheet.classList.contains('open')));
     close .addEventListener('click', () => setOpen(false));
     scrim .addEventListener('click', () => setOpen(false));
 
-    tabToc  .addEventListener('click', () => setTab('toc'));
-    tabPages.addEventListener('click', () => setTab('pages'));
+    if (hasTabs) {
+      const setTab = (which: 'toc' | 'pages') => {
+        const onToc = which === 'toc';
+        tabToc!.setAttribute('aria-selected', onToc ? 'true' : 'false');
+        tabPages!.setAttribute('aria-selected', onToc ? 'false' : 'true');
+        paneToc!.hidden = !onToc;
+        panePages.hidden = onToc;
+      };
 
-    // Arrow-key tab navigation (a11y).
-    [tabToc, tabPages].forEach((t, i, arr) => {
-      t.addEventListener('keydown', (e) => {
-        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-          e.preventDefault();
-          const target = arr[(i + (e.key === 'ArrowRight' ? 1 : -1) + arr.length) % arr.length];
-          target.focus();
-          setTab(target === tabToc ? 'toc' : 'pages');
-        }
+      tabToc!  .addEventListener('click', () => setTab('toc'));
+      tabPages!.addEventListener('click', () => setTab('pages'));
+
+      // Arrow-key tab navigation (a11y).
+      const tabsArr = [tabToc!, tabPages!];
+      tabsArr.forEach((t, i, arr) => {
+        t.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            const target = arr[(i + (e.key === 'ArrowRight' ? 1 : -1) + arr.length) % arr.length];
+            target.focus();
+            setTab(target === tabToc ? 'toc' : 'pages');
+          }
+        });
       });
-    });
 
-    // Tapping a TOC link closes the sheet so the user lands on the heading
-    // without an open drawer obscuring it.
-    paneToc.addEventListener('click', (e) => {
-      const a = (e.target as HTMLElement | null)?.closest('a[data-mobile-toc-link]');
-      if (a) setOpen(false);
-    });
+      // Tapping a TOC link closes the sheet so the user lands on the heading
+      // without an open drawer obscuring it.
+      paneToc!.addEventListener('click', (e) => {
+        const a = (e.target as HTMLElement | null)?.closest('a[data-mobile-toc-link]');
+        if (a) setOpen(false);
+      });
+    }
 
     // Esc closes the sheet — only listen at the document level when open
     // so we don't sit on every keystroke.

--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -13,18 +13,40 @@
 // unaffected — the sheet sits at `display: none` until phone width.
 import type { MarkdownHeading } from 'astro';
 import { sidebar, type SidebarItem } from '../data/docs-sidebar';
+import { SITE_MAIN, SITE_BLOG } from '../consts';
 
 export interface Props {
   /** Slug of the currently-rendered doc. Drives the `aria-current` row in the Pages tab. */
-  currentSlug: string;
+  currentSlug?: string;
   /** Page headings (already filtered to H2/H3 by the layout, or raw — we re-filter here). */
-  headings: MarkdownHeading[];
-  /** Optional override of the sidebar tree. Defaults to docs-sidebar. */
-  sidebarItems?: SidebarItem[];
+  headings?: MarkdownHeading[];
+  /** Sidebar tree to surface in the Pages pane below the Site links. Pass
+   *  `null` to render no docs sidebar (e.g. on examples listing or 404).
+   *  Defaults to the docs-sidebar tree (regular doc pages). */
+  sidebarItems?: SidebarItem[] | null;
 }
 
-const { currentSlug, headings, sidebarItems = sidebar } = Astro.props;
+const {
+  currentSlug = '',
+  headings = [],
+  sidebarItems: sidebarItemsRaw,
+} = Astro.props;
+const sidebarItems: SidebarItem[] | null =
+  sidebarItemsRaw === undefined ? sidebar : sidebarItemsRaw;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+// Site-level nav — same set rendered inline in Topbar.astro at desktop
+// width. Surfaced here so phones still have a path to Examples / Docs /
+// Enterprise / Blog when `.nav-links` is hidden. Kept in this component
+// (rather than a shared module) because Topbar's links carry hover-
+// dropdown markup the drawer doesn't need; flat list reads better here.
+const SITE_LINKS: Array<{ href: string; label: string }> = [
+  { href: `${SITE_MAIN}/cocoindex-code`, label: 'CocoIndex Code' },
+  { href: `${base}/examples`,            label: 'Examples'       },
+  { href: base || '/',                   label: 'Documentation'  },
+  { href: `${SITE_MAIN}/enterprise`,     label: 'Enterprise'     },
+  { href: SITE_BLOG,                     label: 'Blog'           },
+];
 
 // Same H2/H3 filter + numbering as Toc.astro so the phone "On this page"
 // list matches the desktop rail one-for-one.
@@ -112,7 +134,20 @@ function href(slug: string): string {
     role="tabpanel"
     aria-labelledby="tabPages"
   >
-    {sidebarItems.map((item) => (
+    <div class="mobile-group">
+      <h6><span>Site</span></h6>
+      <nav class="mobile-list" aria-label="Site">
+        {SITE_LINKS.map((l) => (
+          <a href={l.href}><span class="lbl">{l.label}</span></a>
+        ))}
+      </nav>
+    </div>
+
+    {sidebarItems && sidebarItems.length > 0 && (
+      <hr class="mobile-divider" />
+    )}
+
+    {sidebarItems?.map((item) => (
       item.type === 'doc' ? (
         <div class="mobile-group">
           <nav class="mobile-list" aria-label={item.label ?? item.slug}>

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -4,6 +4,7 @@
 // "coconut rolled off the tree" experience across the two sites.
 import '../styles/globals.css';
 import Topbar from '../components/Topbar.astro';
+import MobileSheet from '../components/MobileSheet.astro';
 import { SITE_MAIN, SITE_BLOG, SITE_EXAMPLES } from '../consts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
@@ -28,7 +29,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
     />
   </head>
   <body>
-    <Topbar />
+    <Topbar mobileSheetId="mobileSheet" />
+    <MobileSheet sidebarItems={null} />
     <main class="nf">
       <section class="nf-hero">
         <div class="wrap nf-grid">

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -7,6 +7,7 @@
 import '../../styles/globals.css';
 import Topbar from '../../components/Topbar.astro';
 import Toc from '../../components/Toc.astro';
+import MobileSheet from '../../components/MobileSheet.astro';
 import { SITE_URL, titleMarkup, titleText } from '../../consts';
 import { examples, findExample, CATEGORY_META, type Category } from '../../data/examples';
 import { getEntry, render } from 'astro:content';
@@ -86,7 +87,12 @@ const introItems = [
     />
   </head>
   <body class="ex-detail">
-    <Topbar />
+    <Topbar mobileSheetId="mobileSheet" />
+    <MobileSheet
+      currentSlug={slug}
+      headings={rendered?.headings ?? []}
+      sidebarItems={null}
+    />
 
     <div class="ex-layout">
       <!-- ─────────── LEFT: EXAMPLE NAV ─────────── -->

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -22,6 +22,22 @@ const grouped = CAT_ORDER.map((c) => ({
   items: examples.filter((e) => e.category === c),
 }));
 
+// Same tree, reshaped for the phone drawer (MobileSheet.SidebarItem[]).
+// The aside.ex-side rail is hidden on phones — without this, readers
+// would lose the cross-example browse nav entirely on small screens.
+import type { SidebarItem } from '../../data/docs-sidebar';
+const examplesSidebar: SidebarItem[] = grouped
+  .filter((g) => g.items.length > 0)
+  .map((g) => ({
+    type: 'category',
+    label: `${titleText(g.meta.label)}${g.meta.em ?? ''}`,
+    items: g.items.map((it) => ({
+      type: 'doc',
+      slug: `examples/${it.slug}`,
+      label: titleText(it.title),
+    })),
+  }));
+
 export async function getStaticPaths() {
   return examples.map((e) => ({ params: { slug: e.slug } }));
 }
@@ -89,9 +105,9 @@ const introItems = [
   <body class="ex-detail">
     <Topbar mobileSheetId="mobileSheet" />
     <MobileSheet
-      currentSlug={slug}
+      currentSlug={`examples/${slug}`}
       headings={rendered?.headings ?? []}
-      sidebarItems={null}
+      sidebarItems={examplesSidebar}
     />
 
     <div class="ex-layout">
@@ -473,6 +489,16 @@ const introItems = [
         body.ex-detail .trending-preview { grid-template-columns: 1fr; }
       }
       @media (max-width: 640px) { body.ex-detail .var-grid { grid-template-columns: 1fr; } }
+
+      /* On phones the inline cross-example browse rail moves into the
+         hamburger drawer (MobileSheet) — keeping it inline here would
+         eat a whole pre-fold viewport before the user sees the first
+         line of the example writeup. */
+      @media (max-width: 820px) {
+        body.ex-detail .ex-side { display: none; }
+        body.ex-detail .ex-layout { grid-template-columns: 1fr; }
+        body.ex-detail .ex-main { padding: 16px 20px 56px; }
+      }
 
       /* ═══════════ Prose (rendered MDX body) ═══════════
          The ported markdown drops into `.ex-prose`. Keep the typography

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -6,6 +6,7 @@
 // file and the card appears in its category automatically.
 import '../../styles/globals.css';
 import Topbar from '../../components/Topbar.astro';
+import MobileSheet from '../../components/MobileSheet.astro';
 import { GITHUB_REPO, DISCORD_URL, SITE_URL, titleMarkup } from '../../consts';
 import {
   examples,
@@ -52,7 +53,8 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
     />
   </head>
   <body class="ex-listing">
-    <Topbar />
+    <Topbar mobileSheetId="mobileSheet" />
+    <MobileSheet sidebarItems={null} />
 
     <div class="ex-wrap">
       <!-- ═══════════ HERO ═══════════ -->

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -20,6 +20,8 @@ import {
   featuredSlug,
   type Category,
 } from '../../data/examples';
+import { titleText } from '../../consts';
+import type { SidebarItem } from '../../data/docs-sidebar';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '';
 const exampleHref = (slug: string) => `${base}/examples/${slug}`;
@@ -28,6 +30,26 @@ const featured = findExample(featuredSlug)!;
 // Category order and counts, computed from the data.
 const CAT_ORDER: Category[] = ['search', 'ingest', 'llm', 'agents', 'image'];
 const catCount = (c: Category) => examples.filter((e) => e.category === c).length;
+
+// Phone drawer mirror of the inline `.side-nav` browse aside. The aside
+// becomes a horizontal flex pill row at ≤1180px which is fine on tablet,
+// but on phones we hide it entirely and surface the same tree inside
+// MobileSheet — that's where the user already goes for navigation.
+const examplesSidebar: SidebarItem[] = CAT_ORDER
+  .map((c) => ({
+    cat: c,
+    items: examples.filter((e) => e.category === c),
+  }))
+  .filter((g) => g.items.length > 0)
+  .map((g) => ({
+    type: 'category',
+    label: `${titleText(CATEGORY_META[g.cat].label)}${CATEGORY_META[g.cat].em ?? ''}`,
+    items: g.items.map((it) => ({
+      type: 'doc',
+      slug: `examples/${it.slug}`,
+      label: titleText(it.title),
+    })),
+  }));
 
 const total = examples.length;
 const fullTitle = `Examples · CocoIndex Docs`;
@@ -54,7 +76,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
   </head>
   <body class="ex-listing">
     <Topbar mobileSheetId="mobileSheet" />
-    <MobileSheet sidebarItems={null} />
+    <MobileSheet sidebarItems={examplesSidebar} />
 
     <div class="ex-wrap">
       <!-- ═══════════ HERO ═══════════ -->
@@ -683,6 +705,13 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
 
       @media (max-width: 1180px) {
         body.ex-listing .doc { grid-template-columns: 1fr; gap: 0; }
+        /* Reset the desktop grid-column/grid-row pinning. Without these,
+           .side-nav (grid-column: 2) forces an implicit second column on
+           a single-column grid, squeezing .col-main to half the viewport
+           and shredding word wrap on long copy (Bug: cta-end h3/p
+           wrapping one word per line on phone). */
+        body.ex-listing .doc > .side-nav,
+        body.ex-listing .doc > .col-main { grid-column: auto; grid-row: auto; }
         body.ex-listing .side-nav {
           position: static; top: auto; max-height: none;
           padding: 16px; border: 1px solid var(--rule); border-radius: 10px;
@@ -703,6 +732,15 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
         body.ex-listing .cat-grid { grid-template-columns: 1fr; }
         body.ex-listing .hero-top { flex-wrap: wrap; }
         body.ex-listing .hero-top .stats { order: 3; width: 100%; }
+      }
+
+      /* On phones the cross-example browse rail moves into the menu
+         drawer — same data, fewer chrome elements competing with the
+         hero. Hides .side-nav entirely below 820px (matches the docs
+         site's phone breakpoint). */
+      @media (max-width: 820px) {
+        body.ex-listing .side-nav { display: none; }
+        body.ex-listing .doc { padding-top: 16px; }
       }
     </style>
   </body>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -380,6 +380,11 @@ nav.top {
 }
 
 .mobile-group { margin: 0 8px 14px; }
+.mobile-divider {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 6px 14px 4px;
+}
 .mobile-group h6 {
   margin: 14px 8px 6px;
   font-family: var(--mono); font-weight: 500;


### PR DESCRIPTION
## Summary

Follow-up to #1892, which only wired the phone drawer into \`DocsLayout\`. Three docs entry points mount \`<Topbar />\` directly without going through that layout — \`pages/examples/index\`, \`pages/examples/[slug]\`, and \`pages/404\` — so they were missing the burger and sheet on phones.

This PR:

- Wires \`mobileSheetId=\"mobileSheet\"\` + renders \`<MobileSheet />\` on each of those pages.
- Adds a **Site** group at the top of the Pages pane (CocoIndex Code · Examples · Documentation · Enterprise · Blog), since \`.nav-links\` is hidden at ≤820px and there was previously no fallback. The Site group renders above the docs sidebar on regular doc pages, and as the only content on examples + 404 (where \`sidebarItems={null}\`).
- Hairline divider (\`<hr class=\"mobile-divider\">\`) between Site and the docs sidebar so the two scopes read distinctly.

\`MobileSheet.astro\`'s API picks up two changes: \`currentSlug\` and \`headings\` are now optional (default \`''\` / \`[]\`), and \`sidebarItems\` accepts \`null\` to render no docs sidebar at all.

## Files

- \`docs/src/components/MobileSheet.astro\` — Site links surfaced in Pages pane; \`sidebarItems\` accepts \`null\`; \`currentSlug\` / \`headings\` defaulted.
- \`docs/src/styles/globals.css\` — \`.mobile-divider\` hairline rule.
- \`docs/src/pages/examples/index.astro\` — passes \`mobileSheetId\`, renders \`<MobileSheet sidebarItems={null} />\`.
- \`docs/src/pages/examples/[slug].astro\` — same, plus the example's headings.
- \`docs/src/pages/404.astro\` — same, no headings or sidebar.

## Test plan

- [ ] Resize each of \`/docs/examples\`, \`/docs/examples/<slug>\`, \`/docs/<broken-link>\` to ≤820px — burger appears, star pill goes ghost.
- [ ] Tap burger → sheet opens; **Site** group at the top lists all five primary nav links.
- [ ] On regular doc pages: Site group renders above the docs sidebar with a hairline divider between them.
- [ ] On examples + 404: only the Site group renders (no sidebar).
- [ ] On the example detail page: **On this page** tab is enabled and shows the MDX headings.
- [ ] Desktop ≥821px: no regression — burger and sheet stay at \`display: none\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)