### PR TITLE
Revert "search bar visual (#1895)"

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -593,11 +593,12 @@ main.content {
 
 /* Class-level tweaks for the bits variables can't reach. */
 .DocSearch-Container {
-  /* Backdrop blur without the maroon scrim — keeps the page colors
-     visible (no dim wash) but defocuses content so the modal is the
-     unambiguous foreground. Tune `blur(8px)` higher to soften more. */
-  -webkit-backdrop-filter: blur(8px) !important;
-  backdrop-filter: blur(8px) !important;
+  /* Drop the package's default 4px blur — paired with the now-
+     transparent scrim, the blur was the only thing softening the
+     page behind. Remove it so the docs read sharply through the
+     unobscured backdrop. */
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
 }
 .DocSearch-Modal {
   border: 1px solid var(--rule-strong);


### PR DESCRIPTION
Reverts #1895. Restores the no-blur backdrop behind the DocSearch modal.