### PR TITLE
docs: drop remaining pre-release references after v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 <h3 align="center">Get started</h3>
 
 ```sh
-pip install -U --pre cocoindex
+pip install -U cocoindex
 ```
 
 Declare *what* should be in your target — CocoIndex keeps it in sync forever, recomputing only the Δ.

--- a/docs/src/content/docs/getting_started/installation.mdx
+++ b/docs/src/content/docs/getting_started/installation.mdx
@@ -16,40 +16,29 @@ To follow the steps in this guide, you'll need:
 
 ## Install CocoIndex
 
-:::note
-CocoIndex v1 is currently in preview (pre-release on PyPI). You need to allow pre-release versions when installing.
-:::
-
 ### Using pip
 
 ```sh
-pip install -U --pre cocoindex
+pip install -U cocoindex
 ```
 
 ### Using uv
 
 ```sh
-uv add --prerelease explicit cocoindex
-```
-
-Or add to your `pyproject.toml`:
-
-```toml
-[tool.uv]
-prerelease = "explicit"
+uv add cocoindex
 ```
 
 ### Using Poetry
 
 ```sh
-poetry add cocoindex --allow-prereleases
+poetry add cocoindex
 ```
 
 Or specify in `pyproject.toml`:
 
 ```toml
 [tool.poetry.dependencies]
-cocoindex = { version = "^1.0", allow-prereleases = true }
+cocoindex = { version = "^1.0" }
 ```
 
 ## System requirements

