### PR TITLE
docs(search): point Algolia search at the cocoindex index

### DIFF
--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -18,9 +18,9 @@
 // index is read-only with that key.
 const APP_ID  = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID  ?? '') as string;
 const API_KEY = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY ?? '') as string;
-// Keep in sync with the crawler config — v1 docs use `cocoindex_v1`
+// Keep in sync with the crawler config
 // (PR #1551 renamed it from `cocoindex`).
-const INDEX   = 'cocoindex_v1';
+const INDEX   = 'cocoindex';
 ---
 
 <div class="search-wrap">


### PR DESCRIPTION
## Summary
- Point the docs search widget at the `cocoindex` Algolia index again. The `cocoindex_v1` index introduced in PR #1551 is no longer the live target; the crawler now writes back to `cocoindex`.

## Test plan
- Open the docs site, hit the search shortcut, and confirm queries return results.
