### PR TITLE
feat(telemetry): backport Scarf usage tracking to v0

### DIFF
--- a/docs/src/content/docs/about/telemetry.mdx
+++ b/docs/src/content/docs/about/telemetry.mdx
@@ -1,0 +1,75 @@
+---
+title: Anonymous *usage telemetry*
+description: >
+  What CocoIndex's anonymous usage tracking collects, what it doesn't, and how
+  to opt out.
+---
+
+CocoIndex sends a small number of anonymous events to help us understand how
+the library is used across platforms and runtimes. Tracking is strictly
+anonymous, release-only, and opt-out.
+
+## What we collect
+
+On release builds, CocoIndex POSTs a JSON event to our telemetry endpoint
+(the [Scarf](https://about.scarf.sh/) gateway) at five points in the library's
+lifecycle:
+
+- `init` — once per process, when CocoIndex is imported.
+- `flow_create` — when a flow is built (e.g. via `cocoindex.open_flow`).
+- `flow_update` — each time a flow live updater is started (e.g. `flow.update()`
+  or `cocoindex update`).
+- `flow_setup` — each time a flow setup is applied (e.g. `cocoindex setup` or
+  `setup_all_flows()`).
+- `flow_drop` — each time a flow is dropped (e.g. `cocoindex drop` or
+  `drop_all_flows()`).
+
+Each event body contains exactly three fields:
+
+```json
+{ "event": "flow_update", "platform": "aarch64-macos", "lang": "python3.11" }
+```
+
+The package identity and version travel in the request URL, for example
+`https://cocoindex.gateway.scarf.sh/python-0.3.34`.
+
+## What we don't collect
+
+CocoIndex telemetry never sends:
+
+- Your data, flow definitions, or function code.
+- Source/target connector configuration, credentials, URLs, or database names.
+- Flow names, component names, file paths, or any user-provided identifiers.
+- Stats about row counts, processing times, or memory usage.
+- A persistent machine or user identifier. Requests are not tagged; the gateway
+  only sees whatever an HTTP request normally carries (IP address, which Scarf
+  uses for coarse geolocation and then discards).
+
+## When telemetry is active
+
+Telemetry runs only in **release builds** of the native extension (the
+wheels published to PyPI). Local development installs via `maturin develop`
+produce a debug build and never send any events — the check is compile-time,
+so the code path doesn't exist in debug binaries.
+
+Delivery is non-blocking: each event is dispatched on a background task with a
+5-second timeout. Failures are logged at INFO level and never affect your app.
+
+## Opting out
+
+Set the `COCOINDEX_DISABLE_USAGE_TRACKING` environment variable to any non-empty
+value other than `0` before starting your program:
+
+```bash
+export COCOINDEX_DISABLE_USAGE_TRACKING=1
+```
+
+When this variable is set, CocoIndex skips all telemetry initialization — no
+events are ever constructed or dispatched.
+
+## Why we collect this
+
+Knowing which platforms and Python versions are in active use helps us prioritize
+wheel builds, platform support, and compatibility testing. If you have feedback
+about what we track, please [open an issue](https://github.com/cocoindex-io/cocoindex/issues)
+or reach out in our [Discord](https://discord.com/invite/zpA9S2DR7s).

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -115,7 +115,10 @@ export const sidebar: SidebarItem[] = [
   {
     type: 'category',
     label: 'About',
-    items: [{ type: 'doc', slug: 'about/community', label: 'Community' }],
+    items: [
+      { type: 'doc', slug: 'about/community', label: 'Community' },
+      { type: 'doc', slug: 'about/telemetry', label: 'Anonymous usage telemetry' },
+    ],
   },
 ];
 

--- a/python/cocoindex/__init__.py
+++ b/python/cocoindex/__init__.py
@@ -2,6 +2,9 @@
 Cocoindex is a framework for building and running indexing pipelines.
 """
 
+import sys as _sys
+import sysconfig as _sysconfig
+
 from ._version import __version__
 
 from . import _version_check
@@ -53,7 +56,9 @@ from .typing import (
     Json,
 )
 
-_engine.init_pyo3_runtime()
+_gil_suffix = "t" if _sysconfig.get_config_var("Py_GIL_DISABLED") else ""
+_lang = f"python{_sys.version_info.major}.{_sys.version_info.minor}{_gil_suffix}"
+_engine.init_pyo3_runtime(package_id=f"python-{__version__}", lang=_lang)
 
 __all__ = [
     "__version__",

--- a/rust/cocoindex/src/builder/flow_builder.rs
+++ b/rust/cocoindex/src/builder/flow_builder.rs
@@ -718,6 +718,7 @@ impl FlowBuilder {
                 flow_ctx
             }
         };
+        crate::telemetry::track("flow_create");
         Ok(py::Flow(flow_ctx))
     }
 

--- a/rust/cocoindex/src/lib.rs
+++ b/rust/cocoindex/src/lib.rs
@@ -10,3 +10,4 @@ mod server;
 mod service;
 mod settings;
 mod setup;
+mod telemetry;

--- a/rust/cocoindex/src/py/mod.rs
+++ b/rust/cocoindex/src/py/mod.rs
@@ -37,8 +37,9 @@ fn set_settings_fn(get_settings_fn: Py<PyAny>) -> PyResult<()> {
 }
 
 #[pyfunction]
-fn init_pyo3_runtime() {
+fn init_pyo3_runtime(package_id: String, lang: String) {
     pyo3_async_runtimes::tokio::init_with_runtime(get_runtime()).unwrap();
+    crate::telemetry::init(package_id, lang);
 }
 
 #[pyfunction]
@@ -162,6 +163,7 @@ impl FlowLiveUpdater {
         flow: &Flow,
         options: Pythonized<execution::FlowLiveUpdaterOptions>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        crate::telemetry::track("flow_update");
         let flow = flow.0.clone();
         future_into_py(py, async move {
             let lib_context = get_lib_context().await.into_py_result()?;
@@ -494,6 +496,10 @@ impl SetupChangeBundle {
         report_to_stdout: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let bundle = self.0.clone();
+        crate::telemetry::track(match bundle.action {
+            setup::FlowSetupChangeAction::Setup => "flow_setup",
+            setup::FlowSetupChangeAction::Drop => "flow_drop",
+        });
 
         future_into_py(py, async move {
             let lib_context = get_lib_context().await.into_py_result()?;

--- a/rust/cocoindex/src/telemetry/mod.rs
+++ b/rust/cocoindex/src/telemetry/mod.rs
@@ -1,0 +1,275 @@
+//! Anonymous usage telemetry.
+//!
+//! Events are POSTed to the Scarf gateway as fire-and-forget HTTP requests.
+//! Tracking is opt-out via `COCOINDEX_DISABLE_USAGE_TRACKING`, only active in
+//! release builds, and never blocks or fails user operations.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::info;
+
+use crate::lib_context::get_runtime;
+
+const SCARF_BASE: &str = "https://cocoindex.gateway.scarf.sh";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const DISABLE_ENV: &str = "COCOINDEX_DISABLE_USAGE_TRACKING";
+
+static TELEMETRY: OnceLock<TelemetryContext> = OnceLock::new();
+
+struct TelemetryContext {
+    client: reqwest::Client,
+    base_url: String,
+    platform: String,
+    lang: String,
+}
+
+#[derive(Serialize)]
+struct EventPayload<'a> {
+    event: &'a str,
+    platform: &'a str,
+    lang: &'a str,
+}
+
+/// Initialize telemetry. No-op in debug builds, no-op if
+/// `COCOINDEX_DISABLE_USAGE_TRACKING` is set (to any value other than empty or
+/// `"0"`). Safe to call multiple times; only the first successful call
+/// installs the global context. On installation, fires the `init` event.
+///
+/// `package_id` takes the form `"{name}-{version}"`, e.g. `"python-0.3.34"`.
+pub fn init(package_id: String, lang: String) {
+    if cfg!(debug_assertions) {
+        return;
+    }
+    if is_disabled_by_env() {
+        return;
+    }
+    let Some(ctx) = build_context(package_id, lang) else {
+        return;
+    };
+    if TELEMETRY.set(ctx).is_err() {
+        return;
+    }
+    track("init");
+}
+
+/// Fire a telemetry event. No-op if `init` never installed a global context.
+/// Non-blocking: spawns a background task and returns immediately.
+pub fn track(event: &'static str) {
+    let Some(ctx) = TELEMETRY.get() else {
+        return;
+    };
+    get_runtime().spawn(async move { send_event(ctx, event).await });
+}
+
+fn build_context(package_id: String, lang: String) -> Option<TelemetryContext> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .ok()?;
+    Some(TelemetryContext {
+        client,
+        base_url: format!("{SCARF_BASE}/{package_id}"),
+        platform: current_platform(),
+        lang,
+    })
+}
+
+fn current_platform() -> String {
+    format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
+}
+
+fn is_disabled_by_env() -> bool {
+    match std::env::var(DISABLE_ENV) {
+        Ok(v) => parse_disable_value(&v),
+        Err(_) => false,
+    }
+}
+
+fn parse_disable_value(v: &str) -> bool {
+    !v.is_empty() && v != "0"
+}
+
+async fn send_event(ctx: &TelemetryContext, event: &'static str) {
+    let payload = EventPayload {
+        event,
+        platform: &ctx.platform,
+        lang: &ctx.lang,
+    };
+    let result = ctx
+        .client
+        .post(&ctx.base_url)
+        .json(&payload)
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status());
+    if let Err(err) = result {
+        info!("usage tracking event {event} failed: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    use axum::Router;
+    use axum::body::Bytes;
+    use axum::extract::State;
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::post;
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Debug)]
+    struct Recorded {
+        path: String,
+        content_type: Option<String>,
+        body: Value,
+    }
+
+    #[derive(Clone)]
+    struct MockState {
+        recorded: Arc<Mutex<Vec<Recorded>>>,
+        response_status: StatusCode,
+    }
+
+    async fn handle_any(
+        State(state): State<MockState>,
+        headers: HeaderMap,
+        axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+        body: Bytes,
+    ) -> StatusCode {
+        let content_type = headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        state.recorded.lock().unwrap().push(Recorded {
+            path: uri.path().to_string(),
+            content_type,
+            body: parsed,
+        });
+        state.response_status
+    }
+
+    async fn spawn_mock_server(
+        response_status: StatusCode,
+    ) -> (SocketAddr, Arc<Mutex<Vec<Recorded>>>) {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = MockState {
+            recorded: recorded.clone(),
+            response_status,
+        };
+        let app = Router::new()
+            .route("/{*any}", post(handle_any))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (addr, recorded)
+    }
+
+    fn make_test_ctx(base_url: String, lang: String, timeout: Duration) -> TelemetryContext {
+        TelemetryContext {
+            client: reqwest::Client::builder().timeout(timeout).build().unwrap(),
+            base_url,
+            platform: current_platform(),
+            lang,
+        }
+    }
+
+    #[tokio::test]
+    async fn send_event_posts_expected_payload() {
+        let (addr, recorded) = spawn_mock_server(StatusCode::OK).await;
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-0.3.34"),
+            "python3.11".to_string(),
+            Duration::from_secs(5),
+        );
+
+        send_event(&ctx, "flow_create").await;
+
+        let recs = recorded.lock().unwrap().clone();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].path, "/python-0.3.34");
+        assert_eq!(recs[0].content_type.as_deref(), Some("application/json"));
+        let body = &recs[0].body;
+        assert_eq!(body["event"], "flow_create");
+        assert_eq!(body["lang"], "python3.11");
+        assert_eq!(body["platform"], current_platform());
+    }
+
+    #[tokio::test]
+    async fn send_event_handles_non_2xx_without_panic() {
+        let (addr, recorded) = spawn_mock_server(StatusCode::INTERNAL_SERVER_ERROR).await;
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-0.3.34"),
+            "python3.11".to_string(),
+            Duration::from_secs(5),
+        );
+        send_event(&ctx, "flow_update").await;
+        assert_eq!(recorded.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_event_handles_transport_error() {
+        // Port 1 is almost never bound; connection should fail promptly.
+        let ctx = make_test_ctx(
+            "http://127.0.0.1:1/python-0.3.34".to_string(),
+            "python3.11".to_string(),
+            Duration::from_millis(500),
+        );
+        send_event(&ctx, "init").await;
+    }
+
+    #[tokio::test]
+    async fn send_event_respects_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let _ = listener.accept().await;
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        });
+
+        let ctx = make_test_ctx(
+            format!("http://{addr}/python-0.3.34"),
+            "python3.11".to_string(),
+            Duration::from_millis(300),
+        );
+        let start = std::time::Instant::now();
+        send_event(&ctx, "flow_update").await;
+        let elapsed = start.elapsed();
+        assert!(elapsed < Duration::from_secs(2), "elapsed = {elapsed:?}");
+    }
+
+    #[test]
+    fn parse_disable_value_matrix() {
+        assert!(!parse_disable_value(""));
+        assert!(!parse_disable_value("0"));
+        assert!(parse_disable_value("1"));
+        assert!(parse_disable_value("true"));
+        assert!(parse_disable_value("yes"));
+        assert!(parse_disable_value("anything"));
+    }
+
+    #[test]
+    fn track_noops_when_telemetry_not_initialized() {
+        // In debug builds (cargo test), TELEMETRY is never installed.
+        track("flow_create");
+    }
+
+    #[test]
+    fn init_short_circuits_in_debug_build() {
+        // Under `cargo test` we are always in debug mode.
+        init("python-0.3.34".to_string(), "python3.11".to_string());
+        assert!(TELEMETRY.get().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Backport anonymous usage telemetry from #1879 (v1/main) to v0. Fire-and-forget HTTP POSTs to `cocoindex.gateway.scarf.sh/{package_id}` for `init`, `flow_create`, `flow_update`, `flow_setup`, `flow_drop` events with `{event, platform, lang}` payload.
- Release-build only (compile-time `cfg!(debug_assertions)` gate), opt-out via `COCOINDEX_DISABLE_USAGE_TRACKING`, non-blocking with 5s timeout, INFO-level logging on failure. Drops the runtime-shutdown guard from #1879 since v0's `LazyLock<Runtime>` lives the whole process.
- Adds a user-facing docs page under **About → Anonymous usage telemetry**. v0 events are flow-scoped (`flow_*`) rather than app-scoped to match v0's flow-based API; package id (`python-0.x.y` vs `python-1.x.y`) distinguishes branches at the gateway.

## Test plan

- CI (`cargo test`, `pytest`, `mypy` — all green locally; pre-commit hooks ran on commit).
- 7 telemetry unit tests (payload shape against axum mock server, non-2xx handling, transport error, timeout, env-disable matrix, debug-build short-circuit, uninitialized no-op).
