### PR TITLE
docs(v0): cherry-pick search/TOC fixes from main; refresh banner + nav

### DIFF
--- a/.github/workflows/_docs_release.yml
+++ b/.github/workflows/_docs_release.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Install dependencies
         run: npm --prefix docs ci
       - name: Build docs site
+        env:
+          # Re-exported from the Docusaurus era (commit b8e0eda removed
+          # them when the docs migrated to Astro). Names match the
+          # original config so the existing GitHub Actions vars keep
+          # working; Search.astro reads them in frontmatter and inlines
+          # the values into the client bundle via `define:vars`. The
+          # Algolia "search-only API key" is public by design — the
+          # index is read-only with that key.
+          COCOINDEX_DOCS_ALGOLIA_APP_ID:  ${{ vars.COCOINDEX_DOCS_ALGOLIA_APP_ID }}
+          COCOINDEX_DOCS_ALGOLIA_API_KEY: ${{ vars.COCOINDEX_DOCS_ALGOLIA_API_KEY }}
         run: npm --prefix docs run build
       - name: Deploy to cocoindex-io/docs-v0 gh-pages
         env:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -100,4 +100,13 @@ export default defineConfig({
     shikiConfig: { theme: cocoindexCodeTheme, wrap: false },
   },
   redirects,
+  // Vite's default envPrefix is `VITE_`; Astro adds `PUBLIC_`. We also
+  // want unprefixed `COCOINDEX_DOCS_ALGOLIA_*` names exposed to
+  // import.meta.env in `.astro` frontmatter — those come from the
+  // GitHub Actions vars (see .github/workflows/_docs_release.yml) and
+  // are matched by the same names in docs/.env locally. The Algolia
+  // search-only API key is public by design; it's safe to inline.
+  vite: {
+    envPrefix: ['VITE_', 'PUBLIC_', 'COCOINDEX_'],
+  },
 });

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
+        "@docsearch/css": "^4.6.2",
+        "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
         "mdast-util-to-string": "^4.0.0",
         "remark-directive": "^4.0.0",
@@ -214,6 +216,18 @@
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
+      "integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.6.2.tgz",
+      "integrity": "sha512-qj1yoxl3y4GKoK7+VM6fq/rQqPnvUmg3IKzJ9x0VzN14QVzdB/SG/J6VfV1BWT5RcPUFxIcVwoY1fwHM2fSRRw==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
+    "@docsearch/css": "^4.6.2",
+    "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",
     "mdast-util-to-string": "^4.0.0",
     "remark-directive": "^4.0.0",

--- a/docs/src/components/Banner.astro
+++ b/docs/src/components/Banner.astro
@@ -1,19 +1,17 @@
 ---
-// Slim announcement strip below the top nav. The countdown is resolved in
-// the visitor's local timezone — we pick the next upcoming Wednesday 08:00
-// relative to "now" so the banner stays accurate as days pass without
-// needing a rebuild.
+// Slim announcement strip below the top nav. V1 is now generally available;
+// the banner nudges V0 readers to the new docs.
 ---
 
-<div class="banner" role="status" aria-live="polite">
+<div class="banner" role="status">
   <div class="banner-accent" aria-hidden="true"></div>
   <div class="banner-in">
     <span class="tag">V0 Docs</span>
     <span class="msg">
       You are viewing <strong>CocoIndex&nbsp;V0</strong> Documentation.
-      <strong>CocoIndex&nbsp;V1</strong> will be officially supported in
+      <strong>CocoIndex&nbsp;V1</strong> is now available.
     </span>
-    <span class="countdown" data-countdown aria-live="off">—</span>
+    <a class="cta" href="/docs">Try V1 →</a>
   </div>
 </div>
 
@@ -69,32 +67,20 @@
     color: var(--peach);
     white-space: nowrap;
   }
