### PR TITLE
README: remove `v1` mention in cocoindex installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 <h3 align="center">Get started</h3>
 
 ```sh
-pip install -U --pre cocoindex     # v1 is in preview — the --pre flag is required
+pip install -U --pre cocoindex
 ```
 
 Declare *what* should be in your target — CocoIndex keeps it in sync forever, recomputing only the Δ.


### PR DESCRIPTION
Remove `v1` mention from shell command installation in README
Or is this done to let folks download pre-releases (in which case there can be another mention for those users who want to try certain features / releases beforehand in another command as a note than for this to be the main installation command everyone sees).