### PR TITLE
fix(core): propagate cancellation through spawn boundaries

### DIFF
--- a/python/tests/core/test_cancellation.py
+++ b/python/tests/core/test_cancellation.py
@@ -1,0 +1,125 @@
+"""Tests for the cancellation pipeline (see specs/core/cancellation.md).
+
+Verifies that `_core.cancel_all()` (the same call the CLI's SIGINT handler
+makes) propagates from the global token through the AppContext token, into
+the per-component spawned tasks, and ultimately reaches Python coroutines
+via CancelOnDropPy.
+
+The live-component variant lives alongside other live-component tests in
+test_live_component.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import cocoindex as coco
+
+from tests import common
+
+coco_env = common.create_test_env(__file__)
+
+
+@pytest.mark.asyncio
+async def test_non_live_global_cancel_terminates_update() -> None:
+    """Global cancellation must reach a non-live component's Python coroutine.
+
+    Regression test for the case where Component::run / run_in_background
+    spawned detached tokio tasks that did not watch any cancellation token,
+    so dropping the outer App::update future left the spawned task running
+    and the Python `process()` coroutine never received CancelledError.
+    """
+    from cocoindex._internal import core as _core
+
+    started = asyncio.Event()
+    cancelled_in_python = asyncio.Event()
+
+    async def _blocking_main() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()  # block forever
+        except asyncio.CancelledError:
+            cancelled_in_python.set()
+            raise
+
+    _core.reset_global_cancellation()
+    app = coco.App(
+        coco.AppConfig(
+            name="test_non_live_global_cancel_terminates", environment=coco_env
+        ),
+        _blocking_main,
+    )
+    handle = app.update()
+    result_task = asyncio.create_task(handle.result())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        _core.cancel_all()  # simulates SIGINT handler in cli.py
+
+        # Wait for cancellation to actually reach Python. The outer App::update
+        # task may return Err immediately when the app token fires, but the
+        # inner spawned task that drops the work future and triggers
+        # CancelOnDropPy runs async — we need to wait for that propagation.
+        await asyncio.wait_for(cancelled_in_python.wait(), timeout=5.0)
+
+        # And the update task itself should also terminate quickly.
+        try:
+            await asyncio.wait_for(result_task, timeout=5.0)
+        except Exception:
+            pass
+    finally:
+        if not result_task.done():
+            result_task.cancel()
+        _core.reset_global_cancellation()
+
+
+@pytest.mark.asyncio
+async def test_app_drop_interrupts_in_flight_update() -> None:
+    """App.drop() must interrupt a concurrent update.
+
+    The app token is shared between update and drop_app. drop_app cancels
+    it, which fires the cancel arm in App::update and the per-component
+    spawned tasks, propagating CancelledError into Python.
+    """
+    from cocoindex._internal import core as _core
+
+    started = asyncio.Event()
+    cancelled_in_python = asyncio.Event()
+
+    async def _blocking_main() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled_in_python.set()
+            raise
+
+    _core.reset_global_cancellation()
+    app = coco.App(
+        coco.AppConfig(name="test_app_drop_interrupts_update", environment=coco_env),
+        _blocking_main,
+    )
+    handle = app.update()
+    result_task = asyncio.create_task(handle.result())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        # drop_app cancels the app token, which interrupts the running update.
+        # Run drop concurrently — it should complete after the update terminates.
+        await asyncio.wait_for(app.drop(), timeout=5.0)
+
+        try:
+            await asyncio.wait_for(result_task, timeout=5.0)
+        except Exception:
+            pass
+
+        assert cancelled_in_python.is_set(), (
+            "process coroutine never received CancelledError — "
+            "App.drop did not interrupt the in-flight update"
+        )
+    finally:
+        if not result_task.done():
+            result_task.cancel()
+        _core.reset_global_cancellation()

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -620,3 +620,67 @@ def test_mount_each_no_name_raises() -> None:
     )
     with pytest.raises(TypeError, match="requires a ComponentSubpath"):
         app.update_blocking()
+
+
+# ============================================================================
+# Cancellation
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_live_component_global_cancel_terminates_update() -> None:
+    """Global cancellation (Ctrl+C path) must reach a blocked process_live coroutine
+    and let App.update() terminate.
+
+    Regression test for the bug where AppContextInner.cancellation_token was an
+    independent token rather than a child of GLOBAL_CANCEL, so cancel_all() never
+    propagated to LiveComponentState child tokens.
+    """
+    from cocoindex._internal import core as _core
+
+    started = asyncio.Event()
+    cancelled_in_python = asyncio.Event()
+
+    class _BlockingLive:
+        async def process(self) -> None:
+            pass
+
+        async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+            await operator.update_full()
+            await operator.mark_ready()
+            started.set()
+            try:
+                await asyncio.Event().wait()  # Block forever.
+            except asyncio.CancelledError:
+                cancelled_in_python.set()
+                raise
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("live"), _BlockingLive)
+
+    _core.reset_global_cancellation()
+    app = coco.App(
+        coco.AppConfig(name="test_live_global_cancel_terminates", environment=coco_env),
+        _main,
+    )
+    handle = app.update(live=True)
+    # update() is lazy — kick it off by spawning a task that awaits result().
+    result_task = asyncio.create_task(handle.result())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        _core.cancel_all()  # simulates SIGINT handler in cli.py
+
+        # Wait for cancellation to actually reach Python before checking. The
+        # update task may return before the inner Python cancellation has
+        # finished propagating via CancelOnDropPy.
+        await asyncio.wait_for(cancelled_in_python.wait(), timeout=5.0)
+
+        try:
+            await asyncio.wait_for(result_task, timeout=5.0)
+        except Exception:
+            pass
+    finally:
+        if not result_task.done():
+            result_task.cancel()
+        _core.reset_global_cancellation()

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -6,7 +6,7 @@ use crate::engine::component::Component;
 use crate::engine::context::AppContext;
 
 use crate::engine::environment::{AppRegistration, Environment};
-use crate::engine::runtime::{get_runtime, global_cancellation_token};
+use crate::engine::runtime::get_runtime;
 use crate::state::stable_path::StablePath;
 use tokio::sync::watch;
 
@@ -100,6 +100,9 @@ impl<Prof: EngineProfile> App<Prof> {
         host_ctx: Arc<Prof::HostCtx>,
     ) -> Result<AppOpHandle<Prof::FunctionData>> {
         crate::telemetry::track("app_update");
+        // Refresh the app token if a prior operation (e.g. drop_app) cancelled
+        // it, so this update starts with a non-cancelled token.
+        self.app_ctx().reset_cancellation_token_if_cancelled();
         let processing_stats = ProcessingStats::new();
         let version_rx = processing_stats.subscribe();
         let context = self.root_component.new_processor_context_for_build(
@@ -112,7 +115,7 @@ impl<Prof: EngineProfile> App<Prof> {
 
         let root_component = self.root_component.clone();
         let stats_for_task = processing_stats.clone();
-        let cancel_token = global_cancellation_token();
+        let cancel_token = self.app_ctx().cancellation_token();
         let live = options.live;
         let span = Span::current();
         let task = get_runtime().spawn(
@@ -155,6 +158,13 @@ impl<Prof: EngineProfile> App<Prof> {
     #[instrument(name = "app.drop", skip_all, fields(app_name = %self.app_ctx().app_reg().name()))]
     pub fn drop_app(&self, host_ctx: Arc<Prof::HostCtx>) -> Result<AppOpHandle<()>> {
         crate::telemetry::track("app_drop");
+        // Refresh the app token if a prior operation cancelled it, so the
+        // cancel below applies to a token shared with any concurrent update.
+        self.app_ctx().reset_cancellation_token_if_cancelled();
+        // Cancel the app token — interrupts any in-flight update by firing the
+        // cancel arms in App::update / Component::run / run_in_background.
+        // Component::delete intentionally does not watch this token, so the
+        // delete work below proceeds normally.
         self.app_ctx().cancellation_token().cancel();
 
         let processing_stats = ProcessingStats::default();

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -482,9 +482,16 @@ impl<Prof: EngineProfile> Component<Prof> {
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
         let span = info_span!("component.run", component_path = %relative_path);
+        let cancel_token = self.app_ctx().cancellation_token();
         let join_handle = get_runtime().spawn(
             async move {
-                let result = self.execute_once(&context, Some(&processor)).await;
+                // Race the work against app-level cancellation. On cancel, the
+                // work future is dropped, which cascades drop into from_py_future
+                // → CancelOnDropPy and cancels the underlying Python task.
+                let result = tokio::select! {
+                    r = self.execute_once(&context, Some(&processor)) => r,
+                    _ = cancel_token.cancelled() => Err(internal_error!("operation cancelled")),
+                };
                 let (outcome, output) = match result {
                     Ok((outcome, output)) => (outcome, Ok(output)),
                     Err(err) => (ComponentRunOutcome::exception(), Err(err)),
@@ -536,6 +543,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         let child_readiness_guard = context
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
+        let cancel_token = self.app_ctx().cancellation_token();
         let join_handle = get_runtime().spawn(async move {
             // Check if this task has been superseded before executing.
             if let Some(check) = pre_execute_check {
@@ -551,16 +559,22 @@ impl<Prof: EngineProfile> Component<Prof> {
                     return Ok(());
                 }
             }
-            let result = self.execute_once(&context, Some(&processor)).await;
+            // Race the work against app-level cancellation. On cancel, the
+            // work future is dropped, which cascades drop into from_py_future
+            // → CancelOnDropPy and cancels the underlying Python task.
+            let result = tokio::select! {
+                r = self.execute_once(&context, Some(&processor)) => r,
+                _ = cancel_token.cancelled() => Err(internal_error!("operation cancelled")),
+            };
             // For background child component, never propagate the error back to the parent.
             // If an error handler is registered, run it; otherwise log.
-            // During cancellation (e.g. Ctrl+C), suppress error reporting since
-            // failures are expected as coroutines are torn down.
+            // During cancellation, suppress error reporting since failures are
+            // expected as coroutines are torn down.
             let outcome = match result {
                 Ok((outcome, _)) => outcome,
                 Err(err) => {
-                    if crate::engine::runtime::is_cancelled() {
-                        trace!("component build cancelled during shutdown");
+                    if cancel_token.is_cancelled() || err.is_cancelled() {
+                        trace!("component build cancelled");
                     } else if let Some(handler) = &on_error {
                         handler(err).await;
                     } else {

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -26,7 +26,11 @@ struct AppContextInner<Prof: EngineProfile> {
     app_reg: AppRegistration<Prof>,
     id_sequencer_manager: IdSequencerManager,
     inflight_semaphore: Option<Arc<tokio::sync::Semaphore>>,
-    cancellation_token: tokio_util::sync::CancellationToken,
+    /// Cancellation token for in-flight app operations. Wrapped in a `Mutex` so
+    /// it can be replaced with a fresh child of the global token after a
+    /// previous cancellation (e.g. after `App::drop_app` finishes), allowing
+    /// the same `App` instance to be reused for subsequent operations.
+    cancellation_token: std::sync::Mutex<tokio_util::sync::CancellationToken>,
 }
 
 #[derive(Clone)]
@@ -50,7 +54,9 @@ impl<Prof: EngineProfile> AppContext<Prof> {
                 app_reg,
                 id_sequencer_manager: IdSequencerManager::new(),
                 inflight_semaphore,
-                cancellation_token: tokio_util::sync::CancellationToken::new(),
+                cancellation_token: std::sync::Mutex::new(
+                    crate::engine::runtime::global_cancellation_token().child_token(),
+                ),
             }),
         }
     }
@@ -71,8 +77,23 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         self.inner.inflight_semaphore.as_ref()
     }
 
-    pub fn cancellation_token(&self) -> &tokio_util::sync::CancellationToken {
-        &self.inner.cancellation_token
+    /// Returns a clone of the current app-level cancellation token.
+    ///
+    /// The clone stays valid even if the slot is later refreshed via
+    /// `reset_cancellation_token_if_cancelled`.
+    pub fn cancellation_token(&self) -> tokio_util::sync::CancellationToken {
+        self.inner.cancellation_token.lock().unwrap().clone()
+    }
+
+    /// Replace the app-level cancellation token with a fresh child of the global
+    /// token if the current one has been cancelled. Call this before starting a
+    /// new app operation so a prior cancellation (e.g. via `drop_app`) does not
+    /// poison subsequent runs.
+    pub fn reset_cancellation_token_if_cancelled(&self) {
+        let mut slot = self.inner.cancellation_token.lock().unwrap();
+        if slot.is_cancelled() {
+            *slot = crate::engine::runtime::global_cancellation_token().child_token();
+        }
     }
 
     /// Get the next ID for the given key.


### PR DESCRIPTION
## Summary

- Wire the cancellation hierarchy end-to-end so SIGINT (Ctrl+C) and `App.drop` reach Python coroutines via `CancelOnDropPy`. `AppContext.cancellation_token` is now a child of the global token, and `Component::run` / `run_in_background` `select!` on it inside their spawned tokio tasks (the prior code's drop-propagation never crossed the spawn boundary, so live `process_live` and non-live `process` coroutines kept running after Ctrl+C).
- Wrap the per-app token in a `Mutex<CancellationToken>` with `reset_cancellation_token_if_cancelled()` so the same `App` instance can be reused across `update`/`drop` cycles. `App::update` and `drop_app` refresh before use.
- `App::update` now watches the per-app token instead of the global token directly — the global token is purely a cascade root, not a subscription target.
- Add regression tests covering live cancellation, non-live cancellation, and `App.drop` interrupting an in-flight `update`.

## Test plan

- `cargo test -p cocoindex_core` — 30/30 pass
- `uv run pytest python/tests/core/` — 336/336 pass; ran 5x consecutively to confirm stability of the new race-sensitive cancellation tests
- New tests verified to fail without the production-code fix and pass with it
