### PR TITLE
chore: upgrade examples deps to cocoindex-1.0.2

### DIFF
--- a/examples/amazon_s3_embedding/pyproject.toml
+++ b/examples/amazon_s3_embedding/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed S3 text files into Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[amazon_s3,postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[amazon_s3,postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/audio_to_text/pyproject.toml
+++ b/examples/audio_to_text/pyproject.toml
@@ -4,12 +4,9 @@ version = "0.1.0"
 description = "CocoIndex v1 example: transcribe audio files to text using LiteLLM."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[litellm,postgres]>=1.0.0a30",
+    "cocoindex[litellm,postgres]>=1.0.2",
     "asyncpg>=0.29.0",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/code_embedding/pyproject.toml
+++ b/examples/code_embedding/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed code files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/code_embedding_lancedb/pyproject.toml
+++ b/examples/code_embedding_lancedb/pyproject.toml
@@ -3,10 +3,7 @@ name = "code-embedding-lancedb-v1"
 version = "0.1.0"
 description = "CocoIndex v1 example: embed code files and store in LanceDB."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.0a30"]
-
-[tool.uv]
-prerelease = "explicit"
+dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.2"]
 
 [tool.setuptools]
 packages = []

--- a/examples/conversation_to_knowledge/pyproject.toml
+++ b/examples/conversation_to_knowledge/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex example: convert podcast sessions to a knowledge graph in SurrealDB."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[surrealdb,sentence_transformers]>=1.0.0a35",
+    "cocoindex[surrealdb,sentence_transformers]>=1.0.2",
     "yt-dlp",
     "assemblyai",
     "instructor",
@@ -13,9 +13,6 @@ dependencies = [
     "numpy",
     "pydantic",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = ["conv_knowledge"]

--- a/examples/csv_to_kafka/pyproject.toml
+++ b/examples/csv_to_kafka/pyproject.toml
@@ -3,10 +3,7 @@ name = "csv-to-kafka"
 version = "0.1.0"
 description = "CocoIndex example: watch CSV files and publish rows as JSON to Kafka."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[kafka]>=1.0.0a30"]
-
-[tool.uv]
-prerelease = "explicit"
+dependencies = ["cocoindex[kafka]>=1.0.2"]
 
 [tool.setuptools]
 packages = []

--- a/examples/entire_session_search/pyproject.toml
+++ b/examples/entire_session_search/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "Semantic search over AI coding sessions captured by Entire, powered by CocoIndex."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/files_transform/pyproject.toml
+++ b/examples/files_transform/pyproject.toml
@@ -3,10 +3,7 @@ name = "files-transform"
 version = "0.1.0"
 description = "Simple example for cocoindex: transform files in a directory."
 requires-python = ">=3.11"
-dependencies = ["cocoindex>=1.0.0a30", "markdown-it-py[linkify,plugins]"]
-
-[tool.uv]
-prerelease = "explicit"
+dependencies = ["cocoindex>=1.0.2", "markdown-it-py[linkify,plugins]"]
 
 [tool.setuptools]
 packages = []

--- a/examples/gdrive_text_embedding/pyproject.toml
+++ b/examples/gdrive_text_embedding/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed Google Drive text files into Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers,google_drive]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers,google_drive]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/hn_trending_topics/pyproject.toml
+++ b/examples/hn_trending_topics/pyproject.toml
@@ -10,8 +10,5 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
-[tool.uv]
-prerelease = "explicit"
-
 [tool.setuptools]
 packages = []

--- a/examples/image_search/pyproject.toml
+++ b/examples/image_search/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: image search with CLIP embeddings stored in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[qdrant]>=1.0.0a30",
+    "cocoindex[qdrant]>=1.0.2",
     "fastapi>=0.100.0",
     "torch>=2.0.0",
     "transformers>=4.29.0",
@@ -12,9 +12,6 @@ dependencies = [
     "qdrant-client>=1.14.2",
     "uvicorn>=0.34.3",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/image_search_colpali/pyproject.toml
+++ b/examples/image_search_colpali/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: image search with ColPali embeddings stored in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[colpali,qdrant]>=1.0.0a30",
+    "cocoindex[colpali,qdrant]>=1.0.2",
     "transformers>=4.45.0,<5",
     "fastapi>=0.100.0",
     "torch>=2.0.0",
@@ -12,9 +12,6 @@ dependencies = [
     "qdrant-client>=1.14.2",
     "uvicorn>=0.34.3",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/kafka_to_lancedb/pyproject.toml
+++ b/examples/kafka_to_lancedb/pyproject.toml
@@ -3,10 +3,7 @@ name = "kafka-to-lancedb"
 version = "0.1.0"
 description = "CocoIndex example: consume Kafka messages and dispatch to LanceDB tables."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[kafka,lancedb]>=1.0.0a30"]
-
-[tool.uv]
-prerelease = "explicit"
+dependencies = ["cocoindex[kafka,lancedb]>=1.0.2"]
 
 [tool.setuptools]
 packages = []

--- a/examples/multi_codebase_summarization/pyproject.toml
+++ b/examples/multi_codebase_summarization/pyproject.toml
@@ -4,15 +4,12 @@ version = "0.1.0"
 description = "Analyze multiple Python codebases and generate markdown documentation using LLM."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex>=1.0.0a30",
+    "cocoindex>=1.0.2",
     "instructor>=1.4.0",
     "litellm>=1.40.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.1",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/oci_object_storage_embedding/pyproject.toml
+++ b/examples/oci_object_storage_embedding/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed OCI Object Storage text files into Postgres/pgvector, with optional live updates via OCI Streaming."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[oci,kafka,postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[oci,kafka,postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/paper_metadata/pyproject.toml
+++ b/examples/paper_metadata/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: extract paper metadata and embeddings from PDFs."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
@@ -13,9 +13,6 @@ dependencies = [
     "pydantic>=2.12.5",
     "python-dotenv>=1.0.1",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/patient_intake_extraction_baml/pyproject.toml
+++ b/examples/patient_intake_extraction_baml/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "Extract structured information from patient intake forms using BAML (v1)."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex>=1.0.0a30",
+    "cocoindex>=1.0.2",
     "python-dotenv>=1.0.1",
     "baml-py==0.213.0",
     "pydantic>=2.12.5",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/patient_intake_extraction_dspy/pyproject.toml
+++ b/examples/patient_intake_extraction_dspy/pyproject.toml
@@ -4,16 +4,13 @@ version = "0.1.0"
 description = "Extract structured information from patient intake forms using DSPy (v1)."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex>=1.0.0a30",
+    "cocoindex>=1.0.2",
     "dspy-ai>=3.0.4",
     "pillow>=10.0.0",
     "pydantic>=2.12.5",
     "pymupdf>=1.26.5",
     "python-dotenv>=1.0.1",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/pdf_embedding/pyproject.toml
+++ b/examples/pdf_embedding/pyproject.toml
@@ -4,16 +4,13 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed local PDF files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
     "marker-pdf>=1.8.5",
     "python-dotenv>=1.0.1",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/pdf_to_markdown/pyproject.toml
+++ b/examples/pdf_to_markdown/pyproject.toml
@@ -4,12 +4,9 @@ version = "0.1.0"
 description = "CocoIndex v1 example: convert PDF files to markdown using docling."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex>=1.0.0a30",
+    "cocoindex>=1.0.2",
     "docling>=2.0.0",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/postgres_source/pyproject.toml
+++ b/examples/postgres_source/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: read from PostgreSQL source and write embeddings back to Postgres."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/text_embedding/pyproject.toml
+++ b/examples/text_embedding/pyproject.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed local markdown files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.0a30",
+    "cocoindex[postgres,sentence_transformers]>=1.0.2",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/examples/text_embedding_lancedb/pyproject.toml
+++ b/examples/text_embedding_lancedb/pyproject.toml
@@ -3,10 +3,7 @@ name = "text-embedding-lancedb-v1"
 version = "0.1.0"
 description = "CocoIndex v1 example: embed markdown files and store in LanceDB."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.0a30"]
-
-[tool.uv]
-prerelease = "explicit"
+dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.2"]
 
 [tool.setuptools]
 packages = []

--- a/examples/text_embedding_qdrant/pyproject.toml
+++ b/examples/text_embedding_qdrant/pyproject.toml
@@ -4,13 +4,10 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed markdown files and store in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[sentence_transformers,qdrant]>=1.0.0a30",
+    "cocoindex[sentence_transformers,qdrant]>=1.0.2",
     "numpy",
     "qdrant-client>=1.16.0",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 
 [tool.setuptools]
 packages = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ build-test = [
     "mypy",
     "moto[s3]>=5.0.0",
     "aiomoto[s3]>=0.3.0",
-    "testcontainers[postgres]>=4.0.0; sys_platform == 'linux'",
+    "testcontainers[postgres]>=4.0.0",
 ]
 format = ["ruff"]
 type-stubs = ["types-psutil", "asyncpg-stubs"]
@@ -215,6 +215,16 @@ module = [
     "faiss.*",
     "instructor",
     "instructor.*",
+    "oci",
+    "oci.*",
+    "confluent_kafka",
+    "confluent_kafka.*",
+    "openai",
+    "openai.*",
+    "transformers",
+    "transformers.*",
+    "testcontainers",
+    "testcontainers.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ build-test = [
     "mypy",
     "moto[s3]>=5.0.0",
     "aiomoto[s3]>=0.3.0",
-    "testcontainers[postgres]>=4.0.0",
+    "testcontainers[postgres]>=4.0.0; sys_platform != 'win32'",
 ]
 format = ["ruff"]
 type-stubs = ["types-psutil", "asyncpg-stubs"]

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ build-test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers" },
+    { name = "testcontainers", marker = "sys_platform != 'win32'" },
 ]
 ci = [
     { name = "aiomoto", extra = ["s3"] },
@@ -638,7 +638,7 @@ ci = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers" },
+    { name = "testcontainers", marker = "sys_platform != 'win32'" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
@@ -657,7 +657,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers" },
+    { name = "testcontainers", marker = "sys_platform != 'win32'" },
     { name = "types-psutil" },
 ]
 dev-local = [
@@ -744,7 +744,7 @@ build-test = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
 ]
 ci = [
     { name = "aiomoto", extras = ["s3"], specifier = ">=0.3.0" },
@@ -757,7 +757,7 @@ ci = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
@@ -776,7 +776,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 dev-local = [{ name = "prek" }]

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ build-test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform == 'linux'" },
+    { name = "testcontainers" },
 ]
 ci = [
     { name = "aiomoto", extra = ["s3"] },
@@ -638,7 +638,7 @@ ci = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform == 'linux'" },
+    { name = "testcontainers" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
@@ -657,7 +657,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform == 'linux'" },
+    { name = "testcontainers" },
     { name = "types-psutil" },
 ]
 dev-local = [
@@ -744,7 +744,7 @@ build-test = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform == 'linux'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
 ]
 ci = [
     { name = "aiomoto", extras = ["s3"], specifier = ">=0.3.0" },
@@ -757,7 +757,7 @@ ci = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform == 'linux'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
@@ -776,7 +776,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform == 'linux'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 dev-local = [{ name = "prek" }]


### PR DESCRIPTION
## Summary
- Bump `cocoindex` dependency to `>=1.0.2` in all 24 example `pyproject.toml` files.
- Drop the now-unnecessary `[tool.uv] prerelease = "explicit"` pin (1.0 is a stable release).
- Unblock local `mypy` checks on macOS:
  - Make `testcontainers[postgres]` a build-test dep on all platforms (was gated to `sys_platform == 'linux'`), so Postgres-backed tests can typecheck and run on macOS too.
  - Add `oci`, `confluent_kafka`, `openai`, `transformers`, `testcontainers` to the mypy `ignore_missing_imports` list — these are optional/example deps whose stubs are not installed in the dev environment.

## Test plan
- [x] `uv run mypy` passes locally
- [ ] CI passes