### PR TITLE
search bar visual

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -593,12 +593,11 @@ main.content {
 
 /* Class-level tweaks for the bits variables can't reach. */
 .DocSearch-Container {
-  /* Drop the package's default 4px blur — paired with the now-
-     transparent scrim, the blur was the only thing softening the
-     page behind. Remove it so the docs read sharply through the
-     unobscured backdrop. */
-  -webkit-backdrop-filter: none !important;
-  backdrop-filter: none !important;
+  /* Backdrop blur without the maroon scrim — keeps the page colors
+     visible (no dim wash) but defocuses content so the modal is the
+     unambiguous foreground. Tune `blur(8px)` higher to soften more. */
+  -webkit-backdrop-filter: blur(8px) !important;
+  backdrop-filter: blur(8px) !important;
 }
 .DocSearch-Modal {
   border: 1px solid var(--rule-strong);


### PR DESCRIPTION
## Summary

Restores the backdrop blur on the DocSearch modal — earlier visual sweep (#1894) dropped both the maroon-ink scrim *and* the package's 4px backdrop blur, leaving the page sharp behind the modal. With the scrim staying transparent (per design preference: no dim wash on the page), the blur is what tells the eye the modal is foreground.

This PR puts the blur back at 8px (sharper than the package default of 4) while keeping the scrim transparent. Page colors stay true, content defocuses, modal pops.

## Files

- \`docs/src/styles/globals.css\` — \`.DocSearch-Container\` switches \`-webkit-backdrop-filter\` / \`backdrop-filter\` from \`none\` back to \`blur(8px)\` with \`!important\` so the package's own \`:root\` value doesn't beat us.

## Test plan

- [ ] Open \`/docs/getting_started/quickstart\`, hit ⌘K → modal appears, page behind is blurred but not darkened or color-shifted.
- [ ] Esc → blur clears instantly.
- [ ] Safari + Chrome both render the blur (the \`-webkit-\` prefix covers older Safari).

🤖 Generated with [Claude Code](https://claude.com/claude-code)