### PR TITLE
docs(search): drop searchbox border to fix double-rule at modal top

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -602,20 +602,22 @@ main.content {
 .DocSearch-Modal {
   border: 1px solid var(--rule-strong);
 }
-/* Searchbox — a quiet cream pill at rest, slightly darker rule on
-   focus. Earlier version used a coral inset ring, which read as
-   alarmist on top of the cream surface — the focus state should
-   confirm "you can type now", not flag a problem. */
+/* Searchbox — sits flush against the modal frame, so giving it its
+   own border stacks against `.DocSearch-Modal`'s border at the top
+   corners and reads as a double rule. Drop the form's border entirely
+   and let only the cream/paper fill differentiate the input from the
+   results pane. The package's default `border-block-end: 1px solid
+   var(--docsearch-subtle-color)` already separates the form from the
+   first hit underneath. */
 .DocSearch-Form {
-  border: 1px solid var(--rule);
-  border-radius: 8px;
+  border: none;
+  border-radius: 0;
   box-shadow: none;
   background: var(--cream);
 }
 .DocSearch-Form:focus-within {
-  border-color: var(--rule-strong);
-  box-shadow: none;
   background: var(--paper);
+  box-shadow: none;
 }
 .DocSearch-MagnifierLabel,
 .DocSearch-MagnifierLabel svg,


### PR DESCRIPTION
## Summary

The DocSearch modal carried two stacked 1px borders at the top — one on \`.DocSearch-Modal\` (the outer panel) and one on \`.DocSearch-Form\` (the searchbox at the very top of the panel). Where they met at the top corners, they rendered as a visible double rule.

This drops the form's border entirely. The searchbox is still clearly differentiated from the results pane below it via:

- Cream → paper background swap on \`:focus-within\` (rest vs typing).
- The package's own \`border-block-end: 1px solid var(--docsearch-subtle-color)\` separator between the form and the first hit underneath.

The modal's outer hairline (\`.DocSearch-Modal\` border) still defines the panel against the backdrop blur.

## Files

- \`docs/src/styles/globals.css\` — \`.DocSearch-Form\` loses \`border\` + \`border-radius\`; \`:focus-within\` loses the inset coral box-shadow it was carrying. Comment block updated to explain why.

## Test plan

- [ ] \`/docs/getting_started/quickstart\` → ⌘K → modal opens with a single hairline around the panel; no double rule along the top edge of the searchbox.
- [ ] Click into the search input — fill swaps from cream to paper, no flickering border on focus.
- [ ] Esc / scrim-tap closes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)