-  .banner .countdown {
+  .banner .cta {
     font-family: var(--mono);
     font-size: 12px;
-    font-variant-numeric: tabular-nums;
-    padding: 3px 10px;
+    font-weight: 600;
+    padding: 4px 12px;
     background: var(--coral);
     color: var(--cream);
     border-radius: 999px;
+    text-decoration: none;
     flex: none;
-    margin-left: auto;
-    display: inline-flex; align-items: center; gap: 7px;
+    transition: background 120ms ease;
   }
-  /* Live dot — echoes the hero-eyebrow dot in the brand guidelines.
-     Pulses once per second, in sync with the countdown tick. */
-  .banner .countdown::before {
-    content: "";
-    display: inline-block;
-    width: 7px; height: 7px; border-radius: 50%;
-    background: var(--palm);
-    box-shadow: 0 0 0 0 color-mix(in oklab, var(--palm) 60%, transparent);
-    animation: banner-pulse 1s ease-out infinite;
-  }
-  @keyframes banner-pulse {
-    0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--palm) 60%, transparent); transform: scale(1); }
-    70%  { box-shadow: 0 0 0 6px color-mix(in oklab, var(--palm) 0%, transparent); transform: scale(1); }
-    100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--palm) 0%, transparent); transform: scale(1); }
+  .banner .cta:hover {
+    background: color-mix(in oklab, var(--coral) 80%, var(--cream));
   }
   /* `V1` gets a quiet sheen that drifts across it — hint of arrival. */
   .banner .msg strong:last-of-type {
@@ -118,7 +104,6 @@
 
   @media (prefers-reduced-motion: reduce) {
     .banner-accent,
-    .banner .countdown::before,
     .banner .msg strong:last-of-type {
       animation: none;
     }
@@ -134,45 +119,5 @@
       flex-wrap: wrap;
       gap: 8px;
     }
-    .banner .countdown { margin-left: 0; }
   }
 </style>
-
-<script>
-  // Target: next Wednesday 08:00 in the visitor's local timezone. If it's
-  // already past 08:00 on a Wednesday, roll forward a full week so the
-  // banner never shows a negative number or "now".
-  function nextWednesday8am(from: Date = new Date()): Date {
-    const t = new Date(from);
-    t.setHours(8, 0, 0, 0);
-    const dayDelta = (3 - t.getDay() + 7) % 7; // 3 = Wednesday
-    t.setDate(t.getDate() + dayDelta);
-    if (t.getTime() <= from.getTime()) t.setDate(t.getDate() + 7);
-    return t;
-  }
-
-  function format(ms: number): string {
-    if (ms <= 0) return 'now';
-    const s = Math.floor(ms / 1000);
-    const d = Math.floor(s / 86400);
-    const h = Math.floor((s % 86400) / 3600);
-    const m = Math.floor((s % 3600) / 60);
-    const sec = s % 60;
-    const parts: string[] = [];
-    if (d) parts.push(`${d}d`);
-    if (d || h) parts.push(`${h}h`);
-    parts.push(`${m}m`);
-    parts.push(`${sec}s`);
-    return parts.join(' ');
-  }
-
-  function tick() {
-    const el = document.querySelector<HTMLElement>('[data-countdown]');
-    if (!el) return;
-    const target = nextWednesday8am();
-    el.textContent = format(target.getTime() - Date.now());
-  }
-
-  tick();
-  setInterval(tick, 1000);
-</script>

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -18,9 +18,9 @@
 // index is read-only with that key.
 const APP_ID  = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID  ?? '') as string;
 const API_KEY = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY ?? '') as string;
-// Keep in sync with the crawler config — v1 docs use `cocoindex_v1`
+// Keep in sync with the crawler config
 // (PR #1551 renamed it from `cocoindex`).