--- a/docs/src/content/docs/getting_started/quickstart.mdx
+++ b/docs/src/content/docs/getting_started/quickstart.mdx
@@ -32,7 +32,7 @@ When your source data is updated, or your processing logic is changed (for examp
 1. Install CocoIndex (see [Installation](./installation) for other package managers) and the Docling dependency:
 
     ```bash
-    pip install -U --pre cocoindex docling
+    pip install -U cocoindex docling
     ```
 
 2. Create a new directory for your project:

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -40,7 +40,7 @@ When your source data is updated, or your processing logic is changed (for examp
 1. Install CocoIndex and dependencies:
 
     ```bash
-    pip install --pre 'cocoindex>=1.0.0a6' instructor litellm pydantic
+    pip install 'cocoindex>=1.0.0' instructor litellm pydantic
     ```
 
 2. Create a new directory for your project:

--- a/docs/src/content/example-posts/pdf-to-markdown.md
+++ b/docs/src/content/example-posts/pdf-to-markdown.md
@@ -33,7 +33,7 @@ When your source data is updated, or your processing logic is changed (for examp
 1. Install CocoIndex and dependencies:
 
     ```bash
-    pip install 'cocoindex>=1.0.0a1' docling
+    pip install 'cocoindex>=1.0.0' docling
     ```
 
 2. Create a new directory for your project:

--- a/examples/conversation_to_knowledge/design.md
+++ b/examples/conversation_to_knowledge/design.md
@@ -624,7 +624,7 @@ examples/conversation_to_knowledge/
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "yt-dlp",
     "openai",
     "instructor",

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -417,9 +417,6 @@ requires-python = ">=3.11"
 dependencies = [
     "cocoindex>={coco.__version__}",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 """
     (project_path / "pyproject.toml").write_text(pyproject_toml_content)
 

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cocoindex
-description: This skill should be used when building data processing pipelines with CocoIndex, a Python library for incremental data transformation. Use when the task involves processing files/data into databases, creating vector embeddings, building knowledge graphs, ETL workflows, or any data pipeline requiring automatic change detection and incremental updates. CocoIndex is Python-native (supports any Python types), has no DSL, and is currently under pre-release (version 1.0.0a1 or later).
+description: This skill should be used when building data processing pipelines with CocoIndex, a Python library for incremental data transformation. Use when the task involves processing files/data into databases, creating vector embeddings, building knowledge graphs, ETL workflows, or any data pipeline requiring automatic change detection and incremental updates. CocoIndex is Python-native (supports any Python types), has no DSL, and uses version 1.0.0 or later.
 ---
 
 # CocoIndex
@@ -47,10 +47,10 @@ This creates: `main.py`, `pyproject.toml`, `.env`, `README.md`.
 
 ```toml
 # For vector embeddings with PostgreSQL
-dependencies = ["cocoindex>=1.0.0a1", "sentence-transformers", "asyncpg"]
+dependencies = ["cocoindex>=1.0.0", "sentence-transformers", "asyncpg"]
 
 # For LLM extraction
-dependencies = ["cocoindex>=1.0.0a1", "litellm", "instructor", "pydantic>=2.0"]
+dependencies = ["cocoindex>=1.0.0", "litellm", "instructor", "pydantic>=2.0"]
 ```
 
 See [references/setup_project.md](references/setup_project.md) for complete examples.
@@ -448,15 +448,6 @@ table = await postgres.mount_table_target(
 
 ## Troubleshooting
 
-### "Module not found" Error
-
-Ensure pyproject.toml has pre-release config:
-
-```toml
-[tool.uv]
-prerelease = "explicit"
-```
-
 ### Everything Reprocessing
 
 Add `memo=True` to expensive functions:
@@ -488,4 +479,4 @@ Check component paths are stable. Use stable IDs, not object references.
 
 ## Version Note
 
-This skill is for CocoIndex `>=1.0.0a1` (v1). It uses a completely different API from v0.
+This skill is for CocoIndex `>=1.0.0` (v1). It uses a completely different API from v0.

--- a/skills/cocoindex/references/setup_project.md
+++ b/skills/cocoindex/references/setup_project.md
@@ -22,13 +22,10 @@ pip install -e .
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "sentence-transformers",
     "asyncpg",
 ]
-
-[tool.uv]
-prerelease = "explicit"
 ```
 
 ### PostgreSQL Integration
@@ -36,7 +33,7 @@ prerelease = "explicit"
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "asyncpg",
 ]
 ```
@@ -46,7 +43,7 @@ dependencies = [
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "sqlite-vec",
 ]
 ```
@@ -56,7 +53,7 @@ dependencies = [
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "lancedb",
 ]
 ```
@@ -66,7 +63,7 @@ dependencies = [
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "qdrant-client",
 ]
 ```
@@ -76,7 +73,7 @@ dependencies = [
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "confluent-kafka",
 ]
 ```
@@ -86,7 +83,7 @@ dependencies = [
 ```toml
 [project]
 dependencies = [
-    "cocoindex>=1.0.0a1",
+    "cocoindex>=1.0.0",
     "litellm",
     "instructor",
     "pydantic>=2.0",
@@ -128,17 +125,6 @@ def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
 
 ---
 
-## Pre-release Configuration
-
-**Important**: CocoIndex is currently in pre-release. Always include:
-
-```toml
-[tool.uv]
-prerelease = "explicit"
-```
-
----
-
 ## Running Your Pipeline
 
 ```bash
@@ -152,10 +138,6 @@ cocoindex drop main.py -f           # Reset everything
 ---
 
 ## Common Issues
-
-### Pre-release Version Not Found
-
-Add `[tool.uv] prerelease = "explicit"` to `pyproject.toml`.
 
 ### Import Errors
 


### PR DESCRIPTION
## Summary
- Drop the stray `--pre` / `--prerelease` / `prerelease = "explicit"` references the v1.0.0 release sweep missed (installation docs, `cocoindex init` template in `cli.py`, and the cocoindex skill).
- Fix `uv add explicit cocoindex` typo in `installation.mdx` (leftover value from the original `--prerelease explicit` flag pair).
- Reword the cocoindex skill description (was self-contradictory: "currently under pre-release (version 1.0.0 or later)") and remove the now-obsolete pre-release config troubleshooting/setup sections.

## Test plan
- CI (pre-commit hooks ran clean locally: ruff format, mypy, maturin develop, cargo test, pytest).
