### PR TITLE
ci(test): make macOS Docker tests less flaky

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,19 +77,6 @@ jobs:
           shell: bash
           run: rm -f .python-version
 
-        - name: Setup Docker (macOS)
-          # macos-latest GitHub runners don't ship with a running Docker
-          # daemon, so testcontainers-based tests fail with
-          # "FileNotFoundError: /var/run/docker.sock". Colima provides a
-          # lightweight, license-free Docker daemon. Apple's `vz` driver
-          # needs nested virtualization (unavailable on hosted runners),
-          # so use QEMU instead.
-          if: startsWith(matrix.platform.runner, 'macos')
-          run: |
-            brew install colima docker qemu
-            colima start --cpu 2 --memory 4 --vm-type=qemu
-            docker info
-
         - name: Sync Python dependencies
           run: uv sync --no-dev --group ci --no-install-project
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -81,11 +81,13 @@ jobs:
           # macos-latest GitHub runners don't ship with a running Docker
           # daemon, so testcontainers-based tests fail with
           # "FileNotFoundError: /var/run/docker.sock". Colima provides a
-          # lightweight, license-free Docker daemon for these runners.
+          # lightweight, license-free Docker daemon. Apple's `vz` driver
+          # needs nested virtualization (unavailable on hosted runners),
+          # so use QEMU instead.
           if: startsWith(matrix.platform.runner, 'macos')
           run: |
             brew install colima docker
-            colima start --cpu 2 --memory 4
+            colima start --cpu 2 --memory 4 --vm-type=qemu
             docker info
 
         - name: Sync Python dependencies

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,6 +77,17 @@ jobs:
           shell: bash
           run: rm -f .python-version
 
+        - name: Setup Docker (macOS)
+          # macos-latest GitHub runners don't ship with a running Docker
+          # daemon, so testcontainers-based tests fail with
+          # "FileNotFoundError: /var/run/docker.sock". Colima provides a
+          # lightweight, license-free Docker daemon for these runners.
+          if: startsWith(matrix.platform.runner, 'macos')
+          run: |
+            brew install colima docker
+            colima start --cpu 2 --memory 4
+            docker info
+
         - name: Sync Python dependencies
           run: uv sync --no-dev --group ci --no-install-project
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -86,7 +86,7 @@ jobs:
           # so use QEMU instead.
           if: startsWith(matrix.platform.runner, 'macos')
           run: |
-            brew install colima docker
+            brew install colima docker qemu
             colima start --cpu 2 --memory 4 --vm-type=qemu
             docker info
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -2,10 +2,50 @@ import contextlib
 import os
 import time
 
+import pytest
+
 from cocoindex._internal.serde import enable_strict_serialize
 
 os.environ.setdefault("PYTHONASYNCIODEBUG", "1")
 enable_strict_serialize()
+
+
+def _is_docker_available() -> bool:
+    """Check whether a Docker daemon is reachable.
+
+    Used to skip (rather than error) tests that need testcontainers when no
+    Docker socket exists — e.g. macOS GitHub runners that ship without a
+    running daemon.
+    """
+    try:
+        import docker  # type: ignore[import-untyped]
+    except ImportError:
+        return False
+    try:
+        client = docker.from_env(timeout=2)
+        client.ping()
+        return True
+    except Exception:
+        return False
+
+
+_DOCKER_AVAILABLE = _is_docker_available()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_docker: test needs a running Docker daemon (e.g. testcontainers)",
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    if _DOCKER_AVAILABLE:
+        return
+    skip_marker = pytest.mark.skip(reason="Docker daemon not available")
+    for item in items:
+        if item.get_closest_marker("requires_docker") is not None:
+            item.add_marker(skip_marker)
 
 
 def _install_testcontainers_reaper_retry() -> None:

--- a/python/tests/connectors/test_postgres_source.py
+++ b/python/tests/connectors/test_postgres_source.py
@@ -41,6 +41,7 @@ pytestmark = [
     pytest.mark.skipif(
         not TESTCONTAINERS_AVAILABLE, reason="testcontainers not installed"
     ),
+    pytest.mark.requires_docker,
     pytest.mark.timeout(120),
 ]
 

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -51,6 +51,7 @@ pytestmark = [
     pytest.mark.skipif(
         not TESTCONTAINERS_AVAILABLE, reason="testcontainers not installed"
     ),
+    pytest.mark.requires_docker,
     pytest.mark.timeout(120),
 ]
 


### PR DESCRIPTION
## Summary

Fixes flaky `macos-latest` CI failures where 14 testcontainers-backed Postgres tests intermittently error with `docker.errors.DockerException: ... FileNotFoundError(2, '/var/run/docker.sock')` because the runner has no Docker daemon.

- Add a `requires_docker` pytest marker; conftest auto-skips marked tests when no Docker socket is reachable. Suite degrades gracefully on local dev without Docker, on macOS CI runners, and on future runner-image regressions.
- Mark `test_postgres_source.py` and `test_postgres_target.py` with `requires_docker`.

We also tried installing Colima on the macOS jobs to gain real coverage, but neither VM driver works on hosted GH macOS runners: `vz` needs nested virtualization (unavailable in the runner), and lima 2.1.1's QEMU driver panics on Apple Silicon (`send on closed channel`). Linux runners already exercise these tests, so coverage is preserved.

## Test plan

- CI on this PR: macOS jobs should now pass with the postgres tests skipped.
- Verified locally: tests collect normally with Docker up; with `DOCKER_HOST=unix:///nonexistent/...` all 14 tests skip cleanly with reason "Docker daemon not available".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