-const INDEX   = 'cocoindex_v1';
+const INDEX   = 'cocoindex';
 ---
 
 <div class="search-wrap">

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -1,0 +1,152 @@
+---
+// Algolia DocSearch — top-of-sidebar search box that opens the standard
+// DocSearch modal on click or `/` / Cmd+K. Mirrors the Docusaurus-era
+// integration removed in commit b8e0eda; same env vars and indexName
+// (`cocoindex`) so the existing crawler config keeps working.
+//
+// The button itself is rendered server-side and styled to match the
+// design system (cream background, hairline border, mono caps row);
+// the modal markup + listeners come from `@docsearch/js`, which we
+// import dynamically inside a client `<script>` so the search bundle
+// loads only when the page actually carries the integration.
+
+// Same env var names as the Docusaurus era (commit b8e0eda removed
+// these along with the integration). Visible to `import.meta.env`
+// because astro.config.mjs adds `COCOINDEX_` to vite.envPrefix.
+// Values inline into the client `<script>` below via `define:vars`.
+// The Algolia "search-only API key" is public by design — the
+// index is read-only with that key.
+const APP_ID  = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID  ?? '') as string;
+const API_KEY = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY ?? '') as string;
+// Keep in sync with the crawler config — v1 docs use `cocoindex_v1`
+// (PR #1551 renamed it from `cocoindex`).
+const INDEX   = 'cocoindex_v1';
+---
+
+<div class="search-wrap">
+  <button
+    class="search-btn"
+    type="button"
+    data-search-btn
+    aria-label="Search documentation"
+  >
+    <svg class="ic" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="7"></circle>
+      <path d="m20 20-3.5-3.5"></path>
+    </svg>
+    <span class="lbl">Search docs</span>
+    <kbd class="kbd"><span class="cmd">⌘</span>K</kbd>
+  </button>
+</div>
+
+<!--
+  Two scripts here, on purpose:
+
+  1. The first one is `is:inline` + `define:vars` — that combination
+     emits the values directly into the rendered HTML so they survive
+     to the browser. It just stamps `window.__COCOINDEX_DOCSEARCH__`
+     and exits.
+  2. The second one is a plain `<script>` block. Astro routes plain
+     scripts through Vite, which means bare module specifiers like
+     `@docsearch/js` resolve correctly. (A `define:vars` script is
+     treated as inline and skips Vite — that's why the earlier version
+     hit `Failed to resolve module specifier '@docsearch/js'`.) Astro
+     also dedupes plain scripts across the page, so a Search rendered
+     in both the sidebar and the mobile drawer still registers exactly
+     one click handler.
+-->
+<script is:inline define:vars={{ APP_ID, API_KEY, INDEX }}>
+  window.__COCOINDEX_DOCSEARCH__ = { APP_ID, API_KEY, INDEX };
+</script>
+
+<script>
+  import docsearch from '@docsearch/js';
+  import '@docsearch/css';
+
+  type DocSearchConfig = { APP_ID: string; API_KEY: string; INDEX: string };
+
+  declare global {
+    interface Window {
+      __COCOINDEX_DOCSEARCH__?: DocSearchConfig;
+      __docsSearchInit?: boolean;
+    }
+  }
+
+  if (!window.__docsSearchInit) {
+    window.__docsSearchInit = true;
+
+    const cfg = window.__COCOINDEX_DOCSEARCH__ ?? { APP_ID: '', API_KEY: '', INDEX: '' };
+    const hasKeys = !!cfg.APP_ID && !!cfg.API_KEY;
+
+    // Find DocSearch's own button inside our hidden host. DocSearch
+    // renders synchronously after init(), but a requestAnimationFrame
+    // retry covers any future async-render change.
+    const fireDocSearch = (host: HTMLElement) => {
+      const tryClick = (tries: number) => {
+        const btn = host.querySelector<HTMLElement>('.DocSearch-Button');
+        if (btn) { btn.click(); return; }
+        if (tries <= 0) {
+          console.warn('[CocoIndex docs] DocSearch button not found after init.');
+          return;
+        }
+        requestAnimationFrame(() => tryClick(tries - 1));
+      };
+      tryClick(8);
+    };
+
+    let bootP: Promise<HTMLElement | null> | null = null;
+    const boot = (): Promise<HTMLElement | null> => {
+      if (!hasKeys) {
+        console.warn(
+          '[CocoIndex docs] Algolia search disabled — set ' +
+          'COCOINDEX_DOCS_ALGOLIA_APP_ID and ' +
+          'COCOINDEX_DOCS_ALGOLIA_API_KEY in docs/.env to enable.',
+        );
+        return Promise.resolve(null);
+      }
+      if (bootP) return bootP;
+      bootP = Promise.resolve().then(() => {
+        let host = document.getElementById('docsSearchHost');
+        if (!host) {
+          host = document.createElement('div');
+          host.id = 'docsSearchHost';
+          // Off-screen instead of `display: none` so DocSearch's button
+          // still registers layout/clicks.
+          host.style.cssText = 'position:absolute;left:-9999px;top:0;width:1px;height:1px;overflow:hidden;';
+          document.body.appendChild(host);
+        }
+        docsearch({
+          appId: cfg.APP_ID,
+          apiKey: cfg.API_KEY,
+          indexName: cfg.INDEX,
+          container: host,
+        });
+        return host;
+      }).catch((err: unknown) => {
+        console.error('[CocoIndex docs] DocSearch failed to load:', err);
+        return null;
+      });
+      return bootP;
+    };
+
+    // Delegated click — covers buttons added by re-rendered layouts.
+    document.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement | null;
+      const btn = target?.closest?.('[data-search-btn]');
+      if (!btn) return;
+      boot().then((host) => { if (host) fireDocSearch(host); });
+    });
+
+    // Pre-warm on idle so the first click feels instant. DocSearch's
+    // own listeners (Cmd+K, /) only register after this runs.
+    if (hasKeys) {
+      const pre = () => { boot(); };
+      if ('requestIdleCallback' in window) {
+        (window as Window & { requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => void })
+          .requestIdleCallback(pre, { timeout: 1500 });
+      } else {
+        setTimeout(pre, 600);
+      }
+    }
+  }
+</script>

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -20,7 +20,7 @@ const APP_ID  = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_APP_ID  ?? '') as string
 const API_KEY = (import.meta.env.COCOINDEX_DOCS_ALGOLIA_API_KEY ?? '') as string;
 // Keep in sync with the crawler config
 // (PR #1551 renamed it from `cocoindex`).
