### PR TITLE
docs: add build-time link checker; fix 162 broken links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,6 +5,7 @@ import sitemap from '@astrojs/sitemap';
 import remarkDirective from 'remark-directive';
 import remarkAdmonitions from './scripts/remark-admonitions.mjs';
 import remarkCodeTitles from './scripts/remark-code-titles.mjs';
+import remarkLinkChecker from './scripts/remark-link-checker.mjs';
 import { redirects } from './src/data/docs-sidebar.ts';
 
 // Shiki theme — canonical token palette from
@@ -72,12 +73,12 @@ export default defineConfig({
       // MDX's own remark pipeline doesn't inherit `markdown.remarkPlugins`
       // reliably across Astro versions — wire admonitions + code titles
       // explicitly so .mdx content collection pages get them for sure.
-      remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles],
+      remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles, remarkLinkChecker],
     }),
     sitemap(),
   ],
   markdown: {
-    remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles],
+    remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles, remarkLinkChecker],
     shikiConfig: { theme: cocoindexCodeTheme, wrap: false },
   },
   redirects,

--- a/docs/scripts/remark-link-checker.mjs
+++ b/docs/scripts/remark-link-checker.mjs
@@ -1,0 +1,206 @@
+// Validate relative links in Markdown / MDX during the build.
+//
+// Three checks per `link` node:
+//
+//   1. **No `.md` / `.mdx` suffix.** Links resolve to URL paths, not files —
+//      a stray `.mdx` renders a literal href that 404s in the browser.
+//      Astro's renderer doesn't catch this; this plugin does.
+//   2. **Target exists.** A relative link must resolve to a file under
+//      `src/content/docs/` (`<path>.mdx`, `<path>.md`, or
+//      `<path>/index.{mdx,md}`).
+//   3. **Fragment exists** (when the URL has `#fragment`). The fragment
+//      must match a heading id in the target file. Slugification follows
+//      `github-slugger` (the algorithm Astro / rehype-slug also use), so
+//      this matches the IDs Astro renders into the HTML.
+//
+// In-page fragment links (`#section`) are validated against the current
+// file's headings.
+//
+// Skipped: absolute URLs (`https://`), root-relative URLs (`/docs/foo` —
+// would require base-prefix-aware resolution; not common in this codebase),
+// and `mailto:` links.
+//
+// On any failure the plugin throws a single combined error per file, which
+// fails the Astro build.
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, extname, resolve } from 'node:path';
+import GithubSlugger from 'github-slugger';
+import { visit } from 'unist-util-visit';
+
+const ABSOLUTE_URL = /^[a-z][a-z0-9+\-.]*:/i;
+
+// Cache parsed heading slugs per target file. Build-time only, so a simple
+// in-memory map is fine — and the same file can be linked from many places.
+const headingSlugCache = new Map();
+
+// Markdown ATX headings: `#`–`######` followed by a space and the heading
+// text. We strip trailing whitespace and any trailing `#` markers (a
+// CommonMark allowance). Leading whitespace up to 3 spaces is allowed.
+const HEADING_RE = /^[ ]{0,3}(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/;
+// MDX/HTML headings with an explicit `id="..."` attribute. Captures the id.
+const HTML_HEADING_ID_RE = /<h[1-6][^>]*\sid=["']([^"']+)["']/gi;
+// Strip a few markdown wrappers from heading text before slugifying so the
+// input matches the rendered text github-slugger would see. Important: do
+// NOT strip underscores wholesale — they're literal inside code spans
+// (e.g. `mount_each()`), and github-slugger preserves them as `mount_each`.
+function cleanHeadingText(text) {
+  return text
+    // Strip inline code backticks
+    .replace(/`+/g, '')
+    // Strip `*` emphasis (bold/italic). Underscores intentionally left alone.
+    .replace(/\*+/g, '')
+    // Drop link wrappers `[text](url)` → `text`
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .trim();
+}
+
+function loadHeadingSlugs(filePath) {
+  const cached = headingSlugCache.get(filePath);
+  if (cached) return cached;
+
+  const slugs = new Set();
+  let inFence = false;
+  let fenceMarker = '';
+  let text;
+  try {
+    text = readFileSync(filePath, 'utf8');
+  } catch {
+    headingSlugCache.set(filePath, slugs);
+    return slugs;
+  }
+
+  // Strip the YAML frontmatter (between leading `---` markers) so its
+  // contents don't get mistaken for headings.
+  const fmMatch = text.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+  const body = fmMatch ? text.slice(fmMatch[0].length) : text;
+
+  const slugger = new GithubSlugger();
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine;
+    // Track fenced code blocks (``` or ~~~). Inside a fence, ignore everything.
+    const fence = line.match(/^[ \t]*(```+|~~~+)/);
+    if (fence) {
+      const marker = fence[1];
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = marker[0].repeat(3); // store the kind, not length
+      } else if (marker.startsWith(fenceMarker)) {
+        inFence = false;
+      }
+      continue;
+    }
+    if (inFence) continue;
+
+    const m = HEADING_RE.exec(line);
+    if (m) {
+      const cleaned = cleanHeadingText(m[2]);
+      slugs.add(slugger.slug(cleaned));
+      continue;
+    }
+    // Also pick up explicit `<h2 id="...">`-style anchors used in MDX.
+    let h;
+    while ((h = HTML_HEADING_ID_RE.exec(line)) !== null) {
+      slugs.add(h[1]);
+    }
+  }
+
+  headingSlugCache.set(filePath, slugs);
+  return slugs;
+}
+
+function resolveTargetFile(sourceFile, urlPath) {
+  const sourceDir = dirname(sourceFile);
+  const base = resolve(sourceDir, urlPath);
+  for (const candidate of [
+    `${base}.mdx`,
+    `${base}.md`,
+    `${base}/index.mdx`,
+    `${base}/index.md`,
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export default function remarkLinkChecker() {
+  return (tree, file) => {
+    const sourcePath = file.path;
+    if (!sourcePath) return;
+
+    const errors = [];
+
+    visit(tree, 'link', (node) => {
+      const url = node.url;
+      if (!url) return;
+      if (ABSOLUTE_URL.test(url)) return;
+      if (url.startsWith('mailto:')) return;
+      if (url.startsWith('/')) return; // root-relative — skip
+
+      const line = node.position?.start?.line;
+
+      // In-page fragment link (`#section`): validate against this file.
+      if (url.startsWith('#')) {
+        const fragment = url.slice(1);
+        if (!fragment) return;
+        const slugs = loadHeadingSlugs(sourcePath);
+        if (!slugs.has(fragment)) {
+          errors.push({
+            line,
+            message: `link "${url}" — fragment "#${fragment}" does not match any heading in this file`,
+          });
+        }
+        return;
+      }
+
+      const [pathPart, fragment] = url.split('#');
+      if (!pathPart) return;
+
+      const ext = extname(pathPart).toLowerCase();
+      if (ext === '.md' || ext === '.mdx') {
+        errors.push({
+          line,
+          message: `link "${url}" has a ${ext} suffix — drop the extension (links resolve to URL paths, not files)`,
+        });
+        return;
+      }
+
+      const targetFile = resolveTargetFile(sourcePath, pathPart);
+      if (!targetFile) {
+        const sourceDir = dirname(sourcePath);
+        const base = resolve(sourceDir, pathPart);
+        errors.push({
+          line,
+          message: `link "${url}" does not resolve to a file in the docs collection (looked for: ${[
+            `${base}.mdx`,
+            `${base}.md`,
+            `${base}/index.mdx`,
+            `${base}/index.md`,
+          ]
+            .map((c) => c.replace(/^.*\/src\/content\/docs\//, ''))
+            .join(', ')})`,
+        });
+        return;
+      }
+
+      if (fragment) {
+        const slugs = loadHeadingSlugs(targetFile);
+        if (!slugs.has(fragment)) {
+          errors.push({
+            line,
+            message: `link "${url}" — fragment "#${fragment}" does not match any heading in ${targetFile.replace(
+              /^.*\/src\/content\/docs\//,
+              '',
+            )}`,
+          });
+        }
+      }
+    });
+
+    if (errors.length > 0) {
+      const lines = errors
+        .map((e) => `  ${sourcePath}${e.line ? `:${e.line}` : ''} — ${e.message}`)
+        .join('\n');
+      throw new Error(`remark-link-checker found broken links:\n${lines}`);
+    }
+  };
+}

--- a/docs/src/content/docs/advanced_topics/concurrency_control.mdx
+++ b/docs/src/content/docs/advanced_topics/concurrency_control.mdx
@@ -6,7 +6,7 @@ description: >
   environment variable, and understand how CocoIndex avoids deadlocks in
   nested mount scenarios.
 ---
-CocoIndex executes each [processing component](../programming_guide/processing_component.md) as a unit of concurrent work. By default, up to **1024** processing components can be in flight per app. When components perform resource-intensive work (e.g., calling external APIs, running ML models), you may want a tighter limit.
+CocoIndex executes each [processing component](../programming_guide/processing_component) as a unit of concurrent work. By default, up to **1024** processing components can be in flight per app. When components perform resource-intensive work (e.g., calling external APIs, running ML models), you may want a tighter limit.
 
 ## Setting the limit
 

--- a/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
+++ b/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
@@ -68,7 +68,7 @@ The `reconcile()` method must be **non-blocking**. It should only compare states
 :::
 
 :::info[Type annotations]
-Annotate the `prev_possible_records` parameter with `Collection[YourTrackingRecord]` so CocoIndex can properly reconstruct stored tracking records during deserialization. See [Serialization](../programming_guide/serialization.md) for details on supported types.
+Annotate the `prev_possible_records` parameter with `Collection[YourTrackingRecord]` so CocoIndex can properly reconstruct stored tracking records during deserialization. See [Serialization](../programming_guide/serialization) for details on supported types.
 :::
 
 ### Tracking record *(you define)*

