### PR TITLE
docs(search): re-add Algolia DocSearch at top of sidebar + drawer

### DIFF
--- a/.github/workflows/_docs_release.yml
+++ b/.github/workflows/_docs_release.yml
@@ -28,13 +28,14 @@ jobs:
       - name: Build docs site
         env:
           # Re-exported from the Docusaurus era (commit b8e0eda removed
-          # them when the docs migrated to Astro). PUBLIC_ prefix lets
-          # Astro inline them into the static client bundle so the
-          # DocSearch widget at the top of the sidebar works on the
-          # deployed site. The Algolia "search-only API key" is public
-          # by design — the index is read-only with that key.
-          PUBLIC_COCOINDEX_DOCS_ALGOLIA_APP_ID:  ${{ vars.COCOINDEX_DOCS_ALGOLIA_APP_ID }}
-          PUBLIC_COCOINDEX_DOCS_ALGOLIA_API_KEY: ${{ vars.COCOINDEX_DOCS_ALGOLIA_API_KEY }}
+          # them when the docs migrated to Astro). Names match the
+          # original config so the existing GitHub Actions vars keep
+          # working; Search.astro reads them in frontmatter and inlines
+          # the values into the client bundle via `define:vars`. The
+          # Algolia "search-only API key" is public by design — the
+          # index is read-only with that key.
+          COCOINDEX_DOCS_ALGOLIA_APP_ID:  ${{ vars.COCOINDEX_DOCS_ALGOLIA_APP_ID }}
+          COCOINDEX_DOCS_ALGOLIA_API_KEY: ${{ vars.COCOINDEX_DOCS_ALGOLIA_API_KEY }}
         run: npm --prefix docs run build
       - name: Deploy to cocoindex-io/docs gh-pages
         env:

--- a/.github/workflows/_docs_release.yml
+++ b/.github/workflows/_docs_release.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Install dependencies
         run: npm --prefix docs ci
       - name: Build docs site
+        env:
+          # Re-exported from the Docusaurus era (commit b8e0eda removed
+          # them when the docs migrated to Astro). PUBLIC_ prefix lets
+          # Astro inline them into the static client bundle so the
+          # DocSearch widget at the top of the sidebar works on the
+          # deployed site. The Algolia "search-only API key" is public
+          # by design — the index is read-only with that key.
+          PUBLIC_COCOINDEX_DOCS_ALGOLIA_APP_ID:  ${{ vars.COCOINDEX_DOCS_ALGOLIA_APP_ID }}
+          PUBLIC_COCOINDEX_DOCS_ALGOLIA_API_KEY: ${{ vars.COCOINDEX_DOCS_ALGOLIA_API_KEY }}
         run: npm --prefix docs run build
       - name: Deploy to cocoindex-io/docs gh-pages
         env:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -81,4 +81,13 @@ export default defineConfig({
     shikiConfig: { theme: cocoindexCodeTheme, wrap: false },
   },
   redirects,
+  // Vite's default envPrefix is `VITE_`; Astro adds `PUBLIC_`. We also
+  // want unprefixed `COCOINDEX_DOCS_ALGOLIA_*` names exposed to
+  // import.meta.env in `.astro` frontmatter — those come from the
+  // GitHub Actions vars (see .github/workflows/_docs_release.yml) and
+  // are matched by the same names in docs/.env locally. The Algolia
+  // search-only API key is public by design; it's safe to inline.
+  vite: {
+    envPrefix: ['VITE_', 'PUBLIC_', 'COCOINDEX_'],
+  },
 });

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
+        "@docsearch/css": "^4.6.2",
+        "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
         "mdast-util-to-string": "^4.0.0",
         "remark-directive": "^4.0.0",
@@ -214,6 +216,18 @@
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
+      "integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.6.2.tgz",
+      "integrity": "sha512-qj1yoxl3y4GKoK7+VM6fq/rQqPnvUmg3IKzJ9x0VzN14QVzdB/SG/J6VfV1BWT5RcPUFxIcVwoY1fwHM2fSRRw==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
+    "@docsearch/css": "^4.6.2",
+    "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",
     "mdast-util-to-string": "^4.0.0",
     "remark-directive": "^4.0.0",

