### PR TITLE
docs(v0): show H4 headings in right-rail TOC

### DIFF
--- a/docs/src/components/Toc.astro
+++ b/docs/src/components/Toc.astro
@@ -11,8 +11,8 @@ export interface Props {
 
 const { headings, slug } = Astro.props;
 
-// Only H2 and H3 in the right rail — deeper nesting makes noise.
-const rows = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+// H2 through H4 in the right rail — H5+ is too deep to be useful.
+const rows = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
 
 const metaMap = (docsMeta as {
   _version?: string | null;
@@ -42,7 +42,7 @@ const reviewedAgo = relativeReview(editTs);
   <h6>On this page</h6>
   <ul>
     {rows.map((h) => (
-      <li class={h.depth === 3 ? 'sub' : ''} data-toc-item>
+      <li class={h.depth === 3 ? 'sub' : h.depth === 4 ? 'sub-sub' : ''} data-toc-item>
         <a href={`#${h.slug}`} data-toc-link={h.slug}>
           {h.text}
         </a>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -511,6 +511,7 @@ aside.toc li a {
 aside.toc li a:hover { color: var(--coral); text-decoration: none; }
 aside.toc li a.on { color: var(--coral); border-left-color: var(--coral); }
 aside.toc li.sub a { padding-left: 22px; font-size: 12.5px; }
+aside.toc li.sub-sub a { padding-left: 34px; font-size: 12px; }
 
 aside.toc .meta {
   margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--rule);


### PR DESCRIPTION
## Summary
- Many v0 doc pages use H4 sections that were silently dropped from the right-rail "On this page" TOC because the filter only kept H2/H3.
- Extend the filter in `Toc.astro` to include H4, and add a `.sub-sub` rule in `globals.css` (deeper indent, slightly smaller font) so the three levels read as a clear hierarchy.

## Test plan
- `npm run build` in `docs/` (passes locally, 64 pages built).
- Visual: open a page with H4 headings (e.g. `core/flow_methods/`) and confirm L4 entries appear in the right rail, indented one step further than L3.
