### PR TITLE
refactor(entity_resolution): make ResolvedEntities a frozen+slots dataclass

### DIFF
--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -111,6 +111,7 @@ class PairResolver(_typing.Protocol):
     ) -> PairDecision: ...
 
 
+@_dataclasses.dataclass(frozen=True, slots=True)
 class ResolvedEntities:
     """Result of entity resolution.
 
@@ -119,10 +120,7 @@ class ResolvedEntities:
     contract.
     """
 
-    __slots__ = ("_dedup",)
-
-    def __init__(self, dedup: dict[str, str | None]) -> None:
-        self._dedup = dedup
+    _dedup: dict[str, str | None]
 
     def canonical_of(self, name: str) -> str:
         """Return the canonical name for ``name``.


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `__slots__` + `__init__` on `ResolvedEntities` with `@dataclass(frozen=True, slots=True)`.
- Same runtime shape (single `_dedup` field, slotted, immutable), but the dataclass form is recognised by msgspec/pickle helpers — callers can now return `ResolvedEntities` directly from memoised `@coco.fn(memo=True)` functions instead of round-tripping through `to_dict()`.

## Test plan
- CI
