### PR TITLE
docs(v0): restore tabs content lost in Astro migration

### DIFF
--- a/docs/src/components/Tabs.astro
+++ b/docs/src/components/Tabs.astro
@@ -1,0 +1,175 @@
+---
+// CSS-only tabs. Radios are direct children of .coco-tabs so they can
+// be general siblings of the bar + panels; labels reference them by
+// `for=`. No JS required. Each instance gets a unique radio-group name.
+interface Props {
+  labels: string[];
+  initial?: number;
+}
+const { labels, initial = 0 } = Astro.props;
+const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
+---
+<div class="coco-tabs">
+  {labels.map((_, i) => (
+    <input
+      type="radio"
+      class="coco-tabs-radio"
+      name={id}
+      id={`${id}-${i}`}
+      checked={i === initial}
+    />
+  ))}
+  <div class="coco-tabs-bar" role="tablist">
+    {labels.map((label, i) => (
+      <label for={`${id}-${i}`} class="coco-tabs-label" role="tab">
+        <span>{label}</span>
+      </label>
+    ))}
+  </div>
+  <div class="coco-tabs-panels">
+    {labels[0] && (
+      <section class="coco-tabs-panel" data-tab-index="0" role="tabpanel"><slot name="tab-0" /></section>
+    )}
+    {labels[1] && (
+      <section class="coco-tabs-panel" data-tab-index="1" role="tabpanel"><slot name="tab-1" /></section>
+    )}
+    {labels[2] && (
+      <section class="coco-tabs-panel" data-tab-index="2" role="tabpanel"><slot name="tab-2" /></section>
+    )}
+    {labels[3] && (
+      <section class="coco-tabs-panel" data-tab-index="3" role="tabpanel"><slot name="tab-3" /></section>
+    )}
+    {labels[4] && (
+      <section class="coco-tabs-panel" data-tab-index="4" role="tabpanel"><slot name="tab-4" /></section>
+    )}
+  </div>
+</div>
+
+<style>
+.coco-tabs {
+  position: relative;
+  margin: 1.75rem 0;
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  background: var(--cream-soft);
+  overflow: hidden;
+  box-shadow: 0 1px 0 rgba(42, 18, 27, 0.03), 0 6px 20px -12px rgba(42, 18, 27, 0.18);
+}
+
+.coco-tabs-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.coco-tabs-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 10px 10px 0;
+  background: linear-gradient(to bottom, var(--paper), var(--cream-soft));
+  border-bottom: 1px solid var(--rule);
+}
+
+.coco-tabs-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 16px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 8px 8px 0 0;
+  border: 1px solid transparent;
+  border-bottom: none;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  user-select: none;
+  position: relative;
+}
+
+.coco-tabs-label:hover { color: var(--maroon-ink); background: rgba(251, 246, 232, 0.6); }
+
+.coco-tabs-label::after {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 0;
+  height: 2px;
+  background: transparent;
+  border-radius: 2px 2px 0 0;
+  transition: background 0.15s ease;
+}
+
+.coco-tabs-radio:focus-visible + .coco-tabs-bar,
+.coco-tabs-radio:focus-visible ~ .coco-tabs-bar .coco-tabs-label {
+  /* no-op: focus outline handled below per active label */
+}
+
+.coco-tabs-panels {
+  background: var(--paper);
+  padding: 24px 28px;
+}
+
+.coco-tabs-panel { display: none; }
+
+/* Active label + panel, one rule per position.
+   Supports up to 5 tabs; extend if a page ever needs more. */
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1),
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2),
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3),
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4),
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5) {
+  color: var(--maroon-ink);
+  background: var(--paper);
+  border-color: var(--rule);
+  font-weight: 600;
+}
+
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1)::after,
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2)::after,
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3)::after,
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4)::after,
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5)::after {
+  background: var(--coral);
+}
+
+.coco-tabs-radio:nth-of-type(1):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="0"],
+.coco-tabs-radio:nth-of-type(2):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="1"],
+.coco-tabs-radio:nth-of-type(3):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="2"],
+.coco-tabs-radio:nth-of-type(4):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="3"],
+.coco-tabs-radio:nth-of-type(5):checked ~ .coco-tabs-panels > .coco-tabs-panel[data-tab-index="4"] {
+  display: block;
+}
+
+.coco-tabs-radio:focus-visible ~ .coco-tabs-bar .coco-tabs-label:hover { outline: none; }
+.coco-tabs-radio:nth-of-type(1):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(1),
+.coco-tabs-radio:nth-of-type(2):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(2),
+.coco-tabs-radio:nth-of-type(3):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3),
+.coco-tabs-radio:nth-of-type(4):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4),
+.coco-tabs-radio:nth-of-type(5):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5) {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+}
+
+.coco-tabs-panel :global(img) {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 4px auto 18px;
+}
+
+.coco-tabs-panel :global(p:first-child) { margin-top: 0; }
+.coco-tabs-panel :global(p:last-child),
+.coco-tabs-panel :global(ul:last-child) { margin-bottom: 0; }
+
+@media (max-width: 640px) {
+  .coco-tabs-panels { padding: 18px; }
+  .coco-tabs-label { padding: 8px 12px; font-size: 13px; }
+}
+</style>

--- a/docs/src/content/docs/ai/llm.mdx
+++ b/docs/src/content/docs/ai/llm.mdx
@@ -85,11 +85,23 @@ You can find the full list of models supported by OpenAI [here](https://platform
 
 For text generation, a spec for OpenAI looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.OPENAI,
+    model="gpt-4o",
+)
+```
 
 For text embedding, a spec for OpenAI looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.OPENAI,
+    model="text-embedding-3-small",
+    # Optional, use the default output dimension if not specified
+    output_dimension=1536,
+)
+```
 
 ### Azure OpenAI
 
@@ -110,11 +122,31 @@ Spec for Azure OpenAI requires:
 
 For text generation, a spec for Azure OpenAI looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.AZURE_OPENAI,
+    model="gpt-4o",  # This is the base model name
+    address="https://your-resource-name.openai.azure.com",
+    api_config=cocoindex.llm.AzureOpenAiConfig(
+        deployment_id="your-deployment-name",
+        api_version="2024-08-01-preview",  # Optional, defaults to 2024-08-01-preview
+    ),
+)
+```
 
 For text embedding, a spec for Azure OpenAI looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.AZURE_OPENAI,
+    model="text-embedding-3-small",
+    address="https://your-resource-name.openai.azure.com",
+    output_dimension=1536,  # Optional, use the default output dimension if not specified
+    api_config=cocoindex.llm.AzureOpenAiConfig(
+        deployment_id="your-embedding-deployment-name",
+    ),
+)
+```
 
 :::note
 Azure OpenAI uses deployment names instead of direct model names in API calls. The `deployment_id` in the config should match the deployment you created in Azure OpenAI Studio.
@@ -133,7 +165,14 @@ You can find the [list of models](https://ollama.com/library) supported by Ollam
 
 A spec for Ollama looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.OLLAMA,
+    model="llama3.2:latest",
+    # Optional, use Ollama's default port (11434) on localhost if not specified
+    address="http://localhost:11434",
+)
+```
 
 For text embedding with Ollama, you'll need to pull an embedding model first:
 
@@ -143,7 +182,14 @@ ollama pull nomic-embed-text
 
 Then, a spec for Ollama embedding looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.OLLAMA,
+    model="nomic-embed-text",
+    # Optional, use Ollama's default port (11434) on localhost if not specified
+    address="http://localhost:11434",
+)
+```
 
 ### Google Gemini
 