-const INDEX   = 'cocoindex';
+const INDEX   = 'cocoindex_v0';
 ---
 
 <div class="search-wrap">

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -1,5 +1,6 @@
 ---
 import { sidebar, type SidebarItem } from '../data/docs-sidebar';
+import Search from './Search.astro';
 
 export interface Props {
   /** Slug of the currently-rendered doc, e.g. `getting_started/quickstart`. */
@@ -17,6 +18,7 @@ function href(slug: string): string {
 ---
 
 <aside class="side">
+  <Search />
   {sidebar.map((item) => (
     item.type === 'doc' ? (
       <div class="side-group">

--- a/docs/src/components/Toc.astro
+++ b/docs/src/components/Toc.astro
@@ -11,14 +11,8 @@ export interface Props {
 
 const { headings, slug } = Astro.props;
 
-// Only H2 and H3 in the right rail — deeper nesting makes noise. H2s get
-// numbered ("1 · Install") to match the design mock.
-const items = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
-let h2Count = 0;
-const rows = items.map((h) => {
-  if (h.depth === 2) h2Count++;
-  return { ...h, n: h.depth === 2 ? h2Count : null };
-});
+// Only H2 and H3 in the right rail — deeper nesting makes noise.
+const rows = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
 
 const metaMap = (docsMeta as {
   _version?: string | null;
@@ -50,7 +44,6 @@ const reviewedAgo = relativeReview(editTs);
     {rows.map((h) => (
       <li class={h.depth === 3 ? 'sub' : ''} data-toc-item>
         <a href={`#${h.slug}`} data-toc-link={h.slug}>
-          {h.n != null && <span class="n">{h.n}</span>}
           {h.text}
         </a>
       </li>

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -3,11 +3,14 @@
 // so both sites share the exact same header. The stars island is a plain
 // inline script rather than a React component so we don't need to ship
 // React + a client bundle just to render one number.
-import { SITE_MAIN, SITE_EXAMPLES, SITE_BLOG, GITHUB_REPO } from '../consts';
+import { SITE_MAIN, SITE_BLOG, GITHUB_REPO } from '../consts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 const CODE = `${SITE_MAIN}/cocoindex-code`;
-const DOCS = base;
+const DOCS_V0 = `${base}/`;
+const DOCS_V1 = '/docs';
+const EXAMPLES_V0 = `${base}/examples/`;
+const EXAMPLES_V1 = '/examples/';
 const ENTERPRISE = `${SITE_MAIN}/enterprise`;
 ---
 
@@ -19,19 +22,35 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
     </a>
     <div class="nav-links">
       <a href={CODE}>CocoIndex Code</a>
-      <a href={SITE_EXAMPLES}>Examples</a>
       <div class="nav-dd">
-        <a href={DOCS} class="nav-dd-trigger" aria-haspopup="menu">
+        <a href={EXAMPLES_V0} class="nav-dd-trigger" aria-haspopup="menu">
+          Examples
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden>
+            <path d="m2.5 4.5 3.5 3.5 3.5-3.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </a>
+        <div class="nav-dd-menu" role="menu">
+          <a href={EXAMPLES_V1} role="menuitem">
+            <span class="ver">v1</span>
+          </a>
+          <a class="on" href={EXAMPLES_V0} role="menuitem">
+            <span class="ver">v0</span>
+            <span class="tag legacy">legacy</span>
+          </a>
+        </div>
+      </div>
+      <div class="nav-dd">
+        <a href={DOCS_V0} class="nav-dd-trigger" aria-haspopup="menu">
           Documentation
           <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden>
             <path d="m2.5 4.5 3.5 3.5 3.5-3.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </a>
         <div class="nav-dd-menu" role="menu">
-          <a class="on" href="/docs" role="menuitem">
+          <a href={DOCS_V1} role="menuitem">
             <span class="ver">v1</span>
           </a>
-          <a href="/docs-v0" role="menuitem">
+          <a class="on" href={DOCS_V0} role="menuitem">
             <span class="ver">v0</span>
             <span class="tag legacy">legacy</span>
           </a>

--- a/docs/src/consts.ts
+++ b/docs/src/consts.ts
@@ -2,9 +2,9 @@ export const SITE_URL = 'https://cocoindex.io';
 export const GITHUB_REPO = 'https://github.com/cocoindex-io/cocoindex';
 export const DISCORD_URL = 'https://discord.com/invite/zpA9S2DR7s';
 export const SITE_MAIN = 'https://cocoindex.io';
-export const SITE_BLOG = 'https://cocoindex.io/blogs';
+export const SITE_BLOG = 'https://cocoindex.io/blogs/';
 // `import.meta.env.BASE_URL` reflects `base` in astro.config.mjs (e.g. `/docs-v0/`).
-export const SITE_EXAMPLES = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/examples`;
+export const SITE_EXAMPLES = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/examples/`;
 // GitHub web-editor URL prefix for the "Edit this page" link.
 export const DOCS_EDIT_BASE = 'https://github.com/cocoindex-io/cocoindex/edit/main/docs/docs';
 

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -226,7 +226,7 @@ aside.toc h6 {
 }
 aside.toc ul { list-style: none; margin: 0; padding: 0; }
 aside.toc li a {
-  display: flex; align-items: baseline; gap: 8px;
+  display: block;
   padding: 4px 10px;
   color: var(--muted); font-size: 13px;
   text-decoration: none;
@@ -235,14 +235,6 @@ aside.toc li a {
 }
 aside.toc li a:hover { color: var(--coral); text-decoration: none; }
 aside.toc li a.on { color: var(--coral); border-left-color: var(--coral); }
-aside.toc li a.on .n { color: var(--coral); }
-aside.toc li a .n {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--muted);
-  min-width: 12px;
-}
-aside.toc li a .n::after { content: ' ·'; opacity: 0.65; }
 aside.toc li.sub a { padding-left: 22px; font-size: 12.5px; }
 
 aside.toc .meta {
@@ -464,7 +456,6 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
   font-family: var(--mono);
   font-size: 11px;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--muted);
   border-bottom-color: var(--rule-strong);
 }

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -320,12 +320,11 @@ main.content {
 
 /* Class-level tweaks for the bits variables can't reach. */
 .DocSearch-Container {
-  /* Drop the package's default 4px blur — paired with the now-
-     transparent scrim, the blur was the only thing softening the
-     page behind. Remove it so the docs read sharply through the
-     unobscured backdrop. */
-  -webkit-backdrop-filter: none !important;
-  backdrop-filter: none !important;
+  /* Backdrop blur without the maroon scrim — keeps the page colors
+     visible (no dim wash) but defocuses content so the modal is the
+     unambiguous foreground. Tune `blur(8px)` higher to soften more. */
+  -webkit-backdrop-filter: blur(8px) !important;
+  backdrop-filter: blur(8px) !important;
 }
 .DocSearch-Modal {
   border: 1px solid var(--rule-strong);

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -188,6 +188,282 @@ main.content {
   min-width: 0;
 }
 
+/* ─── sidebar search ───
+   Sits at the top of `aside.side`. The button is rendered server-side
+   and styled to match the docs design tokens (cream fill, hairline
+   border, mono caps row). The actual DocSearch modal is mounted lazily
+   on first interaction by Search.astro — see that file for the env
+   var wiring (PUBLIC_COCOINDEX_DOCS_ALGOLIA_*). */
+.search-wrap {
+  position: sticky; top: 0;
+  background: linear-gradient(var(--paper) 80%, transparent);
+  padding: 0 0 14px;
+  margin-bottom: 6px;
+  z-index: 5;
+}
+.search-btn {
+  width: 100%;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--rule-strong);
+  background: var(--cream);
+  color: var(--maroon-ink);
+  font-family: var(--sans); font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  transition: border-color .15s ease, background .15s ease, color .15s ease;
+}
+.search-btn:hover {
+  border-color: var(--coral);
+  color: var(--coral);
+  background: color-mix(in oklab, var(--peach) 10%, var(--cream));
+}
+.search-btn:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+.search-btn .ic { flex: none; opacity: .8; }
+.search-btn:hover .ic { opacity: 1; }
+.search-btn .lbl { flex: 1; text-align: left; }
+.search-btn .kbd {
+  font-family: var(--mono); font-size: 10px; font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: var(--paper);
+  display: inline-flex; align-items: center; gap: 2px;
+}
+.search-btn .kbd .cmd { font-size: 11px; line-height: 1; }
+
+/* ─── DocSearch theme ───
+   Maps every @docsearch/css v4 variable to the CocoIndex design
+   tokens — cream surfaces, coral accent, maroon ink, hairline rules,
+   no drop shadows (elevation reads from the maroon-ink scrim, not
+   from blur — matches the rest of the site).
+
+   Scope note: @docsearch/css ships its own `:root { --docsearch-*: ... }`
+   defaults and is imported AFTER globals.css (because Search.astro's
+   bundled `<script>` does the import). A `:root` override here would
+   lose the cascade fight for unset descendants. Scoping under
+   `.DocSearch-Container` (the modal backdrop) wins by ancestor
+   proximity instead — every modal element resolves variables from
+   the closest ancestor, which is now this rule. */
+.DocSearch-Container {
+  /* — rhythm + radii — */
+  --docsearch-spacing: 12px;
+  --docsearch-border-radius: 10px;
+  --docsearch-icon-stroke-width: 1.6;
+
+  /* — modal frame — */
+  --docsearch-modal-width: 720px;
+  --docsearch-modal-height: 600px;
+  --docsearch-modal-background: var(--paper);
+  --docsearch-modal-shadow: none;
+  /* No scrim — page behind stays its natural color. The hairline
+     border on `.DocSearch-Modal` is enough to delineate the panel. */
+  --docsearch-container-background: transparent;
+
+  /* — palette (replaces every default Algolia-blue) — */
+  --docsearch-primary-color: var(--coral);
+  --docsearch-soft-primary-color: color-mix(in oklab, var(--coral) 12%, transparent);
+  --docsearch-focus-color: var(--coral);
+  --docsearch-text-color: var(--maroon-ink);
+  --docsearch-secondary-text-color: var(--muted);
+  --docsearch-muted-color: var(--muted);
+  --docsearch-muted-color-darker: var(--maroon);
+  --docsearch-subtle-color: var(--rule);
+  --docsearch-icon-color: var(--muted);
+  --docsearch-logo-color: var(--coral);
+  --docsearch-error-color: var(--berry);
+  --docsearch-success-color: var(--palm-ink);
+  --docsearch-background-color: var(--paper);
+
+  /* — searchbox (top of modal) — */
+  --docsearch-searchbox-height: 56px;
+  --docsearch-searchbox-initial-height: 44px;
+  --docsearch-searchbox-background: var(--cream);
+  --docsearch-searchbox-focus-background: var(--paper);
+
+  /* — hits (results list) —
+     `--docsearch-hit-highlight-color` paints the ACTIVE-row background,
+     not the matched-text color (despite the name). Keep it as a soft
+     coral wash so the active row reads as "highlighted but quiet"; the
+     hover state below escalates to a full coral fill. */
+  --docsearch-hit-height: 56px;
+  --docsearch-hit-color: var(--maroon-ink);
+  --docsearch-hit-active-color: var(--maroon-ink);
+  --docsearch-hit-background: var(--cream);
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-highlight-color: color-mix(in oklab, var(--coral) 14%, var(--cream));
+  --docsearch-highlight-color: var(--coral);
+  --docsearch-dropdown-menu-background: var(--paper);
+  --docsearch-dropdown-menu-item-hover-background: color-mix(in oklab, var(--coral) 8%, transparent);
+
+  /* — keyboard hints (⌘K, esc, ↩) — */
+  --docsearch-key-background: var(--cream);
+  --docsearch-key-color: var(--maroon-ink);
+  --docsearch-key-pressed-shadow: none;
+
+  /* — footer — */
+  --docsearch-footer-height: 44px;
+  --docsearch-footer-background: var(--cream);
+  --docsearch-footer-shadow: inset 0 1px 0 var(--rule);
+
+  /* — search-button (package's own trigger; we hide it but theme
+       it anyway so any fallback render stays brand-consistent) — */
+  --docsearch-search-button-background: var(--cream);
+  --docsearch-search-button-text-color: var(--maroon-ink);
+
+  /* — actions (close X, submit) — */
+  --docsearch-actions-width: 28px;
+  --docsearch-actions-height: 28px;
+}
+
+/* Class-level tweaks for the bits variables can't reach. */
+.DocSearch-Container {
+  /* Drop the package's default 4px blur — paired with the now-
+     transparent scrim, the blur was the only thing softening the
+     page behind. Remove it so the docs read sharply through the
+     unobscured backdrop. */
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+.DocSearch-Modal {
+  border: 1px solid var(--rule-strong);
+}
+/* Searchbox — a quiet cream pill at rest, slightly darker rule on
+   focus. Earlier version used a coral inset ring, which read as
+   alarmist on top of the cream surface — the focus state should
+   confirm "you can type now", not flag a problem. */
+.DocSearch-Form {
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  box-shadow: none;
+  background: var(--cream);
+}
+.DocSearch-Form:focus-within {
+  border-color: var(--rule-strong);
+  box-shadow: none;
+  background: var(--paper);
+}
+.DocSearch-MagnifierLabel,
+.DocSearch-MagnifierLabel svg,
+.DocSearch-Search-Icon,
+.DocSearch-Back-Icon { color: var(--coral) !important; }
+.DocSearch-Input {
+  font-family: var(--sans);
+  font-size: 15px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--maroon-ink);
+}
+.DocSearch-Input::placeholder { color: var(--muted); }
+.DocSearch-Cancel,
+.DocSearch-Clear {
+  color: var(--coral) !important;
+  font-family: var(--sans);
+}
+.DocSearch-Hit-source {
+  font-family: var(--mono); font-weight: 500;
+  font-size: 11px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted) !important;
+  background: var(--paper);
+  padding: 14px 4px 6px;
+}
+.DocSearch-Hit a {
+  border-radius: 8px;
+  border: 1px solid var(--rule);
+  background: transparent !important;
+  transition: background-image .18s ease, border-color .18s ease;
+}
+/* Active (keyboard-selected) row — soft coral wash so the row still
+   stands out from a plain hover, even with no fill at rest. */
+.DocSearch-Hit[aria-selected="true"] a {
+  background: color-mix(in oklab, var(--coral) 12%, transparent) !important;
+  border-color: var(--coral);
+}
+/* Hover — standard dotted pattern shared with `.var-card` on examples
+   detail pages and the `.arch-core` radial fill. No fill, just the
+   maroon-ink dot grid stippled over the modal surface. */
+.DocSearch-Hit a:hover {
+  background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px);
+  background-size: 14px 14px;
+  border-color: var(--coral);
+}
+.DocSearch-Hit-title { font-family: var(--sans); font-weight: 500; }
+.DocSearch-Hit-path  { font-family: var(--mono); font-size: 11px; }
+.DocSearch-Hit-icon  { color: var(--muted); }
+.DocSearch-Hit mark {
+  background: transparent;
+  color: var(--coral) !important;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--coral);
+  font-weight: 600;
+}
+
+/* Action chrome — close X, return ↩, dropdown arrows. Default uses
+   `--docsearch-highlight-color` which we want for matched text, not
+   for icon chrome; force coral here for visual consistency. */
+.DocSearch-Action,
+.DocSearch-Action svg,
+.DocSearch-AskAi-Return,
+.DocSearch-Hit-Select-Icon { color: var(--coral) !important; }
+.DocSearch-Action:hover,
+.DocSearch-AskAi-Return:hover {
+  background: color-mix(in oklab, var(--coral) 10%, transparent) !important;
+}
+
+/* Keyboard chips — match the topbar `.kbd` style: cream pill, mono
+   caps, hairline border, no shadow. */
+.DocSearch-Commands-Key,
+.DocSearch-Button-Key {
+  font-family: var(--mono);
+  font-weight: 500; font-size: 11px;
+  border: 1px solid var(--rule) !important;
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: var(--cream) !important;
+  color: var(--maroon-ink) !important;
+  box-shadow: none !important;
+}
+
+/* Footer — hairline rule + mono caps, matches the doc-foot strip. */
+.DocSearch-Footer {
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.06em; color: var(--muted);
+}
+.DocSearch-Commands { color: var(--muted); }
+/* The Algolia logo SVG is multi-path — the "i" stem has a hardcoded
+   accent fill on its own path that ignores `currentColor`. Force fill
+   on every descendant so the whole wordmark renders in a single coral
+   tone. */
+.DocSearch-Logo svg,
+.DocSearch-Logo svg *,
+.DocSearch-Logo svg g,
+.DocSearch-Logo svg path,
+.DocSearch-Logo svg rect,
+.DocSearch-Logo svg use {
+  fill: var(--coral) !important;
+  color: var(--coral) !important;
+}
+.DocSearch-Logo a { color: var(--muted); }
+
+/* No-results — italic-coral serif headline, matching the design system
+   "italic-coral H1" treatment used across the site. */
+.DocSearch-NoResults .DocSearch-Title {
+  font-family: var(--serif); font-style: italic;
+  font-weight: 400; color: var(--maroon-ink);
+}
+.DocSearch-NoResults .DocSearch-Title strong { color: var(--coral); }
+
+/* Tighten letter-spacing where we landed on tabular-mono columns. */
+.DocSearch-Title,
+.DocSearch-Hit-source,
+.DocSearch-NoResults-Prefill-List ul li {
+  letter-spacing: -0.005em;
+}
+
 /* ─── sidebar ─── */
 .side-group { margin-bottom: 22px; }
 .side-group > h5 {


### PR DESCRIPTION
## Summary
- Cherry-picks four docs PRs from `main` into v0 docs:
  - #1891 — clean up right-rail TOC rendering
  - #1894 — re-add Algolia DocSearch at top of sidebar (MobileSheet hunk dropped — v0 has no mobile drawer)
  - #1895 — restore the 8px backdrop blur behind the DocSearch modal
  - #1899 — switch Search to the live Algolia index
- Plus v0-specific polish on top of the cherry-picks:
  - Replace the announcement-banner countdown ("V1 will be supported in …") with a "Try V1 →" CTA — V1 is already GA.
  - Add a v0/v1 dropdown to the Examples nav, mirroring the Documentation dropdown.
  - Point Search.astro at the `cocoindex_v0` Algolia index (the cherry-pick of #1899 set it to the v1 `cocoindex` index, which is wrong on this site).
  - Normalize trailing slashes on `SITE_BLOG` / `SITE_EXAMPLES`.

## Test plan
- CI
- Local `npm --prefix docs run dev`: visit `/docs-v0/`, confirm:
  - Sidebar shows the DocSearch button; opens the Algolia modal.
  - Right-rail TOC has no leading number prefix on H2s.
  - Banner reads "V1 is now available" with a visible "Try V1 →" pill linking to `/docs`.
  - Top-nav Examples is now a dropdown with v0 (current) and v1 entries.

Recommended merge strategy: **rebase** (not squash) so the cherry-pick commits keep their `(#1891)` etc. attribution on v0.