--- a/docs/src/content/docs/advanced_topics/exception_handlers.mdx
+++ b/docs/src/content/docs/advanced_topics/exception_handlers.mdx
@@ -7,7 +7,7 @@ description: >
 ---
 This page covers the full picture of failure behavior in CocoIndex — from how components fail in isolation, through what happens during interrupted updates, to the APIs for observing and reacting to errors in production.
 
-For a quick overview of failure isolation and the two-phase model, see [What happens when a component fails](../programming_guide/processing_component.md#what-happens-when-a-component-fails) in the Processing Component guide.
+For a quick overview of failure isolation and the two-phase model, see [What happens when a component fails](../programming_guide/processing_component#what-happens-when-a-component-fails) in the Processing Component guide.
 
 ## Failure isolation recap
 
@@ -33,7 +33,7 @@ CocoIndex's internal database (LMDB) uses transactions, so its own state is alwa
 
 **Recovery is automatic.** On the next `app.update()`, CocoIndex computes the current desired state and reconciles against all possible previous states. The target connector converges the target to the correct state regardless of whether the previous commit partially succeeded or never ran.
 
-For details on how target handlers deal with multiple possible previous states after an interruption, see [Custom Target Connector — Handle multiple previous states](./custom_target_connector.md#handle-multiple-previous-states).
+For details on how target handlers deal with multiple possible previous states after an interruption, see [Custom Target Connector — Handle multiple previous states](./custom_target_connector#handle-multiple-previous-states).
 
 ## Monitoring errors
 
@@ -52,7 +52,7 @@ async for snapshot in handle.watch():
     print(f"{snapshot.stats.total.num_errored} errors so far")
 ```
 
-See [Monitoring progress](../programming_guide/app.md#monitoring-progress) for the full `UpdateHandle` API.
+See [Monitoring progress](../programming_guide/app#monitoring-progress) for the full `UpdateHandle` API.
 
 ## Exception handlers
 

--- a/docs/src/content/docs/advanced_topics/internal_storage.mdx
+++ b/docs/src/content/docs/advanced_topics/internal_storage.mdx
@@ -15,7 +15,7 @@ CocoIndex needs a database path (`db_path`) to know where to store this internal
 export COCOINDEX_DB=./cocoindex.db
 ```
 
-You can also set it programmatically in a [lifespan function](../programming_guide/app.md#lifespan-optional):
+You can also set it programmatically in a [lifespan function](../programming_guide/app#lifespan-optional):
 
 ```python
 @coco.lifespan
@@ -24,7 +24,7 @@ def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
     yield
 ```
 
-Or pass it directly when creating a [`Settings`](./multiple_environments.md) object:
+Or pass it directly when creating a [`Settings`](./multiple_environments) object:
 
 ```python
 settings = coco.Settings(db_path=pathlib.Path("./cocoindex.db"))

--- a/docs/src/content/docs/advanced_topics/live_component.mdx
+++ b/docs/src/content/docs/advanced_topics/live_component.mdx
@@ -146,7 +146,7 @@ The key difference: the LiveComponent version can later be extended to handle in
 
 ## LiveMapFeed and LiveMapView
 :::tip
-For a user-facing introduction to live mode and when to use it, see [Live Mode](../programming_guide/live_mode.md). This section covers the protocol details for connector authors and advanced use cases.
+For a user-facing introduction to live mode and when to use it, see [Live Mode](../programming_guide/live_mode). This section covers the protocol details for connector authors and advanced use cases.
 :::
 
 Two protocols represent live keyed collections that `mount_each()` can consume. Choose based on whether your source can enumerate its current state:
@@ -191,12 +191,12 @@ async def watch(self, subscriber: LiveMapSubscriber[K, V]) -> None:
 
 To add live support to a source connector, make your source return an object that implements `LiveMapView` (if the source has scannable state) or `LiveMapFeed` (if it only streams changes):
 
-- **`LiveMapView` example**: The [`localfs`](../connectors/localfs.md) connector's `DirWalker` — `walk_dir(..., live=True).items()` returns a `LiveMapView` backed by `watchfiles`.
-- **`LiveMapFeed` example**: The [`kafka`](../connectors/kafka.md) connector — `topic_as_map()` returns a `LiveMapFeed` that consumes messages from Kafka topics.
+- **`LiveMapView` example**: The [`localfs`](../connectors/localfs) connector's `DirWalker` — `walk_dir(..., live=True).items()` returns a `LiveMapView` backed by `watchfiles`.
+- **`LiveMapFeed` example**: The [`kafka`](../connectors/kafka) connector — `topic_as_map()` returns a `LiveMapFeed` that consumes messages from Kafka topics.
 
 ## Live mode vs catch-up mode
 
-See [Live Mode](../programming_guide/live_mode.md) for how the two modes are enabled at the app level and an overview of how they work.
+See [Live Mode](../programming_guide/live_mode) for how the two modes are enabled at the app level and an overview of how they work.
 
 For a manual `LiveComponent`, the mode controls whether `process_live()` continues running after `mark_ready()`:
 
@@ -216,7 +216,7 @@ This lets you use the same `LiveComponent` class in both modes without code chan
 LiveComponent classes can only be used with `coco.mount()` and `operator.update()`. Passing a LiveComponent class to `coco.use_mount()` raises a `TypeError`.
 
 :::tip
-While LiveComponent classes cannot be passed to `mount_each()`, you can get live watching behavior more easily using a [`LiveMapFeed` or `LiveMapView`](#live-map) — `mount_each()` automatically creates an internal LiveComponent when it detects one.
+While LiveComponent classes cannot be passed to `mount_each()`, you can get live watching behavior more easily using a [`LiveMapFeed` or `LiveMapView`](#livemapfeed-and-livemapview) — `mount_each()` automatically creates an internal LiveComponent when it detects one.
 :::
 
 ## Readiness

--- a/docs/src/content/docs/advanced_topics/memoization_keys.mdx
+++ b/docs/src/content/docs/advanced_topics/memoization_keys.mdx
@@ -5,7 +5,7 @@ description: >
   registered functions, and layer state validation (e.g. mtime, then content hash)
   on top — plus NotMemoKeyable to opt out for stateful types.
 ---
-As described in [Function — Change detection](../programming_guide/function.md#change-detection), CocoIndex detects [logic, input, and context changes](../programming_guide/function.md#change-detection) to decide whether a memo can be reused. Function arguments, [`deps`](../programming_guide/function.md#deps) values, and [context values](../programming_guide/context.md#change-detection) with `detect_change=True` are all fingerprinted through the same **data fingerprinting** pipeline. By default, most types are fingerprinted automatically. This page covers how to customize that pipeline — how objects are fingerprinted and validated:
+As described in [Function — Change detection](../programming_guide/function#change-detection), CocoIndex detects [logic, input, and context changes](../programming_guide/function#change-detection) to decide whether a memo can be reused. Function arguments, [`deps`](../programming_guide/function#deps) values, and [context values](../programming_guide/context#change-detection) with `detect_change=True` are all fingerprinted through the same **data fingerprinting** pipeline. By default, most types are fingerprinted automatically. This page covers how to customize that pipeline — how objects are fingerprinted and validated:
 
 - **Memoization keys** — how to control what CocoIndex uses as the fingerprint for your objects.
 - **Memo states** — how to add post-fingerprint validation to check freshness beyond simple equality.
@@ -109,7 +109,7 @@ This decouples "has the state changed?" from "can we reuse the memo?":
 ### Define `__coco_memo_state__` (when you control the type)
 
 :::info[Type annotations]
-Annotate the `prev_state` parameter with its expected type (matching what you return in `MemoStateOutcome(state=...)`) so CocoIndex can properly reconstruct stored state values. See [Serialization](../programming_guide/serialization.md) for details on supported types.
+Annotate the `prev_state` parameter with its expected type (matching what you return in `MemoStateOutcome(state=...)`) so CocoIndex can properly reconstruct stored state values. See [Serialization](../programming_guide/serialization) for details on supported types.
 :::
 
 Add a `__coco_memo_state__` method alongside `__coco_memo_key__`:

--- a/docs/src/content/docs/advanced_topics/multiple_environments.mdx
+++ b/docs/src/content/docs/advanced_topics/multiple_environments.mdx
@@ -32,7 +32,7 @@ env = coco.Environment(
 )
 ```
 
-`Settings` also accepts `lmdb_max_dbs` and `lmdb_map_size` for tuning the internal LMDB database. See [Internal Storage](./internal_storage.md#lmdb-tuning) for details.
+`Settings` also accepts `lmdb_max_dbs` and `lmdb_map_size` for tuning the internal LMDB database. See [Internal Storage](./internal_storage#lmdb-tuning) for details.
 
 ## Associating Apps with an Environment
 

--- a/docs/src/content/docs/common_resources/data_types.mdx
+++ b/docs/src/content/docs/common_resources/data_types.mdx
@@ -5,7 +5,7 @@ description: >
   FilePath, FilePathMatcher, Chunk with text positions, and the Embedder
   protocol for single-text async embedding.
 ---
-The `cocoindex.resources` package provides common data models and abstractions shared across connectors and built-in operations. Connectors provide concrete implementations — for example, `localfs.File` implements `FileLike`, and `localfs.FilePath` extends `FilePath`. See individual [connector docs](../connectors/localfs.md) for connector-specific details.
+The `cocoindex.resources` package provides common data models and abstractions shared across connectors and built-in operations. Connectors provide concrete implementations — for example, `localfs.File` implements `FileLike`, and `localfs.FilePath` extends `FilePath`. See individual [connector docs](../connectors/localfs) for connector-specific details.
 
 ## File
 
@@ -36,7 +36,7 @@ async def process_file(file: FileLike) -> str:
 
 **Memoization:**
 
-`FileLike` objects provide a memoization key based on `file_path` (file identity). When used as arguments to a [memoized function](../programming_guide/function.md#memoization), CocoIndex uses a two-level validation: it checks the modification time first (cheap), then computes a content fingerprint only if the modification time has changed. This means touching a file or moving it won't cause unnecessary recomputation if the content is unchanged.
+`FileLike` objects provide a memoization key based on `file_path` (file identity). When used as arguments to a [memoized function](../programming_guide/function#memoization), CocoIndex uses a two-level validation: it checks the modification time first (cheap), then computes a content fingerprint only if the modification time has changed. This means touching a file or moving it won't cause unnecessary recomputation if the content is unchanged.
 
 ### FilePath
 
@@ -91,7 +91,7 @@ config_path.as_posix()  # "config/settings.json"
 - Two `FilePath` objects with the same base directory key and relative path have the same memo key
 - Moving the entire project directory doesn't invalidate memoization, as long as the same base directory key is used
 
-For connector-specific usage (e.g., `register_base_dir`), see the individual connector documentation like [Local File System](../connectors/localfs.md).
+For connector-specific usage (e.g., `register_base_dir`), see the individual connector documentation like [Local File System](../connectors/localfs).
 
 ### FilePathMatcher
 
@@ -135,7 +135,7 @@ Patterns use [globset](https://docs.rs/globset) semantics: `*.py` matches only i
 
 ## Chunk
 
-The chunk module (`cocoindex.resources.chunk`) defines types for representing text chunks produced by [text splitters](../ops/text.md).
+The chunk module (`cocoindex.resources.chunk`) defines types for representing text chunks produced by [text splitters](../ops/text).
 
 ### Chunk
 A `Chunk` is a frozen dataclass representing a piece of text with its position information in the original document.
@@ -185,7 +185,7 @@ class Embedder(Protocol):
     async def embed(self, text: str) -> NDArray[np.float32]: ...
 ```
 
-This is the call-site contract that consumers like [`resolve_entities`](../ops/entity_resolution.md) rely on. Both [`LiteLLMEmbedder`](../ops/litellm.md) and [`SentenceTransformerEmbedder`](../ops/sentence_transformers.md) satisfy this protocol — `await embedder.embed("some text")` returns a single `NDArray[np.float32]`.
+This is the call-site contract that consumers like [`resolve_entities`](../ops/entity_resolution) rely on. Both [`LiteLLMEmbedder`](../ops/litellm) and [`SentenceTransformerEmbedder`](../ops/sentence_transformers) satisfy this protocol — `await embedder.embed("some text")` returns a single `NDArray[np.float32]`.
 
 The protocol is deliberately narrow: it does not include `dimension()` or `__coco_vector_schema__()`, which are concerns of connectors and table-schema creation, not of embedding consumers.
 

--- a/docs/src/content/docs/common_resources/vector_schema.mdx
+++ b/docs/src/content/docs/common_resources/vector_schema.mdx
@@ -46,13 +46,13 @@ target_collection = await qdrant.mount_collection_target(
 
 A protocol for objects that can provide vector schema information. The primary use case is as metadata in `Annotated` type annotations — connectors extract vector column configuration from the annotation automatically.
 
-Any object that implements the `__coco_vector_schema__()` method satisfies this protocol. The built-in [`SentenceTransformerEmbedder`](../ops/sentence_transformers.md) implements it.
+Any object that implements the `__coco_vector_schema__()` method satisfies this protocol. The built-in [`SentenceTransformerEmbedder`](../ops/sentence_transformers) implements it.
 
 There are three ways to specify vector schema in annotations:
 
 ### Using a `ContextKey` (recommended)
 
-Define a [`ContextKey`](../programming_guide/context.md) for the embedder and use it as the annotation. The connector resolves the key at schema creation time. This is the recommended approach because the embedder is configured once in the lifespan and shared across all functions via context.
+Define a [`ContextKey`](../programming_guide/context) for the embedder and use it as the annotation. The connector resolves the key at schema creation time. This is the recommended approach because the embedder is configured once in the lifespan and shared across all functions via context.
 
 ```python
 import cocoindex as coco
@@ -110,7 +110,7 @@ When a connector's `TableSchema.from_class()` encounters an `Annotated[NDArray, 
 
 ## MultiVectorSchema / MultiVectorSchemaProvider
 
-Analogous types for multi-vector columns (e.g., ColBERT-style token-level embeddings). `MultiVectorSchema` wraps a `VectorSchema` describing the individual vectors. Used by connectors like [Qdrant](../connectors/qdrant.md) that support multi-vector storage.
+Analogous types for multi-vector columns (e.g., ColBERT-style token-level embeddings). `MultiVectorSchema` wraps a `VectorSchema` describing the individual vectors. Used by connectors like [Qdrant](../connectors/qdrant) that support multi-vector storage.
 
 ```python
 from cocoindex.resources.schema import MultiVectorSchema, VectorSchema

--- a/docs/src/content/docs/connectors/amazon_s3.mdx
+++ b/docs/src/content/docs/connectors/amazon_s3.mdx
@@ -63,14 +63,14 @@ def list_objects(
 - `client` — An aiobotocore S3 client.
 - `bucket_name` — The S3 bucket name.
 - `prefix` — Only list objects whose key starts with this prefix. The prefix is stripped from relative paths in the returned files.
-- `path_matcher` — Optional filter for files. Patterns are matched against the relative path (after prefix stripping). See [PatternFilePathMatcher](../common_resources/data_types.md#patternfilepathmatcher).
+- `path_matcher` — Optional filter for files. Patterns are matched against the relative path (after prefix stripping). See [PatternFilePathMatcher](../common_resources/data_types#patternfilepathmatcher).
 - `max_file_size` — Skip objects larger than this size in bytes.
 
 **Returns:** An `S3Walker` that can be used with `async for` loops.
 
 ### Iterating files
 
-`list_objects()` returns an `S3Walker` that yields `S3File` objects (implementing the [`FileLike`](../common_resources/data_types.md#filelike) base class):
+`list_objects()` returns an `S3Walker` that yields `S3File` objects (implementing the [`FileLike`](../common_resources/data_types#filelike) base class):
 
 ```python
 import aiobotocore.session
@@ -83,7 +83,7 @@ async with session.create_client("s3") as client:
         ...
 ```
 
-See [`FileLike`](../common_resources/data_types.md#filelike) for details on the file objects.
+See [`FileLike`](../common_resources/data_types#filelike) for details on the file objects.
 
 ### Keyed iteration with `items()`
 
@@ -184,7 +184,7 @@ async with session.create_client("s3") as client:
 
 ### S3FilePath
 
-Each file returned by the connector has an `S3FilePath` — a [`FilePath`](../common_resources/data_types.md#filepath) specialized for S3:
+Each file returned by the connector has an `S3FilePath` — a [`FilePath`](../common_resources/data_types#filepath) specialized for S3:
 
 - **Relative path** (`file.file_path.path`) — The object key relative to the walker prefix (or the full key if no prefix was used).
 - **Resolved path** (`file.file_path.resolve()`) — The full S3 object key.

--- a/docs/src/content/docs/connectors/doris.mdx
+++ b/docs/src/content/docs/connectors/doris.mdx
@@ -85,7 +85,7 @@ The `doris` connector provides target state APIs for writing rows to tables. Coc
 Create a `ContextKey[doris.ManagedConnection]` to identify your connection, then provide it in your lifespan:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python

--- a/docs/src/content/docs/connectors/google_drive.mdx
+++ b/docs/src/content/docs/connectors/google_drive.mdx
@@ -57,7 +57,7 @@ class GoogleDriveSource(
 
 ### Iterating files
 
-`GoogleDriveSource` provides async iteration via `files()`, yielding `DriveFile` objects (implementing the [`FileLike`](../common_resources/data_types.md#filelike) base class):
+`GoogleDriveSource` provides async iteration via `files()`, yielding `DriveFile` objects (implementing the [`FileLike`](../common_resources/data_types#filelike) base class):
 
 ```python
 source = google_drive.GoogleDriveSource(
@@ -115,7 +115,7 @@ def list_files(spec: GoogleDriveSourceSpec) -> Iterator[DriveFile]
 
 ### DriveFile
 
-`DriveFile` implements [`FileLike`](../common_resources/data_types.md#filelike) with Google Drive-specific behavior:
+`DriveFile` implements [`FileLike`](../common_resources/data_types#filelike) with Google Drive-specific behavior:
 
 - `file_path` — A `DriveFilePath` where `resolve()` returns the Google Drive file ID.
 - `read()` / `read_text()` — Downloads file content via the Google Drive API. Partial reads (`size` parameter) are not supported.

--- a/docs/src/content/docs/connectors/kafka.mdx
+++ b/docs/src/content/docs/connectors/kafka.mdx
@@ -23,7 +23,7 @@ pip install cocoindex[kafka]
 
 ## As source
 
-The `kafka` connector can treat a Kafka topic as a live keyed map — each message is an upsert or delete for a key. It returns a [`LiveMapFeed`](../advanced_topics/live_component.md#live-map) for use with `mount_each()`.
+The `kafka` connector can treat a Kafka topic as a live keyed map — each message is an upsert or delete for a key. It returns a [`LiveMapFeed`](../advanced_topics/live_component#livemapfeed-and-livemapview) for use with `mount_each()`.
 
 ### Setting up a consumer
 
@@ -54,7 +54,7 @@ def topic_as_map(
 
 - `consumer` — An unsubscribed `AIOConsumer`. Auto-commit should be disabled.
 - `topics` — Topics to subscribe to.
-- `is_deletion` — Optional predicate `(message: Message) -> bool` for custom deletion detection on non-tombstone messages (see [Deletion handling](#source-deletion-handling)).
+- `is_deletion` — Optional predicate `(message: Message) -> bool` for custom deletion detection on non-tombstone messages (see [Deletion handling](#deletion-handling)).
 
 **Returns:** A `LiveMapFeed[bytes | str, Message]` where each item is keyed by the message key and the value is the full `confluent_kafka.Message` object.
 
@@ -130,7 +130,7 @@ The `kafka` connector provides target state APIs for producing messages to Kafka
 Create a `ContextKey[AIOProducer]` to identify your producer, then provide it in your lifespan:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track target state for topics produced through this key. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track target state for topics produced through this key. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -54,7 +54,7 @@ The `lancedb` connector provides target state APIs for writing rows to tables. W
 Create a `ContextKey[lancedb.LanceAsyncConnection]` to identify your LanceDB connection, then provide it in your lifespan:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed tables. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed tables. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python
@@ -179,7 +179,7 @@ class MyRow:
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema.md#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
+For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
 
 ### Table schema: explicit column definitions
 

--- a/docs/src/content/docs/connectors/localfs.mdx
+++ b/docs/src/content/docs/connectors/localfs.mdx
@@ -63,7 +63,7 @@ print(config_path.parent)    # FilePath pointing to "config/"
 abs_path = config_path.resolve()  # pathlib.Path
 ```
 
-See [FilePath](../common_resources/data_types.md#filepath) in Resource Types for full details.
+See [FilePath](../common_resources/data_types#filepath) in Resource Types for full details.
 
 ## As source
 
@@ -82,15 +82,15 @@ def walk_dir(
 **Parameters:**
 
 - `path` — The root directory path to walk through. Can be a `FilePath`, a `pathlib.Path`, or a `ContextKey[Path]` (equivalent to `FilePath(base_dir=path)`).
-- `live` — If `True`, `items()` returns a [`LiveMapView`](../advanced_topics/live_component.md#live-map) that supports live file watching via `mount_each()`.
+- `live` — If `True`, `items()` returns a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) that supports live file watching via `mount_each()`.
 - `recursive` — If `True`, recursively walk subdirectories.
-- `path_matcher` — Optional filter for files and directories. See [PatternFilePathMatcher](../common_resources/data_types.md#patternfilepathmatcher).
+- `path_matcher` — Optional filter for files and directories. See [PatternFilePathMatcher](../common_resources/data_types#patternfilepathmatcher).
 
 **Returns:** A `DirWalker` that supports async iteration via `async for`.
 
 ### Iterating files
 
-`walk_dir()` returns a `DirWalker` that supports async iteration, yielding `File` objects (implementing the [`FileLike`](../common_resources/data_types.md#filelike) base class):
+`walk_dir()` returns a `DirWalker` that supports async iteration, yielding `File` objects (implementing the [`FileLike`](../common_resources/data_types#filelike) base class):
 
 ```python
 async for file in localfs.walk_dir("/path/to/documents", recursive=True):
@@ -129,7 +129,7 @@ async for file in localfs.walk_dir("/path/to/project", recursive=True, path_matc
 
 ### Live file watching
 
-When `live=True`, `items()` returns a [`LiveMapView`](../advanced_topics/live_component.md#live-map) instead of a plain `AsyncIterable`. Combined with [`mount_each()`](../programming_guide/processing_component.md#mount-each), this enables automatic incremental file watching — new, modified, and deleted files are processed without a full rescan:
+When `live=True`, `items()` returns a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) instead of a plain `AsyncIterable`. Combined with [`mount_each()`](../programming_guide/processing_component#mount_each), this enables automatic incremental file watching — new, modified, and deleted files are processed without a full rescan:
 
 ```python
 files = localfs.walk_dir(
@@ -140,7 +140,7 @@ files = localfs.walk_dir(
 await coco.mount_each(process_file, files.items(), target)
 ```
 
-See [Live Mode](../programming_guide/live_mode.md) for how this works and how to enable it on the app.
+See [Live Mode](../programming_guide/live_mode) for how this works and how to enable it on the app.
 
 ### Example
 

--- a/docs/src/content/docs/connectors/postgres.mdx
+++ b/docs/src/content/docs/connectors/postgres.mdx
@@ -154,7 +154,7 @@ The `postgres` connector provides target state APIs for writing rows to tables. 
 Create a `ContextKey[asyncpg.Pool]` to identify your connection pool, then provide the pool directly in your lifespan:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python
@@ -373,7 +373,7 @@ schema = postgres.TableSchema(
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider) annotation specifies the vector dimension and dtype. The connector has built-in pgvector support and automatically creates the extension when needed. See [Vector Schema](../common_resources/vector_schema.md#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
+For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. The connector has built-in pgvector support and automatically creates the extension when needed. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
 
 ### Table schema: explicit column definitions
 

--- a/docs/src/content/docs/connectors/qdrant.mdx
+++ b/docs/src/content/docs/connectors/qdrant.mdx
@@ -59,7 +59,7 @@ The `qdrant` connector provides target state APIs for writing points to collecti
 Create a `ContextKey[QdrantClient]` to identify your Qdrant client, then provide it in your lifespan:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed collections. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed collections. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python
@@ -213,7 +213,7 @@ point = qdrant.PointStruct(
 
 #### VectorSchemaProvider
 
-The `schema` field of `QdrantVectorDef` accepts a [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider), a `ContextKey`, or an explicit `VectorSchema` to specify the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema.md#vectorschemaprovider) for details.
+The `schema` field of `QdrantVectorDef` accepts a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider), a `ContextKey`, or an explicit `VectorSchema` to specify the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for details.
 
 #### Multi-vector support
 

--- a/docs/src/content/docs/connectors/sqlite.mdx
+++ b/docs/src/content/docs/connectors/sqlite.mdx
@@ -87,7 +87,7 @@ The `sqlite` connector provides target state APIs for writing rows to tables. Wi
 Create a `ContextKey[sqlite.ManagedConnection]` to identify your SQLite connection, then provide it in your lifespan using `sqlite.managed_connection()`:
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python
@@ -232,7 +232,7 @@ schema = sqlite.TableSchema(
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider) annotation specifies the vector dimension and dtype. Vectors are stored as BLOBs in sqlite-vec compatible float32 format. See [Vector Schema](../common_resources/vector_schema.md#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
+For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. Vectors are stored as BLOBs in sqlite-vec compatible float32 format. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
 
 ### Table schema: explicit column definitions
 

--- a/docs/src/content/docs/connectors/surrealdb.mdx
+++ b/docs/src/content/docs/connectors/surrealdb.mdx
@@ -26,7 +26,7 @@ pip install cocoindex[surrealdb]
 Create a `ConnectionFactory` and provide it via a `ContextKey`. It holds connection parameters and creates authenticated connections on demand.
 
 :::note
-The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context.md#contextkey-as-stable-identity) before renaming.
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
 :::
 
 ```python
@@ -249,7 +249,7 @@ schema = await surrealdb.TableSchema.from_class(
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema.md#vectorschemaprovider) for the full list of annotation options.
+For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options.
 
 ### Table schema: explicit column definitions
 

--- a/docs/src/content/docs/contributing/guide.mdx
+++ b/docs/src/content/docs/contributing/guide.mdx
@@ -28,7 +28,7 @@ To submit your code:
 1. Fork the [CocoIndex repository](https://github.com/cocoindex-io/cocoindex)
 2. [Create a new branch](https://docs.github.com/en/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop) on your fork
 3. Make your changes
-4. Run the prek checks. It will be automatically triggered on `git commit` after you install the prek hooks by `prek install` (see [Setup Development Environment](setup_dev_environment.md)).
+4. Run the prek checks. It will be automatically triggered on `git commit` after you install the prek hooks by `prek install` (see [Setup Development Environment](setup_dev_environment)).
 
     :::tip
     To run them manually (same as CI):

--- a/docs/src/content/docs/faq.mdx
+++ b/docs/src/content/docs/faq.mdx
@@ -27,8 +27,8 @@ Like any memoization system (e.g., `@functools.cache`), CocoIndex's change detec
 
 CocoIndex provides mechanisms to capture some of these dependencies:
 
-- **[`deps`](./programming_guide/function.md#deps)** — declares module-level values (like a prompt string or model name) as part of the function's logic. Changes to these values invalidate dependent memos, just like any other logic change. Note: `deps` is snapshotted once at decoration time.
-- **[`use_context()`](./programming_guide/context.md)** — retrieves shared resources via `ContextKey`. With [`detect_change=True`](./programming_guide/context.md#change-detection), changes to the provided value invalidate dependent memos.
+- **[`deps`](./programming_guide/function#deps)** — declares module-level values (like a prompt string or model name) as part of the function's logic. Changes to these values invalidate dependent memos, just like any other logic change. Note: `deps` is snapshotted once at decoration time.
+- **[`use_context()`](./programming_guide/context)** — retrieves shared resources via `ContextKey`. With [`detect_change=True`](./programming_guide/context#change-detection), changes to the provided value invalidate dependent memos.
 
 For per-call values that change at runtime, pass them as regular function arguments instead.
 
@@ -36,8 +36,8 @@ For per-call values that change at runtime, pass them as regular function argume
 
 ### What happens if my pipeline crashes mid-update?
 
-CocoIndex's internal state is always consistent — even after a crash or `kill -9`. On the next `app.update()`, CocoIndex automatically recovers: it computes the current desired state and reconciles against all possible previous states, converging the target to the correct state. No manual cleanup is needed. See [Error Handling — Interrupted updates and recovery](./advanced_topics/exception_handlers.md#interrupted-updates-and-recovery) for details.
+CocoIndex's internal state is always consistent — even after a crash or `kill -9`. On the next `app.update()`, CocoIndex automatically recovers: it computes the current desired state and reconciles against all possible previous states, converging the target to the correct state. No manual cleanup is needed. See [Error Handling — Interrupted updates and recovery](./advanced_topics/exception_handlers#interrupted-updates-and-recovery) for details.
 
 ### Are target state writes transactional across targets?
 
-Not across targets. When a processing component finishes, CocoIndex sends all its target state changes to each target backend as a unit — all writes happen after processing completes, never partially during execution. Each target backend applies its batch atomically when supported (e.g., within a database transaction). But changes across *different* target backends (e.g., Postgres and local files) are not transactional with each other. See [How target states sync](./programming_guide/processing_component.md#how-target-states-sync) for details.
+Not across targets. When a processing component finishes, CocoIndex sends all its target state changes to each target backend as a unit — all writes happen after processing completes, never partially during execution. Each target backend applies its batch atomically when supported (e.g., within a database transaction). But changes across *different* target backends (e.g., Postgres and local files) are not transactional with each other. See [How target states sync](./programming_guide/processing_component#how-target-states-sync) for details.

--- a/docs/src/content/docs/getting_started/overview.mdx
+++ b/docs/src/content/docs/getting_started/overview.mdx
@@ -58,5 +58,5 @@ You write simple batch-style code — no delta logic, no state handling. CocoInd
 
 ## Next steps
 
-- [Install CocoIndex](./installation.md) and follow the [Quickstart](./quickstart.md) to build your first pipeline in 5 minutes
-- Read [Core Concepts](../programming_guide/core_concepts.mdx) for the mental model behind CocoIndex
+- [Install CocoIndex](./installation) and follow the [Quickstart](./quickstart) to build your first pipeline in 5 minutes
+- Read [Core Concepts](../programming_guide/core_concepts) for the mental model behind CocoIndex

--- a/docs/src/content/docs/getting_started/quickstart.mdx
+++ b/docs/src/content/docs/getting_started/quickstart.mdx
@@ -29,7 +29,7 @@ When your source data is updated, or your processing logic is changed (for examp
 
 ## Setup
 
-1. Install CocoIndex (see [Installation](./installation.md) for other package managers) and the Docling dependency:
+1. Install CocoIndex (see [Installation](./installation) for other package managers) and the Docling dependency:
 
     ```bash
     pip install -U --pre cocoindex docling
@@ -87,9 +87,9 @@ def process_file(
     localfs.declare_file(outdir / outname, markdown, create_parent_dirs=True)
 ```
 
-- **`localfs.File`** — A file object returned by `localfs.walk_dir()`, implementing the [`FileLike`](../common_resources/data_types.md#filelike) base class. See the [localfs connector](../connectors/localfs.md) for full details.
+- **`localfs.File`** — A file object returned by `localfs.walk_dir()`, implementing the [`FileLike`](../common_resources/data_types#filelike) base class. See the [localfs connector](../connectors/localfs) for full details.
 - **`memo=True`** — Caches results; unchanged files are skipped on re-runs
-- **`localfs.declare_file()`** — Declares a file [target state](../programming_guide/target_state.md); auto-deleted if source is removed. See [localfs as target](../connectors/localfs.md#as-target) for the full API.
+- **`localfs.declare_file()`** — Declares a file [target state](../programming_guide/target_state); auto-deleted if source is removed. See [localfs as target](../connectors/localfs#as-target) for the full API.
 
 
 
@@ -186,6 +186,6 @@ The corresponding Markdown file is automatically removed.
 
 ## Next steps
 
-- Read [Core Concepts](../programming_guide/core_concepts.mdx) to understand the mental model — state-driven programming, processing components, and memoization
-- Dive into the [Programming Guide](../programming_guide/app.md), starting with Apps, to learn how to build more complex pipelines
+- Read [Core Concepts](../programming_guide/core_concepts) to understand the mental model — state-driven programming, processing components, and memoization
+- Dive into the [Programming Guide](../programming_guide/app), starting with Apps, to learn how to build more complex pipelines
 - Browse more [examples](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) for real-world patterns (text embedding, RAG, knowledge graphs)

--- a/docs/src/content/docs/ops/entity_resolution.mdx
+++ b/docs/src/content/docs/ops/entity_resolution.mdx
@@ -140,7 +140,7 @@ Each event includes:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `entities` | `Iterable[str]` | *(required)* | Raw entity names. Duplicates collapsed; iterated in sorted order. |
-| `embedder` | [`Embedder`](../common_resources/data_types.md#embedder) | *(required)* | Async single-text embedder. `LiteLLMEmbedder` and `SentenceTransformerEmbedder` both work. |
+| `embedder` | [`Embedder`](../common_resources/data_types#embedder) | *(required)* | Async single-text embedder. `LiteLLMEmbedder` and `SentenceTransformerEmbedder` both work. |
 | `resolve_pair` | `PairResolver` | *(required)* | Pair-resolution callback. See [`LlmPairResolver`](#llmpairresolver) for the built-in option. |
 | `is_existing_canonical` | `Callable[[str], bool] \| None` | `None` | Sync predicate for existing-canonical detection. |
 | `existing_policy` | `ExistingCanonicalPolicy` | `PINNED` | How to treat existing canonicals. Ignored when `is_existing_canonical` is `None`. |
@@ -171,7 +171,7 @@ result = await resolve_entities(
 
 ### Model strings
 
-Uses the same litellm model-string format as [`LiteLLMEmbedder`](./litellm.md):
+Uses the same litellm model-string format as [`LiteLLMEmbedder`](./litellm):
 
 | Provider | Example |
 |----------|---------|

--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -65,7 +65,7 @@ table.declare_row(row=DocEmbedding(text="Hello, world!", embedding=embedding))
 
 ### Using as a type annotation
 
-The `LiteLLMEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.
+The `LiteLLMEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.
 
 ```python
 from dataclasses import dataclass
@@ -99,7 +99,7 @@ target_table = await postgres.mount_table_target(
 )
 ```
 
-The connector automatically creates the appropriate `vector(N)` column. See the [Connectors](../connectors/postgres.md) docs for other supported backends (LanceDB, Qdrant, SQLite).
+The connector automatically creates the appropriate `vector(N)` column. See the [Connectors](../connectors/postgres) docs for other supported backends (LanceDB, Qdrant, SQLite).
 
 ## Supported providers
 

--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -54,7 +54,7 @@ table.declare_row(row=CodeEmbedding(code="Hello, world!", embedding=embedding))
 
 ### Using as a type annotation
 
-The `SentenceTransformerEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema.md#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.
+The `SentenceTransformerEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.
 
 ```python
 from dataclasses import dataclass
@@ -90,7 +90,7 @@ target_table = await postgres.mount_table_target(
 )
 ```
 
-The connector automatically creates the appropriate `vector(384)` column. See the [Connectors](../connectors/postgres.md) docs for other supported backends (LanceDB, Qdrant, SQLite).
+The connector automatically creates the appropriate `vector(384)` column. See the [Connectors](../connectors/postgres) docs for other supported backends (LanceDB, Qdrant, SQLite).
 
 ## Example: text embedding pipeline
 

--- a/docs/src/content/docs/ops/text.mdx
+++ b/docs/src/content/docs/ops/text.mdx
@@ -63,13 +63,13 @@ for chunk in chunks:
 
 ### `RecursiveSplitter`
 
-Advanced text chunking with language awareness and syntax-aware splitting for code. Returns [`Chunk`](../common_resources/data_types.md#chunk) objects with position information.
+Advanced text chunking with language awareness and syntax-aware splitting for code. Returns [`Chunk`](../common_resources/data_types#chunk) objects with position information.
 
 **Features:**
 - Supports many programming languages
 - Preserves code structure
 - Customizable chunk sizes and overlap
-- Returns [`Chunk`](../common_resources/data_types.md#chunk) objects with start/end positions (line, column, byte/char offsets)
+- Returns [`Chunk`](../common_resources/data_types#chunk) objects with start/end positions (line, column, byte/char offsets)
 
 **Usage:**
 

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -6,7 +6,7 @@ description: >
   resources.
 ---
 An **App** is the top-level runnable unit in CocoIndex.
-It names your pipeline and binds a main function with its parameters. When you call `app.update()`, CocoIndex runs that main function as the root [processing component](./processing_component.md) which can mount child processing components to do work and declare target states.
+It names your pipeline and binds a main function with its parameters. When you call `app.update()`, CocoIndex runs that main function as the root [processing component](./processing_component) which can mount child processing components to do work and declare target states.
 
 ## Creating an app
 
@@ -37,7 +37,7 @@ app = coco.App("MyPipeline", app_main, sourcedir=pathlib.Path("./data"))
 ```
 
 :::tip
-The main function can be sync or async. See [How Sync and Async Work Together](./sdk_overview.md#how-sync-and-async-work-together) for details.
+The main function can be sync or async. See [How Sync and Async Work Together](./sdk_overview#how-sync-and-async-work-together) for details.
 :::
 
 ## Updating an app
@@ -56,7 +56,7 @@ result = app.update_blocking()
 
 **Parameters:**
 
-- `live` option keeps the app running after the initial scan so live components can continue watching for changes. See [Live Mode](./live_mode.md).
+- `live` option keeps the app running after the initial scan so live components can continue watching for changes. See [Live Mode](./live_mode).
 - `report_to_stdout` option prints periodic progress updates during execution.
 - `full_reprocess` option reprocesses everything and invalidates existing caches. This forces all components to re-execute and all target states to be re-applied, even if they haven't changed.
 
@@ -115,7 +115,7 @@ For example, an app that processes files might mount one component per file:
     └── "world.md"             ← process_file component
 ```
 
-See [Processing Component](./processing_component.md) for how mounting and component paths define these boundaries.
+See [Processing Component](./processing_component) for how mounting and component paths define these boundaries.
 
 ## Database path
 
@@ -140,7 +140,7 @@ app = coco.App("MyPipeline", app_main)
 app.update_blocking()  # Uses COCOINDEX_DB for storage
 ```
 
-For details on what the internal database stores and how to tune its LMDB settings (e.g., increasing the maximum database size beyond 4 GiB), see [Internal Storage](../advanced_topics/internal_storage.md).
+For details on what the internal database stores and how to tune its LMDB settings (e.g., increasing the maximum database size beyond 4 GiB), see [Internal Storage](../advanced_topics/internal_storage).
 
 ## Lifespan (optional)
 
@@ -152,7 +152,7 @@ If you only need to set the database path, using the `COCOINDEX_DB` environment 
 
 ### Defining a lifespan
 
-Use the `@lifespan` decorator to register a lifespan function. By default, all apps share the same lifespan (unless you explicitly specify an app in a different [*Environment*](../advanced_topics/multiple_environments.md)). The function receives an `EnvironmentBuilder` for configuration and uses `yield` to separate setup from cleanup:
+Use the `@lifespan` decorator to register a lifespan function. By default, all apps share the same lifespan (unless you explicitly specify an app in a different [*Environment*](../advanced_topics/multiple_environments)). The function receives an `EnvironmentBuilder` for configuration and uses `yield` to separate setup from cleanup:
 
 ```python
 import pathlib
@@ -181,7 +181,7 @@ def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
     yield
 ```
 
-You can also use the lifespan to provide resources (like database connections) that processing components can access. See [Context](./context.md) for details on sharing resources across your pipeline.
+You can also use the lifespan to provide resources (like database connections) that processing components can access. See [Context](./context) for details on sharing resources across your pipeline.
 
 ### Explicit lifecycle control (optional)
 
@@ -229,7 +229,7 @@ Run your app once to sync all target states:
 cocoindex update main.py
 ```
 
-This executes your pipeline and applies all declared target states to external systems. Add `--live` (or `-L`) to keep the app running and react to source changes continuously — see [Live Mode](./live_mode.md).
+This executes your pipeline and applies all declared target states to external systems. Add `--live` (or `-L`) to keep the app running and react to source changes continuously — see [Live Mode](./live_mode).
 
 ### Drop an app
 

--- a/docs/src/content/docs/programming_guide/context.mdx
+++ b/docs/src/content/docs/programming_guide/context.mdx
@@ -27,7 +27,7 @@ The type parameter (`asyncpg.Pool`, `SentenceTransformerEmbedder`) enables type 
 
 ### Change detection
 
-By default, context keys have **change detection disabled** — changing the provided value between runs does not automatically invalidate memoized functions that consumed it via `use_context()`. To opt in to change detection, pass `detect_change=True`. When enabled, [context changes](./function.md#change-detection) are their own category — tracked by `use_context()` at the call site, independent of `@coco.fn`. When a fingerprint changes, any memoized function whose execution involved a `use_context()` call on that key is invalidated.
+By default, context keys have **change detection disabled** — changing the provided value between runs does not automatically invalidate memoized functions that consumed it via `use_context()`. To opt in to change detection, pass `detect_change=True`. When enabled, [context changes](./function#change-detection) are their own category — tracked by `use_context()` at the call site, independent of `@coco.fn`. When a fingerprint changes, any memoized function whose execution involved a `use_context()` call on that key is invalidated.
 
 Use `detect_change=True` for resources that affect computation results — models, configuration objects, etc. This ensures memoized functions re-execute when those values change. Resources that don't affect computation results — database connections, loggers, debug flags, monitoring clients — can use the default (`detect_change=False`).
 
@@ -54,7 +54,7 @@ Pick a `ContextKey` name that reflects the *logical* role of the resource, not i
 
 ## Providing values
 
-In your [lifespan function](./app.md#defining-a-lifespan), use `builder.provide()` to make resources available:
+In your [lifespan function](./app#defining-a-lifespan), use `builder.provide()` to make resources available:
 
 ```python
 from typing import AsyncIterator

--- a/docs/src/content/docs/programming_guide/core_concepts.mdx
+++ b/docs/src/content/docs/programming_guide/core_concepts.mdx
@@ -145,7 +145,7 @@ In CocoIndex, both processing components and transforms are expressed as functio
 
 - *Transform level*: If the input to the "embed" transform (the chunk text) hasn't changed and the transform logic (e.g., the model) hasn't changed, that specific embedding computation is skipped.
 
-See [Function Memoization](./function.md#memoization) for more details.
+See [Function Memoization](./function#memoization) for more details.
 
 <ComponentWithChunks memoized={true} />
 
@@ -205,7 +205,7 @@ Here's how memoization behaves in different scenarios:
 
 Now that you understand the mental model, dive into the Programming Guide to learn how to use these concepts in code:
 
-- [App](./app.md) — creating and running pipelines
-- [Target State](./target_state.md) — declaring what should exist in external systems
-- [Processing Component](./processing_component.md) — structuring work and mounting components
-- [Function](./function.md) — the `@coco.fn` decorator, memoization, and change detection
+- [App](./app) — creating and running pipelines
+- [Target State](./target_state) — declaring what should exist in external systems
+- [Processing Component](./processing_component) — structuring work and mounting components
+- [Function](./function) — the `@coco.fn` decorator, memoization, and change detection

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -25,7 +25,7 @@ Decorating a function tells CocoIndex that calls to it are part of the increment
 - Detect when inputs or code have changed (change detection)
 - Skip work when nothing has changed (memoization)
 
-This is what lets CocoIndex avoid rerunning expensive steps on every `app.update()`. See [Processing Component](./processing_component.md) for how decorated functions are mounted at component paths.
+This is what lets CocoIndex avoid rerunning expensive steps on every `app.update()`. See [Processing Component](./processing_component) for how decorated functions are mounted at component paths.
 
 If you don't need any of the above for a helper, keep it as a plain Python function.
 
@@ -41,7 +41,7 @@ CocoIndex detects three kinds of changes:
 
 **Input changes** — the function's arguments. Tracked by `@coco.fn`. When you call a function with different arguments, the fingerprints change. Input fingerprints do not propagate transitively.
 
-**Context changes** — [context values](./context.md) with [`detect_change=True`](./context.md#change-detection). Tracked by [`use_context()`](./context.md#retrieving-values) at the call site — independent of `@coco.fn`. When a context value changes, any memoized function whose execution involved a `use_context()` call on that key is invalidated.
+**Context changes** — [context values](./context) with [`detect_change=True`](./context#change-detection). Tracked by [`use_context()`](./context#retrieving-values) at the call site — independent of `@coco.fn`. When a context value changes, any memoized function whose execution involved a `use_context()` call on that key is invalidated.
 
 ### Memoization
 
@@ -55,7 +55,7 @@ def process_chunk(chunk: Chunk) -> Embedding:
 ```
 
 :::info[Type annotations]
-Add a **return type annotation** to memoized functions so CocoIndex can properly reconstruct cached values. Without a type annotation, cached values may deserialize as basic Python types (`dict`, `list`, etc.) instead of their original types. See [Serialization](./serialization.md) for details on supported types.
+Add a **return type annotation** to memoized functions so CocoIndex can properly reconstruct cached values. Without a type annotation, cached values may deserialize as basic Python types (`dict`, `list`, etc.) instead of their original types. See [Serialization](./serialization) for details on supported types.
 :::
 
 :::tip[When to memoize]
@@ -84,7 +84,7 @@ Three parameters on `@coco.fn` let you customize how logic changes are detected:
 - **`version`** — provides explicit manual control over when dependent memos are invalidated
 - **`deps`** — declares external values (e.g. a module-level prompt string) as part of the function's logic, so changing them invalidates dependent memos
 
-These parameters control code fingerprinting for logic changes. Data fingerprinting (for arguments, `deps` values, and context values) is controlled by the objects themselves (see [Memoization Keys & States](../advanced_topics/memoization_keys.md)).
+These parameters control code fingerprinting for logic changes. Data fingerprinting (for arguments, `deps` values, and context values) is controlled by the objects themselves (see [Memoization Keys & States](../advanced_topics/memoization_keys)).
 
 #### `logic_tracking`
 
@@ -130,7 +130,7 @@ def summarize(text: str) -> str:
     return call_llm(SYSTEM_PROMPT, text, model=MODEL)
 ```
 
-The value is canonicalized through the [memoization-key pipeline](../advanced_topics/memoization_keys.md), which honors `__coco_memo_key__()`, registered memo key functions, and the standard handling for primitives, dataclasses, and Pydantic models.
+The value is canonicalized through the [memoization-key pipeline](../advanced_topics/memoization_keys), which honors `__coco_memo_key__()`, registered memo key functions, and the standard handling for primitives, dataclasses, and Pydantic models.
 
 :::caution[Snapshotted at decoration time]
 `deps` is evaluated **once** when the decorator is applied (typically at module import), not re-evaluated per call. For per-call or per-instance values — instance attributes in a bound method, request-scoped config, anything that changes at runtime — pass them as regular function arguments instead, so the memoization layer observes each new value.
@@ -173,12 +173,12 @@ def embed(text: str) -> list[float]:
 ```
 
 :::note
-[Context changes](./context.md#change-detection) are independent of `@coco.fn` and `logic_tracking`. Even with `logic_tracking=None`, a change in a change-detected context value still invalidates dependent memos, because context tracking is done by `use_context()`, not by the decorator.
+[Context changes](./context#change-detection) are independent of `@coco.fn` and `logic_tracking`. Even with `logic_tracking=None`, a change in a change-detected context value still invalidates dependent memos, because context tracking is done by `use_context()`, not by the decorator.
 :::
 
 ### Customizing data fingerprinting
 
-By default, CocoIndex fingerprints function arguments, `deps` values, and context values automatically for most types — primitives, containers, dataclasses, Pydantic models, and picklable objects. For custom types, or when you need multi-level validation (e.g., check mtime first, then content hash), see [Memoization Keys & States](../advanced_topics/memoization_keys.md).
+By default, CocoIndex fingerprints function arguments, `deps` values, and context values automatically for most types — primitives, containers, dataclasses, Pydantic models, and picklable objects. For custom types, or when you need multi-level validation (e.g., check mtime first, then content hash), see [Memoization Keys & States](../advanced_topics/memoization_keys).
 
 ## Execution capabilities
 

--- a/docs/src/content/docs/programming_guide/live_mode.mdx
+++ b/docs/src/content/docs/programming_guide/live_mode.mdx
@@ -42,16 +42,16 @@ Without `live=True` on the app, the app runs in catch-up mode — everything com
 
 ## Reacting to changes
 
-Enabling live mode keeps the app running, but something in the component tree needs to actually watch for changes. That something is a [**LiveComponent**](../advanced_topics/live_component.md) — a component with a long-running `process_live()` method that delivers incremental updates.
+Enabling live mode keeps the app running, but something in the component tree needs to actually watch for changes. That something is a [**LiveComponent**](../advanced_topics/live_component) — a component with a long-running `process_live()` method that delivers incremental updates.
 
 You rarely need to write a `LiveComponent` manually. The most common pattern is:
 
 ### Sources with `LiveMapView` or `LiveMapFeed`
 
-Source connectors can provide live capabilities via two [protocols](../advanced_topics/live_component.md#live-map):
+Source connectors can provide live capabilities via two [protocols](../advanced_topics/live_component#livemapfeed-and-livemapview):
 
-- **`LiveMapView`** — the source has scannable current state (e.g., a directory or database table). It does a full scan first, then watches for changes. Example: [`localfs.walk_dir(live=True).items()`](../connectors/localfs.md#live-file-watching).
-- **`LiveMapFeed`** — the source only streams changes, with no snapshot to scan (e.g., a Kafka consumer). All data arrives via the change stream. Example: [`kafka.topic_as_map()`](../connectors/kafka.md#as-source).
+- **`LiveMapView`** — the source has scannable current state (e.g., a directory or database table). It does a full scan first, then watches for changes. Example: [`localfs.walk_dir(live=True).items()`](../connectors/localfs#live-file-watching).
+- **`LiveMapFeed`** — the source only streams changes, with no snapshot to scan (e.g., a Kafka consumer). All data arrives via the change stream. Example: [`kafka.topic_as_map()`](../connectors/kafka#as-source).
 
 When `mount_each()` receives either, it automatically creates a `LiveComponent` internally that:
 
@@ -69,7 +69,7 @@ Without live support on the source, `mount_each()` falls back to catch-up behavi
 
 ### `localfs` — file watching with `LiveMapView`
 
-The [`localfs`](../connectors/localfs.md) connector supports live mode via `walk_dir(..., live=True)`, which watches for file system changes using `watchfiles`:
+The [`localfs`](../connectors/localfs) connector supports live mode via `walk_dir(..., live=True)`, which watches for file system changes using `watchfiles`:
 
 ```python
 @coco.fn
@@ -91,7 +91,7 @@ For a complete working example, see [`files_transform`](https://github.com/cocoi
 
 ### `kafka` — consuming a topic with `LiveMapFeed`
 
-The [`kafka`](../connectors/kafka.md) connector treats a topic as a live keyed map — each message is an upsert or delete for a key. Since there's no snapshot to scan, it returns a `LiveMapFeed`:
+The [`kafka`](../connectors/kafka) connector treats a topic as a live keyed map — each message is an upsert or delete for a key. Since there's no snapshot to scan, it returns a `LiveMapFeed`:
 
 ```python
 from confluent_kafka.aio import AIOConsumer
@@ -115,8 +115,8 @@ app.update_blocking(live=True)
 
 The abstractions behind live mode, from most general to most specific:
 
-- **[LiveComponent](../advanced_topics/live_component.md)** — the underlying protocol for components that react to changes incrementally. Most flexible — full control over the lifecycle.
-- **[LiveMapFeed / LiveMapView](../advanced_topics/live_component.md#live-map)** — represents a changing collection of keyed items. `mount_each()` uses it to construct a `LiveComponent` automatically. Connector authors implement this to add live support.
-- **Source connectors** — provide `LiveMapView` (e.g., [`localfs`](../connectors/localfs.md)) or `LiveMapFeed` (e.g., [`kafka`](../connectors/kafka.md)) from their source APIs. Users just pass the result to `mount_each()`.
+- **[LiveComponent](../advanced_topics/live_component)** — the underlying protocol for components that react to changes incrementally. Most flexible — full control over the lifecycle.
+- **[LiveMapFeed / LiveMapView](../advanced_topics/live_component#livemapfeed-and-livemapview)** — represents a changing collection of keyed items. `mount_each()` uses it to construct a `LiveComponent` automatically. Connector authors implement this to add live support.
+- **Source connectors** — provide `LiveMapView` (e.g., [`localfs`](../connectors/localfs)) or `LiveMapFeed` (e.g., [`kafka`](../connectors/kafka)) from their source APIs. Users just pass the result to `mount_each()`.
 
-For custom change feeds, fine-grained lifecycle control, or implementing live map protocols on your own connector, see [Live Components](../advanced_topics/live_component.md).
+For custom change feeds, fine-grained lifecycle control, or implementing live map protocols on your own connector, see [Live Components](../advanced_topics/live_component).

--- a/docs/src/content/docs/programming_guide/processing_component.mdx
+++ b/docs/src/content/docs/programming_guide/processing_component.mdx
@@ -31,7 +31,7 @@ Here's an example component path tree for a pipeline that processes files:
 
 The tree is populated dynamically as the app runs — each `mount()` / `mount_each()` call adds a subpath.
 
-See [StableKey](./sdk_overview.md#stablekey) in the SDK Overview for details on what values can be used in component paths.
+See [StableKey](./sdk_overview#stablekey) in the SDK Overview for details on what values can be used in component paths.
 
 ## Mount
 
@@ -92,7 +92,7 @@ await handle.ready()
 
 You usually only need to call `ready()` when you have logic that depends on the processing component's target states being applied — for example, querying the latest data from a target table after syncing it.
 
-`mount()` also accepts **LiveComponent classes** — components that process continuously and react to changes incrementally instead of rescanning everything. See [Live Components](../advanced_topics/live_component.md) for details.
+`mount()` also accepts **LiveComponent classes** — components that process continuously and react to changes incrementally instead of rescanning everything. See [Live Components](../advanced_topics/live_component) for details.
 
 ### `use_mount()`
 
@@ -122,7 +122,7 @@ files = localfs.walk_dir(sourcedir, path_matcher=PatternFilePathMatcher(included
 await coco.mount_each(process_file, files.items(), target)
 ```
 
-Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an [auto-derived subpath](#auto-subpath) (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
+Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an [auto-derived subpath](#automatic-subpath-derivation) (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
 
 You can provide an explicit subpath as the first argument:
 
@@ -132,7 +132,7 @@ await coco.mount_each(coco.component_subpath("files"), process_file, files.items
 
 Source connectors provide an `items()` method that returns `(StableKey, T)` pairs. For example, `localfs.walk_dir(...).items()` yields `(relative_path, File)` tuples.
 
-When a source connector supports live watching, its `items()` returns a `LiveMapView` or `LiveMapFeed` instead of a plain iterable. `mount_each()` detects this and automatically handles incremental updates — no changes to `mount_each()` itself are needed. See [Live Mode](./live_mode.md).
+When a source connector supports live watching, its `items()` returns a `LiveMapView` or `LiveMapFeed` instead of a plain iterable. `mount_each()` detects this and automatically handles incremental updates — no changes to `mount_each()` itself are needed. See [Live Mode](./live_mode).
 
 ### `mount_target()`
 `mount_target()` mounts a target without requiring an explicit subpath.
@@ -187,7 +187,7 @@ for f in files:
 ```
 
 :::tip
-When iterating over keyed items, prefer [`mount_each()`](#mount-each) — it handles the loop and subpath creation for you.
+When iterating over keyed items, prefer [`mount_each()`](#mount_each) — it handles the loop and subpath creation for you.
 :::
 
 ## How target states sync
@@ -217,10 +217,10 @@ CocoIndex processes each component in two phases: **processing** (running your f
 
 To react to background failures, you can:
 
-- Install [exception handlers](../advanced_topics/exception_handlers.md#exception-handlers) — global or scoped — to send alerts, record metrics, or implement custom logic.
-- [Monitor app progress](./app.md#monitoring-progress) — `UpdateStats` exposes per-component stats including error counts, so you can detect failures programmatically.
+- Install [exception handlers](../advanced_topics/exception_handlers#exception-handlers) — global or scoped — to send alerts, record metrics, or implement custom logic.
+- [Monitor app progress](./app#monitoring-progress) — `UpdateStats` exposes per-component stats including error counts, so you can detect failures programmatically.
 
-For the full picture — including interrupted update recovery and the exception handler API — see [Error Handling](../advanced_topics/exception_handlers.md).
+For the full picture — including interrupted update recovery and the exception handler API — see [Error Handling](../advanced_topics/exception_handlers).
 
 ### No rollback, convergent roll-forward
 
@@ -275,7 +275,7 @@ This pattern ensures that CocoIndex can track component relationships and target
 ## Processing helpers
 
 ### `map()`
-`map()` applies an async function to each item in a collection, running all calls concurrently within the current processing component. Unlike [`mount()`](#mount) and [`mount_each()`](#mount-each), it does **not** create child processing components — it's purely concurrent execution (similar to `asyncio.gather()`).
+`map()` applies an async function to each item in a collection, running all calls concurrently within the current processing component. Unlike [`mount()`](#mount) and [`mount_each()`](#mount_each), it does **not** create child processing components — it's purely concurrent execution (similar to `asyncio.gather()`).
 
 ```python
 @coco.fn(memo=True)

--- a/docs/src/content/docs/programming_guide/sdk_overview.mdx
+++ b/docs/src/content/docs/programming_guide/sdk_overview.mdx
@@ -22,7 +22,7 @@ The CocoIndex SDK is organized into several modules:
 | Package | Description |
 |---------|-------------|
 | `cocoindex.connectors` | Connectors for data sources and targets |
-| `cocoindex.resources` | [Common resources](../common_resources/data_types.md) — shared data types, vector schema annotations, and ID generation utilities |
+| `cocoindex.resources` | [Common resources](../common_resources/data_types) — shared data types, vector schema annotations, and ID generation utilities |
 | `cocoindex.ops` | Built-in operations for common data processing tasks (e.g., text splitting, embedding with SentenceTransformers) |
 
 Import connectors and extras by their specific sub-module:
@@ -48,7 +48,7 @@ StableKey = None | bool | int | str | bytes | uuid.UUID | Symbol | tuple[StableK
 Common examples include strings (like `"setup"` or `"table"`), integers, and UUIDs. Tuples allow composite keys when needed.
 `Symbol` provides predefined names that will never conflict with strings (which typically come from runtime data).
 
-Each processing component must be mounted at a unique path. See [Processing Component](./processing_component.md) for how the component path tree affects target states and ownership.
+Each processing component must be mounted at a unique path. See [Processing Component](./processing_component) for how the component path tree affects target states and ownership.
 
 ## Async vs sync APIs
 
@@ -72,11 +72,11 @@ APIs for starting and running your pipeline have both async and sync variants. S
 | `await coco.stop()` | `coco.stop_blocking()` |
 | `async with coco.runtime():` | `with coco.runtime():` |
 
-`app.update()` returns an `UpdateHandle` that is also awaitable — `await app.update()` returns the result directly, or you can use the handle for [progress monitoring](./app.md#monitoring-progress). Use the `_blocking` variants for scripts and CLI usage. See [App](./app.md) for details.
+`app.update()` returns an `UpdateHandle` that is also awaitable — `await app.update()` returns the result directly, or you can use the handle for [progress monitoring](./app#monitoring-progress). Use the `_blocking` variants for scripts and CLI usage. See [App](./app) for details.
 
 ### Processing functions (your choice)
 
-The `@coco.fn` decorator preserves the sync/async nature of your function — your processing functions can be sync or async. See [Function](./function.md) for details.
+The `@coco.fn` decorator preserves the sync/async nature of your function — your processing functions can be sync or async. See [Function](./function) for details.
 
 ## How sync and async work together
 
@@ -85,7 +85,7 @@ Like any async Python program, **async functions can call into sync code, but no
 CocoIndex provides two ways for async code to call into sync functions:
 
 - **Mounting** — When you mount a processing component, the function is scheduled on CocoIndex's runtime, not called directly. So an async function can mount a sync processing function.
-- **`@coco.fn.as_async`** — Wraps a sync function with an async interface (runs on a thread pool). Useful for compute-intensive leaf functions. See [Function](./function.md) for details.
+- **`@coco.fn.as_async`** — Wraps a sync function with an async interface (runs on a thread pool). Useful for compute-intensive leaf functions. See [Function](./function) for details.
 
 ### Example: async orchestration mounting sync leaf functions
 

--- a/docs/src/content/docs/programming_guide/serialization.mdx
+++ b/docs/src/content/docs/programming_guide/serialization.mdx
@@ -7,7 +7,7 @@ description: >
 ---
 ## Overview
 
-CocoIndex serializes and caches the return values of [memoized functions](./function.md#memoization) so that unchanged work can be skipped on subsequent runs. Most Python types work automatically — the key thing to get right is the **return type annotation**, which tells CocoIndex how to reconstruct your objects:
+CocoIndex serializes and caches the return values of [memoized functions](./function#memoization) so that unchanged work can be skipped on subsequent runs. Most Python types work automatically — the key thing to get right is the **return type annotation**, which tells CocoIndex how to reconstruct your objects:
 
 ```python
 @coco.fn(memo=True)
@@ -18,10 +18,10 @@ async def process_chunk(chunk: Chunk) -> Embedding:  # return type annotation
 Without annotations, values may deserialize as basic Python types (`dict`, `list`, `str`, etc.) instead of their original types.
 
 :::info[Advanced: other places where serialization and type annotations matter]
-Serialization also applies to [memo states](../advanced_topics/memoization_keys.md#memo-state-validation) and [tracking records](../advanced_topics/custom_target_connector.md#targethandler-you-implement). If you're implementing these, add type annotations to:
+Serialization also applies to [memo states](../advanced_topics/memoization_keys#memo-state-validation) and [tracking records](../advanced_topics/custom_target_connector#targethandler-you-implement). If you're implementing these, add type annotations to:
 
-- **`__coco_memo_state__` `prev_state` parameter** — annotate with the state type you return in `MemoStateOutcome(state=...)`. See [Memo state validation](../advanced_topics/memoization_keys.md#memo-state-validation).
-- **`reconcile()` `prev_possible_records` parameter** — annotate with `Collection[YourTrackingRecord]`. See [Custom Target Connector](../advanced_topics/custom_target_connector.md#targethandler-you-implement).
+- **`__coco_memo_state__` `prev_state` parameter** — annotate with the state type you return in `MemoStateOutcome(state=...)`. See [Memo state validation](../advanced_topics/memoization_keys#memo-state-validation).
+- **`reconcile()` `prev_possible_records` parameter** — annotate with `Collection[YourTrackingRecord]`. See [Custom Target Connector](../advanced_topics/custom_target_connector#targethandler-you-implement).
 :::
 
 ## Supported types
@@ -115,7 +115,7 @@ This typically means an unsupported union type. The error message includes a hin
 The type annotation doesn't match the serialized data. Common causes:
 
 - **Missing return type annotation** on a memoized function — add `-> YourType` to the function signature.
-- **Changed type structure** between runs — if you renamed or restructured a dataclass, the cached data won't match. Rebuild the cache by running [`app.update(full_reprocess=True)`](./app.md#updating-an-app) or [`cocoindex update --full-reprocess`](../cli).
+- **Changed type structure** between runs — if you renamed or restructured a dataclass, the cached data won't match. Rebuild the cache by running [`app.update(full_reprocess=True)`](./app#updating-an-app) or [`cocoindex update --full-reprocess`](../cli).
 - **Forward reference not resolved** — if your type annotation uses a string forward reference, ensure the type is defined before the function is first called.
 
 ### `UnpicklingError: Forbidden global during unpickling`

--- a/docs/src/content/docs/programming_guide/target_state.mdx
+++ b/docs/src/content/docs/programming_guide/target_state.mdx
@@ -64,7 +64,7 @@ dir_target.declare_file(filename="output.html", content=html)
 
 ### Example: writing a row to PostgreSQL
 
-This example uses a [`ContextKey`](./context.md) to reference the database connection — see [Context](./context.md) for how keys are defined and provided.
+This example uses a [`ContextKey`](./context) to reference the database connection — see [Context](./context) for how keys are defined and provided.
 
 ```python
 import asyncpg
@@ -87,7 +87,7 @@ table = await postgres.mount_table_target(
 table.declare_row(row=DocEmbedding(...))
 ```
 
-These convenience methods wrap [`mount_target()`](./processing_component.md#mount-target), which automatically derives the component path from the target's globally unique key. See [Processing Component](./processing_component.md) for more on mounting APIs.
+These convenience methods wrap [`mount_target()`](./processing_component#mount_target), which automatically derives the component path from the target's globally unique key. See [Processing Component](./processing_component) for more on mounting APIs.
 
 :::tip[Type safety]
 Targets like `DirTarget` and `TableTarget` have two statuses: **pending** (just created) and **resolved** (after the container target state is ready). The type system tracks this — if you try to use a pending target before it's resolved, type checkers like mypy will flag the error.
@@ -137,7 +137,7 @@ CocoIndex ensures containers exist before their contents are added, and properly
 
 When you change a container target state's declaration (e.g., add a column to a table schema, change a primary key), CocoIndex detects the change and does its best to alter the target in place. If the change is too large to alter (e.g., changing primary keys), the target is dropped and recreated.
 
-When a target is dropped and recreated, CocoIndex automatically reprocesses all affected components to backfill the data — you don't need to manually trigger `--full-reprocess`. This is handled by the target connector's [child invalidation](../advanced_topics/custom_target_connector.md#child-invalidation) mechanism, which signals to CocoIndex whether the change is destructive (all children lost) or lossy (some data may be lost).
+When a target is dropped and recreated, CocoIndex automatically reprocesses all affected components to backfill the data — you don't need to manually trigger `--full-reprocess`. This is handled by the target connector's [child invalidation](../advanced_topics/custom_target_connector#child-invalidation) mechanism, which signals to CocoIndex whether the change is destructive (all children lost) or lossy (some data may be lost).
 
 ## Generic target state APIs
 
@@ -146,4 +146,4 @@ For cases where connector-specific APIs don't cover your needs, CocoIndex provid
 - `declare_target_state()` — declare a leaf target state
 - `declare_target_state_with_child()` — declare a target state that provides child target states
 
-These are exported from `cocoindex` and used internally by connectors. For defining custom targets, see [Custom Target States Connector](../advanced_topics/custom_target_connector.md).
+These are exported from `cocoindex` and used internally by connectors. For defining custom targets, see [Custom Target States Connector](../advanced_topics/custom_target_connector).


### PR DESCRIPTION
## Summary
- Adds a build-time link checker (`docs/scripts/remark-link-checker.mjs`) that fails the Astro build on relative links with stray `.md`/`.mdx` suffixes, links whose target file does not exist under the docs collection, and `#fragment` identifiers that do not match a heading in the target file (slugified via `github-slugger`, the same algorithm Astro uses).
- Fixes 150 stale `.md`/`.mdx` suffixes and 12 broken cross-file/in-page fragments uncovered by the new check (e.g. `#auto-subpath` → `#automatic-subpath-derivation`, `#mount-each` → `#mount_each`, `#live-map` → `#livemapfeed-and-livemapview`).

## Test plan
- `cd docs && npm run build` succeeds (48 pages built).
- Verified the checker rejects deliberately-bad links: a `.mdx` suffix, a non-existent target path, and a bogus `#fragment` each fail the build with a `file:line` error message.
