### PR TITLE
docs: mention the CocoIndex agent skill in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ coco.App(coco.AppConfig(name="docs"), main, src="./docs").update_blocking()
 <p align="center">Run once to backfill. Re-run anytime — only the changed files re-embed.</p>
 
 <p align="center">
+  Building with an AI coding agent?<br/>
+  Drop in our <a href="skills/cocoindex/"><b>CocoIndex skill</b></a> so your agent writes correct v1 code — concepts, APIs, patterns, all in one file.<br/>
+  <sub>See <a href="https://cocoindex.io/docs/getting_started/ai_coding_agents/">Use with AI coding agents</a> for install steps.</sub>
+</p>
+
+<p align="center">
   <a href="https://cocoindex.io/docs/getting_started/quickstart" title="Full CocoIndex quickstart — install, declare sources and targets, run the incremental engine, set up vector search or knowledge graph in 5 minutes"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/quickstart-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/quickstart-btn-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/quickstart-btn-light.svg" alt="Full quickstart — open-book icon linking to the CocoIndex documentation quickstart: pip install, declare sources and targets, run the incremental engine" height="36" align="absmiddle"/></picture></a>
   &nbsp;&nbsp;
   <a href="https://cocoindex.io/docs/programming_guide/core_concepts" title="Learn the CocoIndex core concepts — sources, targets, flows, incremental engine, lineage"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/learn-concept-btn-light.svg" alt="Learn the concept — lightbulb icon linking to the CocoIndex core-concepts guide: sources, targets, flows, incremental engine, and data lineage" height="36" align="absmiddle"/></picture></a>

--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -1,0 +1,67 @@
+---
+title: Use CocoIndex with *AI coding agents*
+description: >
+  Make Claude Code, Cursor, and other AI coding agents write correct CocoIndex v1
+  code by installing the official CocoIndex skill — concepts, APIs, and patterns
+  packaged for agent context.
+---
+CocoIndex ships an official **agent skill** that teaches AI coding agents how to build CocoIndex v1 pipelines correctly — core concepts, API surface, common patterns, connectors, and best practices, all in one place.
+
+The skill lives in the [`skills/cocoindex/`](https://github.com/cocoindex-io/cocoindex/tree/v1/skills/cocoindex) directory of the main repo.
+
+## Why a skill?
+
+CocoIndex v1 is a fundamental redesign from v0. Without context, an LLM trained on older snapshots tends to hallucinate the wrong API (the v0 flow-builder DSL, deprecated decorators, missing `@coco.fn`, unstable component paths). The skill gives the agent a single concise reference covering:
+
+- **Mental model** — `target_state = transform(source_state)`, declarative pipelines, processing components.
+- **Core APIs** — `@coco.fn`, `mount` / `use_mount` / `mount_each`, `ContextKey`, `@coco.lifespan`, target state declarations.
+- **Common patterns** — file transformation, vector embedding, LLM extraction, knowledge graphs.
+- **Connectors** — PostgreSQL, SQLite, LanceDB, Qdrant, SurrealDB, Apache Doris, LocalFS, S3, Kafka, Google Drive.
+- **Best practices** — memoization, stable component paths, vector schema with `Annotated[NDArray, KEY]`.
+
+## Use with Claude Code
+
+Claude Code auto-loads skills from `.claude/skills/` in the current project, or from `~/.claude/skills/` globally.
+
+Project-local install (recommended for repos that build with CocoIndex):
+
+```sh
+mkdir -p .claude/skills
+git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
+cp -r /tmp/cocoindex-skill/skills/cocoindex .claude/skills/
+```
+
+Global install:
+
+```sh
+mkdir -p ~/.claude/skills
+git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
+cp -r /tmp/cocoindex-skill/skills/cocoindex ~/.claude/skills/
+```
+
+Once installed, Claude Code picks up the skill automatically when you ask it to build or modify a CocoIndex pipeline.
+
+## Use with other agents
+
+The skill is plain Markdown — `SKILL.md` plus a few reference files. Any agent that accepts file-based context will work:
+
+- **Cursor** — copy `skills/cocoindex/SKILL.md` into `.cursor/rules/cocoindex.md`.
+- **Generic AGENTS.md / CLAUDE.md** — concatenate or `@import` `SKILL.md` from your top-level agent instructions file.
+- **Custom RAG / agent stack** — index the `skills/cocoindex/` directory like any other documentation source.
+
+## What's inside
+
+```
+skills/cocoindex/
+├── SKILL.md                       # main entry — concepts, APIs, patterns
+└── references/
+    ├── api_reference.md           # quick API reference
+    ├── connectors.md              # full connector reference
+    ├── patterns.md                # detailed pipeline patterns
+    ├── setup_project.md           # project setup
+    └── setup_database.md          # database setup
+```
+
+## Contributing
+
+The skill is versioned alongside the codebase — when the API changes, the skill changes with it. PRs that improve clarity, add examples, or cover new connectors are welcome. See the [contributing guide](../contributing/guide/) for how to get started.

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -27,6 +27,7 @@ export const sidebar: SidebarItem[] = [
       { type: 'doc', slug: 'getting_started/overview', label: 'Overview' },
       { type: 'doc', slug: 'getting_started/installation', label: 'Installation' },
       { type: 'doc', slug: 'getting_started/quickstart', label: 'Quickstart' },
+      { type: 'doc', slug: 'getting_started/ai_coding_agents', label: 'Use with AI coding agents' },
     ],
   },
   { type: 'doc', slug: 'programming_guide/core_concepts', label: 'Core Concepts' },


### PR DESCRIPTION
## Summary
- Add a centered callout to the README right after the Get Started snippet, pointing to `skills/cocoindex/` and the new docs page.
- Add a new Getting Started page **Use with AI coding agents** that explains why the skill exists, install steps for Claude Code (project-local + global), how to use it from Cursor / generic AGENTS.md / a custom RAG stack, and what's inside the `skills/cocoindex/` tree.
- Wire the new page into the docs sidebar under Getting Started.

## Test plan
- `npm run build` in `docs/` (run locally — passes, link checker green, new page renders at `/docs/getting_started/ai_coding_agents/`).
- CI links workflow.