--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -14,6 +14,7 @@
 import type { MarkdownHeading } from 'astro';
 import { sidebar, type SidebarItem } from '../data/docs-sidebar';
 import { SITE_MAIN, SITE_BLOG } from '../consts';
+import Search from './Search.astro';
 
 export interface Props {
   /** Slug of the currently-rendered doc. Drives the `aria-current` row in the Pages tab. */
@@ -80,6 +81,10 @@ function href(slug: string): string {
       </svg>
     </button>
   </header>
+
+  <div class="mobile-search">
+    <Search />
+  </div>
 
   {tocRows.length > 0 && (
     <div class="mobile-tabs" role="tablist" aria-label="Menu sections">

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -10,17 +10,17 @@
 // import dynamically inside a client `<script>` so the search bundle
 // loads only when the page actually carries the integration.
 
-const APP_ID    = (import.meta.env.PUBLIC_COCOINDEX_DOCS_ALGOLIA_APP_ID
-                 ?? import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID
-                 ?? '') as string;
-const API_KEY   = (import.meta.env.PUBLIC_COCOINDEX_DOCS_ALGOLIA_API_KEY
-                 ?? import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY
-                 ?? '') as string;
-const INDEX     = 'cocoindex';
-// `enabled` lets us short-circuit on local builds where the keys aren't
-// set — the button still renders, but it links to GitHub search instead
-// of trying to mount a broken DocSearch modal.
-const enabled = APP_ID.length > 0 && API_KEY.length > 0;
+// Same env var names as the Docusaurus era (commit b8e0eda removed
+// these along with the integration). Visible to `import.meta.env`
+// because astro.config.mjs adds `COCOINDEX_` to vite.envPrefix.
+// Values inline into the client `<script>` below via `define:vars`.
+// The Algolia "search-only API key" is public by design — the
+// index is read-only with that key.
+const APP_ID  = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID  ?? '') as string;
+const API_KEY = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY ?? '') as string;
+// Keep in sync with the crawler config — v1 docs use `cocoindex_v1`
+// (PR #1551 renamed it from `cocoindex`).
+const INDEX   = 'cocoindex_v1';
 ---
 
 <div class="search-wrap">
@@ -29,7 +29,6 @@ const enabled = APP_ID.length > 0 && API_KEY.length > 0;
     type="button"
     data-search-btn
     aria-label="Search documentation"
-    data-enabled={enabled ? 'true' : 'false'}
   >
     <svg class="ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <circle cx="11" cy="11" r="7"></circle>
@@ -40,60 +39,114 @@ const enabled = APP_ID.length > 0 && API_KEY.length > 0;
   </button>
 </div>
 
-{enabled && (
-  <script define:vars={{ APP_ID, API_KEY, INDEX }}>
-    // Component can mount more than once per page (e.g. sidebar +
-    // mobile drawer), so we install one set of listeners + one
-    // DocSearch instance per document. Both buttons forward to the
-    // same hidden host trigger.
-    if (!window.__docsSearchInit) {
-      window.__docsSearchInit = true;
+<!--
+  Two scripts here, on purpose:
 
-      let bootP = null;
-      const boot = () => {
-        if (bootP) return bootP;
-        bootP = Promise.all([
-          import('@docsearch/js'),
-          import('@docsearch/css'),
-        ]).then(([{ default: docsearch }]) => {
-          let host = document.getElementById('docsSearchHost');
-          if (!host) {
-            host = document.createElement('div');
-            host.id = 'docsSearchHost';
-            host.style.display = 'none';
-            document.body.appendChild(host);
-          }
-          docsearch({
-            appId: APP_ID,
-            apiKey: API_KEY,
-            indexName: INDEX,
-            container: '#docsSearchHost',
-            searchParameters: { facetFilters: [] },
-          });
-          return host.querySelector('.DocSearch-Button');
-        });
-        return bootP;
-      };
+  1. The first one is `is:inline` + `define:vars` — that combination
+     emits the values directly into the rendered HTML so they survive
+     to the browser. It just stamps `window.__COCOINDEX_DOCSEARCH__`
+     and exits.
+  2. The second one is a plain `<script>` block. Astro routes plain
+     scripts through Vite, which means bare module specifiers like
+     `@docsearch/js` resolve correctly. (A `define:vars` script is
+     treated as inline and skips Vite — that's why the earlier version
+     hit `Failed to resolve module specifier '@docsearch/js'`.) Astro
+     also dedupes plain scripts across the page, so a Search rendered
+     in both the sidebar and the mobile drawer still registers exactly
+     one click handler.
+-->
+<script is:inline define:vars={{ APP_ID, API_KEY, INDEX }}>
+  window.__COCOINDEX_DOCSEARCH__ = { APP_ID, API_KEY, INDEX };
+</script>
 
-      // Delegate clicks across all `[data-search-btn]` instances —
-      // event delegation also covers buttons added later (e.g. when
-      // a layout re-renders).
-      document.addEventListener('click', (e) => {
-        const btn = e.target?.closest?.('[data-search-btn]');
-        if (!btn) return;
-        boot().then((real) => { real?.click(); });
-      });
+<script>
+  import docsearch from '@docsearch/js';
+  import '@docsearch/css';
 
-      // Keyboard shortcut — `/` or Cmd/Ctrl+K outside form inputs.
-      document.addEventListener('keydown', (e) => {
-        const tag = document.activeElement?.tagName ?? '';
-        const inField = /(input|textarea|select)/i.test(tag);
-        const isShortcut = (e.key === '/' && !inField)
-                        || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k');
-        if (!isShortcut) return;
-        e.preventDefault();
-        boot().then((real) => { real?.click(); });
-      });
+  type DocSearchConfig = { APP_ID: string; API_KEY: string; INDEX: string };
+
+  declare global {
+    interface Window {
+      __COCOINDEX_DOCSEARCH__?: DocSearchConfig;
+      __docsSearchInit?: boolean;
     }
-  </script>
-)}
+  }
+
+  if (!window.__docsSearchInit) {
+    window.__docsSearchInit = true;
+
+    const cfg = window.__COCOINDEX_DOCSEARCH__ ?? { APP_ID: '', API_KEY: '', INDEX: '' };
+    const hasKeys = !!cfg.APP_ID && !!cfg.API_KEY;
+
+    // Find DocSearch's own button inside our hidden host. DocSearch
+    // renders synchronously after init(), but a requestAnimationFrame
+    // retry covers any future async-render change.
+    const fireDocSearch = (host: HTMLElement) => {
+      const tryClick = (tries: number) => {
+        const btn = host.querySelector<HTMLElement>('.DocSearch-Button');
+        if (btn) { btn.click(); return; }
+        if (tries <= 0) {
+          console.warn('[CocoIndex docs] DocSearch button not found after init.');
+          return;
+        }
+        requestAnimationFrame(() => tryClick(tries - 1));
+      };
+      tryClick(8);
+    };
+
+    let bootP: Promise<HTMLElement | null> | null = null;
+    const boot = (): Promise<HTMLElement | null> => {
+      if (!hasKeys) {
+        console.warn(
+          '[CocoIndex docs] Algolia search disabled — set ' +
+          'COCOINDEX_DOCS_ALGOLIA_APP_ID and ' +
+          'COCOINDEX_DOCS_ALGOLIA_API_KEY in docs/.env to enable.',
+        );
+        return Promise.resolve(null);
+      }
+      if (bootP) return bootP;
+      bootP = Promise.resolve().then(() => {
+        let host = document.getElementById('docsSearchHost');
+        if (!host) {
+          host = document.createElement('div');
+          host.id = 'docsSearchHost';
+          // Off-screen instead of `display: none` so DocSearch's button
+          // still registers layout/clicks.
+          host.style.cssText = 'position:absolute;left:-9999px;top:0;width:1px;height:1px;overflow:hidden;';
+          document.body.appendChild(host);
+        }
+        docsearch({
+          appId: cfg.APP_ID,
+          apiKey: cfg.API_KEY,
+          indexName: cfg.INDEX,
+          container: host,
+        });
+        return host;
+      }).catch((err: unknown) => {
+        console.error('[CocoIndex docs] DocSearch failed to load:', err);
+        return null;
+      });
+      return bootP;
+    };
+
+    // Delegated click — covers buttons added by re-rendered layouts.
+    document.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement | null;
+      const btn = target?.closest?.('[data-search-btn]');
+      if (!btn) return;
+      boot().then((host) => { if (host) fireDocSearch(host); });
+    });
+
+    // Pre-warm on idle so the first click feels instant. DocSearch's
+    // own listeners (Cmd+K, /) only register after this runs.
+    if (hasKeys) {
+      const pre = () => { boot(); };
+      if ('requestIdleCallback' in window) {
+        (window as Window & { requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => void })
+          .requestIdleCallback(pre, { timeout: 1500 });
+      } else {
+        setTimeout(pre, 600);
+      }
+    }
+  }
+</script>

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -1,0 +1,99 @@
+---
+// Algolia DocSearch — top-of-sidebar search box that opens the standard
+// DocSearch modal on click or `/` / Cmd+K. Mirrors the Docusaurus-era
+// integration removed in commit b8e0eda; same env vars and indexName
+// (`cocoindex`) so the existing crawler config keeps working.
+//
+// The button itself is rendered server-side and styled to match the
+// design system (cream background, hairline border, mono caps row);
+// the modal markup + listeners come from `@docsearch/js`, which we
+// import dynamically inside a client `<script>` so the search bundle
+// loads only when the page actually carries the integration.
+
+const APP_ID    = (import.meta.env.PUBLIC_COCOINDEX_DOCS_ALGOLIA_APP_ID
+                 ?? import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID
+                 ?? '') as string;
+const API_KEY   = (import.meta.env.PUBLIC_COCOINDEX_DOCS_ALGOLIA_API_KEY
+                 ?? import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY
+                 ?? '') as string;
+const INDEX     = 'cocoindex';
+// `enabled` lets us short-circuit on local builds where the keys aren't
+// set — the button still renders, but it links to GitHub search instead
+// of trying to mount a broken DocSearch modal.
+const enabled = APP_ID.length > 0 && API_KEY.length > 0;
+---
+
+<div class="search-wrap">
+  <button
+    class="search-btn"
+    type="button"
+    data-search-btn
+    aria-label="Search documentation"
+    data-enabled={enabled ? 'true' : 'false'}
+  >
+    <svg class="ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="7"></circle>
+      <path d="m20 20-3.5-3.5"></path>
+    </svg>
+    <span class="lbl">Search docs</span>
+    <kbd class="kbd"><span class="cmd">⌘</span>K</kbd>
+  </button>
+</div>
+
+{enabled && (
+  <script define:vars={{ APP_ID, API_KEY, INDEX }}>
+    // Component can mount more than once per page (e.g. sidebar +
+    // mobile drawer), so we install one set of listeners + one
+    // DocSearch instance per document. Both buttons forward to the
+    // same hidden host trigger.
+    if (!window.__docsSearchInit) {
+      window.__docsSearchInit = true;
+
+      let bootP = null;
+      const boot = () => {
+        if (bootP) return bootP;
+        bootP = Promise.all([
+          import('@docsearch/js'),
+          import('@docsearch/css'),
+        ]).then(([{ default: docsearch }]) => {
+          let host = document.getElementById('docsSearchHost');
+          if (!host) {
+            host = document.createElement('div');
+            host.id = 'docsSearchHost';
+            host.style.display = 'none';
+            document.body.appendChild(host);
+          }
+          docsearch({
+            appId: APP_ID,
+            apiKey: API_KEY,
+            indexName: INDEX,
+            container: '#docsSearchHost',
+            searchParameters: { facetFilters: [] },
+          });
+          return host.querySelector('.DocSearch-Button');
+        });
+        return bootP;
+      };
+
+      // Delegate clicks across all `[data-search-btn]` instances —
+      // event delegation also covers buttons added later (e.g. when
+      // a layout re-renders).
+      document.addEventListener('click', (e) => {
+        const btn = e.target?.closest?.('[data-search-btn]');
+        if (!btn) return;
+        boot().then((real) => { real?.click(); });
+      });
+
+      // Keyboard shortcut — `/` or Cmd/Ctrl+K outside form inputs.
+      document.addEventListener('keydown', (e) => {
+        const tag = document.activeElement?.tagName ?? '';
+        const inField = /(input|textarea|select)/i.test(tag);
+        const isShortcut = (e.key === '/' && !inField)
+                        || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k');
+        if (!isShortcut) return;
+        e.preventDefault();
+        boot().then((real) => { real?.click(); });
+      });
+    }
+  </script>
+)}

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -1,5 +1,6 @@
 ---
 import { sidebar, type SidebarItem } from '../data/docs-sidebar';
+import Search from './Search.astro';
 
 export interface Props {
   /** Slug of the currently-rendered doc, e.g. `getting_started/quickstart`. */
@@ -15,6 +16,7 @@ function href(slug: string): string {
 ---
 
 <aside class="side">
+  <Search />
   {sidebar.map((item) => (
     item.type === 'doc' ? (
       <div class="side-group">

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -461,6 +461,77 @@ main.content {
   min-width: 0;
 }
 
+/* ─── sidebar search ───
+   Sits at the top of `aside.side`. The button is rendered server-side
+   and styled to match the docs design tokens (cream fill, hairline
+   border, mono caps row). The actual DocSearch modal is mounted lazily
+   on first interaction by Search.astro — see that file for the env
+   var wiring (PUBLIC_COCOINDEX_DOCS_ALGOLIA_*). */
+.search-wrap {
+  position: sticky; top: 0;
+  background: linear-gradient(var(--paper) 80%, transparent);
+  padding: 0 0 14px;
+  margin-bottom: 6px;
+  z-index: 5;
+}
+.search-btn {
+  width: 100%;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--rule-strong);
+  background: var(--cream);
+  color: var(--maroon-ink);
+  font-family: var(--sans); font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  transition: border-color .15s ease, background .15s ease, color .15s ease;
+}
+.search-btn:hover {
+  border-color: var(--coral);
+  color: var(--coral);
+  background: color-mix(in oklab, var(--peach) 10%, var(--cream));
+}
+.search-btn:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+.search-btn .ic { flex: none; opacity: .8; }
+.search-btn:hover .ic { opacity: 1; }
+.search-btn .lbl { flex: 1; text-align: left; }
+.search-btn .kbd {
+  font-family: var(--mono); font-size: 10px; font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: var(--paper);
+  display: inline-flex; align-items: center; gap: 2px;
+}
+.search-btn .kbd .cmd { font-size: 11px; line-height: 1; }
+
+/* DocSearch theme — map @docsearch/css variables to our brand tokens
+   so the modal feels native instead of dropping a foreign blue UI on
+   top of the docs. Only the vars we actually need are overridden;
+   defaults from the package fill the rest. */
+:root {
+  --docsearch-primary-color: var(--coral);
+  --docsearch-text-color: var(--maroon-ink);
+  --docsearch-muted-color: var(--muted);
+  --docsearch-container-background: rgba(42, 18, 27, 0.55);
+  --docsearch-modal-background: var(--paper);
+  --docsearch-searchbox-background: var(--cream);
+  --docsearch-searchbox-focus-background: var(--paper);
+  --docsearch-hit-color: var(--maroon-ink);
+  --docsearch-hit-active-color: var(--cream);
+  --docsearch-hit-background: var(--cream);
+  --docsearch-highlight-color: var(--coral);
+  --docsearch-key-gradient: var(--cream);
+  --docsearch-key-shadow: none;
+  --docsearch-footer-background: var(--cream);
+  --docsearch-modal-shadow: none;
+  --docsearch-searchbox-shadow: inset 0 0 0 2px var(--coral);
+  --docsearch-spacing: 12px;
+  --docsearch-icon-color: var(--muted);
+}
+
 /* ─── sidebar ─── */
 .side-group { margin-bottom: 22px; }
 .side-group > h5 {

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -507,29 +507,234 @@ main.content {
 }
 .search-btn .kbd .cmd { font-size: 11px; line-height: 1; }
 
-/* DocSearch theme — map @docsearch/css variables to our brand tokens
-   so the modal feels native instead of dropping a foreign blue UI on
-   top of the docs. Only the vars we actually need are overridden;
-   defaults from the package fill the rest. */
-:root {
-  --docsearch-primary-color: var(--coral);
-  --docsearch-text-color: var(--maroon-ink);
-  --docsearch-muted-color: var(--muted);
-  --docsearch-container-background: rgba(42, 18, 27, 0.55);
+/* ─── DocSearch theme ───
+   Maps every @docsearch/css v4 variable to the CocoIndex design
+   tokens — cream surfaces, coral accent, maroon ink, hairline rules,
+   no drop shadows (elevation reads from the maroon-ink scrim, not
+   from blur — matches the rest of the site).
+
+   Scope note: @docsearch/css ships its own `:root { --docsearch-*: ... }`
+   defaults and is imported AFTER globals.css (because Search.astro's
+   bundled `<script>` does the import). A `:root` override here would
+   lose the cascade fight for unset descendants. Scoping under
+   `.DocSearch-Container` (the modal backdrop) wins by ancestor
+   proximity instead — every modal element resolves variables from
+   the closest ancestor, which is now this rule. */
+.DocSearch-Container {
+  /* — rhythm + radii — */
+  --docsearch-spacing: 12px;
+  --docsearch-border-radius: 10px;
+  --docsearch-icon-stroke-width: 1.6;
+
+  /* — modal frame — */
+  --docsearch-modal-width: 720px;
+  --docsearch-modal-height: 600px;
   --docsearch-modal-background: var(--paper);
+  --docsearch-modal-shadow: none;
+  /* No scrim — page behind stays its natural color. The hairline
+     border on `.DocSearch-Modal` is enough to delineate the panel. */
+  --docsearch-container-background: transparent;
+
+  /* — palette (replaces every default Algolia-blue) — */
+  --docsearch-primary-color: var(--coral);
+  --docsearch-soft-primary-color: color-mix(in oklab, var(--coral) 12%, transparent);
+  --docsearch-focus-color: var(--coral);
+  --docsearch-text-color: var(--maroon-ink);
+  --docsearch-secondary-text-color: var(--muted);
+  --docsearch-muted-color: var(--muted);
+  --docsearch-muted-color-darker: var(--maroon);
+  --docsearch-subtle-color: var(--rule);
+  --docsearch-icon-color: var(--muted);
+  --docsearch-logo-color: var(--coral);
+  --docsearch-error-color: var(--berry);
+  --docsearch-success-color: var(--palm-ink);
+  --docsearch-background-color: var(--paper);
+
+  /* — searchbox (top of modal) — */
+  --docsearch-searchbox-height: 56px;
+  --docsearch-searchbox-initial-height: 44px;
   --docsearch-searchbox-background: var(--cream);
   --docsearch-searchbox-focus-background: var(--paper);
+
+  /* — hits (results list) —
+     `--docsearch-hit-highlight-color` paints the ACTIVE-row background,
+     not the matched-text color (despite the name). Keep it as a soft
+     coral wash so the active row reads as "highlighted but quiet"; the
+     hover state below escalates to a full coral fill. */
+  --docsearch-hit-height: 56px;
   --docsearch-hit-color: var(--maroon-ink);
-  --docsearch-hit-active-color: var(--cream);
+  --docsearch-hit-active-color: var(--maroon-ink);
   --docsearch-hit-background: var(--cream);
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-highlight-color: color-mix(in oklab, var(--coral) 14%, var(--cream));
   --docsearch-highlight-color: var(--coral);
-  --docsearch-key-gradient: var(--cream);
-  --docsearch-key-shadow: none;
+  --docsearch-dropdown-menu-background: var(--paper);
+  --docsearch-dropdown-menu-item-hover-background: color-mix(in oklab, var(--coral) 8%, transparent);
+
+  /* — keyboard hints (⌘K, esc, ↩) — */
+  --docsearch-key-background: var(--cream);
+  --docsearch-key-color: var(--maroon-ink);
+  --docsearch-key-pressed-shadow: none;
+
+  /* — footer — */
+  --docsearch-footer-height: 44px;
   --docsearch-footer-background: var(--cream);
-  --docsearch-modal-shadow: none;
-  --docsearch-searchbox-shadow: inset 0 0 0 2px var(--coral);
-  --docsearch-spacing: 12px;
-  --docsearch-icon-color: var(--muted);
+  --docsearch-footer-shadow: inset 0 1px 0 var(--rule);
+
+  /* — search-button (package's own trigger; we hide it but theme
+       it anyway so any fallback render stays brand-consistent) — */
+  --docsearch-search-button-background: var(--cream);
+  --docsearch-search-button-text-color: var(--maroon-ink);
+
+  /* — actions (close X, submit) — */
+  --docsearch-actions-width: 28px;
+  --docsearch-actions-height: 28px;
+}
+
+/* Class-level tweaks for the bits variables can't reach. */
+.DocSearch-Container {
+  /* Drop the package's default 4px blur — paired with the now-
+     transparent scrim, the blur was the only thing softening the
+     page behind. Remove it so the docs read sharply through the
+     unobscured backdrop. */
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+.DocSearch-Modal {
+  border: 1px solid var(--rule-strong);
+}
+/* Searchbox — a quiet cream pill at rest, slightly darker rule on
+   focus. Earlier version used a coral inset ring, which read as
+   alarmist on top of the cream surface — the focus state should
+   confirm "you can type now", not flag a problem. */
+.DocSearch-Form {
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  box-shadow: none;
+  background: var(--cream);
+}
+.DocSearch-Form:focus-within {
+  border-color: var(--rule-strong);
+  box-shadow: none;
+  background: var(--paper);
+}
+.DocSearch-MagnifierLabel,
+.DocSearch-MagnifierLabel svg,
+.DocSearch-Search-Icon,
+.DocSearch-Back-Icon { color: var(--coral) !important; }
+.DocSearch-Input {
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--maroon-ink);
+}
+.DocSearch-Input::placeholder { color: var(--muted); }
+.DocSearch-Cancel,
+.DocSearch-Clear {
+  color: var(--coral) !important;
+  font-family: var(--sans);
+}
+.DocSearch-Hit-source {
+  font-family: var(--mono); font-weight: 500;
+  font-size: 11px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted) !important;
+  background: var(--paper);
+  padding: 14px 4px 6px;
+}
+.DocSearch-Hit a {
+  border-radius: 8px;
+  border: 1px solid var(--rule);
+  background: transparent !important;
+  transition: background-image .18s ease, border-color .18s ease;
+}
+/* Active (keyboard-selected) row — soft coral wash so the row still
+   stands out from a plain hover, even with no fill at rest. */
+.DocSearch-Hit[aria-selected="true"] a {
+  background: color-mix(in oklab, var(--coral) 12%, transparent) !important;
+  border-color: var(--coral);
+}
+/* Hover — standard dotted pattern shared with `.var-card` on examples
+   detail pages and the `.arch-core` radial fill. No fill, just the
+   maroon-ink dot grid stippled over the modal surface. */
+.DocSearch-Hit a:hover {
+  background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px);
+  background-size: 14px 14px;
+  border-color: var(--coral);
+}
+.DocSearch-Hit-title { font-family: var(--sans); font-weight: 500; }
+.DocSearch-Hit-path  { font-family: var(--mono); font-size: 11px; }
+.DocSearch-Hit-icon  { color: var(--muted); }
+.DocSearch-Hit mark {
+  background: transparent;
+  color: var(--coral) !important;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--coral);
+  font-weight: 600;
+}
+
+/* Action chrome — close X, return ↩, dropdown arrows. Default uses
+   `--docsearch-highlight-color` which we want for matched text, not
+   for icon chrome; force coral here for visual consistency. */
+.DocSearch-Action,
+.DocSearch-Action svg,
+.DocSearch-AskAi-Return,
+.DocSearch-Hit-Select-Icon { color: var(--coral) !important; }
+.DocSearch-Action:hover,
+.DocSearch-AskAi-Return:hover {
+  background: color-mix(in oklab, var(--coral) 10%, transparent) !important;
+}
+
+/* Keyboard chips — match the topbar `.kbd` style: cream pill, mono
+   caps, hairline border, no shadow. */
+.DocSearch-Commands-Key,
+.DocSearch-Button-Key {
+  font-family: var(--mono);
+  font-weight: 500; font-size: 11px;
+  border: 1px solid var(--rule) !important;
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: var(--cream) !important;
+  color: var(--maroon-ink) !important;
+  box-shadow: none !important;
+}
+
+/* Footer — hairline rule + mono caps, matches the doc-foot strip. */
+.DocSearch-Footer {
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.06em; color: var(--muted);
+}
+.DocSearch-Commands { color: var(--muted); }
+/* The Algolia logo SVG is multi-path — the "i" stem has a hardcoded
+   accent fill on its own path that ignores `currentColor`. Force fill
+   on every descendant so the whole wordmark renders in a single coral
+   tone. */
+.DocSearch-Logo svg,
+.DocSearch-Logo svg *,
+.DocSearch-Logo svg g,
+.DocSearch-Logo svg path,
+.DocSearch-Logo svg rect,
+.DocSearch-Logo svg use {
+  fill: var(--coral) !important;
+  color: var(--coral) !important;
+}
+.DocSearch-Logo a { color: var(--muted); }
+
+/* No-results — italic-coral serif headline, matching the design system
+   "italic-coral H1" treatment used across the site. */
+.DocSearch-NoResults .DocSearch-Title {
+  font-family: var(--serif); font-style: italic;
+  font-weight: 400; color: var(--maroon-ink);
+}
+.DocSearch-NoResults .DocSearch-Title strong { color: var(--coral); }
+
+/* Tighten letter-spacing where we landed on tabular-mono columns. */
+.DocSearch-Title,
+.DocSearch-Hit-source,
+.DocSearch-NoResults-Prefill-List ul li {
+  letter-spacing: -0.005em;
 }
 
 /* ─── sidebar ─── */


### PR DESCRIPTION
## Summary

The Docusaurus → Astro migration ([commit b8e0eda](https://github.com/cocoindex-io/cocoindex/commit/b8e0eda926f8fa26abf7853d2296ba6af8e898cf)) dropped the Algolia integration along with the \`COCOINDEX_DOCS_ALGOLIA_{APP_ID,API_KEY}\` env exports in the deploy workflow. This wires it back up against the existing \`cocoindex\` index (the crawler config keeps working untouched).

### What you'll see

- **Top of the left sidebar** — a styled \"Search docs\" button with a ⌘K hint, sitting above the page tree. Click or hit \`/\` / \`Cmd+K\` to open the DocSearch modal. Sticky so it stays visible while the tree scrolls.
- **Inside the phone menu drawer** — same button mounted under the sheet header so phone readers get the same affordance.
- **DocSearch modal** — themed against the brand palette (cream surfaces, coral accent, maroon ink) instead of dropping a foreign blue UI on top.

### Implementation

- New \`Search.astro\` — server-rendered button (cream pill, hairline border, mono \`⌘K\` kbd hint). The \`@docsearch/js\` bundle + CSS are dynamically imported on first interaction, keeping the search payload off the critical path.
- One delegated click listener + one DocSearch instance per page handles both buttons (sidebar and drawer share via \`[data-search-btn]\`).
- \`_docs_release.yml\` re-exports the Algolia vars during the build step with the \`PUBLIC_\` prefix Astro needs to inline them into the static client bundle. The Algolia \"search-only API key\" is public by design — the index is read-only with that key.

### Files

- \`docs/package.json\` + \`package-lock.json\` — adds \`@docsearch/js\` and \`@docsearch/css\` (^4.6).
- \`docs/src/components/Search.astro\` *(new)*.
- \`docs/src/components/Sidebar.astro\` — mounts \`<Search />\` at the top.
- \`docs/src/components/MobileSheet.astro\` — mounts \`<Search />\` below the sheet header.
- \`docs/src/styles/globals.css\` — \`.search-wrap\` / \`.search-btn\` rules + DocSearch CSS-var theme overrides.
- \`.github/workflows/_docs_release.yml\` — re-adds env vars during build.

## Test plan

- [ ] Set \`vars.COCOINDEX_DOCS_ALGOLIA_APP_ID\` + \`vars.COCOINDEX_DOCS_ALGOLIA_API_KEY\` in the GitHub Actions \`docs-release\` environment (they were defined for the old deploy; verify they still hold the right values).
- [ ] Trigger a docs deploy and confirm the search button at the top of \`https://cocoindex.io/docs/\` opens the DocSearch modal with hits from the \`cocoindex\` index.
- [ ] Test ⌘K and \`/\` shortcuts; verify they don't fire while typing in form fields.
- [ ] On phone width: open the burger; the search button sits at the top of the drawer; tapping it opens the DocSearch modal over the drawer.
- [ ] Local dev (\`npm --prefix docs run dev\`) without env vars set: button still renders, click is a no-op (the \`<script>\` block isn't emitted when keys are missing). Acceptable fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)