### PR TITLE
docs(v0): document IndexUpdateInfo.stats from Flow.update()

### DIFF
--- a/docs/src/content/docs/core/flow_methods.mdx
+++ b/docs/src/content/docs/core/flow_methods.mdx
@@ -152,9 +152,7 @@ The `Flow.update()` method creates/updates data in the target. It accepts the fo
 * `reexport_targets` (type: `bool`, default: `False`): Whether to reexport the targets even if there's no change.
 * `print_stats` (type: `bool`, default: `False`): Whether to print stats during update.
 
-It returns an object, with the following properties:
-
-* `stats` (type: `dict[str, dict[str, int]]`): A dictionary of stats by source. Keyed by source name, value is a dictionary of stats by metrics: `num_no_change`, `num_insertions`, `num_updates`, `num_reprocesses`, `num_deletions`, `num_errors`.
+It returns an `IndexUpdateInfo` object describing what happened during the update; see [Update info](#update-info) below.
 
 Example:
 
@@ -334,6 +332,46 @@ CocoIndex also provides asynchronous versions of APIs for blocking operations, i
         # Perform your own logic (e.g. a query loop).
         ...
     ```
+
+### Update info
+
+Both update modes report progress and outcomes through an `IndexUpdateInfo` object:
+
+* [`Flow.update()` / `Flow.update_async()`](#library-api-1) return one directly when the update finishes.
+* [`FlowLiveUpdater.update_stats()`](#library-api-2) returns the latest one for a running or finished live updater.
+
+Its `stats` property is a dict keyed by source name. Each value is a per-source dict of counters describing what happened to source rows during the update:
+
+| Field | Meaning |
+|-------|---------|
+| `num_no_change` | Source rows that were unchanged since the previous run and skipped. |
+| `num_insertions` | Source rows seen for the first time and added to the target. |
+| `num_deletions` | Source rows that disappeared from the source and were removed from the target. |
+| `num_updates` | Source rows whose content changed and were reprocessed. |
+| `num_reprocesses` | Source rows reprocessed because the flow logic (or `reexport_targets=True`) forced it, even though the row content was unchanged. |
+| `num_errors` | Source rows that failed to process. |
+| `processing.num_starts` | Total rows that have started processing. |
+| `processing.num_ends` | Total rows that have finished processing. The difference `num_starts - num_ends` is the number of rows currently in flight — only meaningful for live update, since one time update returns once everything has drained. |
+
+Example:
+
+```python
+update_info = demo_flow.update()
+print(update_info.stats)
+# {
+#   'files': {
+#     'num_no_change': 293,
+#     'num_insertions': 65,
+#     'num_deletions': 41,
+#     'num_updates': 12,
+#     'num_reprocesses': 0,
+#     'num_errors': 0,
+#     'processing': {'num_starts': 367, 'num_ends': 367},
+#   },
+# }
+```
+
+You can also pass the object to `print()` directly to get a human-readable progress bar summary — this is what `print_stats=True` uses under the hood.
 
 ## Evaluate the flow
 

--- a/examples/code_embedding/main.py
+++ b/examples/code_embedding/main.py
@@ -136,8 +136,8 @@ def search(query: str) -> cocoindex.QueryOutput:
 
 def _main() -> None:
     # Make sure the flow is built and up-to-date.
-    stats = code_embedding_flow.update()
-    print("Updated index: ", stats)
+    update_info = code_embedding_flow.update()
+    print("Updated index: ", update_info.stats)
 
     # Run queries in a loop to demonstrate the query capabilities.
     while True:


### PR DESCRIPTION
## Summary

- Add an **Update info** reference subsection under *Build/update target data* in `docs/src/content/docs/core/flow_methods.mdx` that documents the `IndexUpdateInfo` object returned by `Flow.update()` / `Flow.update_async()` and exposed via `FlowLiveUpdater.update_stats()`, including the per-source `stats` dict (`num_no_change`, `num_insertions`, `num_deletions`, `num_updates`, `num_reprocesses`, `num_errors`) and the nested `processing.{num_starts, num_ends}` counters.
- Replace the inline `stats` schema in the *One time update → Library API* block with a link to the new section so the schema is documented in one place.
- Fix the `code_embedding` example to use `update_info.stats` instead of treating the `update()` return value as a stats dict directly.

## Test plan

CI (link checker / docs build).
