### PR TITLE
docs: rewrite relative links to canonical absolute URLs at build time

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -63,22 +63,46 @@ const cocoindexCodeTheme = {
 
 // V1 docs are served from https://cocoindex.io/docs/, matching the
 // Docusaurus URLs on the v1 branch (`baseUrl: '/docs/'` in
-// docs/docusaurus.config.ts). `base` handles the prefix; `trailingSlash:
-// 'never'` keeps /docs/core/basics shaped exactly like Docusaurus.
+// docs/docusaurus.config.ts). `base` handles the prefix.
+const BASE = '/docs';
+// `remark-link-checker` both validates *and* rewrites relative links: under
+// `build.format: 'directory'` (the default), source-relative `./foo` links
+// resolve incorrectly in the browser (a page at `/programming_guide/x/`
+// makes `./foo` mean `/programming_guide/x/foo`). The plugin emits absolute
+// hrefs (`/docs/<slug>`) so links work regardless of trailing-slash quirks.
+// `[plugin, options]` tuples need an explicit type — TypeScript otherwise
+// widens the array literal to `(Plugin | Options)[]` and Astro rejects it.
+/** @type {any[]} */
+const remarkPlugins = [
+  remarkDirective,
+  remarkAdmonitions,
+  remarkCodeTitles,
+  [remarkLinkChecker, { base: BASE }],
+];
+
 export default defineConfig({
   site: 'https://cocoindex.io',
-  base: '/docs',
+  base: BASE,
+  // `trailingSlash: 'always'` matches `build.format: 'directory'`: every
+  // page lives at `<slug>/index.html` and is canonical at `<slug>/`. In
+  // dev, requests without the trailing slash 404 — that strictness is the
+  // point: the link-checker plugin catches no-slash hrefs in markdown/MDX,
+  // and `'always'` catches no-slash hrefs in `.astro` components (sidebar,
+  // breadcrumb, pager, future pieces) before they ship. External / legacy
+  // links without the slash still resolve in production via GitHub Pages's
+  // own 301 redirect, so this doesn't break inbound traffic.
+  trailingSlash: 'always',
   integrations: [
     mdx({
       // MDX's own remark pipeline doesn't inherit `markdown.remarkPlugins`
       // reliably across Astro versions — wire admonitions + code titles
       // explicitly so .mdx content collection pages get them for sure.
-      remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles, remarkLinkChecker],
+      remarkPlugins,
     }),
     sitemap(),
   ],
   markdown: {
-    remarkPlugins: [remarkDirective, remarkAdmonitions, remarkCodeTitles, remarkLinkChecker],
+    remarkPlugins,
     shikiConfig: { theme: cocoindexCodeTheme, wrap: false },
   },
   redirects,

--- a/docs/scripts/remark-link-checker.mjs
+++ b/docs/scripts/remark-link-checker.mjs
@@ -1,4 +1,5 @@
-// Validate relative links in Markdown / MDX during the build.
+// Validate (and optionally rewrite) relative links in Markdown / MDX during
+// the build.
 //
 // Three checks per `link` node:
 //
@@ -16,18 +17,34 @@
 // In-page fragment links (`#section`) are validated against the current
 // file's headings.
 //
-// Skipped: absolute URLs (`https://`), root-relative URLs (`/docs/foo` —
-// would require base-prefix-aware resolution; not common in this codebase),
-// and `mailto:` links.
+// **Rewrite (default on).** After a relative link's target is resolved, the
+// link's `url` is replaced with an absolute path of the form
+// `<base>/<slug>` (e.g. `./app` from `programming_guide/core_concepts.mdx`
+// becomes `/docs/programming_guide/app`). This is needed under Astro's
+// `build.format: 'directory'` mode: source-relative links and URL-relative
+// links diverge once each page lives at `<slug>/index.html`. Authors keep
+// writing the natural source-relative form; the plugin emits absolute hrefs
+// that resolve identically regardless of trailing-slash quirks.
 //
-// On any failure the plugin throws a single combined error per file, which
-// fails the Astro build.
+// In-page fragment links (`#section`) are NOT rewritten — they target the
+// current page and need no base prefix.
+//
+// Skipped entirely: absolute URLs (`https://`), root-relative URLs
+// (`/docs/foo` — already canonical), and `mailto:` links.
+//
+// Plugin option:
+//   - `base` (default `''`): URL prefix to prepend when rewriting. Pass the
+//     same value as Astro's `base` config. Trailing slashes normalized away.
+//
+// On any check failure the plugin throws a single combined error per file,
+// which fails the Astro build.
 import { readFileSync, existsSync } from 'node:fs';
-import { dirname, extname, resolve } from 'node:path';
+import { dirname, extname, posix, resolve, sep } from 'node:path';
 import GithubSlugger from 'github-slugger';
 import { visit } from 'unist-util-visit';
 
 const ABSOLUTE_URL = /^[a-z][a-z0-9+\-.]*:/i;
+const CONTENT_ROOT_MARKER = `${sep}src${sep}content${sep}docs${sep}`;
 
 // Cache parsed heading slugs per target file. Build-time only, so a simple
 // in-memory map is fine — and the same file can be linked from many places.
@@ -122,7 +139,34 @@ function resolveTargetFile(sourceFile, urlPath) {
   return null;
 }
 
-export default function remarkLinkChecker() {
+// Convert an absolute target file path (under `src/content/docs/`) to its
+// content-collection slug — the URL path Astro serves it at, *without* the
+// `base` prefix. `<root>/foo/bar.mdx` → `foo/bar`; `<root>/foo/index.mdx`
+// → `foo`. POSIX-separated regardless of host platform.
+function fileToSlug(targetFile) {
+  const ix = targetFile.indexOf(CONTENT_ROOT_MARKER);
+  if (ix < 0) return null;
+  let rel = targetFile.slice(ix + CONTENT_ROOT_MARKER.length);
+  // Normalize to POSIX separators for URL output.
+  rel = rel.split(sep).join('/');
+  // Strip extension.
+  rel = rel.replace(/\.(mdx|md)$/i, '');
+  // index files map to the directory URL (or '' for the root index).
+  rel = rel.replace(/(?:^|\/)index$/, (m) => (m === 'index' ? '' : ''));
+  return rel;
+}
+
+function normalizeBase(base) {
+  if (!base) return '';
+  // Trim trailing slashes; ensure a single leading slash.
+  let b = base.replace(/\/+$/, '');
+  if (b && !b.startsWith('/')) b = `/${b}`;
+  return b;
+}
+
+export default function remarkLinkChecker(options = {}) {
+  const base = normalizeBase(options.base);
+
   return (tree, file) => {
     const sourcePath = file.path;
     if (!sourcePath) return;
@@ -138,7 +182,8 @@ export default function remarkLinkChecker() {
 
       const line = node.position?.start?.line;
 
-      // In-page fragment link (`#section`): validate against this file.
+      // In-page fragment link (`#section`): validate against this file. Not
+      // rewritten — fragment-only URLs target the current page.
       if (url.startsWith('#')) {
         const fragment = url.slice(1);
         if (!fragment) return;
@@ -167,14 +212,14 @@ export default function remarkLinkChecker() {
       const targetFile = resolveTargetFile(sourcePath, pathPart);
       if (!targetFile) {
         const sourceDir = dirname(sourcePath);
-        const base = resolve(sourceDir, pathPart);
+        const probeBase = resolve(sourceDir, pathPart);
         errors.push({
           line,
           message: `link "${url}" does not resolve to a file in the docs collection (looked for: ${[
-            `${base}.mdx`,
-            `${base}.md`,
-            `${base}/index.mdx`,
-            `${base}/index.md`,
+            `${probeBase}.mdx`,
+            `${probeBase}.md`,
+            `${probeBase}/index.mdx`,
+            `${probeBase}/index.md`,
           ]
             .map((c) => c.replace(/^.*\/src\/content\/docs\//, ''))
             .join(', ')})`,
@@ -192,7 +237,21 @@ export default function remarkLinkChecker() {
               '',
             )}`,
           });
+          return;
         }
+      }
+
+      // Rewrite: replace the source-relative URL with the canonical absolute
+      // one (`<base>/<slug>/[#fragment]`). The trailing slash matches the
+      // canonical URL Astro emits under `build.format: 'directory'` — without
+      // it, the host (e.g. GitHub Pages) issues a 301 redirect on every click.
+      // Robust under directory format because the browser no longer has to
+      // interpret `./` against a trailing-slash-bearing URL.
+      const slug = fileToSlug(targetFile);
+      if (slug !== null) {
+        const joined = posix.join('/', base.replace(/^\//, ''), slug);
+        const absPath = joined.endsWith('/') ? joined : `${joined}/`;
+        node.url = fragment ? `${absPath}#${fragment}` : absPath;
       }
     });
 

--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -59,7 +59,9 @@ const tocRows = tocItems.map((h) => {
 });
 
 function href(slug: string): string {
-  return `${base}/${slug}`;
+  // Trailing slash matches the canonical URL Astro emits under
+  // `build.format: 'directory'` — saves a 301 round-trip per click.
+  return `${base}/${slug}/`;
 }
 ---
 

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -11,7 +11,9 @@ const { currentSlug } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 function href(slug: string): string {
-  return `${base}/${slug}`;
+  // Trailing slash matches the canonical URL Astro emits under
+  // `build.format: 'directory'` — saves a 301 round-trip per click.
+  return `${base}/${slug}/`;
 }
 ---
 

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -63,7 +63,7 @@ const introItems = [
   { k: 'Version',       v: version,             reviewed: false },
   { k: 'Last reviewed', v: lastReviewed,        reviewed: true  },
 ].filter((m) => m.v);
-const canonical = new URL(`${base}/${slug}`, SITE_URL).toString();
+const canonical = new URL(`${base}/${slug}/`, SITE_URL).toString();
 
 // Breadcrumb: walk the sidebar tree for the current slug so category
 // labels light up correctly even for nested pages.
@@ -73,7 +73,7 @@ function findPath(items: SidebarItem[], acc: Array<{ label: string; href?: strin
       return [...acc, { label: item.label ?? slug }];
     }
     if (item.type === 'category') {
-      const next = [...acc, { label: item.label, href: item.slug ? `${base}/${item.slug}` : undefined }];
+      const next = [...acc, { label: item.label, href: item.slug ? `${base}/${item.slug}/` : undefined }];
       if (item.slug === slug) return next;
       const down = findPath(item.items, next);
       if (down) return down;
@@ -166,13 +166,13 @@ const next = i >= 0 && i < flat.length - 1 ? flat[i + 1] : null;
         {(prev || next) && (
           <div class="pager">
             {prev ? (
-              <a href={`${base}/${prev.slug}`}>
+              <a href={`${base}/${prev.slug}/`}>
                 <span class="dir">Previous</span>
                 <span class="ttl">{prev.label ?? prev.slug}</span>
               </a>
             ) : <span />}
             {next ? (
-              <a class="next" href={`${base}/${next.slug}`}>
+              <a class="next" href={`${base}/${next.slug}/`}>
                 <span class="dir">Next</span>
                 <span class="ttl">{next.label ?? next.slug}</span>
               </a>


### PR DESCRIPTION
## Summary
- `remark-link-checker` now also **rewrites** relative markdown/MDX links to canonical absolute URLs (`<base>/<slug>/`), with trailing slash. Source-relative `./foo` links break under `build.format: 'directory'` (a page at `/x/` resolves `./foo` to `/x/foo`); the rewrite emits hrefs that resolve correctly without depending on the current page's URL shape.
- Per-component `href()` helpers (`Sidebar`, `MobileSheet`, `DocsLayout`) and the canonical / breadcrumb / pager URLs in `DocsLayout` gained the trailing slash so `.astro`-emitted URLs match the canonical form.
- `trailingSlash: 'always'` makes the Astro dev server enforce the canonical form, surfacing any future no-slash href bug as an immediate 404 instead of a silent production redirect. External inbound `/foo` links still resolve in production via GitHub Pages's host-level redirect.

## Test plan
- `cd docs && npm run build` — passes; built HTML's internal hrefs all carry trailing slashes.
- Verified against `dist/programming_guide/core_concepts/index.html`: every `programming_guide/app` href is `/docs/programming_guide/app/`.
- Verified against `astro dev`: `/docs/programming_guide/app/` serves 200; `/docs/programming_guide/app` 404s (intentional under `'always'`).
