### PR TITLE
feat(falkordb): add FalkorDB target connector

### DIFF
--- a/docs/src/content/docs/connectors/falkordb.mdx
+++ b/docs/src/content/docs/connectors/falkordb.mdx
@@ -1,0 +1,389 @@
+---
+title: "*FalkorDB* connector"
+toc_max_heading_level: 4
+description: >
+  Write to FalkorDB — a Redis-backed graph database — with support for node
+  tables, relationship tables (edges), per-graph multitenancy, and vector
+  indexes with cosine / euclidean / inner-product distances.
+---
+
+The `falkordb` connector writes records to FalkorDB, a Cypher-compatible graph database that runs as a Redis module. It supports node tables (labels), relationship tables (edge types), per-graph multitenancy (one Redis instance, many isolated graphs), and vector indexes.
+
+```python
+from cocoindex.connectors import falkordb
+```
+
+:::note[Dependencies]
+This connector requires additional dependencies. Install with:
+
+```bash
+pip install cocoindex[falkordb]
+```
+
+:::
+
+## Connection setup
+
+Create a `ConnectionFactory` and provide it via a `ContextKey`. The factory holds the FalkorDB URI plus the target graph name, and yields a graph handle on demand.
+
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
+:::
+
+```python
+from collections.abc import AsyncIterator
+from cocoindex.connectors import falkordb
+import cocoindex as coco
+
+KG_DB: coco.ContextKey[falkordb.ConnectionFactory] = coco.ContextKey("kg_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(
+        KG_DB,
+        falkordb.ConnectionFactory(
+            uri="falkor://localhost:6379",
+            graph="knowledge_graph",
+        ),
+    )
+    yield
+```
+
+### Multitenancy
+
+A single Redis instance can host many fully isolated graphs. Pair each graph with its own `ContextKey` and `ConnectionFactory(graph=...)`:
+
+```python
+KG_DB: coco.ContextKey[falkordb.ConnectionFactory] = coco.ContextKey("kg_db")
+APIS_DB: coco.ContextKey[falkordb.ConnectionFactory] = coco.ContextKey("apis_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    uri = "falkor://localhost:6379"
+    builder.provide(KG_DB, falkordb.ConnectionFactory(uri=uri, graph="knowledge_graph"))
+    builder.provide(APIS_DB, falkordb.ConnectionFactory(uri=uri, graph="apis_graph"))
+    yield
+```
+
+Different `ContextKey`s with different graph names produce fully separate target-state trees — changes to one never spill into the other.
+
+## As target
+
+The `falkordb` connector provides target state APIs for writing records to node tables and relation tables. CocoIndex tracks what records should exist and automatically handles upserts and deletions.
+
+Each `graph.query` call against FalkorDB is its own atomic unit (FalkorDB does not expose multi-statement transactions); the connector orders writes within a batch as **node upserts → relation upserts → relation deletes → node deletes** so dependent edges always see their endpoints.
+
+### Declaring target states
+
+#### Node tables (parent state)
+
+Declares a node label as a target state. Returns a `TableTarget` for declaring records.
+
+```python
+def declare_table_target(
+    db: ContextKey,
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: Literal["system", "user"] = "system",
+) -> TableTarget[RowT, coco.PendingS]
+```
+
+**Parameters:**
+
+- `db` — A `ContextKey[falkordb.ConnectionFactory]` for the FalkorDB connection.
+- `table_name` — The Cypher node label (e.g. `"Document"`).
+- `table_schema` — Optional schema definition (see [Table Schema](#table-schema-from-python-class)). FalkorDB does not enforce per-property types server-side, so the schema participates in CocoIndex's fingerprint (so two flows declaring the same label must agree) but no per-column DDL is emitted.
+- `primary_key` — Single property name used as the node's primary key. Defaults to `"id"`. Compound primary keys are not supported in v1.0.
+- `managed_by` — Whether CocoIndex manages the table lifecycle (`"system"`) or assumes it exists (`"user"`).
+
+**Returns:** A pending `TableTarget`. Use `await falkordb.mount_table_target(KG_DB, ...)` to get a resolved target.
+
+#### Records (child states)
+
+Once a `TableTarget` is resolved, declare records to be upserted (translated to `MERGE (n:Label {pk: $key_0}) SET n += $props`):
+
+```python
+def TableTarget.declare_record(
+    self,
+    *,
+    row: RowT,
+) -> None
+```
+
+**Parameters:**
+
+- `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include the `primary_key` field declared above.
+
+`declare_row` is an alias for `declare_record`, for compatibility with Postgres and other RDBMS targets.
+
+#### Relation tables (parent state)
+
+Declares a relationship type as a target state. Returns a `RelationTarget` for declaring edges.
+
+```python
+def declare_relation_target(
+    db: ContextKey,
+    table_name: str,
+    from_table: TableTarget,
+    to_table: TableTarget,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: Literal["system", "user"] = "system",
+) -> RelationTarget[RowT, coco.PendingS]
+```
+
+**Parameters:**
+
+- `db` — A `ContextKey[falkordb.ConnectionFactory]` for the FalkorDB connection.
+- `table_name` — The Cypher relationship type (e.g. `"MENTION"`).
+- `from_table` — The `TableTarget` whose nodes are the *source* endpoints of edges in this relationship.
+- `to_table` — The `TableTarget` whose nodes are the *target* endpoints of edges in this relationship.
+- `table_schema` — Optional schema for the relationship's own properties (see [Table Schema](#table-schema-from-python-class)). The relationship's `primary_key` field uniquely identifies each edge.
+- `primary_key` — Single property name used as the edge's primary key. Defaults to `"id"`.
+- `managed_by` — Whether CocoIndex manages the relationship lifecycle (`"system"`) or assumes it exists (`"user"`).
+
+**Returns:** A pending `RelationTarget`. Use `await falkordb.mount_relation_target(KG_DB, ...)` to get a resolved target.
+
+#### Relations (child states)
+
+Once a `RelationTarget` is resolved, declare edges. Each declaration produces a triple-MERGE: source endpoint, target endpoint, then the relationship.
+
+```python
+def RelationTarget.declare_relation(
+    self,
+    *,
+    from_id: Any,
+    to_id: Any,
+    record: RowT | None = None,
+) -> None
+```
+
+**Parameters:**
+
+- `from_id` — The source node's primary-key value. The connector MERGEs `(s:FromLabel {pk: $from_id})` so endpoints are auto-created if absent.
+- `to_id` — The target node's primary-key value. Same MERGE behavior.
+- `record` — Optional row object whose fields populate the relationship's properties. Must include the relationship's `primary_key` field if provided.
+
+If `record` is omitted, the connector derives a deterministic edge id from `(from_label, from_id, to_label, to_id)`. This is convenient when an edge has no properties of its own.
+
+#### Vector indexes (attachment)
+
+Declares a vector index on a column of a node table. Vector indexes are an [attachment](../advanced_topics/custom_target_connector#implementing-attachment-providers) to a `TableTarget`:
+
+```python
+def TableTarget.declare_vector_index(
+    self,
+    *,
+    name: str | None = None,
+    field: str,
+    metric: Literal["cosine", "euclidean", "ip"] = "cosine",
+    dimension: int,
+) -> None
+```
+
+**Parameters:**
+
+- `name` — Optional logical name for the index. Defaults to `f"idx_{table_name}__{field}"`.
+- `field` — The node property holding the vector.
+- `metric` — Similarity metric: `"cosine"`, `"euclidean"`, or `"ip"` (inner product). Translated to FalkorDB's `similarityFunction` option.
+- `dimension` — The vector's dimension. Required.
+
+The connector emits `CREATE VECTOR INDEX FOR (e:Label) ON (e.field) OPTIONS {dimension: N, similarityFunction: '...'}`. Vectors are float32 only — wider vector dtypes are not supported.
+
+### Table schema: from Python class
+
+Build a `TableSchema` by introspecting a record type:
+
+```python
+@classmethod
+async def TableSchema.from_class(
+    cls,
+    record_type: type[RowT],
+    *,
+    primary_key: str = "id",
+    column_overrides: dict[str, FalkorType | VectorSchemaProvider] | None = None,
+) -> TableSchema[RowT]
+```
+
+**Parameters:**
+
+- `record_type` — A dataclass, NamedTuple, or Pydantic model.
+- `primary_key` — Field name to use as the table's primary key. Defaults to `"id"`.
+- `column_overrides` — Optional dict mapping field names to `FalkorType` or `VectorSchemaProvider` to override the default Python-to-FalkorDB type mapping.
+
+**Returns:** A `TableSchema[RowT]` populated from the class's fields.
+
+#### Default Python → FalkorDB type mapping
+
+| Python type | FalkorDB type | Notes |
+|---|---|---|
+| `bool` | `boolean` | |
+| `int`, NumPy integer scalars | `integer` | |
+| `float`, NumPy float scalars | `float` | |
+| `decimal.Decimal` | `string` | Encoded via `str()` — FalkorDB has no decimal type. |
+| `str` | `string` | |
+| `bytes` | `string` | Encoded as base64. |
+| `uuid.UUID` | `string` | Encoded via `str()`. |
+| `datetime.date` / `datetime.datetime` / `datetime.time` | `string` | Encoded via `.isoformat()`. |
+| `datetime.timedelta` | `integer` | Encoded as milliseconds (`int(td.total_seconds() * 1000)`). |
+| `numpy.ndarray` (with `VectorSchema` annotation) | `vector<float32, N>` | Encoded as `list[float]`. |
+| `dict`, list, nested record, `Any` | `map` / `array` | Passed through native parameter binding. |
+
+#### FalkorType
+
+Override the default mapping for a single column with `FalkorType`:
+
+```python
+class FalkorType(NamedTuple):
+    falkor_type: str
+    encoder: ValueEncoder | None = None
+```
+
+Use with `typing.Annotated`:
+
+```python
+from typing import Annotated
+from dataclasses import dataclass
+from cocoindex.connectors.falkordb import FalkorType
+
+@dataclass
+class Row:
+    id: str
+    score: Annotated[float, FalkorType("decimal", encoder=str)]
+```
+
+The `falkor_type` string is metadata-only — it participates in the schema fingerprint (so two flows declaring the same table must agree) but no DDL is emitted from it.
+
+#### VectorSchemaProvider
+
+For NumPy `ndarray` columns, attach a `VectorSchema` annotation to specify dtype + dimension. See [VectorSchema](../common_resources/vector_schema) for details.
+
+### Table schema: explicit column definitions
+
+Build a `TableSchema` directly from a dict of column definitions when the row type is dynamic:
+
+```python
+from cocoindex.connectors.falkordb import TableSchema, ColumnDef
+
+schema = TableSchema(
+    columns={
+        "filename": ColumnDef(type="string"),
+        "title": ColumnDef(type="string"),
+        "summary": ColumnDef(type="string", nullable=True),
+    },
+    primary_key="filename",
+)
+```
+
+`ColumnDef` fields:
+
+- `type` — The FalkorDB type string (metadata only; see table above).
+- `nullable` — Whether the column may be `None`. Defaults to `True`.
+- `encoder` — Optional `Callable[[Any], Any]` applied to non-`None` values before they're sent to FalkorDB.
+
+### DDL: indexes and constraints
+
+For each managed table, the connector creates the supporting Cypher index on the primary key field on first run:
+
+- For node tables: `CREATE INDEX FOR (e:Label) ON (e.<pk>)`.
+- For relation tables: `CREATE INDEX FOR ()-[e:RelType]-() ON (e.<pk>)`.
+
+It then attempts a uniqueness constraint via the `GRAPH.CONSTRAINT CREATE` Redis command (best-effort — failures are logged but do not abort). Indexes and constraints are dropped on `cocoindex drop` or when the table is no longer declared.
+
+When `managed_by="user"` is set, the connector skips DDL entirely — you're responsible for creating and dropping the schema. Record-level upserts and deletes still work.
+
+### Example: Node tables
+
+```python
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+import cocoindex as coco
+from cocoindex.connectors import falkordb
+
+KG_DB: coco.ContextKey[falkordb.ConnectionFactory] = coco.ContextKey("kg_db")
+
+
+@dataclass
+class Document:
+    filename: str
+    title: str
+    summary: str
+
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(KG_DB, falkordb.ConnectionFactory(
+        uri="falkor://localhost:6379", graph="knowledge_graph",
+    ))
+    yield
+
+
+@coco.fn
+async def app_main() -> None:
+    schema = await falkordb.TableSchema.from_class(Document, primary_key="filename")
+    documents = await falkordb.mount_table_target(
+        KG_DB, "Document", schema, primary_key="filename",
+    )
+    documents.declare_record(
+        row=Document(
+            filename="overview.md",
+            title="Overview",
+            summary="An overview of CocoIndex...",
+        )
+    )
+
+
+app = coco.App(coco.AppConfig(name="docs_to_falkordb"), app_main)
+```
+
+### Example: Relation tables (knowledge graph)
+
+```python
+@dataclass
+class Entity:
+    value: str
+
+
+@dataclass
+class RelationshipRow:
+    id: str
+    predicate: str
+
+
+@coco.fn
+async def kg_app_main() -> None:
+    documents = await falkordb.mount_table_target(
+        KG_DB, "Document",
+        await falkordb.TableSchema.from_class(Document, primary_key="filename"),
+        primary_key="filename",
+    )
+    entities = await falkordb.mount_table_target(
+        KG_DB, "Entity",
+        await falkordb.TableSchema.from_class(Entity, primary_key="value"),
+        primary_key="value",
+    )
+    relationships = await falkordb.mount_relation_target(
+        KG_DB, "RELATIONSHIP",
+        entities, entities,
+        await falkordb.TableSchema.from_class(RelationshipRow, primary_key="id"),
+        primary_key="id",
+    )
+
+    # populate ...
+    documents.declare_record(row=Document(filename="overview.md", title="Overview", summary="..."))
+    entities.declare_record(row=Entity(value="CocoIndex"))
+    entities.declare_record(row=Entity(value="FalkorDB"))
+    relationships.declare_relation(
+        from_id="CocoIndex",
+        to_id="FalkorDB",
+        record=RelationshipRow(id="rel-1", predicate="writes_to"),
+    )
+
+
+kg_app = coco.App(coco.AppConfig(name="kg_app"), kg_app_main)
+```
+
+The `Entity` table is declared up-front (via `mount_table_target`) so its index and constraint are reconciled before any `RELATIONSHIP` edge MERGEs entity endpoints. The relationship's three-MERGE pattern (source endpoint → target endpoint → edge) means missing endpoints are auto-created — but it's good practice to declare them explicitly so deletion-cascade behavior stays predictable.

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -59,6 +59,7 @@ export const sidebar: SidebarItem[] = [
     items: [
       { type: 'doc', slug: 'connectors/amazon_s3', label: 'Amazon S3' },
       { type: 'doc', slug: 'connectors/doris', label: 'Apache Doris' },
+      { type: 'doc', slug: 'connectors/falkordb', label: 'FalkorDB' },
       { type: 'doc', slug: 'connectors/google_drive', label: 'Google Drive' },
       { type: 'doc', slug: 'connectors/kafka', label: 'Kafka' },
       { type: 'doc', slug: 'connectors/lancedb', label: 'LanceDB' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ surrealdb = ["surrealdb>=1.0.0"]
 google_drive = ["google-api-python-client>=2.0.0", "google-auth>=2.0.0"]
 amazon_s3 = ["aiobotocore>=2.0.0"]
 doris = ["aiohttp>=3.9.0", "pymysql>=1.1.0", "aiomysql>=0.2.0"]
+falkordb = ["falkordb>=1.1.0"]
 kafka = ["confluent_kafka>=2.6"]
 oci = ["oci>=2.0"]
 entity_resolution = ["faiss-cpu>=1.7"]
@@ -106,6 +107,7 @@ all = [
     "aiohttp>=3.9.0",
     "pymysql>=1.1.0",
     "aiomysql>=0.2.0",
+    "falkordb>=1.1.0",
     "confluent_kafka>=2.6",
     "oci>=2.0",
     "faiss-cpu>=1.7",
@@ -200,6 +202,8 @@ module = [
     "aiomysql.*",
     "pymysql",
     "pymysql.*",
+    "falkordb",
+    "falkordb.*",
     "faiss",
     "faiss.*",
     "instructor",

--- a/python/cocoindex/connectors/falkordb/__init__.py
+++ b/python/cocoindex/connectors/falkordb/__init__.py
@@ -1,0 +1,4 @@
+from . import _target
+from ._target import *
+
+__all__ = _target.__all__

--- a/python/cocoindex/connectors/falkordb/_cypher.py
+++ b/python/cocoindex/connectors/falkordb/_cypher.py
@@ -1,0 +1,200 @@
+"""
+Pure Cypher generation for the FalkorDB connector.
+
+This module has no runtime dependency on the ``falkordb`` driver and no I/O —
+every function returns a Cypher string suitable for ``graph.query(cypher, params)``
+where ``params`` is the dict assembled by the caller.
+
+All identifiers (labels, property names, index field names) are validated by the
+caller before being passed in; values always bind via ``$``-parameters.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+__all__ = [
+    "IDENTIFIER_RE",
+    "build_node_upsert",
+    "build_node_delete",
+    "build_relationship_upsert",
+    "build_relationship_delete",
+    "build_node_index_create",
+    "build_node_index_drop",
+    "build_relationship_index_create",
+    "build_relationship_index_drop",
+    "build_vector_index_create",
+    "build_vector_index_drop",
+    "validate_identifier",
+]
+
+
+IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def validate_identifier(name: str, kind: str) -> None:
+    """Reject anything that isn't ``[a-zA-Z_][a-zA-Z0-9_]*``.
+
+    Cypher labels and property names cannot be parameter-bound, so untrusted
+    names must be validated at API entry — never escaped at query construction
+    time.
+    """
+    if not IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid FalkorDB {kind}: {name!r}. Must match [a-zA-Z_][a-zA-Z0-9_]*."
+        )
+
+
+def _quote(name: str) -> str:
+    """Backtick-wrap an already-validated identifier for inline use in Cypher."""
+    return f"`{name}`"
+
+
+def _key_clause(prefix: str, fields: Sequence[str], var: str) -> str:
+    """Build ``{<f1>: $<prefix>_0, <f2>: $<prefix>_1, ...}`` for a MATCH/MERGE pattern.
+
+    ``var`` is unused here but accepted so callers can self-document intent
+    (e.g. ``var="n"`` makes it clear this clause attaches to ``n``).
+    """
+    parts = [f"{_quote(f)}: ${prefix}_{i}" for i, f in enumerate(fields)]
+    return "{" + ", ".join(parts) + "}"
+
+
+def build_node_upsert(
+    label: str,
+    pk_fields: Sequence[str],
+    has_value_fields: bool,
+) -> str:
+    """``MERGE (n:`Label` {pk: $key_0, ...}) [SET n += $props]``.
+
+    ``has_value_fields`` controls whether the ``SET n += $props`` clause is
+    emitted. Caller passes ``True`` when there is at least one non-PK column to
+    write; otherwise the MERGE alone suffices.
+    """
+    if not pk_fields:
+        raise ValueError("build_node_upsert requires at least one primary key field")
+    cypher = f"MERGE (n:{_quote(label)} {_key_clause('key', pk_fields, 'n')})"
+    if has_value_fields:
+        cypher += " SET n += $props"
+    return cypher
+
+
+def build_node_delete(label: str, pk_fields: Sequence[str]) -> str:
+    """``MATCH (n:`Label` {pk: $key_0, ...}) DETACH DELETE n``.
+
+    DETACH DELETE removes any incident edges as a safety measure for nodes that
+    are also referenced as relationship endpoints — without it, the DELETE
+    would fail on nodes that still have edges.
+    """
+    if not pk_fields:
+        raise ValueError("build_node_delete requires at least one primary key field")
+    return (
+        f"MATCH (n:{_quote(label)} {_key_clause('key', pk_fields, 'n')}) "
+        f"DETACH DELETE n"
+    )
+
+
+def build_relationship_upsert(
+    rel_type: str,
+    from_label: str,
+    from_pk_fields: Sequence[str],
+    to_label: str,
+    to_pk_fields: Sequence[str],
+    rel_pk_fields: Sequence[str],
+    has_value_fields: bool,
+) -> str:
+    """Three MERGEs: source endpoint, target endpoint, then the relationship.
+
+    Endpoint properties are NOT touched — they are owned by their table's own
+    record handler. We only ``SET r += $props`` on the relationship itself.
+    """
+    if not from_pk_fields or not to_pk_fields or not rel_pk_fields:
+        raise ValueError(
+            "build_relationship_upsert requires PK fields for from, to, and the relationship"
+        )
+    cypher = (
+        f"MERGE (s:{_quote(from_label)} {_key_clause('from_key', from_pk_fields, 's')}) "
+        f"MERGE (t:{_quote(to_label)} {_key_clause('to_key', to_pk_fields, 't')}) "
+        f"MERGE (s)-[r:{_quote(rel_type)} {_key_clause('rel_key', rel_pk_fields, 'r')}]->(t)"
+    )
+    if has_value_fields:
+        cypher += " SET r += $props"
+    return cypher
+
+
+def build_relationship_delete(rel_type: str, pk_fields: Sequence[str]) -> str:
+    """``MATCH ()-[r:`RelType` {pk: $key_0, ...}]->() DELETE r``.
+
+    Endpoints are intentionally not deleted — they're tracked by their own
+    table handlers and will be deleted by their own reconciler if orphaned.
+    """
+    if not pk_fields:
+        raise ValueError(
+            "build_relationship_delete requires at least one primary key field"
+        )
+    return (
+        f"MATCH ()-[r:{_quote(rel_type)} "
+        f"{_key_clause('key', pk_fields, 'r')}]->() DELETE r"
+    )
+
+
+def build_node_index_create(label: str, fields: Sequence[str]) -> str:
+    """``CREATE INDEX FOR (e:`Label`) ON (e.`f1`, e.`f2`, ...)``."""
+    if not fields:
+        raise ValueError("build_node_index_create requires at least one field")
+    field_list = ", ".join(f"e.{_quote(f)}" for f in fields)
+    return f"CREATE INDEX FOR (e:{_quote(label)}) ON ({field_list})"
+
+
+def build_node_index_drop(label: str, fields: Sequence[str]) -> str:
+    """``DROP INDEX FOR (e:`Label`) ON (e.`f1`, ...)``."""
+    if not fields:
+        raise ValueError("build_node_index_drop requires at least one field")
+    field_list = ", ".join(f"e.{_quote(f)}" for f in fields)
+    return f"DROP INDEX FOR (e:{_quote(label)}) ON ({field_list})"
+
+
+def build_relationship_index_create(rel_type: str, fields: Sequence[str]) -> str:
+    """``CREATE INDEX FOR ()-[e:`RelType`]-() ON (e.`f1`, ...)``."""
+    if not fields:
+        raise ValueError("build_relationship_index_create requires at least one field")
+    field_list = ", ".join(f"e.{_quote(f)}" for f in fields)
+    return f"CREATE INDEX FOR ()-[e:{_quote(rel_type)}]-() ON ({field_list})"
+
+
+def build_relationship_index_drop(rel_type: str, fields: Sequence[str]) -> str:
+    """``DROP INDEX FOR ()-[e:`RelType`]-() ON (e.`f1`, ...)``."""
+    if not fields:
+        raise ValueError("build_relationship_index_drop requires at least one field")
+    field_list = ", ".join(f"e.{_quote(f)}" for f in fields)
+    return f"DROP INDEX FOR ()-[e:{_quote(rel_type)}]-() ON ({field_list})"
+
+
+def build_vector_index_create(
+    label: str,
+    field: str,
+    dimension: int,
+    metric: str,
+) -> str:
+    """``CREATE VECTOR INDEX FOR (e:`Label`) ON (e.`field`) OPTIONS {...}``.
+
+    ``metric`` is the FalkorDB-side ``similarityFunction`` value
+    (e.g. ``"cosine"``, ``"euclidean"``). Caller is responsible for translating
+    user-facing names into the FalkorDB vocabulary before invoking.
+    """
+    if dimension <= 0:
+        raise ValueError(f"Invalid vector dimension: {dimension}")
+    return (
+        f"CREATE VECTOR INDEX FOR (e:{_quote(label)}) ON (e.{_quote(field)}) "
+        f"OPTIONS {{dimension: {int(dimension)}, similarityFunction: '{metric}'}}"
+    )
+
+
+def build_vector_index_drop(label: str, field: str) -> str:
+    """``DROP VECTOR INDEX FOR (e:`Label`) ON (e.`field`)``.
+
+    Confirmed via spike against FalkorDB latest: the DROP statement does NOT
+    take an index name — it identifies the index by (label, field).
+    """
+    return f"DROP VECTOR INDEX FOR (e:{_quote(label)}) ON (e.{_quote(field)})"

--- a/python/cocoindex/connectors/falkordb/_target.py
+++ b/python/cocoindex/connectors/falkordb/_target.py
@@ -1,0 +1,1602 @@
+"""
+FalkorDB target for CocoIndex.
+
+Two-level state system:
+1. Table level — creates/drops Cypher indexes (and best-effort unique
+   constraints) for node labels and relationship types.
+2. Record level — upserts/deletes nodes via Cypher MERGE and edges via
+   triple-MERGE (source, target, relationship).
+
+Multitenancy is by FalkorDB graph name (one Redis instance, many isolated
+graphs); the graph is part of the ``ConnectionFactory``.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import decimal
+import logging
+import re
+import uuid as uuid_mod
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Generic,
+    Literal,
+    NamedTuple,
+    Sequence,
+)
+
+from typing_extensions import TypeVar
+
+try:
+    import falkordb as _falkordb  # type: ignore[import-untyped]
+    import falkordb.asyncio as _falkordb_asyncio  # type: ignore[import-untyped]
+except ImportError as e:
+    raise ImportError(
+        "falkordb is required to use the FalkorDB connector. "
+        "Please install cocoindex[falkordb]."
+    ) from e
+
+if TYPE_CHECKING:
+    AsyncFalkorDB = Any
+    AsyncGraph = Any
+else:
+    AsyncFalkorDB = _falkordb_asyncio.FalkorDB
+    AsyncGraph = Any
+
+import numpy as np
+import msgspec
+
+import cocoindex as coco
+from cocoindex.connectorkits import statediff, target
+from cocoindex.connectorkits.fingerprint import fingerprint_object
+from cocoindex._internal.datatype import (
+    AnyType,
+    MappingType,
+    SequenceType,
+    RecordType,
+    TypeChecker,
+    UnionType,
+    analyze_type_info,
+    is_record_type,
+)
+
+from cocoindex.resources import schema as res_schema
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+
+from . import _cypher
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation
+# ---------------------------------------------------------------------------
+
+_IDENTIFIER_RE = _cypher.IDENTIFIER_RE
+_validate_identifier = _cypher.validate_identifier
+
+
+# ---------------------------------------------------------------------------
+# Connection factory
+# ---------------------------------------------------------------------------
+
+
+class ConnectionFactory:
+    """
+    Connection factory for FalkorDB.
+
+    Holds connection parameters and yields a graph handle on demand. The graph
+    name is part of the factory (not the table key) — different graphs in the
+    same Redis instance are addressed via separate ``ConnectionFactory`` /
+    ``ContextKey`` pairs.
+
+    Example::
+
+        factory = falkordb.ConnectionFactory(
+            uri="falkor://localhost:6379",
+            graph="knowledge_graph",
+        )
+        builder.provide(FALKOR_DB, factory)
+    """
+
+    def __init__(self, uri: str, *, graph: str = "default") -> None:
+        _validate_identifier(graph, "graph name")
+        self._uri = uri
+        self._graph = graph
+
+    @property
+    def graph(self) -> str:
+        return self._graph
+
+    async def acquire(self) -> Any:
+        """Return an AsyncGraph handle ready to issue ``query(cypher, params)``."""
+        client = AsyncFalkorDB.from_url(self._uri)
+        return client.select_graph(self._graph)
+
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+_RowKey = tuple[Any, ...]  # The primary key tuple — single-element in v1.0
+_ROW_KEY_CHECKER = TypeChecker(tuple[Any, ...])
+_RowFingerprint = bytes
+
+
+class _RelationRowValue(NamedTuple):
+    """Value type for relation records.
+
+    Endpoint metadata is structured (not pre-formatted strings) so values can
+    bind via ``$``-parameters at query time rather than being string-interpolated.
+    """
+
+    from_label: str
+    from_pk_field: str
+    from_id: Any
+    to_label: str
+    to_pk_field: str
+    to_id: Any
+    fields: dict[str, Any]
+
+
+_RowValue = dict[str, Any] | _RelationRowValue
+ValueEncoder = Callable[[Any], Any]
+
+
+# ---------------------------------------------------------------------------
+# FalkorType annotation
+# ---------------------------------------------------------------------------
+
+
+class FalkorType(NamedTuple):
+    """
+    Annotation to override the default Python → FalkorDB type mapping for a
+    column. FalkorDB does not enforce property types at write time, so the
+    type string is metadata-only — it participates in the schema fingerprint
+    (so two flows declaring the same table must agree) but is not used to
+    emit any DDL.
+
+    Use with ``typing.Annotated``::
+
+        from typing import Annotated
+        from cocoindex.connectors.falkordb import FalkorType
+
+        @dataclass
+        class Row:
+            id: str
+            score: Annotated[float, FalkorType("decimal", encoder=str)]
+    """
+
+    falkor_type: str
+    encoder: ValueEncoder | None = None
+
+
+# ---------------------------------------------------------------------------
+# Value encoders
+# ---------------------------------------------------------------------------
+
+
+def _bytes_to_b64(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return base64.b64encode(bytes(value)).decode("ascii")
+
+
+def _datetime_iso(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    result: str = value.isoformat()
+    return result
+
+
+def _timedelta_ms(value: Any) -> int:
+    return int(value.total_seconds() * 1000)
+
+
+def _decimal_str(value: Any) -> str:
+    return str(value)
+
+
+def _ndarray_to_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return value.tolist()  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Type mapping
+# ---------------------------------------------------------------------------
+
+
+class _TypeMapping(NamedTuple):
+    falkor_type: str
+    encoder: ValueEncoder | None = None
+
+
+_LEAF_TYPE_MAPPINGS: dict[type, _TypeMapping] = {
+    # Boolean
+    bool: _TypeMapping("boolean"),
+    # Integers
+    int: _TypeMapping("integer"),
+    np.int8: _TypeMapping("integer"),
+    np.int16: _TypeMapping("integer"),
+    np.int32: _TypeMapping("integer"),
+    np.int64: _TypeMapping("integer"),
+    np.uint8: _TypeMapping("integer"),
+    np.uint16: _TypeMapping("integer"),
+    np.uint32: _TypeMapping("integer"),
+    np.uint64: _TypeMapping("integer"),
+    np.int_: _TypeMapping("integer"),
+    np.uint: _TypeMapping("integer"),
+    # Floats
+    float: _TypeMapping("float"),
+    np.float16: _TypeMapping("float"),
+    np.float32: _TypeMapping("float"),
+    np.float64: _TypeMapping("float"),
+    # Decimal — FalkorDB has no decimal; store as string.
+    decimal.Decimal: _TypeMapping("string", _decimal_str),
+    # Strings
+    str: _TypeMapping("string"),
+    bytes: _TypeMapping("string", _bytes_to_b64),
+    uuid_mod.UUID: _TypeMapping("string", _decimal_str),
+    # Date/time
+    datetime.date: _TypeMapping("string", _datetime_iso),
+    datetime.time: _TypeMapping("string", _datetime_iso),
+    datetime.datetime: _TypeMapping("string", _datetime_iso),
+    datetime.timedelta: _TypeMapping("integer", _timedelta_ms),
+}
+
+_OBJECT_MAPPING = _TypeMapping("map")
+_ARRAY_MAPPING = _TypeMapping("array")
+
+
+async def _get_type_mapping(
+    python_type: Any, *, vector_schema: res_schema.VectorSchema | None = None
+) -> _TypeMapping:
+    type_info = analyze_type_info(python_type)
+
+    for annotation in type_info.annotations:
+        if isinstance(annotation, FalkorType):
+            return _TypeMapping(annotation.falkor_type, annotation.encoder)
+
+    base_type = type_info.base_type
+
+    if base_type in _LEAF_TYPE_MAPPINGS:
+        return _LEAF_TYPE_MAPPINGS[base_type]
+
+    if base_type is np.ndarray:
+        if vector_schema is None:
+            raise ValueError("VectorSchemaProvider is required for NumPy ndarray type.")
+        if vector_schema.size <= 0:
+            raise ValueError(f"Invalid vector dimension: {vector_schema.size}")
+        return _TypeMapping(
+            falkor_type=f"vector<float32, {vector_schema.size}>",
+            encoder=_ndarray_to_list,
+        )
+    elif vector_schema is not None:
+        raise ValueError(
+            "VectorSchemaProvider is only supported for NumPy ndarray type. "
+            f"Got type: {python_type}"
+        )
+
+    if isinstance(type_info.variant, (SequenceType,)):
+        return _ARRAY_MAPPING
+    if isinstance(type_info.variant, (MappingType, RecordType, UnionType, AnyType)):
+        return _OBJECT_MAPPING
+
+    return _OBJECT_MAPPING
+
+
+# ---------------------------------------------------------------------------
+# ColumnDef
+# ---------------------------------------------------------------------------
+
+
+class ColumnDef(NamedTuple):
+    """Definition of a column (property) in a FalkorDB table.
+
+    ``type`` is metadata-only — FalkorDB does not enforce per-property types
+    server-side. The string contributes to the schema fingerprint and is
+    surfaced in error messages, but no DDL is emitted from it.
+    """
+
+    type: str
+    nullable: bool = True
+    encoder: ValueEncoder | None = None
+
+
+# ---------------------------------------------------------------------------
+# TableSchema
+# ---------------------------------------------------------------------------
+
+RowT = TypeVar("RowT", default=dict[str, Any])
+
+
+@dataclass(slots=True)
+class TableSchema(Generic[RowT]):
+    """Schema definition for a FalkorDB table (node label or relationship type).
+
+    Single-field primary key (named via ``primary_key``, default ``"id"``).
+    Compound primary keys are not supported in v1.0.
+    """
+
+    columns: dict[str, ColumnDef]
+    primary_key: str
+    row_type: type[RowT] | None
+
+    def __init__(
+        self,
+        columns: dict[str, ColumnDef],
+        *,
+        primary_key: str = "id",
+        row_type: type[RowT] | None = None,
+    ) -> None:
+        for col_name in columns:
+            _validate_identifier(col_name, "column name")
+        if primary_key not in columns:
+            raise ValueError(
+                f"primary_key {primary_key!r} not found in columns "
+                f"({sorted(columns)!r})"
+            )
+        self.columns = columns
+        self.primary_key = primary_key
+        self.row_type = row_type
+
+    @property
+    def value_field_names(self) -> list[str]:
+        """Column names other than the primary key, in declared order."""
+        return [c for c in self.columns if c != self.primary_key]
+
+    @classmethod
+    async def from_class(
+        cls,
+        record_type: type[RowT],
+        *,
+        primary_key: str = "id",
+        column_overrides: dict[str, FalkorType | res_schema.VectorSchemaProvider]
+        | None = None,
+    ) -> "TableSchema[RowT]":
+        """Build a TableSchema by introspecting a dataclass / NamedTuple / Pydantic model."""
+        if not is_record_type(record_type):
+            raise TypeError(
+                f"record_type must be a record type (dataclass, NamedTuple, "
+                f"Pydantic model), got {type(record_type)}"
+            )
+        columns = await cls._columns_from_record_type(record_type, column_overrides)
+        return cls(columns, primary_key=primary_key, row_type=record_type)
+
+    @staticmethod
+    async def _columns_from_record_type(
+        record_type: type,
+        column_overrides: dict[str, FalkorType | res_schema.VectorSchemaProvider]
+        | None,
+    ) -> dict[str, ColumnDef]:
+        record_info = RecordType(record_type)
+        columns: dict[str, ColumnDef] = {}
+
+        for field in record_info.fields:
+            type_info = analyze_type_info(field.type_hint)
+
+            all_annotations: list[Any] = []
+            if (
+                override := column_overrides and column_overrides.get(field.name)
+            ) is not None:
+                all_annotations.append(override)
+            all_annotations.extend(type_info.annotations)
+
+            falkor_type_annotation = next(
+                (t for t in all_annotations if isinstance(t, FalkorType)), None
+            )
+            vector_schema = None
+            for annot in all_annotations:
+                vs = await res_schema.get_vector_schema(annot)
+                if vs is not None:
+                    vector_schema = vs
+                    break
+
+            if falkor_type_annotation is not None:
+                type_mapping = _TypeMapping(
+                    falkor_type_annotation.falkor_type,
+                    falkor_type_annotation.encoder,
+                )
+            else:
+                type_mapping = await _get_type_mapping(
+                    field.type_hint, vector_schema=vector_schema
+                )
+
+            columns[field.name] = ColumnDef(
+                type=type_mapping.falkor_type.strip(),
+                nullable=type_info.nullable,
+                encoder=type_mapping.encoder,
+            )
+
+        return columns
+
+
+# ---------------------------------------------------------------------------
+# _RecordAction + _SharedRecordApplier
+# ---------------------------------------------------------------------------
+
+
+class _RecordAction(NamedTuple):
+    """Action to perform on a record (upsert or delete)."""
+
+    table_name: str
+    is_relation: bool
+    pk_field: str
+    record_id: Any
+    value: dict[str, Any] | None  # None = delete
+    # Relation endpoints (None for non-relation actions).
+    from_label: str | None
+    from_pk_field: str | None
+    from_id: Any | None
+    to_label: str | None
+    to_pk_field: str | None
+    to_id: Any | None
+
+
+class _SharedRecordApplier:
+    """Owns a TargetActionSink shared by all record handlers for one graph.
+
+    FalkorDB does not support multi-statement Cypher transactions, so each
+    action issues its own ``graph.query(cypher, params)`` call. Actions are
+    grouped into the v0 ordering — node upserts → relation upserts → relation
+    deletes → node deletes — to avoid temporarily-orphaned endpoints during
+    incremental updates.
+    """
+
+    _graph: Any
+    sink: coco.TargetActionSink[_RecordAction, None]
+
+    def __init__(self, graph: Any) -> None:
+        self._graph = graph
+        self.sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_RecordAction]
+    ) -> None:
+        if not actions:
+            return
+
+        upsert_normal: list[_RecordAction] = []
+        upsert_relation: list[_RecordAction] = []
+        delete_relation: list[_RecordAction] = []
+        delete_normal: list[_RecordAction] = []
+
+        for action in actions:
+            if action.value is not None:
+                if action.is_relation:
+                    upsert_relation.append(action)
+                else:
+                    upsert_normal.append(action)
+            else:
+                if action.is_relation:
+                    delete_relation.append(action)
+                else:
+                    delete_normal.append(action)
+
+        for action in upsert_normal:
+            await self._apply_node_upsert(action)
+        for action in upsert_relation:
+            await self._apply_relation_upsert(action)
+        for action in delete_relation:
+            await self._apply_relation_delete(action)
+        for action in delete_normal:
+            await self._apply_node_delete(action)
+
+    async def _apply_node_upsert(self, action: _RecordAction) -> None:
+        assert action.value is not None
+        # PK is always single-field in v1.0; props are everything except the PK.
+        pk_value = action.value.get(action.pk_field, action.record_id)
+        props = {k: v for k, v in action.value.items() if k != action.pk_field}
+        cypher = _cypher.build_node_upsert(
+            label=action.table_name,
+            pk_fields=[action.pk_field],
+            has_value_fields=bool(props),
+        )
+        params: dict[str, Any] = {"key_0": pk_value}
+        if props:
+            params["props"] = props
+        await self._graph.query(cypher, params)
+
+    async def _apply_node_delete(self, action: _RecordAction) -> None:
+        cypher = _cypher.build_node_delete(
+            label=action.table_name, pk_fields=[action.pk_field]
+        )
+        await self._graph.query(cypher, {"key_0": action.record_id})
+
+    async def _apply_relation_upsert(self, action: _RecordAction) -> None:
+        assert action.value is not None
+        assert action.from_label is not None and action.from_pk_field is not None
+        assert action.to_label is not None and action.to_pk_field is not None
+        props = {k: v for k, v in action.value.items() if k != action.pk_field}
+        cypher = _cypher.build_relationship_upsert(
+            rel_type=action.table_name,
+            from_label=action.from_label,
+            from_pk_fields=[action.from_pk_field],
+            to_label=action.to_label,
+            to_pk_fields=[action.to_pk_field],
+            rel_pk_fields=[action.pk_field],
+            has_value_fields=bool(props),
+        )
+        params: dict[str, Any] = {
+            "from_key_0": action.from_id,
+            "to_key_0": action.to_id,
+            "rel_key_0": action.record_id,
+        }
+        if props:
+            params["props"] = props
+        await self._graph.query(cypher, params)
+
+    async def _apply_relation_delete(self, action: _RecordAction) -> None:
+        cypher = _cypher.build_relationship_delete(
+            rel_type=action.table_name, pk_fields=[action.pk_field]
+        )
+        await self._graph.query(cypher, {"key_0": action.record_id})
+
+
+# ---------------------------------------------------------------------------
+# Vector index
+# ---------------------------------------------------------------------------
+
+
+_METRIC_TO_FALKORDB: dict[str, str] = {
+    "cosine": "cosine",
+    "euclidean": "euclidean",
+    "ip": "ip",
+}
+
+
+class _VectorIndexSpec(NamedTuple):
+    field: str
+    metric: str
+    dimension: int
+
+
+_VectorIndexFingerprint = bytes
+
+
+class _VectorIndexAction(NamedTuple):
+    """Vector index DDL action.
+
+    ``field`` is always populated (carries the column name even on delete, so
+    the DROP statement can identify the index without round-tripping to the
+    spec). ``spec`` is ``None`` only on delete.
+    """
+
+    name: str
+    table_name: str
+    field: str
+    spec: _VectorIndexSpec | None
+
+
+# Tracking record for a vector index — store the spec itself rather than just
+# its fingerprint so a subsequent delete can recover the field name.
+_VectorIndexTrackingRecord = _VectorIndexSpec
+
+
+class _VectorIndexHandler:
+    """Attachment handler for vector indexes on a FalkorDB node label."""
+
+    _graph: Any
+    _table_name: str
+    _sink: coco.TargetActionSink[_VectorIndexAction, None]
+
+    def __init__(self, graph: Any, table_name: str) -> None:
+        self._graph = graph
+        self._table_name = table_name
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_VectorIndexAction]
+    ) -> None:
+        for action in actions:
+            if action.spec is None:
+                try:
+                    await self._graph.query(
+                        _cypher.build_vector_index_drop(action.table_name, action.field)
+                    )
+                except Exception as e:  # noqa: BLE001
+                    _logger.debug(
+                        "FalkorDB DROP VECTOR INDEX %s.%s (best-effort) failed: %s",
+                        action.table_name,
+                        action.field,
+                        e,
+                    )
+                continue
+
+            # Drop-and-recreate so a metric/dimension change takes effect.
+            try:
+                await self._graph.query(
+                    _cypher.build_vector_index_drop(
+                        action.table_name, action.spec.field
+                    )
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "FalkorDB DROP VECTOR INDEX (pre-create best-effort) failed: %s",
+                    e,
+                )
+            await self._graph.query(
+                _cypher.build_vector_index_create(
+                    label=action.table_name,
+                    field=action.spec.field,
+                    dimension=action.spec.dimension,
+                    metric=_METRIC_TO_FALKORDB.get(
+                        action.spec.metric, action.spec.metric
+                    ),
+                )
+            )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _VectorIndexSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_VectorIndexTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[_VectorIndexAction, _VectorIndexTrackingRecord, None]
+        | None
+    ):
+        assert isinstance(key, str)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            # Recover the field from the most recent tracked spec — needed for
+            # the DROP statement, since FalkorDB identifies vector indexes by
+            # (label, field) not by name.
+            prev_field: str | None = None
+            for prev in prev_possible_records:
+                prev_field = prev.field
+                break
+            if prev_field is None:
+                # Nothing to drop and we don't know what the field was — skip.
+                return None
+            return coco.TargetReconcileOutput(
+                action=_VectorIndexAction(
+                    name=key,
+                    table_name=self._table_name,
+                    field=prev_field,
+                    spec=None,
+                ),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        if not prev_may_be_missing and all(
+            prev == desired_state for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_VectorIndexAction(
+                name=key,
+                table_name=self._table_name,
+                field=desired_state.field,
+                spec=desired_state,
+            ),
+            sink=self._sink,
+            tracking_record=desired_state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _RecordHandler
+# ---------------------------------------------------------------------------
+
+
+class _RecordHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
+    """Handler for record-level target states within a FalkorDB table."""
+
+    _table_name: str
+    _is_relation: bool
+    _pk_field: str
+    _table_schema: TableSchema[Any] | None
+    _graph: Any
+    _sink: coco.TargetActionSink[_RecordAction, None]
+
+    def __init__(
+        self,
+        table_name: str,
+        is_relation: bool,
+        pk_field: str,
+        table_schema: TableSchema[Any] | None,
+        graph: Any,
+        sink: coco.TargetActionSink[_RecordAction, None],
+    ) -> None:
+        self._table_name = table_name
+        self._is_relation = is_relation
+        self._pk_field = pk_field
+        self._table_schema = table_schema
+        self._graph = graph
+        self._sink = sink
+
+    def attachments(self) -> dict[str, _VectorIndexHandler]:
+        # Eagerly declare all attachment types so the engine can cleanup
+        # orphaned attachments even on runs that don't re-declare them.
+        return {
+            "vector_index": _VectorIndexHandler(self._graph, self._table_name),
+        }
+
+    def _encode_row(self, row_dict: dict[str, Any]) -> dict[str, Any]:
+        if self._table_schema is None:
+            return row_dict
+        out: dict[str, Any] = {}
+        for k, v in row_dict.items():
+            col = self._table_schema.columns.get(k)
+            if col is not None and col.encoder is not None and v is not None:
+                out[k] = col.encoder(v)
+            else:
+                out[k] = v
+        return out
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _RowValue | coco.NonExistenceType,
+        prev_possible_records: Collection[_RowFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_RecordAction, _RowFingerprint, None] | None:
+        key = _ROW_KEY_CHECKER.check(key)
+
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_RecordAction(
+                    table_name=self._table_name,
+                    is_relation=self._is_relation,
+                    pk_field=self._pk_field,
+                    record_id=key[0],
+                    value=None,
+                    from_label=None,
+                    from_pk_field=None,
+                    from_id=None,
+                    to_label=None,
+                    to_pk_field=None,
+                    to_id=None,
+                ),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(desired_state)
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        if isinstance(desired_state, _RelationRowValue):
+            from_label = desired_state.from_label
+            from_pk_field = desired_state.from_pk_field
+            from_id = desired_state.from_id
+            to_label = desired_state.to_label
+            to_pk_field = desired_state.to_pk_field
+            to_id = desired_state.to_id
+            encoded = self._encode_row(desired_state.fields)
+        else:
+            from_label = None
+            from_pk_field = None
+            from_id = None
+            to_label = None
+            to_pk_field = None
+            to_id = None
+            encoded = self._encode_row(desired_state)
+
+        return coco.TargetReconcileOutput(
+            action=_RecordAction(
+                table_name=self._table_name,
+                is_relation=self._is_relation,
+                pk_field=self._pk_field,
+                record_id=key[0],
+                value=encoded,
+                from_label=from_label,
+                from_pk_field=from_pk_field,
+                from_id=from_id,
+                to_label=to_label,
+                to_pk_field=to_pk_field,
+                to_id=to_id,
+            ),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Table-level types
+# ---------------------------------------------------------------------------
+
+
+class _TableKey(NamedTuple):
+    db_key: str
+    table_name: str
+
+
+_TABLE_KEY_CHECKER = TypeChecker(tuple[str, str])
+
+
+@dataclass
+class _TableSpec:
+    table_schema: TableSchema[Any] | None
+    primary_key: str
+    is_relation: bool
+    from_label: str | None
+    from_pk_field: str | None
+    to_label: str | None
+    to_pk_field: str | None
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+
+
+class _TableMainRecord(msgspec.Struct, frozen=True):
+    """Tracking record for table-level properties — change ⇒ DROP+CREATE index."""
+
+    has_schema: bool
+    is_relation: bool
+    primary_key: str
+    pk_type: str | None
+    from_label: str | None
+    from_pk_field: str | None
+    to_label: str | None
+    to_pk_field: str | None
+
+
+class _FieldTrackingRecord(msgspec.Struct, frozen=True):
+    """Per-field tracking record. FalkorDB has no per-field DDL, so this is
+    fingerprint-only — schema fingerprint stability lets two flows share a
+    table only if they declare matching columns."""
+
+    falkor_type: str
+    nullable: bool
+
+
+_FIELD_SUBKEY_PREFIX: str = "field:"
+
+
+def _field_subkey(name: str) -> str:
+    return f"{_FIELD_SUBKEY_PREFIX}{name}"
+
+
+class _TableAction(NamedTuple):
+    key: _TableKey
+    spec: _TableSpec | coco.NonExistenceType
+    is_relation: bool
+    main_action: statediff.DiffAction | None
+    column_actions: dict[str, statediff.DiffAction]
+    # Recovered from the most recent system-managed prev tracking record.
+    # Needed on "delete"/"replace" to know what artifact to drop, since
+    # FalkorDB has no IF EXISTS for DROP INDEX and we have to identify the
+    # index by its underlying field set.
+    prev_pk_field: str | None
+    prev_is_relation: bool
+
+
+def _table_composite_tracking_record_from_spec(
+    spec: _TableSpec,
+) -> statediff.CompositeTrackingRecord[_TableMainRecord, str, _FieldTrackingRecord]:
+    schema = spec.table_schema
+    has_schema = schema is not None
+    pk_type: str | None = None
+    sub: dict[str, _FieldTrackingRecord] = {}
+
+    if schema is not None:
+        pk_col = schema.columns.get(spec.primary_key)
+        if pk_col is not None:
+            pk_type = pk_col.type
+        for col_name, col_def in schema.columns.items():
+            if col_name == spec.primary_key:
+                continue
+            sub[_field_subkey(col_name)] = _FieldTrackingRecord(
+                falkor_type=col_def.type,
+                nullable=col_def.nullable,
+            )
+
+    main = _TableMainRecord(
+        has_schema=has_schema,
+        is_relation=spec.is_relation,
+        primary_key=spec.primary_key,
+        pk_type=pk_type,
+        from_label=spec.from_label,
+        from_pk_field=spec.from_pk_field,
+        to_label=spec.to_label,
+        to_pk_field=spec.to_pk_field,
+    )
+    return statediff.CompositeTrackingRecord(main=main, sub=sub)
+
+
+_TableTrackingRecord = statediff.MutualTrackingRecord[
+    statediff.CompositeTrackingRecord[_TableMainRecord, str, _FieldTrackingRecord]
+]
+
+
+# ---------------------------------------------------------------------------
+# _TableHandler
+# ---------------------------------------------------------------------------
+
+
+class _TableHandler(
+    coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RecordHandler]
+):
+    """Handler for table-level state — Cypher index DDL + best-effort constraints."""
+
+    _sink: coco.TargetActionSink[_TableAction, _RecordHandler]
+
+    def __init__(self) -> None:
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _TableSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_TableTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[_TableAction, _TableTrackingRecord, _RecordHandler]
+        | None
+    ):
+        key = _TableKey(*_TABLE_KEY_CHECKER.check(key))
+
+        if coco.is_non_existence(desired_state):
+            tracking_record: _TableTrackingRecord | coco.NonExistenceType = (
+                coco.NON_EXISTENCE
+            )
+            is_relation = False
+        else:
+            tracking_record = statediff.MutualTrackingRecord(
+                tracking_record=_table_composite_tracking_record_from_spec(
+                    desired_state
+                ),
+                managed_by=desired_state.managed_by,
+            )
+            is_relation = desired_state.is_relation
+
+        resolved = statediff.resolve_system_transition(
+            statediff.TrackingRecordTransition(
+                tracking_record, prev_possible_records, prev_may_be_missing
+            )
+        )
+        main_action, column_transitions = statediff.diff_composite(resolved)
+
+        column_actions: dict[str, statediff.DiffAction] = {}
+        if main_action is None:
+            for sub_key, t in column_transitions.items():
+                action = statediff.diff(t)
+                if action is not None:
+                    column_actions[sub_key] = action
+
+        if (
+            main_action is None
+            and not column_actions
+            and coco.is_non_existence(desired_state)
+        ):
+            return None
+
+        # Recover prev PK + entity kind from the most recent system-managed
+        # tracking record so DROP INDEX can identify the underlying artifact.
+        prev_pk_field: str | None = None
+        prev_is_relation = False
+        for prev in prev_possible_records:
+            if prev.managed_by != target.ManagedBy.SYSTEM:
+                continue
+            prev_pk_field = prev.tracking_record.main.primary_key
+            prev_is_relation = prev.tracking_record.main.is_relation
+            break
+
+        child_invalidation: Literal["destructive", "lossy"] | None = None
+        if main_action == "replace":
+            # Index is dropped and recreated — all rows lose their tracking.
+            child_invalidation = "destructive"
+        elif main_action is None and any(
+            a != "insert" for a in column_actions.values()
+        ):
+            # FalkorDB has no per-field DDL so column changes don't actually
+            # destroy data, but mark lossy so dependents re-upsert to be safe.
+            child_invalidation = "lossy"
+
+        return coco.TargetReconcileOutput(
+            action=_TableAction(
+                key=key,
+                spec=desired_state,
+                is_relation=is_relation,
+                main_action=main_action,
+                column_actions=column_actions,
+                prev_pk_field=prev_pk_field,
+                prev_is_relation=prev_is_relation,
+            ),
+            sink=self._sink,
+            tracking_record=tracking_record,
+            child_invalidation=child_invalidation,
+        )
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_TableAction]
+    ) -> list[coco.ChildTargetDef[_RecordHandler] | None]:
+        actions_list = list(actions)
+        outputs: list[coco.ChildTargetDef[_RecordHandler] | None] = [None] * len(
+            actions_list
+        )
+
+        # Group by db_key so each Redis connection is acquired once per batch.
+        by_db: dict[str, list[int]] = {}
+        for i, action in enumerate(actions_list):
+            by_db.setdefault(action.key.db_key, []).append(i)
+
+        for db_key, idxs in by_db.items():
+            factory: ConnectionFactory = context_provider.get(db_key)  # type: ignore[assignment]
+            graph = await factory.acquire()
+            shared_applier = _SharedRecordApplier(graph)
+
+            # Order: create nodes → create relations → drop relations → drop nodes.
+            # Mirrors v0's apply_mutation ordering so dependent edges don't
+            # reference indexes that haven't been created (or have been dropped).
+            create_normal: list[int] = []
+            create_relation: list[int] = []
+            remove_relation: list[int] = []
+            remove_normal: list[int] = []
+
+            for i in idxs:
+                action = actions_list[i]
+                if coco.is_non_existence(action.spec):
+                    if action.is_relation:
+                        remove_relation.append(i)
+                    else:
+                        remove_normal.append(i)
+                else:
+                    if action.is_relation:
+                        create_relation.append(i)
+                    else:
+                        create_normal.append(i)
+
+            ordered = create_normal + create_relation + remove_relation + remove_normal
+
+            for i in ordered:
+                action = actions_list[i]
+                spec = action.spec
+
+                if action.main_action in ("replace", "delete"):
+                    await self._drop_table_artifacts(graph, action.key, action)
+
+                if coco.is_non_existence(spec):
+                    outputs[i] = None
+                    continue
+
+                if action.main_action in ("insert", "upsert", "replace"):
+                    await self._create_table(graph, action.key, spec)
+                # FalkorDB has no incremental column DDL — column_actions are
+                # tracked for fingerprint stability but not applied here.
+
+                outputs[i] = coco.ChildTargetDef(
+                    handler=_RecordHandler(
+                        table_name=action.key.table_name,
+                        is_relation=spec.is_relation,
+                        pk_field=spec.primary_key,
+                        table_schema=spec.table_schema,
+                        graph=graph,
+                        sink=shared_applier.sink,
+                    )
+                )
+
+        return outputs
+
+    @staticmethod
+    async def _create_table(graph: Any, key: _TableKey, spec: _TableSpec) -> None:
+        """Create the supporting Cypher index and best-effort unique constraint."""
+        if spec.is_relation:
+            try:
+                await graph.query(
+                    _cypher.build_relationship_index_create(
+                        key.table_name, [spec.primary_key]
+                    )
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "FalkorDB CREATE INDEX on relationship %s (best-effort) failed: %s",
+                    key.table_name,
+                    e,
+                )
+            try:
+                await _exec_constraint(
+                    graph,
+                    "CREATE",
+                    "RELATIONSHIP",
+                    key.table_name,
+                    [spec.primary_key],
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "FalkorDB GRAPH.CONSTRAINT CREATE on relationship %s "
+                    "(best-effort) failed: %s",
+                    key.table_name,
+                    e,
+                )
+        else:
+            try:
+                await graph.query(
+                    _cypher.build_node_index_create(key.table_name, [spec.primary_key])
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "FalkorDB CREATE INDEX on node %s (best-effort) failed: %s",
+                    key.table_name,
+                    e,
+                )
+            try:
+                await _exec_constraint(
+                    graph,
+                    "CREATE",
+                    "NODE",
+                    key.table_name,
+                    [spec.primary_key],
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "FalkorDB GRAPH.CONSTRAINT CREATE on node %s "
+                    "(best-effort) failed: %s",
+                    key.table_name,
+                    e,
+                )
+
+    @staticmethod
+    async def _drop_table_artifacts(
+        graph: Any, key: _TableKey, action: _TableAction
+    ) -> None:
+        """Drop the supporting Cypher index + unique constraint on table teardown.
+
+        Uses ``prev_pk_field`` recovered during reconcile from the previous
+        tracking record — that's what was actually CREATEd, so it's what we
+        need to DROP. Falls back to the current spec's PK if there's no prev
+        (defensive — shouldn't happen on a true delete/replace, but allows
+        the apply loop to be tolerant).
+        """
+        pk_field = action.prev_pk_field
+        is_relation = action.prev_is_relation
+        if pk_field is None and isinstance(action.spec, _TableSpec):
+            pk_field = action.spec.primary_key
+            is_relation = action.spec.is_relation
+        if pk_field is None:
+            return  # Nothing to drop.
+        entity_kind = "RELATIONSHIP" if is_relation else "NODE"
+        try:
+            await _exec_constraint(
+                graph, "DROP", entity_kind, key.table_name, [pk_field]
+            )
+        except Exception as e:  # noqa: BLE001
+            _logger.debug(
+                "FalkorDB GRAPH.CONSTRAINT DROP on %s %s (best-effort) failed: %s",
+                entity_kind.lower(),
+                key.table_name,
+                e,
+            )
+        try:
+            if is_relation:
+                await graph.query(
+                    _cypher.build_relationship_index_drop(key.table_name, [pk_field])
+                )
+            else:
+                await graph.query(
+                    _cypher.build_node_index_drop(key.table_name, [pk_field])
+                )
+        except Exception as e:  # noqa: BLE001
+            _logger.debug(
+                "FalkorDB DROP INDEX on %s (best-effort) failed: %s",
+                key.table_name,
+                e,
+            )
+
+
+async def _exec_constraint(
+    graph: Any,
+    op: str,
+    entity_kind: str,
+    label: str,
+    fields: Sequence[str],
+) -> Any:
+    """Issue ``GRAPH.CONSTRAINT CREATE|DROP <graph> UNIQUE NODE|RELATIONSHIP <label> PROPERTIES <n> <f1>...``.
+
+    Constraints are issued via the underlying redis client's ``execute_command``
+    because they are GRAPH-module commands, not Cypher statements.
+    """
+    client = getattr(graph, "execute_command", None)
+    if client is None:
+        # Fall back to the underlying connection on the FalkorDB client.
+        client = graph.connection.execute_command  # type: ignore[union-attr]
+    return await client(
+        "GRAPH.CONSTRAINT",
+        op,
+        graph.name,
+        "UNIQUE",
+        entity_kind,
+        label,
+        "PROPERTIES",
+        str(len(fields)),
+        *fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Root provider registration
+# ---------------------------------------------------------------------------
+
+_table_provider = coco.register_root_target_states_provider(
+    "cocoindex/falkordb/table", _TableHandler()
+)
+
+
+# ---------------------------------------------------------------------------
+# TableTarget
+# ---------------------------------------------------------------------------
+
+
+class TableTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["TableTarget[RowT]"]
+):
+    """A target for writing records to a FalkorDB node table."""
+
+    _provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS]
+    _table_schema: TableSchema[RowT] | None
+    _table_name: str
+    _primary_key: str
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS],
+        table_schema: TableSchema[RowT] | None,
+        table_name: str,
+        primary_key: str,
+    ) -> None:
+        self._provider = provider
+        self._table_schema = table_schema
+        self._table_name = table_name
+        self._primary_key = primary_key
+
+    @property
+    def table_name(self) -> str:
+        return self._table_name
+
+    @property
+    def primary_key(self) -> str:
+        return self._primary_key
+
+    def declare_record(self: TableTarget[RowT], *, row: RowT) -> None:
+        """Declare a record (node) to be upserted to this table."""
+        row_dict = self._row_to_dict(row)
+        if self._primary_key not in row_dict:
+            raise ValueError(f"row is missing primary key field {self._primary_key!r}")
+        pk_values = (row_dict[self._primary_key],)
+        coco.declare_target_state(self._provider.target_state(pk_values, row_dict))
+
+    declare_row = declare_record
+
+    def _row_to_dict(self, row: RowT) -> dict[str, Any]:
+        if self._table_schema is not None:
+            out: dict[str, Any] = {}
+            for col_name, col in self._table_schema.columns.items():
+                if isinstance(row, dict):
+                    value = row.get(col_name)
+                else:
+                    value = getattr(row, col_name)
+                if value is not None and col.encoder is not None:
+                    value = col.encoder(value)
+                out[col_name] = value
+            return out
+        if isinstance(row, dict):
+            return dict(row)
+        record_info = RecordType(type(row))
+        return {f.name: getattr(row, f.name) for f in record_info.fields}
+
+    def declare_vector_index(
+        self: TableTarget[RowT],
+        *,
+        name: str | None = None,
+        field: str,
+        metric: Literal["cosine", "euclidean", "ip"] = "cosine",
+        dimension: int,
+    ) -> None:
+        """Declare a vector index on a column of this table."""
+        _validate_identifier(field, "vector index field")
+        if name is None:
+            name = f"idx_{self._table_name}__{field}"
+        _validate_identifier(name, "vector index name")
+        if dimension <= 0:
+            raise ValueError(f"Invalid vector dimension: {dimension}")
+        spec = _VectorIndexSpec(field=field, metric=metric, dimension=dimension)
+        att_provider = self._provider.attachment("vector_index")
+        coco.declare_target_state(att_provider.target_state(name, spec))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+# ---------------------------------------------------------------------------
+# RelationTarget
+# ---------------------------------------------------------------------------
+
+
+class RelationTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["RelationTarget[RowT]"]
+):
+    """A target for writing relation records (edges) to a FalkorDB relationship type."""
+
+    _provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS]
+    _table_name: str
+    _table_schema: TableSchema[RowT] | None
+    _primary_key: str
+    _from_table: TableTarget[Any]
+    _to_table: TableTarget[Any]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS],
+        table_name: str,
+        table_schema: TableSchema[RowT] | None,
+        primary_key: str,
+        from_table: TableTarget[Any],
+        to_table: TableTarget[Any],
+    ) -> None:
+        self._provider = provider
+        self._table_name = table_name
+        self._table_schema = table_schema
+        self._primary_key = primary_key
+        self._from_table = from_table
+        self._to_table = to_table
+
+    def declare_relation(
+        self: RelationTarget[RowT],
+        *,
+        from_id: Any,
+        to_id: Any,
+        record: RowT | None = None,
+    ) -> None:
+        """Declare a relation record (edge)."""
+        from_label = self._from_table.table_name
+        from_pk_field = self._from_table.primary_key
+        to_label = self._to_table.table_name
+        to_pk_field = self._to_table.primary_key
+
+        if record is not None:
+            if self._table_schema is not None:
+                row_dict: dict[str, Any] = {}
+                for col_name, col in self._table_schema.columns.items():
+                    if col_name == self._primary_key:
+                        continue
+                    if isinstance(record, dict):
+                        value = record.get(col_name)
+                    else:
+                        value = getattr(record, col_name)
+                    if value is not None and col.encoder is not None:
+                        value = col.encoder(value)
+                    row_dict[col_name] = value
+                record_id = (
+                    record.get(self._primary_key)
+                    if isinstance(record, dict)
+                    else getattr(record, self._primary_key, None)
+                )
+            elif isinstance(record, dict):
+                row_dict = {k: v for k, v in record.items() if k != self._primary_key}
+                record_id = record.get(self._primary_key)
+            else:
+                record_info = RecordType(type(record))
+                row_dict = {
+                    f.name: getattr(record, f.name)
+                    for f in record_info.fields
+                    if f.name != self._primary_key
+                }
+                record_id = getattr(record, self._primary_key, None)
+        else:
+            row_dict = {}
+            record_id = None
+
+        if record_id is None:
+            record_id = f"{from_label}_{from_id}_{to_label}_{to_id}"
+
+        row_value: _RowValue = _RelationRowValue(
+            from_label=from_label,
+            from_pk_field=from_pk_field,
+            from_id=from_id,
+            to_label=to_label,
+            to_pk_field=to_pk_field,
+            to_id=to_id,
+            fields=row_dict,
+        )
+
+        pk_values = (record_id,)
+        coco.declare_target_state(self._provider.target_state(pk_values, row_value))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+# ---------------------------------------------------------------------------
+# Module-level entry points
+# ---------------------------------------------------------------------------
+
+
+def table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> coco.TargetState[_RecordHandler]:
+    """Create a ``TargetState`` for a FalkorDB node table (label)."""
+    _validate_identifier(table_name, "table name")
+    _validate_identifier(primary_key, "primary key")
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match the schema's "
+            f"declared primary_key {table_schema.primary_key!r}"
+        )
+    key = _TableKey(db_key=db.key, table_name=table_name)
+    spec = _TableSpec(
+        table_schema=table_schema,
+        primary_key=primary_key,
+        is_relation=False,
+        from_label=None,
+        from_pk_field=None,
+        to_label=None,
+        to_pk_field=None,
+        managed_by=managed_by,
+    )
+    return _table_provider.target_state(key, spec)
+
+
+def declare_table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT, coco.PendingS]:
+    """Declare a node table target (no records flow into this declaration's
+    own handler — typically used to register a table that is referenced as a
+    relationship endpoint by other handlers).
+    """
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's {table_schema.primary_key!r}"
+        )
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = coco.declare_target_state_with_child(
+        table_target(
+            db, table_name, table_schema, primary_key=pk, managed_by=managed_by
+        )
+    )
+    return TableTarget(provider, table_schema, table_name, pk)
+
+
+async def mount_table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT]:
+    """Mount a node table target ready to receive ``declare_record`` calls."""
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's {table_schema.primary_key!r}"
+        )
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = await coco.mount_target(
+        table_target(
+            db, table_name, table_schema, primary_key=pk, managed_by=managed_by
+        )
+    )
+    return TableTarget(provider, table_schema, table_name, pk)
+
+
+def relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> coco.TargetState[_RecordHandler]:
+    """Create a ``TargetState`` for a FalkorDB relationship type."""
+    _validate_identifier(table_name, "relation table name")
+    _validate_identifier(primary_key, "primary key")
+    _validate_identifier(from_table.table_name, "from table name")
+    _validate_identifier(to_table.table_name, "to table name")
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's {table_schema.primary_key!r}"
+        )
+    key = _TableKey(db_key=db.key, table_name=table_name)
+    spec = _TableSpec(
+        table_schema=table_schema,
+        primary_key=primary_key,
+        is_relation=True,
+        from_label=from_table.table_name,
+        from_pk_field=from_table.primary_key,
+        to_label=to_table.table_name,
+        to_pk_field=to_table.primary_key,
+        managed_by=managed_by,
+    )
+    return _table_provider.target_state(key, spec)
+
+
+def declare_relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> RelationTarget[RowT, coco.PendingS]:
+    """Declare a relation table target."""
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = coco.declare_target_state_with_child(
+        relation_target(
+            db,
+            table_name,
+            from_table,
+            to_table,
+            table_schema,
+            primary_key=pk,
+            managed_by=managed_by,
+        )
+    )
+    return RelationTarget(provider, table_name, table_schema, pk, from_table, to_table)
+
+
+async def mount_relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> RelationTarget[RowT]:
+    """Mount a relation table target ready to receive ``declare_relation`` calls."""
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = await coco.mount_target(
+        relation_target(
+            db,
+            table_name,
+            from_table,
+            to_table,
+            table_schema,
+            primary_key=pk,
+            managed_by=managed_by,
+        )
+    )
+    return RelationTarget(provider, table_name, table_schema, pk, from_table, to_table)
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "ColumnDef",
+    "ConnectionFactory",
+    "FalkorType",
+    "RelationTarget",
+    "TableSchema",
+    "TableTarget",
+    "ValueEncoder",
+    "declare_relation_target",
+    "declare_table_target",
+    "mount_relation_target",
+    "mount_table_target",
+    "relation_target",
+    "table_target",
+]

--- a/python/tests/connectors/test_falkordb_target.py
+++ b/python/tests/connectors/test_falkordb_target.py
@@ -1,0 +1,600 @@
+"""Tests for the FalkorDB target connector.
+
+Run with:
+    uv run pytest python/tests/connectors/test_falkordb_target.py -v
+
+Unit tests run without a server. Integration tests require a running FalkorDB
+and the env vars below:
+    FALKORDB_TEST_SERVER=1     - opt in to integration tests
+    FALKORDB_URI=falkor://localhost:6379  (default)
+"""
+
+from __future__ import annotations
+
+import os
+import uuid as uuid_mod
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+import cocoindex as coco
+
+from tests import common
+
+coco_env = common.create_test_env(__file__)
+
+
+# =============================================================================
+# Skip gates
+# =============================================================================
+
+try:
+    import falkordb  # type: ignore[import-untyped]  # noqa: F401
+    from falkordb.asyncio import FalkorDB as AsyncFalkorDB  # type: ignore[import-untyped]
+
+    HAS_FALKORDB = True
+except ImportError:
+    HAS_FALKORDB = False
+
+requires_falkordb = pytest.mark.skipif(
+    not HAS_FALKORDB, reason="falkordb is not installed"
+)
+
+_FALKORDB_URI = os.environ.get("FALKORDB_URI", "falkor://localhost:6379")
+_HAS_FALKORDB_SERVER = bool(os.environ.get("FALKORDB_TEST_SERVER"))
+
+requires_falkordb_server = pytest.mark.skipif(
+    not (HAS_FALKORDB and _HAS_FALKORDB_SERVER),
+    reason="FALKORDB_TEST_SERVER is not set",
+)
+
+if HAS_FALKORDB:
+    from cocoindex.connectors import falkordb as falkor  # type: ignore[attr-defined]
+    from cocoindex.connectors.falkordb._cypher import (  # type: ignore[import-untyped]
+        build_node_delete,
+        build_node_index_create,
+        build_node_index_drop,
+        build_node_upsert,
+        build_relationship_delete,
+        build_relationship_index_create,
+        build_relationship_index_drop,
+        build_relationship_upsert,
+        build_vector_index_create,
+        build_vector_index_drop,
+        validate_identifier,
+    )
+
+    KG_DB: coco.ContextKey[Any] = coco.ContextKey("test_falkordb_kg")
+
+
+# =============================================================================
+# Unit tests — identifier validation (no DB)
+# =============================================================================
+
+
+@requires_falkordb
+class TestValidateIdentifier:
+    @pytest.mark.parametrize(
+        "name", ["users", "_private", "T1", "a_b_c", "X", "Document", "MENTION"]
+    )
+    def test_valid(self, name: str) -> None:
+        validate_identifier(name, "test")
+
+    @pytest.mark.parametrize(
+        "name",
+        ["my-table", "123abc", "", "has space", "ba`ck", "semi;colon", "a.b", "X-Y"],
+    )
+    def test_invalid(self, name: str) -> None:
+        with pytest.raises(ValueError, match="Invalid FalkorDB"):
+            validate_identifier(name, "test")
+
+
+@requires_falkordb
+class TestIdentifierValidationAtApiEntryPoints:
+    def test_table_schema_invalid_column(self) -> None:
+        with pytest.raises(ValueError, match="column name"):
+            falkor.TableSchema(
+                columns={
+                    "id": falkor.ColumnDef(type="string"),
+                    "bad-name": falkor.ColumnDef(type="string"),
+                },
+                primary_key="id",
+            )
+
+    def test_table_schema_pk_must_exist_in_columns(self) -> None:
+        with pytest.raises(ValueError, match="primary_key"):
+            falkor.TableSchema(
+                columns={"id": falkor.ColumnDef(type="string")},
+                primary_key="missing",
+            )
+
+    def test_table_target_invalid_name(self) -> None:
+        with pytest.raises(ValueError, match="table name"):
+            falkor.table_target(KG_DB, "bad-table")
+
+    def test_relation_target_invalid_name(self) -> None:
+        # The relation table name validation fires first in relation_target(),
+        # before from_table/to_table are touched, so we can pass None safely.
+        from typing import cast
+
+        with pytest.raises(ValueError, match="relation table name"):
+            falkor.relation_target(
+                KG_DB,
+                "bad-rel",
+                cast(Any, None),
+                cast(Any, None),
+            )
+
+
+# =============================================================================
+# Unit tests — Cypher generation (no DB)
+# =============================================================================
+
+
+@requires_falkordb
+class TestNodeUpsertCypher:
+    def test_single_pk_with_props(self) -> None:
+        assert (
+            build_node_upsert("Document", ["filename"], True)
+            == "MERGE (n:`Document` {`filename`: $key_0}) SET n += $props"
+        )
+
+    def test_single_pk_no_props(self) -> None:
+        assert (
+            build_node_upsert("Document", ["filename"], False)
+            == "MERGE (n:`Document` {`filename`: $key_0})"
+        )
+
+    def test_compound_pk(self) -> None:
+        assert build_node_upsert("X", ["a", "b"], True) == (
+            "MERGE (n:`X` {`a`: $key_0, `b`: $key_1}) SET n += $props"
+        )
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_node_upsert("X", [], True)
+
+
+@requires_falkordb
+class TestNodeDeleteCypher:
+    def test_uses_detach_delete(self) -> None:
+        # DETACH DELETE is critical: protects against the shared-Entity case
+        # where a node still has incident edges that another flow owns.
+        assert (
+            build_node_delete("Document", ["filename"])
+            == "MATCH (n:`Document` {`filename`: $key_0}) DETACH DELETE n"
+        )
+
+
+@requires_falkordb
+class TestRelationshipUpsertCypher:
+    def test_three_merges_with_props(self) -> None:
+        assert build_relationship_upsert(
+            "REL", "Entity", ["value"], "Entity", ["value"], ["id"], True
+        ) == (
+            "MERGE (s:`Entity` {`value`: $from_key_0}) "
+            "MERGE (t:`Entity` {`value`: $to_key_0}) "
+            "MERGE (s)-[r:`REL` {`id`: $rel_key_0}]->(t) "
+            "SET r += $props"
+        )
+
+    def test_no_set_on_endpoints(self) -> None:
+        # Critical: SET only on the relationship, not on s or t. Endpoint
+        # properties are owned by their table's own _RecordHandler.
+        cypher = build_relationship_upsert("REL", "A", ["x"], "B", ["y"], ["id"], True)
+        # Three SET-able sites: s, t, r. Only r should have SET applied.
+        assert "SET s" not in cypher
+        assert "SET t" not in cypher
+        assert "SET r += $props" in cypher
+
+    def test_no_props(self) -> None:
+        assert build_relationship_upsert(
+            "REL", "A", ["x"], "B", ["y"], ["id"], False
+        ) == (
+            "MERGE (s:`A` {`x`: $from_key_0}) "
+            "MERGE (t:`B` {`y`: $to_key_0}) "
+            "MERGE (s)-[r:`REL` {`id`: $rel_key_0}]->(t)"
+        )
+
+
+@requires_falkordb
+class TestRelationshipDeleteCypher:
+    def test_does_not_cascade(self) -> None:
+        # Endpoints are NOT deleted by the relationship delete — they live
+        # under their own table handlers' tracking and reconciliation.
+        cypher = build_relationship_delete("REL", ["id"])
+        assert cypher == "MATCH ()-[r:`REL` {`id`: $key_0}]->() DELETE r"
+        assert "DELETE s" not in cypher
+        assert "DELETE t" not in cypher
+
+
+@requires_falkordb
+class TestIndexDdlCypher:
+    def test_node_index_create(self) -> None:
+        assert (
+            build_node_index_create("Document", ["filename"])
+            == "CREATE INDEX FOR (e:`Document`) ON (e.`filename`)"
+        )
+
+    def test_node_index_create_compound(self) -> None:
+        assert build_node_index_create("X", ["a", "b"]) == (
+            "CREATE INDEX FOR (e:`X`) ON (e.`a`, e.`b`)"
+        )
+
+    def test_node_index_drop(self) -> None:
+        assert (
+            build_node_index_drop("Document", ["filename"])
+            == "DROP INDEX FOR (e:`Document`) ON (e.`filename`)"
+        )
+
+    def test_relationship_index_create(self) -> None:
+        assert (
+            build_relationship_index_create("REL", ["id"])
+            == "CREATE INDEX FOR ()-[e:`REL`]-() ON (e.`id`)"
+        )
+
+    def test_relationship_index_drop(self) -> None:
+        assert (
+            build_relationship_index_drop("REL", ["id"])
+            == "DROP INDEX FOR ()-[e:`REL`]-() ON (e.`id`)"
+        )
+
+
+@requires_falkordb
+class TestVectorIndexCypher:
+    def test_create(self) -> None:
+        assert build_vector_index_create("Doc", "embedding", 384, "cosine") == (
+            "CREATE VECTOR INDEX FOR (e:`Doc`) ON (e.`embedding`) "
+            "OPTIONS {dimension: 384, similarityFunction: 'cosine'}"
+        )
+
+    def test_drop_uses_label_field_not_name(self) -> None:
+        # FalkorDB identifies vector indexes by (label, field), not by name —
+        # confirmed via spike against the running server.
+        assert build_vector_index_drop("Doc", "embedding") == (
+            "DROP VECTOR INDEX FOR (e:`Doc`) ON (e.`embedding`)"
+        )
+
+    def test_zero_dimension_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            build_vector_index_create("Doc", "embedding", 0, "cosine")
+
+
+# =============================================================================
+# Unit tests — TableSchema.from_class type mapping
+# =============================================================================
+
+
+@requires_falkordb
+class TestTableSchemaFromClass:
+    @pytest.mark.asyncio
+    async def test_basic_dataclass(self) -> None:
+        @dataclass
+        class Row:
+            id: str
+            count: int
+            score: float
+            flag: bool
+
+        schema = await falkor.TableSchema.from_class(Row, primary_key="id")
+        assert schema.primary_key == "id"
+        assert schema.columns["id"].type == "string"
+        assert schema.columns["count"].type == "integer"
+        assert schema.columns["score"].type == "float"
+        assert schema.columns["flag"].type == "boolean"
+        assert schema.value_field_names == ["count", "score", "flag"]
+
+    @pytest.mark.asyncio
+    async def test_custom_pk(self) -> None:
+        @dataclass
+        class Doc:
+            filename: str
+            title: str
+
+        schema = await falkor.TableSchema.from_class(Doc, primary_key="filename")
+        assert schema.primary_key == "filename"
+        assert schema.value_field_names == ["title"]
+
+
+# =============================================================================
+# Integration tests — require running FalkorDB
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def falkor_graph_name() -> AsyncIterator[str]:
+    """Yield a unique graph name and tear it down at the end of the test.
+
+    Each test runs against its own graph so concurrent runs and re-runs are
+    isolated (FalkorDB graphs are cheap — Redis namespaces).
+    """
+    name = f"test_{uuid_mod.uuid4().hex[:8]}"
+    yield name
+    if HAS_FALKORDB:
+        try:
+            client = AsyncFalkorDB.from_url(_FALKORDB_URI)
+            g = client.select_graph(name)
+            await g.delete()
+            await client.aclose()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def _read_nodes(graph_name: str, label: str) -> list[dict[str, Any]]:
+    """Return all nodes of a given label, with their properties."""
+    client = AsyncFalkorDB.from_url(_FALKORDB_URI)
+    g = client.select_graph(graph_name)
+    res = await g.query(f"MATCH (n:`{label}`) RETURN properties(n)")
+    rows = [r[0] for r in res.result_set]
+    await client.aclose()
+    return rows
+
+
+async def _read_relationships(
+    graph_name: str, rel_type: str
+) -> list[tuple[Any, Any, dict[str, Any]]]:
+    """Return (from_props, to_props, rel_props) tuples for all edges of a type."""
+    client = AsyncFalkorDB.from_url(_FALKORDB_URI)
+    g = client.select_graph(graph_name)
+    res = await g.query(
+        f"MATCH (s)-[r:`{rel_type}`]->(t) "
+        f"RETURN properties(s), properties(t), properties(r)"
+    )
+    out = [(r[0], r[1], r[2]) for r in res.result_set]
+    await client.aclose()
+    return out
+
+
+# Per-test global state shared with the declare function (mirrors the
+# surrealdb test pattern — globals are re-bound at the top of each test).
+_current_graph: str = ""
+_node_rows: list[Any] = []
+_rel_pairs: list[tuple[Any, Any]] = []
+
+
+@dataclass
+class Document:
+    filename: str
+    title: str
+    summary: str
+
+
+@dataclass
+class Entity:
+    value: str
+
+
+@dataclass
+class RelRow:
+    id: str
+    predicate: str
+
+
+async def _declare_documents_only() -> None:
+    schema = await falkor.TableSchema.from_class(Document, primary_key="filename")
+    table: Any = await coco.use_mount(  # type: ignore[call-overload]
+        coco.component_subpath("setup", "doc_table"),
+        falkor.mount_table_target,  # type: ignore[arg-type]
+        KG_DB,
+        "Document",
+        schema,
+        primary_key="filename",
+    )
+    for row in _node_rows:
+        table.declare_record(row=row)
+
+
+async def _declare_entities_and_relationships() -> None:
+    entity_schema = await falkor.TableSchema.from_class(Entity, primary_key="value")
+    rel_schema = await falkor.TableSchema.from_class(RelRow, primary_key="id")
+    entity_table: Any = await coco.use_mount(  # type: ignore[call-overload]
+        coco.component_subpath("setup", "entity_table"),
+        falkor.mount_table_target,
+        KG_DB,
+        "Entity",
+        entity_schema,
+        primary_key="value",
+    )
+    rel_table: Any = await coco.use_mount(  # type: ignore[call-overload]
+        coco.component_subpath("setup", "rel_table"),
+        falkor.mount_relation_target,
+        KG_DB,
+        "REL",
+        entity_table,
+        entity_table,
+        rel_schema,
+        primary_key="id",
+    )
+    # Drive entity table directly so endpoints exist with their own tracking.
+    seen_entities: set[str] = set()
+    for from_id, to_id in _rel_pairs:
+        for v in (from_id, to_id):
+            if v not in seen_entities:
+                entity_table.declare_record(row=Entity(value=v))
+                seen_entities.add(v)
+        rel_table.declare_relation(
+            from_id=from_id,
+            to_id=to_id,
+            record=RelRow(id=f"{from_id}->{to_id}", predicate="connects"),
+        )
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_node_upsert_and_readback(falkor_graph_name: str) -> None:
+    global _current_graph, _node_rows
+    _current_graph = falkor_graph_name
+    _node_rows = [
+        Document(filename="a.md", title="A", summary="alpha"),
+        Document(filename="b.md", title="B", summary="beta"),
+    ]
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_node_upsert", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+
+    rows = await _read_nodes(falkor_graph_name, "Document")
+    by_fn = {r["filename"]: r for r in rows}
+    assert set(by_fn) == {"a.md", "b.md"}
+    assert by_fn["a.md"]["title"] == "A"
+    assert by_fn["a.md"]["summary"] == "alpha"
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_reconcile_twice_is_noop(falkor_graph_name: str) -> None:
+    """Second update with identical input must not produce duplicate writes."""
+    global _current_graph, _node_rows
+    _current_graph = falkor_graph_name
+    _node_rows = [Document(filename="a.md", title="A", summary="alpha")]
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_noop", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    rows1 = await _read_nodes(falkor_graph_name, "Document")
+    await app.update()  # identical input
+    rows2 = await _read_nodes(falkor_graph_name, "Document")
+    assert rows1 == rows2
+    assert len(rows2) == 1
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_modify_value_triggers_one_upsert(falkor_graph_name: str) -> None:
+    global _current_graph, _node_rows
+    _current_graph = falkor_graph_name
+    _node_rows = [Document(filename="a.md", title="A", summary="alpha")]
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_modify", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    _node_rows[0] = Document(filename="a.md", title="A", summary="ALPHA-2")
+    await app.update()
+    rows = await _read_nodes(falkor_graph_name, "Document")
+    assert len(rows) == 1
+    assert rows[0]["summary"] == "ALPHA-2"
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_delete_removes_node(falkor_graph_name: str) -> None:
+    global _current_graph, _node_rows
+    _current_graph = falkor_graph_name
+    _node_rows = [
+        Document(filename="a.md", title="A", summary="alpha"),
+        Document(filename="b.md", title="B", summary="beta"),
+    ]
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_delete", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    assert {
+        r["filename"] for r in await _read_nodes(falkor_graph_name, "Document")
+    } == {
+        "a.md",
+        "b.md",
+    }
+    _node_rows.pop()  # drop b.md
+    await app.update()
+    assert {
+        r["filename"] for r in await _read_nodes(falkor_graph_name, "Document")
+    } == {"a.md"}
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_relationship_upsert_with_endpoint_merge(
+    falkor_graph_name: str,
+) -> None:
+    """Verify three-MERGE relationship insert: source endpoint, target endpoint, edge."""
+    global _current_graph, _rel_pairs
+    _current_graph = falkor_graph_name
+    _rel_pairs = [("alice", "bob"), ("bob", "carol")]
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_rel_upsert", environment=coco_env),
+        _declare_entities_and_relationships,
+    )
+    await app.update()
+
+    nodes = await _read_nodes(falkor_graph_name, "Entity")
+    assert {n["value"] for n in nodes} == {"alice", "bob", "carol"}
+
+    edges = await _read_relationships(falkor_graph_name, "REL")
+    assert len(edges) == 2
+    pairs = {(s["value"], t["value"]) for s, t, _ in edges}
+    assert pairs == {("alice", "bob"), ("bob", "carol")}
+    # Relationship props are written
+    for _, _, rel in edges:
+        assert rel["predicate"] == "connects"
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_vector_index_attached(falkor_graph_name: str) -> None:
+    """declare_vector_index() should create a queryable vector index."""
+    global _current_graph, _node_rows
+    _current_graph = falkor_graph_name
+    _node_rows = []  # No record traffic — just verify the index DDL fires.
+
+    @dataclass
+    class _DocWithVec:
+        filename: str
+        title: str
+        summary: str  # placeholder; vector field is created separately by index
+
+    async def _declare_doc_with_vector_index() -> None:
+        schema = await falkor.TableSchema.from_class(
+            _DocWithVec, primary_key="filename"
+        )
+        table: Any = await coco.use_mount(  # type: ignore[call-overload]
+            coco.component_subpath("setup", "doc_table"),
+            falkor.mount_table_target,
+            KG_DB,
+            "VecDoc",
+            schema,
+            primary_key="filename",
+        )
+        table.declare_vector_index(field="summary", metric="cosine", dimension=4)
+
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_vec_idx", environment=coco_env),
+        _declare_doc_with_vector_index,
+    )
+    await app.update()
+
+    client = AsyncFalkorDB.from_url(_FALKORDB_URI)
+    g = client.select_graph(falkor_graph_name)
+    res = await g.query("CALL db.indexes()")
+    found = False
+    for row in res.result_set:
+        # Each row: [label, fields, types_dict, options_dict, ...].
+        if row[0] == "VecDoc" and "summary" in row[1]:
+            found = True
+            break
+    await client.aclose()
+    assert found, "Expected vector index on VecDoc.summary"

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,6 +542,7 @@ all = [
     { name = "colpali-engine" },
     { name = "confluent-kafka" },
     { name = "faiss-cpu" },
+    { name = "falkordb" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "instructor" },
@@ -565,6 +575,9 @@ entity-resolution-llm = [
     { name = "faiss-cpu" },
     { name = "instructor" },
     { name = "litellm" },
+]
+falkordb = [
+    { name = "falkordb" },
 ]
 google-drive = [
     { name = "google-api-python-client" },
@@ -676,6 +689,8 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'all'", specifier = ">=1.7" },
     { name = "faiss-cpu", marker = "extra == 'entity-resolution'", specifier = ">=1.7" },
     { name = "faiss-cpu", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.7" },
+    { name = "falkordb", marker = "extra == 'all'", specifier = ">=1.1.0" },
+    { name = "falkordb", marker = "extra == 'falkordb'", specifier = ">=1.1.0" },
     { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "google-api-python-client", marker = "extra == 'google-drive'", specifier = ">=2.0.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.0.0" },
@@ -710,7 +725,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchfiles", specifier = ">=1.1.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "google-drive", "kafka", "lancedb", "litellm", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb"]
+provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "kafka", "lancedb", "litellm", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -949,6 +964,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/52/5d10642da628f63544aab27e48416be4a7ea25c6b81d8bd65016d8538b00/faiss_cpu-1.13.2-cp313-cp313-win_arm64.whl", hash = "sha256:1243967eeb2298791ff7f3683a4abd2100d7e6ec7542ca05c3b75d47a7f621e5", size = 8553088, upload-time = "2025-12-24T10:27:31.325Z" },
     { url = "https://files.pythonhosted.org/packages/b0/b1/daaab8046f56c60079648bd83774f61b283b59a9930a2f60790ee4cdedfe/faiss_cpu-1.13.2-cp314-cp314-win_amd64.whl", hash = "sha256:c8b645e7d56591aa35dc75415bb53a62e4a494dba010e16f4b67daeffd830bd7", size = 18892621, upload-time = "2025-12-24T10:27:33.923Z" },
     { url = "https://files.pythonhosted.org/packages/06/6f/5eaf3e249c636e616ebb52e369a4a2f1d32b1caf9a611b4f917b3dd21423/faiss_cpu-1.13.2-cp314-cp314-win_arm64.whl", hash = "sha256:8113a2a80b59fe5653cf66f5c0f18be0a691825601a52a614c30beb1fca9bc7c", size = 8556374, upload-time = "2025-12-24T10:27:36.653Z" },
+]
+
+[[package]]
+name = "falkordb"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/52/5495fcba8e21c269a605092a7c4a8b33ceecae283dbfe76fc53f7f5b50ab/falkordb-1.6.0.tar.gz", hash = "sha256:5c307d973f3fc3987a18478ebd5882f7e842d4225463a8ef5e026970ebfba8c6", size = 98157, upload-time = "2026-02-21T06:36:19.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/8b/59ec60885abd3b6b2b3a1e5917627c3cae656b4cff7f847c5217ec3dc952/falkordb-1.6.0-py3-none-any.whl", hash = "sha256:0f190e9d6104595fd51ece4f1e7b5d49d62cfee346d94151d7986a138fd90d89", size = 37378, upload-time = "2026-02-21T06:36:17.769Z" },
 ]
 
 [[package]]
@@ -3083,6 +3111,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/7d/3cd10e26ae97b35cf856ca1dc67576e42414ae39502c51165bb36bb1dff8/qdrant_client-1.16.2.tar.gz", hash = "sha256:ca4ef5f9be7b5eadeec89a085d96d5c723585a391eb8b2be8192919ab63185f0", size = 331112, upload-time = "2025-12-12T10:58:30.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/13/8ce16f808297e16968269de44a14f4fef19b64d9766be1d6ba5ba78b579d/qdrant_client-1.16.2-py3-none-any.whl", hash = "sha256:442c7ef32ae0f005e88b5d3c0783c63d4912b97ae756eb5e052523be682f17d3", size = 377186, upload-time = "2025-12-12T10:58:29.282Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pure-Python connector under cocoindex.connectors.falkordb, modeled on the SurrealDB connector. Supports node tables, relation (edge) tables, per-graph multitenancy, and vector index attachments.

- _cypher.py: pure Cypher (MERGE upsert, DETACH DELETE, three-MERGE relationship insert with $-bound params, vector index DDL)
- _target.py: ConnectionFactory, TableSchema (with from_class + FalkorType override), TableTarget, RelationTarget, module-level entry points, root provider "cocoindex/falkordb/table"
- Two-level state via statediff.diff_composite, with prev_pk_field recovered from prior tracking records so DROP INDEX can identify the underlying artifact on table delete/replace
- Vector index attachment via attachments() (the plural form is what the engine actually introspects)
- pyproject.toml: falkordb=[falkordb>=1.1.0] extra + all=[...] + mypy ignore for falkordb.*
- 44 tests (38 unit, 6 integration vs live FalkorDB), mypy strict clean, docs build clean
- Docs page + sidebar entry under Connectors