@@ -158,11 +204,25 @@ You can find the full list of models supported by Gemini [here](https://ai.googl
 
 For text generation, a spec looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.GEMINI,
+    model="gemini-2.5-flash",
+)
+```
 
 For text embedding, a spec looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.GEMINI,
+    model="text-embedding-004",
+    # Optional, use the default task type if not specified
+    task_type="SEMANTICS_SIMILARITY",
+    # Optional, use the default output dimension if not specified
+    output_dimension=1536,
+)
+```
 
 All supported embedding models can be found [here](https://ai.google.dev/gemini-api/docs/embeddings#embeddings-models).
 Gemini supports task type (optional), which can be found [here](https://ai.google.dev/gemini-api/docs/embeddings#supported-task-types).
@@ -200,12 +260,27 @@ You can find the full list of models supported by Vertex AI [here](https://cloud
 
 For text generation, a spec for Vertex AI looks like this:
 
-
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.VERTEX_AI,
+    model="gemini-2.0-flash",
+    api_config=cocoindex.llm.VertexAiConfig(project="your-project-id"),
+)
+```
 
 For text embedding, a spec for Vertex AI looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.VERTEX_AI,
+    model="text-embedding-005",
+    # Optional, use the default task type if not specified
+    task_type="SEMANTICS_SIMILARITY",
+    # Optional, use the default output dimension if not specified
+    output_dimension=1536,
+    api_config=cocoindex.llm.VertexAiConfig(project="your-project-id"),
+)
+```
 
 Vertex AI API supports task type (optional), which can be found [here](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#parameter-list).
 
@@ -216,7 +291,12 @@ You can generate the API key from [Anthropic API](https://console.anthropic.com/
 
 A text generation spec for Anthropic looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.ANTHROPIC,
+    model="claude-3-5-sonnet-latest",
+)
+```
 
 You can find the full list of models supported by Anthropic [here](https://docs.anthropic.com/en/docs/about-claude/models/all-models).
 
@@ -227,7 +307,13 @@ You can generate the API key from [Voyage dashboard](https://dashboard.voyageai.
 
 A text embedding spec for Voyage looks like this:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.VOYAGE,
+    model="voyage-code-3",
+    task_type="document",
+)
+```
 
 Voyage API supports `document` and `query` as task types (optional, a.k.a. `input_type` in Voyage API, see [Voyage API documentation](https://docs.voyageai.com/reference/embeddings-api) for details).
 
@@ -280,7 +366,13 @@ litellm --config config.yml
 
 #### 4. A Spec for LiteLLM will look like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.LITE_LLM,
+    model="deepseek-chat",
+    address="http://127.0.0.1:4000", # default url of LiteLLM
+)
+```
 
 You can find the full list of models supported by LiteLLM [here](https://docs.litellm.ai/docs/providers).
 
@@ -291,13 +383,27 @@ You can generate the API key from [here](https://openrouter.ai/settings/keys).
 
 A text generation spec for OpenRouter looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.OPEN_ROUTER,
+    model="deepseek/deepseek-r1:free",
+)
+```
 
 OpenRouter also supports some text embedding models. Note that for OpenRouter embedding
 models, you need to explicitly provide the `output_dimension` parameter in the spec.
 Here's how you can define the spec to use an OpenRouter embedding model:
 
-
+```python
+cocoindex.functions.EmbedText(
+    api_type=cocoindex.LlmApiType.OPEN_ROUTER,
+    model="openai/text-embedding-3-small",
+    # Task type for embedding model
+    task_type="SEMANTICS_SIMILARITY",
+    # Required: the number of output dimensions for the embedding model
+    output_dimension=1536,
+)
+```
 
 You can find the full list of models supported by OpenRouter [here](https://openrouter.ai/models).
 
@@ -318,7 +424,13 @@ vllm serve deepseek-ai/deepseek-coder-1.3b-instruct
 
 A spec for vLLM looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.VLLM,
+    model="deepseek-ai/deepseek-coder-1.3b-instruct",
+    address="http://127.0.0.1:8000/v1",
+)
+```
 
 ### Bedrock
 
@@ -330,6 +442,11 @@ To use the Bedrock API, you need to set up AWS credentials. You can do this by s
 
 A spec for Bedrock looks like this:
 
-
+```python
+cocoindex.LlmSpec(
+    api_type=cocoindex.LlmApiType.BEDROCK,
+    model="us.anthropic.claude-3-5-haiku-20241022-v1:0",
+)
+```
 
 You can find the full list of models supported by Bedrock [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).

--- a/docs/src/content/docs/core/flow_def.mdx
+++ b/docs/src/content/docs/core/flow_def.mdx
@@ -11,7 +11,48 @@ You connect input/output of these operations with fields of data scopes.
 
 A CocoIndex flow is defined by a function:
 
+The easiest way is to use the `@cocoindex.flow_def` decorator:
 
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+```
+
+This `@cocoindex.flow_def` decorator declares this function as a CocoIndex flow definition.
+
+It takes two arguments:
+
+* `flow_builder`: a `FlowBuilder` object to help build the flow.
+* `data_scope`: a `DataScope` object, representing the top-level data scope. Any data created by the flow should be added to it.
+
+Alternatively, for more flexibility (e.g. you want to do this conditionally or generate dynamic name), you can explicitly call the `cocoindex.open_flow()` method:
+
+```python
+def demo_flow_def(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+
+# Add the flow definition to the flow registry.
+demo_flow = cocoindex.open_flow("DemoFlow", demo_flow_def)
+```
+
+In both cases, `demo_flow` will be an object with `cocoindex.Flow` class type.
+See [Flow Running](/docs-v0/core/flow_methods) for more details on it.
+
+Sometimes you no longer want to keep states of the flow in memory. We provide a `close()` method for this purpose:
+
+```python
+demo_flow.close()
+```
+
+After it's called, `demo_flow` becomes an invalid object, and you should not call any methods of it.
+
+:::note
+
+This only removes states of the flow from the current process, and it won't affect the persistent states.
+See [Setup / drop flow](/docs-v0/core/flow_methods#setupdrop-flow) if you want to clean up the persistent states.
+
+:::
 
 ## Data Scope
 
@@ -28,7 +69,21 @@ You cannot override an existing field.
 
 :::
 
+Getting and setting a field of a data scope is done by the `[]` operator with a field name:
 
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+
+    # Add "documents" to the top-level data scope.
+    data_scope["documents"] = flow_builder.add_source(DemoSourceSpec(...))
+
+    # Each row of "documents" is a child scope.
+    with data_scope["documents"].row() as document:
+
+        # Get "content" from the document scope, transform, and add "summary" to scope.
+        document["summary"] = field1_row["content"].transform(DemoFunctionSpec(...))
+```
 
 ### Add a collector
 
@@ -46,7 +101,12 @@ To get the initial data slice, we need to start from importing data from a sourc
 A *source spec* needs to be provided for any import operation, to describe the source and parameters related to the source.
 Import must happen at the top level, and the field created by import must be in the top-level struct.
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["documents"] = flow_builder.add_source(DemoSourceSpec(...))
+    ......
+```
 
 :::note
 
@@ -60,7 +120,15 @@ In a flow definition, you can use a data representation as input for operations,
 You can provide a `refresh_interval` argument.
 When present, in the [live update mode](/docs-v0/core/flow_methods#live-update), the data source will be refreshed by specified interval.
 
+The `refresh_interval` argument is of type `datetime.timedelta`. For example, this refreshes the data source every 1 minute:
 
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    data_scope["documents"] = flow_builder.add_source(
+        DemoSourceSpec(...), refresh_interval=datetime.timedelta(minutes=1))
+    ......
+```
 
 :::info
 
@@ -79,13 +147,28 @@ The function takes one or multiple data arguments.
 The first argument is the data slice to be transformed, and the `transform()` method is applied from it.
 Other arguments can be passed in as positional arguments or keyword arguments, after the function spec.
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+    data_scope["field2"] = data_scope["field1"].transform(
+                               DemoFunctionSpec(...),
+                               arg1, arg2, ..., key0=kwarg0, key1=kwarg1, ...)
+    ...
+```
 
 ### For-each-row
 
 If the data slice has [table type](/docs-v0/core/data_types#table-types), you can call `row()` method to obtain a child scope representing each row, to apply operations on each row.
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+  ...
+  with data_scope["table1"].row() as table1_row:
+    # Children operations
+    table1_row["field2"] = table1_row["field1"].transform(DemoFunctionSpec(...))
+```
 
 ### Get a sub field
 
@@ -112,7 +195,18 @@ Each field has a name as specified by the argument name, and a value in one of t
 
 For example,
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+    demo_collector = data_scope.add_collector()
+    with data_scope["documents"].row() as document:
+        ...
+        demo_collector.collect(id=cocoindex.GeneratedField.UUID,
+                               filename=document["filename"],
+                               summary=document["summary"])
+    ...
+```
 
 Here the collector is in the top-level data scope.
 It collects `filename` and `summary` fields from each row of `documents`,
@@ -137,7 +231,17 @@ Export must happen at the top level of a flow, i.e. not within any child scopes 
      If `True`, the export target will be managed by users, and users are responsible for creating the target and updating it upon change.
 * Fields to configure [storage indexes](#storage-indexes). `primary_key_fields` is required, and all others are optional.
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+    demo_collector = data_scope.add_collector()
+    ...
+    demo_collector.export(
+        "demo_target", DemoTargetSpec(...),
+        primary_key_fields=["field1"],
+        vector_indexes=[cocoindex.VectorIndexDef("field2", cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY)])
+```
 
 The target is managed by CocoIndex, i.e. it'll be created or dropped when [setup / drop flow](/docs-v0/core/flow_methods#setupdrop-flow), and the data will be automatically updated (including stale data removal) when updating the index.
 The `name` for the same target should remain stable across different runs.
@@ -180,7 +284,22 @@ Following metrics are supported:
 
 For example, with LanceDB:
 
-
+```python
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+    demo_collector = data_scope.add_collector()
+    ...
+    demo_collector.export(
+        "demo_target", DemoTargetSpec(...),
+        primary_key_fields=["id"],
+        fts_indexes=[
+            # Basic FTS index with default tokenizer
+            cocoindex.FtsIndexDef("content"),
+            # FTS index with custom tokenizer
+            cocoindex.FtsIndexDef("description", parameters={"language": "English"})
+        ])
+```
 
 :::note
 
@@ -203,7 +322,16 @@ e.g. when the current app namespace is `Staging`, `flow.get_app_namespace(traili
 
 For example,
 
-
+```python
+doc_embeddings.export(
+    "doc_embeddings",
+    cocoindex.targets.Qdrant(
+        collection_name=cocoindex.get_app_namespace(trailing_delimiter='__') + "doc_embeddings",
+        ...
+    ),
+    ...
+)
+```
 
 It will use `Staging__doc_embeddings` as the collection name if the current app namespace is `Staging`, and use `doc_embeddings` if the app namespace is empty.
 
@@ -269,7 +397,11 @@ To specify configurations for these nodes, you can *declare* spec for related no
 
 `FlowBuilder` provides `declare()` method for this purpose, which takes the spec to declare, as provided by various target types.
 
-
+```python
+flow_builder.declare(
+    cocoindex.targets.Neo4jDeclarations(...)
+)
+```
 
 ### Auth Registry
 
@@ -291,7 +423,36 @@ An auth entry is an entry in the auth registry with an explicit key.
 * You can create new *auth entry* by a key and a value.
 * You can reference the entry by the key, and pass it as part of spec for certain operations. e.g. `Neo4j` takes `connection` field in the form of auth entry reference.
 
+You can add an auth entry by `cocoindex.add_auth_entry()` function, which returns a `cocoindex.AuthEntryReference[T]`:
 
+```python
+my_graph_conn = cocoindex.add_auth_entry(
+    "my_graph_conn",
+    cocoindex.targets.Neo4jConnectionSpec(
+            uri="bolt://localhost:7687",
+            user="neo4j",
+            password="cocoindex",
+    ))
+```
+
+Then reference it when building a spec that takes an auth entry:
+
+* You can either reference by the `AuthEntryReference[T]` object directly:
+
+    ```python
+    demo_collector.export(
+        "MyGraph",
+        cocoindex.targets.Neo4jRelationship(connection=my_graph_conn, ...)
+    )
+    ```
+
+* You can also reference it by the key string, using `cocoindex.ref_auth_entry()` function:
+
+    ```python
+    demo_collector.export(
+        "MyGraph",
+        cocoindex.targets.Neo4jRelationship(connection=cocoindex.ref_auth_entry("my_graph_conn"), ...))
+    ```
 
 Note that CocoIndex backends use the key of an auth entry to identify the backend.
 
@@ -306,6 +467,15 @@ Note that CocoIndex backends use the key of an auth entry to identify the backen
 A transient auth entry is an entry in the auth registry with an automatically generated key.
 It's usually used for sources and functions, where key stability is not important.
 
+You can create a new *transient auth entry* by `cocoindex.add_transient_auth_entry()` function, which returns a `cocoindex.TransientAuthEntryReference[T]`, and pass it to a source or function spec that takes it, e.g.
 
+```python
+flow_builder.add_source(
+    cocoindex.sources.AzureBlob(
+        ...
+        sas_token=cocoindex.add_transient_auth_entry("...")
+    )
+)
+```
 
 Whenever a `TransientAuthEntryReference[T]` is expected, you can also pass a `AuthEntryReference[T]` instead, as `AuthEntryReference[T]` is a subtype of `TransientAuthEntryReference[T]`.

--- a/docs/src/content/docs/core/flow_methods.mdx
+++ b/docs/src/content/docs/core/flow_methods.mdx
@@ -16,7 +16,13 @@ It can be achieved in two ways:
 
 The following sections assume you have a flow `demo_flow`:
 
+```python title="main.py"
+@cocoindex.flow_def(name="DemoFlow")
+def demo_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope):
+    ...
+```
 
+It creates a `demo_flow` object in `cocoindex.Flow` type.
 
 ## Setup/drop flow
 
@@ -41,7 +47,41 @@ CocoIndex supports two types of actions to manage the persistent backends automa
 
 ### Library API
 
+`Flow` provides the following APIs to setup / drop individual flows:
 
+* `setup(report_to_stdout: bool = False)`: Setup the flow.
+* `drop(report_to_stdout: bool = False)`: Drop the flow.
+
+For example:
+
+```python
+demo_flow.setup(report_to_stdout=True)
+demo_flow.drop(report_to_stdout=True)
+```
+
+We also provide the following asynchronous versions of the APIs:
+
+* `setup_async(report_to_stdout: bool = False)`: Setup the flow asynchronously.
+* `drop_async(report_to_stdout: bool = False)`: Drop the flow asynchronously.
+
+For example:
+
+```python
+await demo_flow.setup_async(report_to_stdout=True)
+await demo_flow.drop_async(report_to_stdout=True)
+```
+
+Besides, CocoIndex also provides APIs to setup / drop all flows at once:
+
+* `setup_all_flows(report_to_stdout: bool = False)`: Setup all flows.
+* `drop_all_flows(report_to_stdout: bool = False)`: Drop all flows.
+
+For example:
+
+```python
+cocoindex.setup_all_flows(report_to_stdout=True)
+cocoindex.drop_all_flows(report_to_stdout=True)
+```
 
 :::note
 
@@ -107,7 +147,35 @@ cocoindex update --reexport main.py
 
 #### Library API
 
+The `Flow.update()` method creates/updates data in the target. It accepts the following options:
 
+* `reexport_targets` (type: `bool`, default: `False`): Whether to reexport the targets even if there's no change.
+* `print_stats` (type: `bool`, default: `False`): Whether to print stats during update.
+
+It returns an object, with the following properties:
+
+* `stats` (type: `dict[str, dict[str, int]]`): A dictionary of stats by source. Keyed by source name, value is a dictionary of stats by metrics: `num_no_change`, `num_insertions`, `num_updates`, `num_reprocesses`, `num_deletions`, `num_errors`.
+
+Example:
+
+```python
+update_info = demo_flow.update(print_stats=True)
+```
+
+`update_async()` is the asynchronous version of `update()`.
+
+```python
+update_info = await demo_flow.update_async(print_stats=True)
+```
+
+Once the function finishes, the target data is fresh up to the moment when the function is called.
+
+:::info
+
+`update()` and `update_async()` can be called simultaneously, even if a previous call is not finished yet.
+It's quite cheap to do so, as CocoIndex will automatically combine multiple calls into a single update, as long as we hold the guarantee that the target data is fresh up to the moment when the last call is initiated.
+
+:::
 
 ### Live update
 
@@ -136,7 +204,136 @@ Otherwise, it falls back to the same behavior as one time update, and will finis
 
 #### Library API
 
+To perform live update, you need to create a `cocoindex.FlowLiveUpdater` object using the `cocoindex.Flow` object.
+It takes an optional `cocoindex.FlowLiveUpdaterOptions` option, with the following fields:
 
+* `live_mode` (type: `bool`, default: `True`):
+     Whether to perform live update for data sources with change capture mechanisms.
+     It has no effect for data sources without any change capture mechanism.
+
+* `print_stats` (type: `bool`, default: `False`): Whether to print stats during update.
+
+* `reexport_targets` (type: `bool`, default: `False`): Whether to reexport the targets even if there's no change.
+
+Note that `cocoindex.FlowLiveUpdater` provides a unified interface for both one-time update and live update.
+It only performs live update when `live_mode` is `True`, and only for sources with change capture mechanisms enabled.
+If a source has multiple change capture mechanisms enabled, all will take effect to trigger updates.
+
+This creates a `cocoindex.FlowLiveUpdater` object, with an optional `cocoindex.FlowLiveUpdaterOptions` option:
+
+```python
+my_updater = cocoindex.FlowLiveUpdater(
+    demo_flow, cocoindex.FlowLiveUpdaterOptions(print_stats=True))
+```
+
+A `FlowLiveUpdater` object supports the following methods:
+
+* `start()`: Start the updater.
+    CocoIndex will continuously capture changes from the source data and update the target data accordingly in background threads managed by the engine.
+
+* `abort()`: Abort the updater.
+
+* `wait()`: Wait for the updater to finish. It only unblocks in one of the following cases:
+  * The updater was aborted.
+  * A one time update is done, and live update is not enabled:
+        either `live_mode` is `False`, or all data sources have no change capture mechanisms enabled.
+
+* `next_status_updates()`: Get the next status updates.
+    It blocks until there's a new status updates, including the processing finishes for a bunch of source updates, and live updater stops (aborted, or no more sources to process).
+    You can continuously call this method in a loop to get the latest status updates and react accordingly.
+
+    It returns a `cocoindex.FlowUpdaterStatusUpdates` object, with the following properties:
+  * `active_sources`: Names of sources that are still active, i.e. not stopped processing. If it's empty, it means the updater is stopped.
+  * `updated_sources`: Names of sources with updates since last time.
+        You can check this to see which sources have recent updates and get processed.
+
+* `update_stats()`: It returns the stats of the updater.
+
+This snippets shows the lifecycle of a live updater:
+
+```python
+my_updater = cocoindex.FlowLiveUpdater(demo_flow)
+# Start the updater.
+my_updater.start()
+
+# Perform your own logic (e.g. a query loop).
+...
+
+...
+# Wait for the updater to finish.
+my_updater.wait()
+# Print the update stats.
+print(my_updater.update_stats())
+```
+
+Somewhere (in the same or other threads) you can also continuously call `next_status_updates()` to get the latest status updates and react accordingly, e.g.
+
+```python
+while True:
+    updates = my_updater.next_status_updates()
+
+    for source in updates.updated_sources:
+        # Perform downstream operations on the target of the source.
+        run_your_downstream_operations_for(source)
+
+    # Break the loop if there's no more active sources.
+    if not updates.active_sources:
+        break
+```
+
+:::info
+
+`next_status_updates()` automatically combines multiple status updates if more than one arrives between two calls,
+e.g. your downstream operations may take more time, or you don't need to process too frequently (in which case you can explicitly sleep for a while).
+
+So you don't need to worry about the status updates piling up.
+
+:::
+
+Python SDK also allows you to use the updater as a context manager.
+It will automatically start the updater during the context entry, and abort and wait for the updater to finish automatically when the context is exited.
+The following code is equivalent to the code above (if no early return happens):
+
+```python
+with cocoindex.FlowLiveUpdater(demo_flow) as my_updater:
+    # Perform your own logic (e.g. a query loop).
+    ...
+```
+
+CocoIndex also provides asynchronous versions of APIs for blocking operations, including:
+
+* `start_async()` and `wait_async()`, e.g.
+
+    ```python
+    my_updater = cocoindex.FlowLiveUpdater(demo_flow)
+    # Start the updater.
+    await my_updater.start_async()
+
+    # Perform your own logic (e.g. a query loop).
+    ...
+
+    # Wait for the updater to finish.
+    await my_updater.wait_async()
+    # Print the update stats.
+    print(my_updater.update_stats())
+    ```
+
+* `next_status_updates_async()`, e.g.
+
+    ```python
+    while True:
+        updates = await my_updater.next_status_updates_async()
+
+        ...
+    ```
+
+* Async context manager, e.g.
+
+    ```python
+    async with cocoindex.FlowLiveUpdater(demo_flow) as my_updater:
+        # Perform your own logic (e.g. a query loop).
+        ...
+    ```
 
 ## Evaluate the flow
 
@@ -159,3 +356,17 @@ cocoindex evaluate main.py --output-dir ./eval_output
 ```
 
 ### Library API
+
+The `evaluate_and_dump()` method runs the transformation and dumps flow outputs to files.
+
+It takes a `EvaluateAndDumpOptions` dataclass as input to configure, with the following fields:
+
+* `output_dir` (type: `str`, required): The directory to dump the result to.
+* `use_cache` (type: `bool`, default: `True`): Use already-cached intermediate data if available.
+    Note that we only read existing cached data without updating the cache, even if it's turned on.
+
+Example:
+
+```python
+demo_flow.evaluate_and_dump(EvaluateAndDumpOptions(output_dir="./eval_output"))
+```

--- a/docs/src/content/docs/custom_ops/custom_functions.mdx
+++ b/docs/src/content/docs/custom_ops/custom_functions.mdx
@@ -13,7 +13,23 @@ A custom function can be defined in one of the following ways:
 
 It fits into simple cases that the function doesn't need to take additional configurations and extra setup logic.
 
+The standalone function needs to be decorated by `@cocoindex.op.function()`, like this:
 
+```python
+@cocoindex.op.function(...)
+def compute_something(arg1: str, arg2: int | None = None) -> str:
+    """
+    Documentation for the function.
+    """
+    ...
+```
+
+Notes:
+
+* The `cocoindex.op.function()` function decorator also takes optional parameters.
+    See [Parameters for custom functions](#parameters-for-custom-functions) for details.
+* Types of arguments and the return value must be annotated, so that CocoIndex will have information about data types of the operation's output fields.
+    See [Data Types](/docs-v0/core/data_types) for supported types.
 
 ### Examples
 
@@ -34,7 +50,22 @@ It allows a function to be configured with the function spec, and allow preparat
 The function spec of a function configures behavior of a specific instance of the function.
 When you use this function in a flow (typically by a [`transform()`](/docs-v0/core/flow_def#transform)), you instantiate this function spec, with specific parameter values.
 
+A function spec is defined as a class that inherits from `cocoindex.op.FunctionSpec`.
 
+```python
+class ComputeSomething(cocoindex.op.FunctionSpec):
+    """
+    Documentation for the function.
+    """
+    param1: str
+    param2: int | None = None
+    ...
+```
+
+Notes:
+
+* All fields of the spec must have a type serializable / deserializable by the `json` module.
+* All subclasses of `FunctionSpec` can be instantiated similar to a dataclass, i.e. `ClassName(param1=value1, param2=value2, ...)`.
 
 ### Function Executor
 
@@ -47,7 +78,31 @@ The function executor is responsible for:
     e.g. if the function calls a machine learning model, the model name can be a parameter as a field of the spec, and we may load the model in this phase.
 * *Run* the function, for each specific input arguments. This happens multiple times, for each specific row of data.
 
+A function executor is defined as a class decorated by `@cocoindex.op.executor_class()`.
 
+```python
+@cocoindex.op.executor_class(...)
+class ComputeSomethingExecutor:
+    spec: ComputeSomething
+    ...
+
+    def prepare(self) -> None:
+        ...
+
+    def __call__(self, arg1: str, arg2: int | None = None) -> str:
+        ...
+```
+
+Notes:
+
+* The `cocoindex.op.executor_class()` class decorator also takes optional parameters.
+    See [Parameters for custom functions](#parameters-for-custom-functions) for details.
+
+* A `spec` field must be present in the class, and must be annotated with the spec class name.
+* The `prepare()` method is optional. It's executed once and only once before any `__call__` execution, to prepare the function execution.
+* The `__call__()` method is required. It's executed for each specific rows of data.
+    Types of arugments and the return value must be decorated, so that CocoIndex will have information about data types of the operation's output fields.
+    See [Data Types](/docs-v0/core/data_types) for supported types.
 
 ### Examples
 
@@ -91,7 +146,26 @@ Custom functions take the following additional parameters:
 
 For example:
 
+This enables cache for a standalone function:
 
+```python
+@cocoindex.op.function(cache=True, behavior_version=1)
+def compute_something(arg1: str, arg2: int | None = None) -> str:
+    ...
+```
+
+This enables cache for a function defined by a spec and an executor:
+
+```python
+class ComputeSomething(cocoindex.op.FunctionSpec):
+    ...
+
+@cocoindex.op.executor_class(cache=True, behavior_version=1)
+class ComputeSomethingExecutor:
+    spec: ComputeSomething
+
+    ...
+```
 
 ## Batching
 
@@ -101,3 +175,44 @@ Sometimes batching is more efficient than processing them one by one, e.g. runni
 Batching can be enabled by setting the `batching` parameter to `True` in custom function parameters.
 Once it's set to `True`, type of the argument and return value must be a `list`.
 Currently we only support batching functions taking a single argument.
+
+For example, for a CocoIndex custom function taking `str` as argument and returning `str` as result, it can be defined as:
+
+```python
+@cocoindex.op.function(batching=True)
+def compute_something(args: list[str]) -> list[str]:
+    ...
+```
+
+or for such a function defined by an executor:
+
+```python
+@cocoindex.op.executor_class(batching=True)
+class ComputeSomethingExecutor:
+    spec: ComputeSomething
+    ...
+
+    def __call__(self, args: list[str]) -> list[str]:
+        ...
+```
+
+### Controlling Batch Size
+
+You can control the maximum batch size using the `max_batch_size` parameter. This is useful for:
+
+* Limiting memory usage when processing large batches
+* Reducing latency by flushing batches before they grow too large
+* Working with APIs that have request size limits
+
+```python
+@cocoindex.op.function(batching=True, max_batch_size=32)
+def compute_something(args: list[str]) -> list[str]:
+    ...
+```
+
+With `max_batch_size` set, a batch will be flushed when either:
+
+1. No ongoing batches are running
+2. The pending batch size reaches `max_batch_size`
+
+This ensures that requests don't wait indefinitely for a batch to fill up, while still allowing efficient batch processing.

--- a/docs/src/content/docs/custom_ops/custom_targets.mdx
+++ b/docs/src/content/docs/custom_ops/custom_targets.mdx
@@ -33,7 +33,21 @@ The implementation of a target connector needs to deal with changes, in two aspe
 
 The target spec defines the configuration parameters for your custom target. When you use this target in a flow (typically by calling [`export()`](/docs-v0/core/flow_def#export)), you instantiate this target spec with specific parameter values.
 
+A target spec is defined as a class that inherits from `cocoindex.op.TargetSpec`.
 
+```python
+class CustomTarget(cocoindex.op.TargetSpec):
+    """
+    Documentation for the target.
+    """
+    param1: str
+    param2: int | None = None
+    ...
+```
+
+Notes:
+*   All fields of the spec must have a type serializable / deserializable by the `json` module.
+*   All subclasses of `TargetSpec` can be instantiated similar to a dataclass, i.e. `ClassName(param1=value1, param2=value2, ...)`.
 
 ## Target Connector
 
@@ -41,7 +55,42 @@ A target connector handles the actual data export operations for your custom tar
 
 Target connectors implement two categories of methods: setup methods to deal with setup changes, and data methods to deal with data changes.
 
+A target connector is defined as a class decorated by `@cocoindex.op.target_connector(spec_cls=CustomTarget)`.
 
+```python
+@cocoindex.op.target_connector(spec_cls=CustomTarget)
+class CustomTargetConnector:
+    # Setup methods
+    @staticmethod
+    def get_persistent_key(spec: CustomTarget, target_name: str) -> PersistentKey:
+        """Required. Return a persistent key that uniquely identifies this target instance."""
+        ...
+
+    @staticmethod
+    def apply_setup_change(
+        key: PersistentKey, previous: CustomTarget | None, current: CustomTarget | None
+    ) -> None:
+        """Required. Apply setup changes to the target."""
+        ...
+
+    @staticmethod
+    def describe(key: PersistentKey) -> str:
+        """Optional. Return a human-readable description of the target."""
+        ...
+
+    # Data methods
+    @staticmethod
+    def prepare(spec: CustomTarget) -> PreparedCustomTarget:
+        """Optional. Prepare for execution before applying mutations."""
+        ...
+
+    @staticmethod
+    def mutate(
+        *all_mutations: tuple[PreparedCustomTarget, dict[DataKeyType, DataValueType | None]],
+    ) -> None:
+        """Required. Apply data mutations to the target."""
+        ...
+```
 
 The following data types are involved in the method definitions above:  `CustomTarget`, `PersistentKey`, `PreparedCustomTarget`, `DataKeyType`, `DataValueType`. They should be replaced with the actual types in your implementation. We will explain each of them below.
 
@@ -133,6 +182,80 @@ In this example, we define a custom target that accepts data with the following 
 - `author` (value field)
 - `html` (value field)
 
+```python
+import dataclasses
+import cocoindex
 
+# 1. Define the target spec
+class MyCustomTarget(cocoindex.op.TargetSpec):
+    """Spec of the custom target, to configure the target location etc."""
+    location: str
+
+# 2. Define the value dataclass for exported data
+@dataclasses.dataclass
+class LocalFileTargetValues:
+    """Represents value fields of exported data."""
+    author: str
+    html: str
+
+# 3. Define the target connector
+@cocoindex.op.target_connector(spec_cls=MyCustomTarget)
+class LocalFileTargetConnector:
+    @staticmethod
+    def get_persistent_key(spec: MyCustomTarget, target_name: str) -> str:
+        return spec.location
+
+    @staticmethod
+    def apply_setup_change(
+        key: str, previous: MyCustomTarget | None, current: MyCustomTarget | None
+    ) -> None:
+        # Setup/teardown logic here
+        ...
+
+    @staticmethod
+    def mutate(
+        *all_mutations: tuple[MyCustomTarget, dict[str, LocalFileTargetValues | None]],
+    ) -> None:
+        """Apply data mutations to the target."""
+        for spec, mutations in all_mutations:
+            for filename, mutation in mutations.items():
+                if mutation is None:
+                    # Delete the file
+                    ...
+                else:
+                    # Write the file with author and html content
+                    ...
+
+# 4. Usage in a flow
+@cocoindex.flow_def(name="ExampleFlow")
+def example_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoindex.DataScope) -> None:
+    # Add data source
+    data_scope["documents"] = flow_builder.add_source(...)
+
+    # Create collector
+    output_data = data_scope.add_collector()
+
+    # Collect data
+    with data_scope["documents"].row() as doc:
+        # Create the "author" and "fieldname" field
+        ...
+
+        # Collect the data
+        output_data.collect(filename=doc["filename"], author=doc["author"], html=doc["transformed_html"])
+
+    # Export to custom target
+    output_data.export(
+        "OutputData",
+        MyCustomTarget(location=...),
+        primary_key_fields=["filename"],
+    )
+```
+
+In this example, the type for data in `all_mutations` is `dict[str, LocalFileTargetValues | None]`:
+- `str` is the `DataKeyType` (the filename)
+- `LocalFileTargetValues` is the `DataValueType` (containing `html` and `author` fields)
+- The `mutate()` method receives tuples of `(MyCustomTarget, dict[str, LocalFileTargetValues | None])`
+
+For simplicity, the type hints can be omitted and a `dict` will be created instead of a dataclass instance, and `author` and `html` will be the keys of the dict.
 
 See the [custom_output_files](https://github.com/cocoindex-io/cocoindex/blob/main/examples/custom_output_files/main.py) for the an end-to-end example.

--- a/docs/src/content/docs/getting_started/quickstart.mdx
+++ b/docs/src/content/docs/getting_started/quickstart.mdx
@@ -6,8 +6,8 @@ meta:
   language: Python 3.11+
   requires: Postgres + pgvector
 ---
-
-
+- [GitHub: cocoindex-quickstart](https://github.com/cocoindex-io/cocoindex-quickstart)
+- [YouTube tutorial](https://www.youtube.com/watch?v=gv5R8nOXsWU)
 
 In this tutorial, we’ll build an index with text embeddings, keeping it minimal and focused on the core indexing flow.
 
@@ -64,8 +64,7 @@ doc_embeddings = data_scope.add_collector()
 
 `flow_builder.add_source` will create a table with sub fields (`filename`, `content`)
 
-
-
+See [Source](/docs-v0/sources) and [Data Collector](/docs-v0/core/flow_def#data-collector) for more details.
 
 
 ### Process each document
@@ -87,7 +86,7 @@ doc["chunks"] = doc["content"].transform(
 
 We extend a new field `chunks` to each row by *transforming* the `content` field using `SplitRecursively`. The output of the `SplitRecursively` is a KTable representing each chunk of the document.
 
-
+See [SplitRecursively](/docs-v0/ops/functions#splitrecursively) for more details.
 
 ![Chunking](/docs-v0/img/quickstart/chunk.png)
 
@@ -115,7 +114,7 @@ This code embeds each chunk using the SentenceTransformer library and collects t
 
 ![Embedding](/docs-v0/img/quickstart/embed.png)
 
-
+See [SentenceTransformerEmbed](/docs-v0/ops/functions#sentencetransformerembed) for more details.
 
 ### Export the embeddings to Postgres
 
@@ -135,7 +134,7 @@ doc_embeddings.export(
 
 CocoIndex supports other vector databases as well, with 1-line switch.
 
-
+See [Targets](/docs-v0/targets) for the full list.
 
 ## Run the indexing pipeline
 

--- a/docs/src/content/docs/query.mdx
+++ b/docs/src/content/docs/query.mdx
@@ -32,8 +32,41 @@ In this case, you can:
     To do this, declare the function as a *transform flow*, by decorating it with `@cocoindex.transform_flow()`.
     This will add `eval()` and `eval_async()` methods to the function, so that you can directly call with specific input data.
 
+For example, based on the flow in [quickstart](getting_started/quickstart), you can extract the invocation of `SentenceTransformerEmbed` into a standalone function:
 
+```python
+@cocoindex.transform_flow()
+def text_to_embedding(text: cocoindex.DataSlice[str]) -> cocoindex.DataSlice[NDArray[np.float32]]:
+    return text.transform(
+        cocoindex.functions.SentenceTransformerEmbed(
+            model="sentence-transformers/all-MiniLM-L6-v2"))
+```
 
+When you're defining your indexing flow, you can directly call the function:
+
+```python
+with doc["chunks"].row() as chunk:
+    chunk["embedding"] = text_to_embedding(chunk["text"])
+```
+
+or, using the `call()` method of the transform flow on the first argument, to make operations chainable:
+
+```python
+with doc["chunks"].row() as chunk:
+    chunk["embedding"] = chunk["text"].call(text_to_embedding)
+```
+
+Any time, you can call the `eval()` method with specific string, which will return a `NDArray[np.float32]`:
+
+```python
+print(text_to_embedding.eval("Hello, world!"))
+```
+
+If you're in an async context, please call the `eval_async()` method instead:
+
+```python
+print(await text_to_embedding.eval_async("Hello, world!"))
+```
 
 ## Query Handler
 
@@ -48,7 +81,15 @@ Query handlers let you expose a simple function that takes a query string and re
 
 A minimum query handler looks like this:
 
+```python
+@my_flow.query_handler(name="run_query")  # Name is optional, use the function name by default
+def run_query(query: str) -> cocoindex.QueryOutput:
+    # 1) Perform your query against the input `query`
+    ...
 
+    # 2) Return structured results
+    return cocoindex.QueryOutput(results=[{"filename": "...", "text": "..."}])
+```
 
 Notes about the decorator:
 
@@ -64,7 +105,30 @@ A simple query handler like this will enable CocoInsight to display the query re
 
 You can provide additional information by extra fields like this:
 
+```python
+@my_flow.query_handler(
+    name="run_query",  # Name is optional, use the function name by default
+    result_fields=cocoindex.QueryHandlerResultFields(
+        embedding=["embedding"],  # path to the vector field in each result
+        score="score",            # numeric similarity score (higher is better)
+    )
+)
+def run_query(query: str) -> cocoindex.QueryOutput:
+    # 1) Compute embedding for the input query (often via a transform flow)
+    query_vector = text_to_embedding.eval(query)
 
+    # 2) Run your database/vector store query
+    ...
+
+    # 3) Return structured results plus optional query_info
+    return cocoindex.QueryOutput(
+        results=[{"text": "...", "embedding": some_vec, "score": 0.92}],
+        query_info=cocoindex.QueryInfo(
+            embedding=query_vector,
+            similarity_metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
+        ),
+    )
+```
 
 - `result_fields` within `query_handler` specifies field names in the query results returned by the query handler. This provides metadata for tools like CocoInsight to recognize structure of the query results, as specified by the following fields (all optional):
     - `embedding` is a list of keys that navigates to the embedding in each result (use multiple in case of multiple embeddings, e.g. using different models).
@@ -112,3 +176,9 @@ It takes the following arguments:
 *   `target_name` (type: `str`): The export target name, appeared in the `export()` call.
 
 For example:
+
+```python
+table_name = cocoindex.utils.get_target_default_name(text_embedding_flow, "doc_embeddings")
+query = f"SELECT filename, text FROM {table_name} ORDER BY embedding <=> %s DESC LIMIT 5"
+...
+```

--- a/docs/src/content/docs/sources/postgres.mdx
+++ b/docs/src/content/docs/sources/postgres.mdx
@@ -110,4 +110,4 @@ data_scope["products"] = flow_builder.add_source(
 
 You can find end-to-end example using Postgres source at:
 
-* [examples/postgres_source](https://github.com/cocoindex-io/cocoindex/tree/main/examples/postgres_source)
+* [examples/postgres_source](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/postgres_source)

--- a/docs/src/content/docs/targets/chromadb.mdx
+++ b/docs/src/content/docs/targets/chromadb.mdx
@@ -112,3 +112,5 @@ def text_embedding_flow(flow_builder: cocoindex.FlowBuilder, data_scope: cocoind
         ],
     )
 ```
+
+You can find an end-to-end [Text Embedding ChromaDB Example](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_chromadb).

--- a/docs/src/content/docs/targets/doris.mdx
+++ b/docs/src/content/docs/targets/doris.mdx
@@ -277,3 +277,5 @@ pip install aiohttp aiomysql
 ```
 
 ## Example
+
+You can find an end-to-end [Text Embedding Example with Doris](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_doris).

--- a/docs/src/content/docs/targets/index.mdx
+++ b/docs/src/content/docs/targets/index.mdx
@@ -332,5 +332,5 @@ graph TD
 
 You can find end-to-end examples fitting into any of supported property graphs in the following directories:
 
-* [Property graph for a knowledge base](https://github.com/cocoindex-io/cocoindex/tree/main/examples/docs_to_knowledge_graph)
-* [Property graph for product catalog](https://github.com/cocoindex-io/cocoindex/tree/main/examples/product_taxonomy_knowledge_graph)
+* [Property graph for a knowledge base](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/docs_to_knowledge_graph)
+* [Property graph for product catalog](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/product_taxonomy_knowledge_graph)

--- a/docs/src/content/docs/targets/ladybug.mdx
+++ b/docs/src/content/docs/targets/ladybug.mdx
@@ -42,3 +42,5 @@ pip install real_ladybug
 ```
 
 ## Example
+
+You can find an end-to-end [Docs to Knowledge Graph](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/docs_to_knowledge_graph) example.

--- a/docs/src/content/docs/targets/lancedb.mdx
+++ b/docs/src/content/docs/targets/lancedb.mdx
@@ -56,7 +56,7 @@ If you want to use vector indexes, you can run the flow once to populate the tar
 
 :::
 
-You can find an end-to-end example here: [examples/text_embedding_lancedb](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding_lancedb).
+You can find an end-to-end example here: [examples/text_embedding_lancedb](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_lancedb).
 
 ### FTS Index Example
 
@@ -116,3 +116,5 @@ Once `db_uri` matches, it automatically reuses the same connection instance with
 This achieves strong consistency between your indexing and querying logic, if they run in the same process.
 
 ## Example
+
+You can find an end-to-end [Text Embedding LanceDB Example](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_lancedb).

--- a/docs/src/content/docs/targets/neo4j.mdx
+++ b/docs/src/content/docs/targets/neo4j.mdx
@@ -45,6 +45,7 @@ You can access the Neo4j browser at [http://localhost:7474](http://localhost:747
 
 ## Example
 
+You can find an end-to-end [Docs to Knowledge Graph](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/docs_to_knowledge_graph) example.
 
 ## Data Clean up between different projects
 If you are building multiple CocoIndex flows from different projects to neo4j, we recommend you to

--- a/docs/src/content/docs/targets/pinecone.mdx
+++ b/docs/src/content/docs/targets/pinecone.mdx
@@ -59,7 +59,7 @@ Pinecone indexes must be created before use. If the index doesn't exist, CocoInd
 
 :::
 
-You can find an end-to-end example here: [examples/text_embedding_pinecone](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding_pinecone).
+You can find an end-to-end example here: [examples/text_embedding_pinecone](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_pinecone).
 
 ### Example Usage
 ```python
@@ -125,3 +125,5 @@ def get_index(
 This helper creates a Pinecone index reference configured with your API key and index name, making it easy to query the data you've indexed with CocoIndex.
 
 ## Example
+
+You can find an end-to-end [Text Embedding Pinecone Example](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_pinecone).

--- a/docs/src/content/docs/targets/postgres.mdx
+++ b/docs/src/content/docs/targets/postgres.mdx
@@ -94,3 +94,5 @@ collector.export(
 ```
 
 ## Example
+
+You can find an end-to-end [Text Embedding Example with Postgres](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding).

--- a/docs/src/content/docs/targets/qdrant.mdx
+++ b/docs/src/content/docs/targets/qdrant.mdx
@@ -44,6 +44,6 @@ The spec takes the following fields:
 
 *   `collection_name` (`str`, required): The name of the collection to export the data to.
 
-You can find an end-to-end example [here](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding_qdrant).
-
 ## Example
+
+You can find an end-to-end [Text Embedding Qdrant Example](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding_qdrant).

--- a/docs/src/content/docs/tutorials/live_updates.mdx
+++ b/docs/src/content/docs/tutorials/live_updates.mdx
@@ -96,7 +96,7 @@ This allows you to react to updates in your application, for example, by notifyi
 
 ## Example
 
-Let's walk through an example of how to set up a live update flow. For the complete, runnable code, see the [live updates example](https://github.com/cocoindex-io/cocoindex/tree/main/examples/live_updates) in the CocoIndex repository.
+Let's walk through an example of how to set up a live update flow. For the complete, runnable code, see the [live updates example](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/live_updates) in the CocoIndex repository.
 
 ### 1. Setting up the Source
 

--- a/docs/src/content/example-posts/academic_papers_index.md
+++ b/docs/src/content/example-posts/academic_papers_index.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/paper_metadata)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/paper_metadata)
 
 ![Academic Papers Index](https://cocoindex.io/blobs/docs/img/examples/academic_papers_index/cover.png)
 

--- a/docs/src/content/example-posts/code_index.md
+++ b/docs/src/content/example-posts/code_index.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/codebase_index/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/code_embedding)
 [→ Watch on YouTube](https://youtu.be/G3WstvhHO24?si=ndYfM0XRs03_hVPR)
 
 ![Codebase Index](https://cocoindex.io/blobs/docs/img/examples/codebase_index/cover.png)

--- a/docs/src/content/example-posts/custom_source_hackernews.md
+++ b/docs/src/content/example-posts/custom_source_hackernews.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/custom_source_hn)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/custom_source_hn)
 
 
 ![Extract structured information from HackerNews with a Custom Source and export in Postgres](https://cocoindex.io/blobs/docs/img/examples/custom_source_hackernews/cover.png)

--- a/docs/src/content/example-posts/custom_targets.md
+++ b/docs/src/content/example-posts/custom_targets.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/custom_targets/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/custom_output_files)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/custom_output_files)
 
 ![Custom Targets](https://cocoindex.io/blobs/docs/img/examples/custom_targets/cover.png)
 

--- a/docs/src/content/example-posts/hackernews-trending-topics.md
+++ b/docs/src/content/example-posts/hackernews-trending-topics.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/hn_trending_topics)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/hn_trending_topics)
 
 ![Building a Real-Time HackerNews Trending Topics Detector with CocoIndex: A Deep Dive into Custom Sources and AI](https://cocoindex.io/blobs/docs/img/examples/hackernews-trending-topics/cover.png)
 

--- a/docs/src/content/example-posts/image_search.md
+++ b/docs/src/content/example-posts/image_search.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/image_search/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/image_search)
 
 ![Image Search](https://cocoindex.io/blobs/docs/img/examples/image_search/cover.png)
 

--- a/docs/src/content/example-posts/image_search_clip.md
+++ b/docs/src/content/example-posts/image_search_clip.md
@@ -249,7 +249,7 @@ This initialization ensures that all necessary components are properly configure
 
 
 ### Frontend
-You can check the frontend code [here](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search/frontend). We intentionally kept it simple and minimalistic to focus on the image search functionality.
+You can check the frontend code [here](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/image_search/frontend). We intentionally kept it simple and minimalistic to focus on the image search functionality.
 
 
 ## Time to have fun!

--- a/docs/src/content/example-posts/knowledge-graph-for-docs.md
+++ b/docs/src/content/example-posts/knowledge-graph-for-docs.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/docs_to_knowledge_graph)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/docs_to_knowledge_graph)
 [→ Watch on YouTube](https://youtu.be/2KVkpUGRtnk?si=MRalDweWrid-IFje)
 
 ![Knowledge Graph for Docs](https://cocoindex.io/blobs/docs/img/examples/docs_to_knowledge_graph/cover.png)
@@ -45,7 +45,7 @@ and then build a knowledge graph.
 
 ### Add documents as source
 
-We will process CocoIndex documentation markdown files (`.md`, `.mdx`) from the `docs/core` directory ([markdown files](https://github.com/cocoindex-io/cocoindex/tree/main/docs/docs/core), [deployed docs](https://cocoindex.io/docs-v0/core/basics)).
+We will process CocoIndex documentation markdown files (`.md`, `.mdx`) from the `docs/core` directory ([markdown files](https://github.com/cocoindex-io/cocoindex/tree/v0/docs/docs/core), [deployed docs](https://cocoindex.io/docs-v0/core/basics)).
 
 ```python
 

--- a/docs/src/content/example-posts/manual_extraction.md
+++ b/docs/src/content/example-posts/manual_extraction.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/manual_extraction/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/manuals_llm_extraction)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/manuals_llm_extraction)
 
 ![Manual Extraction](https://cocoindex.io/blobs/docs/img/examples/manual_extraction/cover.png)
 

--- a/docs/src/content/example-posts/meeting_notes_graph.md
+++ b/docs/src/content/example-posts/meeting_notes_graph.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/meeting_notes_graph)
 
 ![Meeting Notes Graph](https://cocoindex.io/blobs/docs/img/examples/meeting_notes_graph/cover.png)
 

--- a/docs/src/content/example-posts/multi_format_index.md
+++ b/docs/src/content/example-posts/multi_format_index.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/multi_format_index/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/multi_format_indexing)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/multi_format_indexing)
 
 ![Multi Format Index](https://cocoindex.io/blobs/docs/img/examples/multi_format_index/cover.png)
 

--- a/docs/src/content/example-posts/patient_form_extraction.md
+++ b/docs/src/content/example-posts/patient_form_extraction.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/patient_intake_extraction)
 [→ Watch on YouTube](https://youtu.be/_mjlwVtnBn0?si=-TBImMyZbnKh-5FB)
 
 ![Patient Form Extraction](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction/cover.png)

--- a/docs/src/content/example-posts/patient_form_extraction_baml.md
+++ b/docs/src/content/example-posts/patient_form_extraction_baml.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_baml)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/patient_intake_extraction_baml)
 
 ![Patient Form Extraction](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_baml/cover.png)
 

--- a/docs/src/content/example-posts/patient_form_extraction_dspy.md
+++ b/docs/src/content/example-posts/patient_form_extraction_dspy.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_dspy)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/patient_intake_extraction_dspy)
 
 ![Patient Form Extraction with DSPy](https://cocoindex.io/blobs/docs/img/examples/patient_form_extraction_dspy/cover.png)
 

--- a/docs/src/content/example-posts/pdf_elements.md
+++ b/docs/src/content/example-posts/pdf_elements.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/pdf_elements/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/pdf_elements_embedding)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/pdf_elements_embedding)
 
 ![Index PDF Elements](https://cocoindex.io/blobs/docs/img/examples/pdf_elements/cover.png)
 

--- a/docs/src/content/example-posts/photo_search.md
+++ b/docs/src/content/example-posts/photo_search.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/photo_search/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/face_recognition)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/face_recognition)
 
 ![Photo Search](https://cocoindex.io/blobs/docs/img/examples/photo_search/cover.png)
 

--- a/docs/src/content/example-posts/postgres_source.md
+++ b/docs/src/content/example-posts/postgres_source.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/postgres_source/cover.png
 ---
 
-<GitHubButton url="https://github.com/cocoindex-io/cocoindex/tree/main/examples/postgres_source" margin="0 0 24px 0" /
+<GitHubButton url="https://github.com/cocoindex-io/cocoindex/tree/v0/examples/postgres_source" margin="0 0 24px 0" /
 >
 ![PostgreSQL Product Indexing Flow](https://cocoindex.io/blobs/docs/img/examples/postgres_source/cover.png)
 

--- a/docs/src/content/example-posts/product_recommendation.md
+++ b/docs/src/content/example-posts/product_recommendation.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/product_recommendation/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/product_recommendation)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/product_recommendation)
 
 ![Product Recommendation](https://cocoindex.io/blobs/docs/img/examples/product_recommendation/cover.png)
 

--- a/docs/src/content/example-posts/simple_vector_index.md
+++ b/docs/src/content/example-posts/simple_vector_index.md
@@ -2,7 +2,7 @@
 image: https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/cover.png
 ---
 
-[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/text_embedding)
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/v0/examples/text_embedding)
 
 ![Simple Vector Index](https://cocoindex.io/blobs/docs/img/examples/simple_vector_index/cover.png)
 

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -35,7 +35,7 @@ const fullTitle = `${plainTitle} · CocoIndex Examples`;
 const canonical = new URL(`${base}/examples/${slug}`, SITE_URL).toString();
 // The repo directory usually matches the slug; override via sourceSlug when
 // it doesn't (e.g. listing slug `code_index` vs repo dir `code_embedding`).
-const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/main/examples/${ex.sourceSlug ?? slug}`;
+const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/v0/examples/${ex.sourceSlug ?? slug}`;
 
 // Pull the ported markdown body. Every listed example should have a
 // matching entry, but we tolerate a missing one so we can ship the


### PR DESCRIPTION
## Summary
- Backport CSS-only `<Tabs>` Astro component from #1861 to v0.
- Restore content the Docusaurus→Astro migration stripped: 37 single-Python tab code blocks across `ai/llm.mdx`, `core/flow_def.mdx`, `core/flow_methods.mdx`, `custom_ops/custom_*.mdx`, `query.mdx`; plus button components (`<ExampleButton>`, `<DocumentationButton>`, `<GitHubButton>`, `<YouTubeButton>`) restored as plain markdown links in `quickstart.mdx` and the empty `## Example` sections in 8 target pages.
- Update GitHub example URLs from `tree/main/examples/` to `tree/v0/examples/` across docs and example posts, since the previous `main` became `v0`.

## Test plan
- [x] `npm run build` — 64 pages built, no errors, no broken links.
- [ ] Spot-check that the restored code blocks and example links render correctly on each page.
