### PR TITLE
neo4j: connector + cypher builders + integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ google_drive = [
 amazon_s3 = ["aiobotocore>=2.0.0"]
 doris = ["aiohttp>=3.9.0", "pymysql>=1.1.0", "aiomysql>=0.2.0"]
 falkordb = ["falkordb>=1.1.0"]
+neo4j = ["neo4j>=5.13.0"]
 kafka = ["confluent_kafka>=2.6"]
 oci = ["oci>=2.0"]
 entity_resolution = ["faiss-cpu>=1.7"]
@@ -115,6 +116,7 @@ all = [
     "pymysql>=1.1.0",
     "aiomysql>=0.2.0",
     "falkordb>=1.1.0",
+    "neo4j>=5.13.0",
     "confluent_kafka>=2.6",
     "oci>=2.0",
     "faiss-cpu>=1.7",
@@ -131,11 +133,11 @@ build-test = [
     "mypy",
     "moto[s3]>=5.0.0",
     "aiomoto[s3]>=0.3.0",
-    "testcontainers[postgres]>=4.0.0; sys_platform != 'win32'",
+    "testcontainers[postgres,neo4j]>=4.0.0; sys_platform != 'win32'",
 ]
 format = ["ruff"]
 type-stubs = ["types-psutil", "asyncpg-stubs"]
-ci-enabled-optional-deps = ["pydantic>=2.11.9", "asyncpg>=0.31.0"]
+ci-enabled-optional-deps = ["pydantic>=2.11.9", "asyncpg>=0.31.0", "neo4j>=5.13.0"]
 examples = ["sentence-transformers>=3.0.0", "numpy"]
 
 ci = [
@@ -211,6 +213,8 @@ module = [
     "pymysql.*",
     "falkordb",
     "falkordb.*",
+    "neo4j",
+    "neo4j.*",
     "faiss",
     "faiss.*",
     "instructor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ google_drive = [
 amazon_s3 = ["aiobotocore>=2.0.0"]
 doris = ["aiohttp>=3.9.0", "pymysql>=1.1.0", "aiomysql>=0.2.0"]
 falkordb = ["falkordb>=1.1.0"]
-neo4j = ["neo4j>=5.13.0"]
+neo4j = ["neo4j>=5.18.0"]
 kafka = ["confluent_kafka>=2.6"]
 oci = ["oci>=2.0"]
 entity_resolution = ["faiss-cpu>=1.7"]
@@ -116,7 +116,7 @@ all = [
     "pymysql>=1.1.0",
     "aiomysql>=0.2.0",
     "falkordb>=1.1.0",
-    "neo4j>=5.13.0",
+    "neo4j>=5.18.0",
     "confluent_kafka>=2.6",
     "oci>=2.0",
     "faiss-cpu>=1.7",
@@ -137,7 +137,7 @@ build-test = [
 ]
 format = ["ruff"]
 type-stubs = ["types-psutil", "asyncpg-stubs"]
-ci-enabled-optional-deps = ["pydantic>=2.11.9", "asyncpg>=0.31.0", "neo4j>=5.13.0"]
+ci-enabled-optional-deps = ["pydantic>=2.11.9", "asyncpg>=0.31.0", "neo4j>=5.18.0"]
 examples = ["sentence-transformers>=3.0.0", "numpy"]
 
 ci = [

--- a/python/cocoindex/connectors/neo4j/__init__.py
+++ b/python/cocoindex/connectors/neo4j/__init__.py
@@ -1,11 +1,4 @@
-"""Neo4j connector for CocoIndex.
+from . import _target
+from ._target import *  # noqa: F401, F403
 
-Public API will be re-exported from ``_target`` once that module lands. For
-now only the pure Cypher generators in ``_cypher`` are in place — they have
-no runtime dependency on the ``neo4j`` driver and are unit-testable in
-isolation.
-"""
-
-from . import _cypher
-
-__all__ = ["_cypher"]
+__all__ = _target.__all__

--- a/python/cocoindex/connectors/neo4j/__init__.py
+++ b/python/cocoindex/connectors/neo4j/__init__.py
@@ -1,0 +1,11 @@
+"""Neo4j connector for CocoIndex.
+
+Public API will be re-exported from ``_target`` once that module lands. For
+now only the pure Cypher generators in ``_cypher`` are in place — they have
+no runtime dependency on the ``neo4j`` driver and are unit-testable in
+isolation.
+"""
+
+from . import _cypher
+
+__all__ = ["_cypher"]

--- a/python/cocoindex/connectors/neo4j/_cypher.py
+++ b/python/cocoindex/connectors/neo4j/_cypher.py
@@ -1,0 +1,269 @@
+"""
+Pure Cypher generation for the Neo4j connector.
+
+This module has no runtime dependency on the ``neo4j`` driver and no I/O —
+every function returns a Cypher string suitable for ``tx.run(cypher, **params)``
+where ``params`` is the dict assembled by the caller.
+
+All identifiers (labels, property names, index names) are validated by the
+caller before being passed in; values always bind via ``$``-parameters.
+
+Targets Neo4j 5.13+ (vector indexes shipped in 5.13).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+__all__ = [
+    "IDENTIFIER_RE",
+    "build_constraint_create",
+    "build_constraint_drop",
+    "build_node_delete",
+    "build_node_index_create",
+    "build_node_index_drop",
+    "build_node_upsert",
+    "build_relationship_delete",
+    "build_relationship_index_create",
+    "build_relationship_index_drop",
+    "build_relationship_upsert",
+    "build_vector_index_create",
+    "build_vector_index_drop",
+    "constraint_name",
+    "index_name",
+    "validate_identifier",
+    "vector_index_name",
+]
+
+
+IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def validate_identifier(name: str, kind: str) -> None:
+    """Reject anything that isn't ``[a-zA-Z_][a-zA-Z0-9_]*``.
+
+    Cypher labels, property names, and index names cannot be parameter-bound,
+    so untrusted names must be validated at API entry — never escaped at query
+    construction time.
+    """
+    if not IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid Neo4j {kind}: {name!r}. Must match [a-zA-Z_][a-zA-Z0-9_]*."
+        )
+
+
+def _quote(name: str) -> str:
+    """Backtick-wrap an already-validated identifier for inline use in Cypher."""
+    return f"`{name}`"
+
+
+def _key_clause(prefix: str, fields: Sequence[str]) -> str:
+    """Build ``{<f1>: $<prefix>_0, <f2>: $<prefix>_1, ...}`` for a MATCH/MERGE pattern."""
+    parts = [f"{_quote(f)}: ${prefix}_{i}" for i, f in enumerate(fields)]
+    return "{" + ", ".join(parts) + "}"
+
+
+def index_name(kind: str, label: str, fields: Sequence[str]) -> str:
+    """Deterministic index name for a (kind, label, fields) triple.
+
+    Neo4j 5 indexes are identified by name on DROP, so the connector mints
+    one at CREATE time and persists it in the tracking record. ``kind`` is
+    one of ``"node"`` / ``"rel"``.
+    """
+    field_part = "__".join(fields)
+    return f"coco_idx_{kind}_{label}__{field_part}"
+
+
+def constraint_name(label: str, fields: Sequence[str]) -> str:
+    """Deterministic constraint name for a (label, fields) pair."""
+    field_part = "__".join(fields)
+    return f"coco_uniq_{label}__{field_part}"
+
+
+def vector_index_name(label: str, field: str) -> str:
+    """Deterministic vector index name for a (label, field) pair."""
+    return f"coco_vec_{label}__{field}"
+
+
+def build_node_upsert(
+    label: str,
+    pk_fields: Sequence[str],
+    has_value_fields: bool,
+) -> str:
+    """``MERGE (n:`Label` {pk: $key_0, ...}) [SET n += $props]``.
+
+    Same shape as FalkorDB — Neo4j 5 understands the literal property
+    pattern in MERGE just fine.
+    """
+    if not pk_fields:
+        raise ValueError("build_node_upsert requires at least one primary key field")
+    cypher = f"MERGE (n:{_quote(label)} {_key_clause('key', pk_fields)})"
+    if has_value_fields:
+        cypher += " SET n += $props"
+    return cypher
+
+
+def build_node_delete(label: str, pk_fields: Sequence[str]) -> str:
+    """``MATCH (n:`Label` {pk: $key_0, ...}) DETACH DELETE n``.
+
+    DETACH DELETE removes any incident edges as a safety measure for nodes
+    that are also referenced as relationship endpoints — without it, the
+    DELETE would fail on nodes that still have edges.
+    """
+    if not pk_fields:
+        raise ValueError("build_node_delete requires at least one primary key field")
+    return f"MATCH (n:{_quote(label)} {_key_clause('key', pk_fields)}) DETACH DELETE n"
+
+
+def build_relationship_upsert(
+    rel_type: str,
+    from_label: str,
+    from_pk_fields: Sequence[str],
+    to_label: str,
+    to_pk_fields: Sequence[str],
+    rel_pk_fields: Sequence[str],
+    has_value_fields: bool,
+) -> str:
+    """Three MERGEs: source endpoint, target endpoint, then the relationship.
+
+    Endpoint properties are NOT touched — they are owned by their table's own
+    record handler. We only ``SET r += $props`` on the relationship itself.
+    """
+    if not from_pk_fields or not to_pk_fields or not rel_pk_fields:
+        raise ValueError(
+            "build_relationship_upsert requires PK fields for from, to, and the relationship"
+        )
+    cypher = (
+        f"MERGE (s:{_quote(from_label)} {_key_clause('from_key', from_pk_fields)}) "
+        f"MERGE (t:{_quote(to_label)} {_key_clause('to_key', to_pk_fields)}) "
+        f"MERGE (s)-[r:{_quote(rel_type)} {_key_clause('rel_key', rel_pk_fields)}]->(t)"
+    )
+    if has_value_fields:
+        cypher += " SET r += $props"
+    return cypher
+
+
+def build_relationship_delete(rel_type: str, pk_fields: Sequence[str]) -> str:
+    """``MATCH ()-[r:`RelType` {pk: $key_0, ...}]->() DELETE r``.
+
+    Endpoints are intentionally not deleted — they're tracked by their own
+    table handlers and will be deleted by their own reconciler if orphaned.
+    """
+    if not pk_fields:
+        raise ValueError(
+            "build_relationship_delete requires at least one primary key field"
+        )
+    return (
+        f"MATCH ()-[r:{_quote(rel_type)} {_key_clause('key', pk_fields)}]->() DELETE r"
+    )
+
+
+def build_node_index_create(
+    name: str,
+    label: str,
+    fields: Sequence[str],
+) -> str:
+    """``CREATE INDEX <name> IF NOT EXISTS FOR (n:`Label`) ON (n.`f1`, n.`f2`, ...)``.
+
+    Neo4j requires named indexes; ``IF NOT EXISTS`` makes setup idempotent.
+    """
+    if not fields:
+        raise ValueError("build_node_index_create requires at least one field")
+    field_list = ", ".join(f"n.{_quote(f)}" for f in fields)
+    return (
+        f"CREATE INDEX {_quote(name)} IF NOT EXISTS "
+        f"FOR (n:{_quote(label)}) ON ({field_list})"
+    )
+
+
+def build_node_index_drop(name: str) -> str:
+    """``DROP INDEX <name> IF EXISTS``.
+
+    Unlike FalkorDB's by-(label, field) drop, Neo4j drops indexes by name
+    regardless of kind (node or relationship).
+    """
+    return f"DROP INDEX {_quote(name)} IF EXISTS"
+
+
+def build_relationship_index_create(
+    name: str,
+    rel_type: str,
+    fields: Sequence[str],
+) -> str:
+    """``CREATE INDEX <name> IF NOT EXISTS FOR ()-[r:`RelType`]-() ON (r.`f1`, ...)``."""
+    if not fields:
+        raise ValueError("build_relationship_index_create requires at least one field")
+    field_list = ", ".join(f"r.{_quote(f)}" for f in fields)
+    return (
+        f"CREATE INDEX {_quote(name)} IF NOT EXISTS "
+        f"FOR ()-[r:{_quote(rel_type)}]-() ON ({field_list})"
+    )
+
+
+def build_relationship_index_drop(name: str) -> str:
+    """``DROP INDEX <name> IF EXISTS``.
+
+    Same DROP statement as for node indexes — Neo4j unifies the namespace.
+    """
+    return f"DROP INDEX {_quote(name)} IF EXISTS"
+
+
+def build_constraint_create(
+    name: str,
+    label: str,
+    fields: Sequence[str],
+) -> str:
+    """``CREATE CONSTRAINT <name> IF NOT EXISTS FOR (n:`Label`) REQUIRE n.`f1` IS UNIQUE``.
+
+    For a single-field PK uses ``REQUIRE n.f IS UNIQUE``; for compound PKs
+    uses ``REQUIRE (n.f1, n.f2) IS NODE KEY`` (Neo4j 5 syntax).
+    """
+    if not fields:
+        raise ValueError("build_constraint_create requires at least one field")
+    if len(fields) == 1:
+        field_expr = f"n.{_quote(fields[0])} IS UNIQUE"
+    else:
+        field_list = ", ".join(f"n.{_quote(f)}" for f in fields)
+        field_expr = f"({field_list}) IS NODE KEY"
+    return (
+        f"CREATE CONSTRAINT {_quote(name)} IF NOT EXISTS "
+        f"FOR (n:{_quote(label)}) REQUIRE {field_expr}"
+    )
+
+
+def build_constraint_drop(name: str) -> str:
+    """``DROP CONSTRAINT <name> IF EXISTS``."""
+    return f"DROP CONSTRAINT {_quote(name)} IF EXISTS"
+
+
+def build_vector_index_create(
+    name: str,
+    label: str,
+    field: str,
+    dimension: int,
+    metric: str,
+) -> str:
+    """``CREATE VECTOR INDEX <name> IF NOT EXISTS FOR (n:`Label`) ON n.`field` OPTIONS {...}``.
+
+    ``metric`` is the Neo4j ``vector.similarity_function`` value
+    (``"cosine"`` or ``"euclidean"``). Caller is responsible for translating
+    user-facing names into the Neo4j vocabulary before invoking.
+    """
+    if dimension <= 0:
+        raise ValueError(f"Invalid vector dimension: {dimension}")
+    return (
+        f"CREATE VECTOR INDEX {_quote(name)} IF NOT EXISTS "
+        f"FOR (n:{_quote(label)}) ON n.{_quote(field)} "
+        f"OPTIONS {{ indexConfig: {{ "
+        f"`vector.dimensions`: {int(dimension)}, "
+        f"`vector.similarity_function`: '{metric}' }} }}"
+    )
+
+
+def build_vector_index_drop(name: str) -> str:
+    """``DROP INDEX <name> IF EXISTS``.
+
+    Vector indexes share the index namespace; the same DROP works.
+    """
+    return f"DROP INDEX {_quote(name)} IF EXISTS"

--- a/python/cocoindex/connectors/neo4j/_cypher.py
+++ b/python/cocoindex/connectors/neo4j/_cypher.py
@@ -8,7 +8,8 @@ where ``params`` is the dict assembled by the caller.
 All identifiers (labels, property names, index names) are validated by the
 caller before being passed in; values always bind via ``$``-parameters.
 
-Targets Neo4j 5.13+ (vector indexes shipped in 5.13).
+Targets Neo4j 5.18+ (CREATE VECTOR INDEX DDL shipped in 5.18; older
+versions need the db.index.vector.createNodeIndex procedure instead).
 """
 
 from __future__ import annotations

--- a/python/cocoindex/connectors/neo4j/_target.py
+++ b/python/cocoindex/connectors/neo4j/_target.py
@@ -1,0 +1,1579 @@
+"""
+Neo4j target for CocoIndex.
+
+Two-level state system:
+1. Table level — creates/drops Cypher indexes and uniqueness constraints
+   for node labels and relationship types (real Cypher DDL, not best-effort
+   like FalkorDB's GRAPH.CONSTRAINT redis command).
+2. Record level — upserts/deletes nodes via Cypher MERGE and edges via
+   triple-MERGE (source, target, relationship).
+
+Multitenancy is by Neo4j database name (one Neo4j cluster, many isolated
+databases); the database is part of the ``ConnectionFactory``.
+
+Targets Neo4j 5.18+. Vector indexes use the CREATE VECTOR INDEX DDL form
+that shipped in 5.18; older Neo4j 5 servers will reject the DDL.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import logging
+import re
+import uuid as uuid_mod
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Generic,
+    Literal,
+    NamedTuple,
+    Sequence,
+)
+
+from typing_extensions import TypeVar
+
+try:
+    import neo4j as _neo4j  # type: ignore[import-not-found]
+except ImportError as e:
+    raise ImportError(
+        "neo4j is required to use the Neo4j connector. Please install cocoindex[neo4j]."
+    ) from e
+
+if TYPE_CHECKING:
+    AsyncDriver = Any
+else:
+    AsyncDriver = _neo4j.AsyncDriver
+
+import msgspec
+import numpy as np
+
+import cocoindex as coco
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+from cocoindex._internal.datatype import (
+    AnyType,
+    MappingType,
+    RecordType,
+    SequenceType,
+    TypeChecker,
+    UnionType,
+    analyze_type_info,
+    is_record_type,
+)
+from cocoindex.connectorkits import statediff, target
+from cocoindex.connectorkits.fingerprint import fingerprint_object
+from cocoindex.resources import schema as res_schema
+
+from . import _cypher
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation
+# ---------------------------------------------------------------------------
+
+_IDENTIFIER_RE = _cypher.IDENTIFIER_RE
+_validate_identifier = _cypher.validate_identifier
+
+
+# ---------------------------------------------------------------------------
+# Connection factory
+# ---------------------------------------------------------------------------
+
+
+class _GraphHandle:
+    """Thin wrapper around a Neo4j async driver+database that exposes a
+    ``query(cypher, params)`` method for parity with the FalkorDB connector.
+
+    A new session is opened per ``query`` call and closed before returning.
+    The driver itself is shared and connection-pooled internally.
+
+    For batched apply paths that need atomicity, callers can use
+    :meth:`begin_tx` to wrap multiple statements in a single managed
+    transaction.
+    """
+
+    _driver: AsyncDriver
+    _database: str
+
+    def __init__(self, driver: AsyncDriver, database: str) -> None:
+        self._driver = driver
+        self._database = database
+
+    @property
+    def database(self) -> str:
+        return self._database
+
+    async def query(
+        self, cypher: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """Run a single statement against this database and return the rows."""
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(cypher, **(params or {}))
+            return [dict(record) async for record in result]
+
+
+class ConnectionFactory:
+    """
+    Connection factory for Neo4j.
+
+    Holds connection parameters and creates an authenticated, pooled async
+    driver on demand. The database name is part of the factory (not the
+    table key) — different databases on the same Neo4j cluster are
+    addressed via separate ``ConnectionFactory`` / ``ContextKey`` pairs.
+
+    Example::
+
+        factory = neo4j.ConnectionFactory(
+            uri="bolt://localhost:7687",
+            auth=("neo4j", "cocoindex"),
+            database="neo4j",
+        )
+        builder.provide(NEO4J_DB, factory)
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        auth: tuple[str, str] | None = None,
+        database: str = "neo4j",
+    ) -> None:
+        # Database identifiers in Neo4j 5 may contain hyphens and dots; be
+        # less strict than the Cypher identifier validator. Just reject the
+        # obviously dangerous characters so we don't have to escape.
+        if not re.match(r"^[A-Za-z0-9._-]+$", database):
+            raise ValueError(
+                f"Invalid Neo4j database name: {database!r}. "
+                "Must match [A-Za-z0-9._-]+."
+            )
+        self._uri = uri
+        self._auth = auth
+        self._database = database
+
+    @property
+    def database(self) -> str:
+        return self._database
+
+    async def acquire(self) -> _GraphHandle:
+        """Return a graph handle ready to issue ``query(cypher, params)``."""
+        driver = _neo4j.AsyncGraphDatabase.driver(self._uri, auth=self._auth)
+        return _GraphHandle(driver, self._database)
+
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+_RowKey = tuple[Any, ...]  # The primary key tuple — single-element in v1.0
+_ROW_KEY_CHECKER = TypeChecker(tuple[Any, ...])
+_RowFingerprint = bytes
+
+
+class _RelationRowValue(NamedTuple):
+    """Value type for relation records.
+
+    Endpoint metadata is structured (not pre-formatted strings) so values can
+    bind via ``$``-parameters at query time rather than being string-interpolated.
+    """
+
+    from_label: str
+    from_pk_field: str
+    from_id: Any
+    to_label: str
+    to_pk_field: str
+    to_id: Any
+    fields: dict[str, Any]
+
+
+_RowValue = dict[str, Any] | _RelationRowValue
+ValueEncoder = Callable[[Any], Any]
+
+
+# ---------------------------------------------------------------------------
+# Neo4jType annotation
+# ---------------------------------------------------------------------------
+
+
+class Neo4jType(NamedTuple):
+    """
+    Annotation to override the default Python → Neo4j type mapping for a
+    column. The Neo4j Bolt protocol has rich native types (bytes, datetime,
+    duration, point) so most overrides are not needed, but this hook is
+    available for cases where you want to encode a value differently before
+    it's sent over the wire.
+
+    Use with ``typing.Annotated``::
+
+        from typing import Annotated
+        from cocoindex.connectors.neo4j import Neo4jType
+
+        @dataclass
+        class Row:
+            id: str
+            score: Annotated[float, Neo4jType("decimal", encoder=str)]
+    """
+
+    neo4j_type: str
+    encoder: ValueEncoder | None = None
+
+
+# ---------------------------------------------------------------------------
+# Value encoders
+# ---------------------------------------------------------------------------
+
+
+def _decimal_str(value: Any) -> str:
+    return str(value)
+
+
+def _ndarray_to_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return value.tolist()  # type: ignore[no-any-return]
+
+
+def _uuid_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Type mapping
+# ---------------------------------------------------------------------------
+
+
+class _TypeMapping(NamedTuple):
+    neo4j_type: str
+    encoder: ValueEncoder | None = None
+
+
+# Neo4j Bolt has native bool/int/float/str/bytes/list/map/datetime/date/time/
+# duration/point — most types pass through unencoded. The exceptions are:
+# Decimal (no native), UUID (sent as string by convention), and ndarray
+# (send as list, paired with vector-index DDL).
+_LEAF_TYPE_MAPPINGS: dict[type, _TypeMapping] = {
+    # Boolean
+    bool: _TypeMapping("BOOLEAN"),
+    # Integers
+    int: _TypeMapping("INTEGER"),
+    np.int8: _TypeMapping("INTEGER"),
+    np.int16: _TypeMapping("INTEGER"),
+    np.int32: _TypeMapping("INTEGER"),
+    np.int64: _TypeMapping("INTEGER"),
+    np.uint8: _TypeMapping("INTEGER"),
+    np.uint16: _TypeMapping("INTEGER"),
+    np.uint32: _TypeMapping("INTEGER"),
+    np.uint64: _TypeMapping("INTEGER"),
+    np.int_: _TypeMapping("INTEGER"),
+    np.uint: _TypeMapping("INTEGER"),
+    # Floats
+    float: _TypeMapping("FLOAT"),
+    np.float16: _TypeMapping("FLOAT"),
+    np.float32: _TypeMapping("FLOAT"),
+    np.float64: _TypeMapping("FLOAT"),
+    # Decimal — Neo4j has no decimal; store as string.
+    decimal.Decimal: _TypeMapping("STRING", _decimal_str),
+    # Strings — UUID encodes as STRING.
+    str: _TypeMapping("STRING"),
+    bytes: _TypeMapping("BYTES"),
+    uuid_mod.UUID: _TypeMapping("STRING", _uuid_str),
+    # Date/time — pass-through; Neo4j Bolt accepts datetime/date/time/timedelta.
+    datetime.date: _TypeMapping("DATE"),
+    datetime.time: _TypeMapping("LOCAL_TIME"),
+    datetime.datetime: _TypeMapping("ZONED_DATETIME"),
+    datetime.timedelta: _TypeMapping("DURATION"),
+}
+
+_OBJECT_MAPPING = _TypeMapping("MAP")
+_ARRAY_MAPPING = _TypeMapping("LIST<ANY>")
+
+
+async def _get_type_mapping(
+    python_type: Any, *, vector_schema: res_schema.VectorSchema | None = None
+) -> _TypeMapping:
+    type_info = analyze_type_info(python_type)
+
+    for annotation in type_info.annotations:
+        if isinstance(annotation, Neo4jType):
+            return _TypeMapping(annotation.neo4j_type, annotation.encoder)
+
+    base_type = type_info.base_type
+
+    if base_type in _LEAF_TYPE_MAPPINGS:
+        return _LEAF_TYPE_MAPPINGS[base_type]
+
+    if base_type is np.ndarray:
+        if vector_schema is None:
+            raise ValueError("VectorSchemaProvider is required for NumPy ndarray type.")
+        if vector_schema.size <= 0:
+            raise ValueError(f"Invalid vector dimension: {vector_schema.size}")
+        return _TypeMapping(
+            neo4j_type="LIST<FLOAT>",
+            encoder=_ndarray_to_list,
+        )
+    elif vector_schema is not None:
+        raise ValueError(
+            "VectorSchemaProvider is only supported for NumPy ndarray type. "
+            f"Got type: {python_type}"
+        )
+
+    if isinstance(type_info.variant, (SequenceType,)):
+        return _ARRAY_MAPPING
+    if isinstance(type_info.variant, (MappingType, RecordType, UnionType, AnyType)):
+        return _OBJECT_MAPPING
+
+    return _OBJECT_MAPPING
+
+
+# ---------------------------------------------------------------------------
+# ColumnDef
+# ---------------------------------------------------------------------------
+
+
+class ColumnDef(NamedTuple):
+    """Definition of a column (property) in a Neo4j table.
+
+    ``type`` is metadata-only — Neo4j does not enforce per-property types
+    server-side without optional property type constraints (Neo4j 5.9+).
+    The string contributes to the schema fingerprint and is surfaced in
+    error messages, but no DDL is emitted from it in this version.
+    """
+
+    type: str
+    nullable: bool = True
+    encoder: ValueEncoder | None = None
+
+
+# ---------------------------------------------------------------------------
+# TableSchema
+# ---------------------------------------------------------------------------
+
+RowT = TypeVar("RowT", default=dict[str, Any])
+
+
+@dataclass(slots=True)
+class TableSchema(Generic[RowT]):
+    """Schema definition for a Neo4j table (node label or relationship type).
+
+    Single-field primary key (named via ``primary_key``, default ``"id"``).
+    Compound primary keys are not supported in v1.0.
+    """
+
+    columns: dict[str, ColumnDef]
+    primary_key: str
+    row_type: type[RowT] | None
+
+    def __init__(
+        self,
+        columns: dict[str, ColumnDef],
+        *,
+        primary_key: str = "id",
+        row_type: type[RowT] | None = None,
+    ) -> None:
+        for col_name in columns:
+            _validate_identifier(col_name, "column name")
+        if primary_key not in columns:
+            raise ValueError(
+                f"primary_key {primary_key!r} not found in columns "
+                f"({sorted(columns)!r})"
+            )
+        self.columns = columns
+        self.primary_key = primary_key
+        self.row_type = row_type
+
+    @property
+    def value_field_names(self) -> list[str]:
+        """Column names other than the primary key, in declared order."""
+        return [c for c in self.columns if c != self.primary_key]
+
+    @classmethod
+    async def from_class(
+        cls,
+        record_type: type[RowT],
+        *,
+        primary_key: str = "id",
+        column_overrides: dict[str, Neo4jType | res_schema.VectorSchemaProvider]
+        | None = None,
+    ) -> "TableSchema[RowT]":
+        """Build a TableSchema by introspecting a dataclass / NamedTuple / Pydantic model."""
+        if not is_record_type(record_type):
+            raise TypeError(
+                f"record_type must be a record type (dataclass, NamedTuple, "
+                f"Pydantic model), got {type(record_type)}"
+            )
+        columns = await cls._columns_from_record_type(record_type, column_overrides)
+        return cls(columns, primary_key=primary_key, row_type=record_type)
+
+    @staticmethod
+    async def _columns_from_record_type(
+        record_type: type,
+        column_overrides: dict[str, Neo4jType | res_schema.VectorSchemaProvider] | None,
+    ) -> dict[str, ColumnDef]:
+        record_info = RecordType(record_type)
+        columns: dict[str, ColumnDef] = {}
+
+        for field in record_info.fields:
+            type_info = analyze_type_info(field.type_hint)
+
+            all_annotations: list[Any] = []
+            if (
+                override := column_overrides and column_overrides.get(field.name)
+            ) is not None:
+                all_annotations.append(override)
+            all_annotations.extend(type_info.annotations)
+
+            neo4j_type_annotation = next(
+                (t for t in all_annotations if isinstance(t, Neo4jType)), None
+            )
+            vector_schema = None
+            for annot in all_annotations:
+                vs = await res_schema.get_vector_schema(annot)
+                if vs is not None:
+                    vector_schema = vs
+                    break
+
+            if neo4j_type_annotation is not None:
+                type_mapping = _TypeMapping(
+                    neo4j_type_annotation.neo4j_type,
+                    neo4j_type_annotation.encoder,
+                )
+            else:
+                type_mapping = await _get_type_mapping(
+                    field.type_hint, vector_schema=vector_schema
+                )
+
+            columns[field.name] = ColumnDef(
+                type=type_mapping.neo4j_type.strip(),
+                nullable=type_info.nullable,
+                encoder=type_mapping.encoder,
+            )
+
+        return columns
+
+
+# ---------------------------------------------------------------------------
+# _RecordAction + _SharedRecordApplier
+# ---------------------------------------------------------------------------
+
+
+class _RecordAction(NamedTuple):
+    """Action to perform on a record (upsert or delete)."""
+
+    table_name: str
+    is_relation: bool
+    pk_field: str
+    record_id: Any
+    value: dict[str, Any] | None  # None = delete
+    # Relation endpoints (None for non-relation actions).
+    from_label: str | None
+    from_pk_field: str | None
+    from_id: Any | None
+    to_label: str | None
+    to_pk_field: str | None
+    to_id: Any | None
+
+
+class _SharedRecordApplier:
+    """Owns a TargetActionSink shared by all record handlers for one
+    Neo4j database.
+
+    Unlike FalkorDB which can't multi-statement transact, we wrap each
+    apply batch in a single Neo4j transaction so partial writes roll back
+    on failure. Actions are still grouped into the four-bucket ordering
+    so an edge is never written before its endpoints exist.
+    """
+
+    _graph: _GraphHandle
+    sink: coco.TargetActionSink[_RecordAction, None]
+
+    def __init__(self, graph: _GraphHandle) -> None:
+        self._graph = graph
+        self.sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_RecordAction]
+    ) -> None:
+        if not actions:
+            return
+
+        upsert_normal: list[_RecordAction] = []
+        upsert_relation: list[_RecordAction] = []
+        delete_relation: list[_RecordAction] = []
+        delete_normal: list[_RecordAction] = []
+
+        for action in actions:
+            if action.value is not None:
+                if action.is_relation:
+                    upsert_relation.append(action)
+                else:
+                    upsert_normal.append(action)
+            else:
+                if action.is_relation:
+                    delete_relation.append(action)
+                else:
+                    delete_normal.append(action)
+
+        async with self._graph._driver.session(  # noqa: SLF001
+            database=self._graph.database
+        ) as session:
+            tx = await session.begin_transaction()
+            try:
+                for action in upsert_normal:
+                    await self._apply_node_upsert(tx, action)
+                for action in upsert_relation:
+                    await self._apply_relation_upsert(tx, action)
+                for action in delete_relation:
+                    await self._apply_relation_delete(tx, action)
+                for action in delete_normal:
+                    await self._apply_node_delete(tx, action)
+                await tx.commit()
+            except BaseException:
+                await tx.rollback()
+                raise
+
+    @staticmethod
+    async def _apply_node_upsert(tx: Any, action: _RecordAction) -> None:
+        assert action.value is not None
+        # PK is always single-field in v1.0; props are everything except the PK.
+        pk_value = action.value.get(action.pk_field, action.record_id)
+        props = {k: v for k, v in action.value.items() if k != action.pk_field}
+        cypher = _cypher.build_node_upsert(
+            label=action.table_name,
+            pk_fields=[action.pk_field],
+            has_value_fields=bool(props),
+        )
+        params: dict[str, Any] = {"key_0": pk_value}
+        if props:
+            params["props"] = props
+        await tx.run(cypher, **params)
+
+    @staticmethod
+    async def _apply_node_delete(tx: Any, action: _RecordAction) -> None:
+        cypher = _cypher.build_node_delete(
+            label=action.table_name, pk_fields=[action.pk_field]
+        )
+        await tx.run(cypher, key_0=action.record_id)
+
+    @staticmethod
+    async def _apply_relation_upsert(tx: Any, action: _RecordAction) -> None:
+        assert action.value is not None
+        assert action.from_label is not None and action.from_pk_field is not None
+        assert action.to_label is not None and action.to_pk_field is not None
+        props = {k: v for k, v in action.value.items() if k != action.pk_field}
+        cypher = _cypher.build_relationship_upsert(
+            rel_type=action.table_name,
+            from_label=action.from_label,
+            from_pk_fields=[action.from_pk_field],
+            to_label=action.to_label,
+            to_pk_fields=[action.to_pk_field],
+            rel_pk_fields=[action.pk_field],
+            has_value_fields=bool(props),
+        )
+        params: dict[str, Any] = {
+            "from_key_0": action.from_id,
+            "to_key_0": action.to_id,
+            "rel_key_0": action.record_id,
+        }
+        if props:
+            params["props"] = props
+        await tx.run(cypher, **params)
+
+    @staticmethod
+    async def _apply_relation_delete(tx: Any, action: _RecordAction) -> None:
+        cypher = _cypher.build_relationship_delete(
+            rel_type=action.table_name, pk_fields=[action.pk_field]
+        )
+        await tx.run(cypher, key_0=action.record_id)
+
+
+# ---------------------------------------------------------------------------
+# Vector index
+# ---------------------------------------------------------------------------
+
+
+# Neo4j accepts only "cosine" and "euclidean" for vector.similarity_function.
+_METRIC_TO_NEO4J: dict[str, str] = {
+    "cosine": "cosine",
+    "euclidean": "euclidean",
+}
+
+
+class _VectorIndexSpec(NamedTuple):
+    field: str
+    metric: str
+    dimension: int
+
+
+_VectorIndexFingerprint = bytes
+
+
+class _VectorIndexAction(NamedTuple):
+    """Vector index DDL action.
+
+    ``index_name`` is always populated (carries the persisted index name
+    even on delete, so DROP can identify the index). ``spec`` is ``None``
+    only on delete.
+    """
+
+    name: str
+    table_name: str
+    index_name: str
+    spec: _VectorIndexSpec | None
+
+
+# Tracking record for a vector index — store the spec itself rather than just
+# its fingerprint so a subsequent delete can recover the field name.
+_VectorIndexTrackingRecord = _VectorIndexSpec
+
+
+class _VectorIndexHandler:
+    """Attachment handler for vector indexes on a Neo4j node label."""
+
+    _graph: _GraphHandle
+    _table_name: str
+    _sink: coco.TargetActionSink[_VectorIndexAction, None]
+
+    def __init__(self, graph: _GraphHandle, table_name: str) -> None:
+        self._graph = graph
+        self._table_name = table_name
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self,
+        context_provider: ContextProvider,
+        actions: Sequence[_VectorIndexAction],
+    ) -> None:
+        for action in actions:
+            if action.spec is None:
+                try:
+                    await self._graph.query(
+                        _cypher.build_vector_index_drop(action.index_name)
+                    )
+                except Exception as e:  # noqa: BLE001
+                    _logger.debug(
+                        "Neo4j DROP VECTOR INDEX %s (best-effort) failed: %s",
+                        action.index_name,
+                        e,
+                    )
+                continue
+
+            # Drop-and-recreate so a metric/dimension change takes effect.
+            try:
+                await self._graph.query(
+                    _cypher.build_vector_index_drop(action.index_name)
+                )
+            except Exception as e:  # noqa: BLE001
+                _logger.debug(
+                    "Neo4j DROP VECTOR INDEX (pre-create best-effort) failed: %s",
+                    e,
+                )
+            await self._graph.query(
+                _cypher.build_vector_index_create(
+                    name=action.index_name,
+                    label=action.table_name,
+                    field=action.spec.field,
+                    dimension=action.spec.dimension,
+                    metric=_METRIC_TO_NEO4J.get(action.spec.metric, action.spec.metric),
+                )
+            )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _VectorIndexSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_VectorIndexTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[_VectorIndexAction, _VectorIndexTrackingRecord, None]
+        | None
+    ):
+        assert isinstance(key, str)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            # Recover the field from the most recent tracked spec — needed
+            # to mint the index name for the DROP statement (Neo4j drops
+            # by name, but we don't persist the name separately).
+            prev_field: str | None = None
+            for prev in prev_possible_records:
+                prev_field = prev.field
+                break
+            if prev_field is None:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_VectorIndexAction(
+                    name=key,
+                    table_name=self._table_name,
+                    index_name=_cypher.vector_index_name(self._table_name, prev_field),
+                    spec=None,
+                ),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        if not prev_may_be_missing and all(
+            prev == desired_state for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_VectorIndexAction(
+                name=key,
+                table_name=self._table_name,
+                index_name=_cypher.vector_index_name(
+                    self._table_name, desired_state.field
+                ),
+                spec=desired_state,
+            ),
+            sink=self._sink,
+            tracking_record=desired_state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _RecordHandler
+# ---------------------------------------------------------------------------
+
+
+class _RecordHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
+    """Handler for record-level target states within a Neo4j table."""
+
+    _table_name: str
+    _is_relation: bool
+    _pk_field: str
+    _table_schema: TableSchema[Any] | None
+    _graph: _GraphHandle
+    _sink: coco.TargetActionSink[_RecordAction, None]
+
+    def __init__(
+        self,
+        table_name: str,
+        is_relation: bool,
+        pk_field: str,
+        table_schema: TableSchema[Any] | None,
+        graph: _GraphHandle,
+        sink: coco.TargetActionSink[_RecordAction, None],
+    ) -> None:
+        self._table_name = table_name
+        self._is_relation = is_relation
+        self._pk_field = pk_field
+        self._table_schema = table_schema
+        self._graph = graph
+        self._sink = sink
+
+    def attachments(self) -> dict[str, _VectorIndexHandler]:
+        # Eagerly declare all attachment types so the engine can clean up
+        # orphaned attachments even on runs that don't re-declare them.
+        return {
+            "vector_index": _VectorIndexHandler(self._graph, self._table_name),
+        }
+
+    def _encode_row(self, row_dict: dict[str, Any]) -> dict[str, Any]:
+        if self._table_schema is None:
+            return row_dict
+        out: dict[str, Any] = {}
+        for k, v in row_dict.items():
+            col = self._table_schema.columns.get(k)
+            if col is not None and col.encoder is not None and v is not None:
+                out[k] = col.encoder(v)
+            else:
+                out[k] = v
+        return out
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _RowValue | coco.NonExistenceType,
+        prev_possible_records: Collection[_RowFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_RecordAction, _RowFingerprint, None] | None:
+        key = _ROW_KEY_CHECKER.check(key)
+
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_RecordAction(
+                    table_name=self._table_name,
+                    is_relation=self._is_relation,
+                    pk_field=self._pk_field,
+                    record_id=key[0],
+                    value=None,
+                    from_label=None,
+                    from_pk_field=None,
+                    from_id=None,
+                    to_label=None,
+                    to_pk_field=None,
+                    to_id=None,
+                ),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(desired_state)
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        if isinstance(desired_state, _RelationRowValue):
+            from_label = desired_state.from_label
+            from_pk_field = desired_state.from_pk_field
+            from_id = desired_state.from_id
+            to_label = desired_state.to_label
+            to_pk_field = desired_state.to_pk_field
+            to_id = desired_state.to_id
+            encoded = self._encode_row(desired_state.fields)
+        else:
+            from_label = None
+            from_pk_field = None
+            from_id = None
+            to_label = None
+            to_pk_field = None
+            to_id = None
+            encoded = self._encode_row(desired_state)
+
+        return coco.TargetReconcileOutput(
+            action=_RecordAction(
+                table_name=self._table_name,
+                is_relation=self._is_relation,
+                pk_field=self._pk_field,
+                record_id=key[0],
+                value=encoded,
+                from_label=from_label,
+                from_pk_field=from_pk_field,
+                from_id=from_id,
+                to_label=to_label,
+                to_pk_field=to_pk_field,
+                to_id=to_id,
+            ),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Table-level types
+# ---------------------------------------------------------------------------
+
+
+class _TableKey(NamedTuple):
+    db_key: str
+    table_name: str
+
+
+_TABLE_KEY_CHECKER = TypeChecker(tuple[str, str])
+
+
+@dataclass
+class _TableSpec:
+    table_schema: TableSchema[Any] | None
+    primary_key: str
+    is_relation: bool
+    from_label: str | None
+    from_pk_field: str | None
+    to_label: str | None
+    to_pk_field: str | None
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+
+
+class _TableMainRecord(msgspec.Struct, frozen=True):
+    """Tracking record for table-level properties — change ⇒ DROP+CREATE index."""
+
+    has_schema: bool
+    is_relation: bool
+    primary_key: str
+    pk_type: str | None
+    from_label: str | None
+    from_pk_field: str | None
+    to_label: str | None
+    to_pk_field: str | None
+
+
+class _FieldTrackingRecord(msgspec.Struct, frozen=True):
+    """Per-field tracking record. Neo4j has optional property-type
+    constraints (5.9+) but this connector does not emit them yet, so the
+    record is fingerprint-only — schema fingerprint stability lets two
+    flows share a table only if they declare matching columns.
+    """
+
+    neo4j_type: str
+    nullable: bool
+
+
+_FIELD_SUBKEY_PREFIX: str = "field:"
+
+
+def _field_subkey(name: str) -> str:
+    return f"{_FIELD_SUBKEY_PREFIX}{name}"
+
+
+class _TableAction(NamedTuple):
+    key: _TableKey
+    spec: _TableSpec | coco.NonExistenceType
+    is_relation: bool
+    main_action: statediff.DiffAction | None
+    column_actions: dict[str, statediff.DiffAction]
+    # Recovered from the most recent system-managed prev tracking record.
+    # Needed on "delete"/"replace" to know what artifact to drop.
+    prev_pk_field: str | None
+    prev_is_relation: bool
+
+
+def _table_composite_tracking_record_from_spec(
+    spec: _TableSpec,
+) -> statediff.CompositeTrackingRecord[_TableMainRecord, str, _FieldTrackingRecord]:
+    schema = spec.table_schema
+    has_schema = schema is not None
+    pk_type: str | None = None
+    sub: dict[str, _FieldTrackingRecord] = {}
+
+    if schema is not None:
+        pk_col = schema.columns.get(spec.primary_key)
+        if pk_col is not None:
+            pk_type = pk_col.type
+        for col_name, col_def in schema.columns.items():
+            if col_name == spec.primary_key:
+                continue
+            sub[_field_subkey(col_name)] = _FieldTrackingRecord(
+                neo4j_type=col_def.type,
+                nullable=col_def.nullable,
+            )
+
+    main = _TableMainRecord(
+        has_schema=has_schema,
+        is_relation=spec.is_relation,
+        primary_key=spec.primary_key,
+        pk_type=pk_type,
+        from_label=spec.from_label,
+        from_pk_field=spec.from_pk_field,
+        to_label=spec.to_label,
+        to_pk_field=spec.to_pk_field,
+    )
+    return statediff.CompositeTrackingRecord(main=main, sub=sub)
+
+
+_TableTrackingRecord = statediff.MutualTrackingRecord[
+    statediff.CompositeTrackingRecord[_TableMainRecord, str, _FieldTrackingRecord]
+]
+
+
+# ---------------------------------------------------------------------------
+# _TableHandler
+# ---------------------------------------------------------------------------
+
+
+class _TableHandler(
+    coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RecordHandler]
+):
+    """Handler for table-level state — Cypher index DDL + uniqueness constraints."""
+
+    _sink: coco.TargetActionSink[_TableAction, _RecordHandler]
+
+    def __init__(self) -> None:
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _TableSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_TableTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[_TableAction, _TableTrackingRecord, _RecordHandler]
+        | None
+    ):
+        key = _TableKey(*_TABLE_KEY_CHECKER.check(key))
+
+        if coco.is_non_existence(desired_state):
+            tracking_record: _TableTrackingRecord | coco.NonExistenceType = (
+                coco.NON_EXISTENCE
+            )
+            is_relation = False
+        else:
+            tracking_record = statediff.MutualTrackingRecord(
+                tracking_record=_table_composite_tracking_record_from_spec(
+                    desired_state
+                ),
+                managed_by=desired_state.managed_by,
+            )
+            is_relation = desired_state.is_relation
+
+        resolved = statediff.resolve_system_transition(
+            statediff.TrackingRecordTransition(
+                tracking_record, prev_possible_records, prev_may_be_missing
+            )
+        )
+        main_action, column_transitions = statediff.diff_composite(resolved)
+
+        column_actions: dict[str, statediff.DiffAction] = {}
+        if main_action is None:
+            for sub_key, t in column_transitions.items():
+                action = statediff.diff(t)
+                if action is not None:
+                    column_actions[sub_key] = action
+
+        if (
+            main_action is None
+            and not column_actions
+            and coco.is_non_existence(desired_state)
+        ):
+            return None
+
+        # Recover prev PK + entity kind from the most recent system-managed
+        # tracking record so DROP can identify the underlying artifact.
+        prev_pk_field: str | None = None
+        prev_is_relation = False
+        for prev in prev_possible_records:
+            if prev.managed_by != target.ManagedBy.SYSTEM:
+                continue
+            prev_pk_field = prev.tracking_record.main.primary_key
+            prev_is_relation = prev.tracking_record.main.is_relation
+            break
+
+        child_invalidation: Literal["destructive", "lossy"] | None = None
+        if main_action == "replace":
+            child_invalidation = "destructive"
+        elif main_action is None and any(
+            a != "insert" for a in column_actions.values()
+        ):
+            # No incremental property DDL emitted in v1; treat column
+            # changes as lossy so dependents re-upsert defensively.
+            child_invalidation = "lossy"
+
+        return coco.TargetReconcileOutput(
+            action=_TableAction(
+                key=key,
+                spec=desired_state,
+                is_relation=is_relation,
+                main_action=main_action,
+                column_actions=column_actions,
+                prev_pk_field=prev_pk_field,
+                prev_is_relation=prev_is_relation,
+            ),
+            sink=self._sink,
+            tracking_record=tracking_record,
+            child_invalidation=child_invalidation,
+        )
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_TableAction]
+    ) -> list[coco.ChildTargetDef[_RecordHandler] | None]:
+        actions_list = list(actions)
+        outputs: list[coco.ChildTargetDef[_RecordHandler] | None] = [None] * len(
+            actions_list
+        )
+
+        # Group by db_key so each Neo4j driver is acquired once per batch.
+        by_db: dict[str, list[int]] = {}
+        for i, action in enumerate(actions_list):
+            by_db.setdefault(action.key.db_key, []).append(i)
+
+        for db_key, idxs in by_db.items():
+            factory: ConnectionFactory = context_provider.get(db_key)  # type: ignore[assignment]
+            graph = await factory.acquire()
+            shared_applier = _SharedRecordApplier(graph)
+
+            # Order: create nodes → create relations → drop relations → drop nodes.
+            create_normal: list[int] = []
+            create_relation: list[int] = []
+            remove_relation: list[int] = []
+            remove_normal: list[int] = []
+
+            for i in idxs:
+                action = actions_list[i]
+                if coco.is_non_existence(action.spec):
+                    if action.is_relation:
+                        remove_relation.append(i)
+                    else:
+                        remove_normal.append(i)
+                else:
+                    if action.is_relation:
+                        create_relation.append(i)
+                    else:
+                        create_normal.append(i)
+
+            ordered = create_normal + create_relation + remove_relation + remove_normal
+
+            for i in ordered:
+                action = actions_list[i]
+                spec = action.spec
+
+                if action.main_action in ("replace", "delete"):
+                    await self._drop_table_artifacts(graph, action.key, action)
+
+                if coco.is_non_existence(spec):
+                    outputs[i] = None
+                    continue
+
+                if action.main_action in ("insert", "upsert", "replace"):
+                    await self._create_table(graph, action.key, spec)
+                # No incremental column DDL — column_actions are tracked
+                # for fingerprint stability but not applied here.
+
+                outputs[i] = coco.ChildTargetDef(
+                    handler=_RecordHandler(
+                        table_name=action.key.table_name,
+                        is_relation=spec.is_relation,
+                        pk_field=spec.primary_key,
+                        table_schema=spec.table_schema,
+                        graph=graph,
+                        sink=shared_applier.sink,
+                    )
+                )
+
+        return outputs
+
+    @staticmethod
+    async def _create_table(
+        graph: _GraphHandle, key: _TableKey, spec: _TableSpec
+    ) -> None:
+        """Create the supporting Cypher index and uniqueness constraint.
+
+        Neo4j 5 has real CREATE CONSTRAINT … IS UNIQUE on node labels (and
+        IS RELATIONSHIP UNIQUE on relationship types in 5.7+). Neo4j auto-
+        creates a backing index for each constraint, so a separate CREATE
+        INDEX on the same property is redundant for nodes — but we still
+        emit one for relationship types where the constraint isn't a
+        full primary-key.
+        """
+        idx_name = _cypher.index_name(
+            "rel" if spec.is_relation else "node",
+            key.table_name,
+            [spec.primary_key],
+        )
+        if spec.is_relation:
+            await graph.query(
+                _cypher.build_relationship_index_create(
+                    idx_name, key.table_name, [spec.primary_key]
+                )
+            )
+        else:
+            constraint_name = _cypher.constraint_name(
+                key.table_name, [spec.primary_key]
+            )
+            await graph.query(
+                _cypher.build_constraint_create(
+                    constraint_name, key.table_name, [spec.primary_key]
+                )
+            )
+
+    @staticmethod
+    async def _drop_table_artifacts(
+        graph: _GraphHandle, key: _TableKey, action: _TableAction
+    ) -> None:
+        """Drop the supporting Cypher index + uniqueness constraint on
+        table teardown.
+
+        Uses ``prev_pk_field`` recovered during reconcile from the previous
+        tracking record — that's what was actually CREATEd, so it's what
+        we need to DROP.
+        """
+        pk_field = action.prev_pk_field
+        is_relation = action.prev_is_relation
+        if pk_field is None and isinstance(action.spec, _TableSpec):
+            pk_field = action.spec.primary_key
+            is_relation = action.spec.is_relation
+        if pk_field is None:
+            return  # Nothing to drop.
+
+        if is_relation:
+            idx_name = _cypher.index_name("rel", key.table_name, [pk_field])
+            await graph.query(_cypher.build_relationship_index_drop(idx_name))
+        else:
+            cn = _cypher.constraint_name(key.table_name, [pk_field])
+            await graph.query(_cypher.build_constraint_drop(cn))
+
+
+# ---------------------------------------------------------------------------
+# Root provider registration
+# ---------------------------------------------------------------------------
+
+_table_provider = coco.register_root_target_states_provider(
+    "cocoindex/neo4j/table", _TableHandler()
+)
+
+
+# ---------------------------------------------------------------------------
+# TableTarget
+# ---------------------------------------------------------------------------
+
+
+class TableTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["TableTarget[RowT]"]
+):
+    """A target for writing records to a Neo4j node table."""
+
+    _provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS]
+    _table_schema: TableSchema[RowT] | None
+    _table_name: str
+    _primary_key: str
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS],
+        table_schema: TableSchema[RowT] | None,
+        table_name: str,
+        primary_key: str,
+    ) -> None:
+        self._provider = provider
+        self._table_schema = table_schema
+        self._table_name = table_name
+        self._primary_key = primary_key
+
+    @property
+    def table_name(self) -> str:
+        return self._table_name
+
+    @property
+    def primary_key(self) -> str:
+        return self._primary_key
+
+    def declare_record(self: TableTarget[RowT], *, row: RowT) -> None:
+        """Declare a record (node) to be upserted to this table."""
+        row_dict = self._row_to_dict(row)
+        if self._primary_key not in row_dict:
+            raise ValueError(f"row is missing primary key field {self._primary_key!r}")
+        pk_values = (row_dict[self._primary_key],)
+        coco.declare_target_state(self._provider.target_state(pk_values, row_dict))
+
+    declare_row = declare_record
+
+    def _row_to_dict(self, row: RowT) -> dict[str, Any]:
+        if self._table_schema is not None:
+            out: dict[str, Any] = {}
+            for col_name, col in self._table_schema.columns.items():
+                if isinstance(row, dict):
+                    value = row.get(col_name)
+                else:
+                    value = getattr(row, col_name)
+                if value is not None and col.encoder is not None:
+                    value = col.encoder(value)
+                out[col_name] = value
+            return out
+        if isinstance(row, dict):
+            return dict(row)
+        record_info = RecordType(type(row))
+        return {f.name: getattr(row, f.name) for f in record_info.fields}
+
+    def declare_vector_index(
+        self: TableTarget[RowT],
+        *,
+        name: str | None = None,
+        field: str,
+        metric: Literal["cosine", "euclidean"] = "cosine",
+        dimension: int,
+    ) -> None:
+        """Declare a vector index on a column of this table."""
+        _validate_identifier(field, "vector index field")
+        if name is None:
+            name = f"vec_{self._table_name}__{field}"
+        _validate_identifier(name, "vector index name")
+        if dimension <= 0:
+            raise ValueError(f"Invalid vector dimension: {dimension}")
+        spec = _VectorIndexSpec(field=field, metric=metric, dimension=dimension)
+        att_provider = self._provider.attachment("vector_index")
+        coco.declare_target_state(att_provider.target_state(name, spec))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+# ---------------------------------------------------------------------------
+# RelationTarget
+# ---------------------------------------------------------------------------
+
+
+class RelationTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["RelationTarget[RowT]"]
+):
+    """A target for writing relation records (edges) to a Neo4j relationship type."""
+
+    _provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS]
+    _table_name: str
+    _table_schema: TableSchema[RowT] | None
+    _primary_key: str
+    _from_table: TableTarget[Any]
+    _to_table: TableTarget[Any]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS],
+        table_name: str,
+        table_schema: TableSchema[RowT] | None,
+        primary_key: str,
+        from_table: TableTarget[Any],
+        to_table: TableTarget[Any],
+    ) -> None:
+        self._provider = provider
+        self._table_name = table_name
+        self._table_schema = table_schema
+        self._primary_key = primary_key
+        self._from_table = from_table
+        self._to_table = to_table
+
+    def declare_relation(
+        self: RelationTarget[RowT],
+        *,
+        from_id: Any,
+        to_id: Any,
+        record: RowT | None = None,
+    ) -> None:
+        """Declare a relation record (edge)."""
+        from_label = self._from_table.table_name
+        from_pk_field = self._from_table.primary_key
+        to_label = self._to_table.table_name
+        to_pk_field = self._to_table.primary_key
+
+        if record is not None:
+            if self._table_schema is not None:
+                row_dict: dict[str, Any] = {}
+                for col_name, col in self._table_schema.columns.items():
+                    if col_name == self._primary_key:
+                        continue
+                    if isinstance(record, dict):
+                        value = record.get(col_name)
+                    else:
+                        value = getattr(record, col_name)
+                    if value is not None and col.encoder is not None:
+                        value = col.encoder(value)
+                    row_dict[col_name] = value
+                record_id = (
+                    record.get(self._primary_key)
+                    if isinstance(record, dict)
+                    else getattr(record, self._primary_key, None)
+                )
+            elif isinstance(record, dict):
+                row_dict = {k: v for k, v in record.items() if k != self._primary_key}
+                record_id = record.get(self._primary_key)
+            else:
+                record_info = RecordType(type(record))
+                row_dict = {
+                    f.name: getattr(record, f.name)
+                    for f in record_info.fields
+                    if f.name != self._primary_key
+                }
+                record_id = getattr(record, self._primary_key, None)
+        else:
+            row_dict = {}
+            record_id = None
+
+        if record_id is None:
+            record_id = f"{from_label}_{from_id}_{to_label}_{to_id}"
+
+        row_value: _RowValue = _RelationRowValue(
+            from_label=from_label,
+            from_pk_field=from_pk_field,
+            from_id=from_id,
+            to_label=to_label,
+            to_pk_field=to_pk_field,
+            to_id=to_id,
+            fields=row_dict,
+        )
+
+        pk_values = (record_id,)
+        coco.declare_target_state(self._provider.target_state(pk_values, row_value))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+# ---------------------------------------------------------------------------
+# Module-level entry points
+# ---------------------------------------------------------------------------
+
+
+def table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> coco.TargetState[_RecordHandler]:
+    """Create a ``TargetState`` for a Neo4j node table (label)."""
+    _validate_identifier(table_name, "table name")
+    _validate_identifier(primary_key, "primary key")
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match the schema's "
+            f"declared primary_key {table_schema.primary_key!r}"
+        )
+    key = _TableKey(db_key=db.key, table_name=table_name)
+    spec = _TableSpec(
+        table_schema=table_schema,
+        primary_key=primary_key,
+        is_relation=False,
+        from_label=None,
+        from_pk_field=None,
+        to_label=None,
+        to_pk_field=None,
+        managed_by=managed_by,
+    )
+    return _table_provider.target_state(key, spec)
+
+
+def declare_table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT, coco.PendingS]:
+    """Declare a node table target.
+
+    Use this for tables that exist only as relationship endpoints — no
+    records flow into this declaration's own handler.
+    """
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's "
+            f"{table_schema.primary_key!r}"
+        )
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = coco.declare_target_state_with_child(
+        table_target(
+            db, table_name, table_schema, primary_key=pk, managed_by=managed_by
+        )
+    )
+    return TableTarget(provider, table_schema, table_name, pk)
+
+
+async def mount_table_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT]:
+    """Mount a node table target ready to receive ``declare_record`` calls."""
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's "
+            f"{table_schema.primary_key!r}"
+        )
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = await coco.mount_target(
+        table_target(
+            db, table_name, table_schema, primary_key=pk, managed_by=managed_by
+        )
+    )
+    return TableTarget(provider, table_schema, table_name, pk)
+
+
+def relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> coco.TargetState[_RecordHandler]:
+    """Create a ``TargetState`` for a Neo4j relationship type."""
+    _validate_identifier(table_name, "relation table name")
+    _validate_identifier(primary_key, "primary key")
+    _validate_identifier(from_table.table_name, "from table name")
+    _validate_identifier(to_table.table_name, "to table name")
+    if table_schema is not None and table_schema.primary_key != primary_key:
+        raise ValueError(
+            f"primary_key {primary_key!r} does not match schema's "
+            f"{table_schema.primary_key!r}"
+        )
+    key = _TableKey(db_key=db.key, table_name=table_name)
+    spec = _TableSpec(
+        table_schema=table_schema,
+        primary_key=primary_key,
+        is_relation=True,
+        from_label=from_table.table_name,
+        from_pk_field=from_table.primary_key,
+        to_label=to_table.table_name,
+        to_pk_field=to_table.primary_key,
+        managed_by=managed_by,
+    )
+    return _table_provider.target_state(key, spec)
+
+
+def declare_relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> RelationTarget[RowT, coco.PendingS]:
+    """Declare a relation table target."""
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = coco.declare_target_state_with_child(
+        relation_target(
+            db,
+            table_name,
+            from_table,
+            to_table,
+            table_schema,
+            primary_key=pk,
+            managed_by=managed_by,
+        )
+    )
+    return RelationTarget(provider, table_name, table_schema, pk, from_table, to_table)
+
+
+async def mount_relation_target(
+    db: ContextKey[ConnectionFactory],
+    table_name: str,
+    from_table: TableTarget[Any],
+    to_table: TableTarget[Any],
+    table_schema: TableSchema[RowT] | None = None,
+    *,
+    primary_key: str = "id",
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> RelationTarget[RowT]:
+    """Mount a relation table target ready to receive ``declare_relation`` calls."""
+    pk = table_schema.primary_key if table_schema is not None else primary_key
+    provider = await coco.mount_target(
+        relation_target(
+            db,
+            table_name,
+            from_table,
+            to_table,
+            table_schema,
+            primary_key=pk,
+            managed_by=managed_by,
+        )
+    )
+    return RelationTarget(provider, table_name, table_schema, pk, from_table, to_table)
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "ColumnDef",
+    "ConnectionFactory",
+    "Neo4jType",
+    "RelationTarget",
+    "TableSchema",
+    "TableTarget",
+    "ValueEncoder",
+    "declare_relation_target",
+    "declare_table_target",
+    "mount_relation_target",
+    "mount_table_target",
+    "relation_target",
+    "table_target",
+]

--- a/python/tests/connectors/test_neo4j_target.py
+++ b/python/tests/connectors/test_neo4j_target.py
@@ -1,0 +1,249 @@
+"""Tests for the Neo4j target connector.
+
+Run with:
+    uv run pytest python/tests/connectors/test_neo4j_target.py -v
+
+Unit tests run without a server. Integration tests require a running Neo4j
+(spun up automatically via testcontainers when ``NEO4J_TEST_SERVER=1``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# =============================================================================
+# Cypher builder unit tests — no DB needed, no driver needed
+# =============================================================================
+
+
+from cocoindex.connectors.neo4j._cypher import (
+    build_constraint_create,
+    build_constraint_drop,
+    build_node_delete,
+    build_node_index_create,
+    build_node_index_drop,
+    build_node_upsert,
+    build_relationship_delete,
+    build_relationship_index_create,
+    build_relationship_index_drop,
+    build_relationship_upsert,
+    build_vector_index_create,
+    build_vector_index_drop,
+    constraint_name,
+    index_name,
+    validate_identifier,
+    vector_index_name,
+)
+
+
+class TestValidateIdentifier:
+    @pytest.mark.parametrize(
+        "name", ["users", "_private", "T1", "a_b_c", "X", "Document", "MENTION"]
+    )
+    def test_valid(self, name: str) -> None:
+        validate_identifier(name, "test")
+
+    @pytest.mark.parametrize(
+        "name",
+        ["my-table", "123abc", "", "has space", "ba`ck", "semi;colon", "a.b", "X-Y"],
+    )
+    def test_invalid(self, name: str) -> None:
+        with pytest.raises(ValueError, match="Invalid Neo4j"):
+            validate_identifier(name, "test")
+
+
+class TestNameBuilders:
+    def test_index_name_node(self) -> None:
+        assert index_name("node", "Document", ["filename"]) == (
+            "coco_idx_node_Document__filename"
+        )
+
+    def test_index_name_relationship(self) -> None:
+        assert index_name("rel", "MENTION", ["id"]) == "coco_idx_rel_MENTION__id"
+
+    def test_index_name_compound_pk(self) -> None:
+        assert index_name("node", "X", ["a", "b"]) == "coco_idx_node_X__a__b"
+
+    def test_constraint_name(self) -> None:
+        assert constraint_name("Document", ["filename"]) == (
+            "coco_uniq_Document__filename"
+        )
+
+    def test_vector_index_name(self) -> None:
+        assert vector_index_name("Document", "embedding") == (
+            "coco_vec_Document__embedding"
+        )
+
+
+class TestNodeUpsertCypher:
+    def test_single_pk_with_props(self) -> None:
+        assert (
+            build_node_upsert("Document", ["filename"], True)
+            == "MERGE (n:`Document` {`filename`: $key_0}) SET n += $props"
+        )
+
+    def test_single_pk_no_props(self) -> None:
+        assert (
+            build_node_upsert("Document", ["filename"], False)
+            == "MERGE (n:`Document` {`filename`: $key_0})"
+        )
+
+    def test_compound_pk(self) -> None:
+        # Same shape as FalkorDB; Neo4j MERGE accepts compound keys.
+        assert build_node_upsert("X", ["a", "b"], True) == (
+            "MERGE (n:`X` {`a`: $key_0, `b`: $key_1}) SET n += $props"
+        )
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_node_upsert("X", [], True)
+
+
+class TestNodeDeleteCypher:
+    def test_uses_detach_delete(self) -> None:
+        # DETACH DELETE protects against DELETE failing on nodes that still
+        # have incident edges another flow owns.
+        assert (
+            build_node_delete("Document", ["filename"])
+            == "MATCH (n:`Document` {`filename`: $key_0}) DETACH DELETE n"
+        )
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_node_delete("X", [])
+
+
+class TestRelationshipUpsertCypher:
+    def test_three_merges_with_props(self) -> None:
+        assert build_relationship_upsert(
+            "REL", "Entity", ["value"], "Entity", ["value"], ["id"], True
+        ) == (
+            "MERGE (s:`Entity` {`value`: $from_key_0}) "
+            "MERGE (t:`Entity` {`value`: $to_key_0}) "
+            "MERGE (s)-[r:`REL` {`id`: $rel_key_0}]->(t) "
+            "SET r += $props"
+        )
+
+    def test_no_set_on_endpoints(self) -> None:
+        # Endpoints' properties are owned by their own table's _RecordHandler.
+        cypher = build_relationship_upsert("REL", "A", ["x"], "B", ["y"], ["id"], True)
+        assert "SET s" not in cypher
+        assert "SET t" not in cypher
+        assert "SET r += $props" in cypher
+
+    def test_no_props(self) -> None:
+        assert build_relationship_upsert(
+            "REL", "A", ["x"], "B", ["y"], ["id"], False
+        ) == (
+            "MERGE (s:`A` {`x`: $from_key_0}) "
+            "MERGE (t:`B` {`y`: $to_key_0}) "
+            "MERGE (s)-[r:`REL` {`id`: $rel_key_0}]->(t)"
+        )
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_relationship_upsert("REL", "A", [], "B", ["y"], ["id"], True)
+        with pytest.raises(ValueError):
+            build_relationship_upsert("REL", "A", ["x"], "B", [], ["id"], True)
+        with pytest.raises(ValueError):
+            build_relationship_upsert("REL", "A", ["x"], "B", ["y"], [], True)
+
+
+class TestRelationshipDeleteCypher:
+    def test_does_not_cascade(self) -> None:
+        cypher = build_relationship_delete("REL", ["id"])
+        assert cypher == "MATCH ()-[r:`REL` {`id`: $key_0}]->() DELETE r"
+        assert "DELETE s" not in cypher
+        assert "DELETE t" not in cypher
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_relationship_delete("REL", [])
+
+
+class TestIndexDdlCypher:
+    def test_node_index_create_named_with_if_not_exists(self) -> None:
+        # Neo4j 5 syntax: CREATE INDEX <name> IF NOT EXISTS FOR (n:L) ON (n.f)
+        assert build_node_index_create(
+            "coco_idx_node_Document__filename", "Document", ["filename"]
+        ) == (
+            "CREATE INDEX `coco_idx_node_Document__filename` IF NOT EXISTS "
+            "FOR (n:`Document`) ON (n.`filename`)"
+        )
+
+    def test_node_index_create_compound(self) -> None:
+        assert build_node_index_create("idx_x", "X", ["a", "b"]) == (
+            "CREATE INDEX `idx_x` IF NOT EXISTS FOR (n:`X`) ON (n.`a`, n.`b`)"
+        )
+
+    def test_node_index_drop_uses_name(self) -> None:
+        # Unlike FalkorDB's by-(label,field) drop, Neo4j drops by name.
+        assert build_node_index_drop("coco_idx_node_Document__filename") == (
+            "DROP INDEX `coco_idx_node_Document__filename` IF EXISTS"
+        )
+
+    def test_relationship_index_create(self) -> None:
+        assert build_relationship_index_create(
+            "coco_idx_rel_REL__id", "REL", ["id"]
+        ) == (
+            "CREATE INDEX `coco_idx_rel_REL__id` IF NOT EXISTS "
+            "FOR ()-[r:`REL`]-() ON (r.`id`)"
+        )
+
+    def test_relationship_index_drop_uses_name(self) -> None:
+        assert build_relationship_index_drop("coco_idx_rel_REL__id") == (
+            "DROP INDEX `coco_idx_rel_REL__id` IF EXISTS"
+        )
+
+
+class TestConstraintDdlCypher:
+    def test_single_field_creates_unique_constraint(self) -> None:
+        assert build_constraint_create(
+            "coco_uniq_Document__filename", "Document", ["filename"]
+        ) == (
+            "CREATE CONSTRAINT `coco_uniq_Document__filename` IF NOT EXISTS "
+            "FOR (n:`Document`) REQUIRE n.`filename` IS UNIQUE"
+        )
+
+    def test_compound_creates_node_key(self) -> None:
+        # Neo4j 5: REQUIRE (n.a, n.b) IS NODE KEY
+        assert build_constraint_create("c", "X", ["a", "b"]) == (
+            "CREATE CONSTRAINT `c` IF NOT EXISTS "
+            "FOR (n:`X`) REQUIRE (n.`a`, n.`b`) IS NODE KEY"
+        )
+
+    def test_drop(self) -> None:
+        assert build_constraint_drop("coco_uniq_Document__filename") == (
+            "DROP CONSTRAINT `coco_uniq_Document__filename` IF EXISTS"
+        )
+
+    def test_empty_fields_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_constraint_create("c", "X", [])
+
+
+class TestVectorIndexCypher:
+    def test_create(self) -> None:
+        assert build_vector_index_create(
+            "coco_vec_Doc__embedding", "Doc", "embedding", 384, "cosine"
+        ) == (
+            "CREATE VECTOR INDEX `coco_vec_Doc__embedding` IF NOT EXISTS "
+            "FOR (n:`Doc`) ON n.`embedding` "
+            "OPTIONS { indexConfig: { "
+            "`vector.dimensions`: 384, "
+            "`vector.similarity_function`: 'cosine' } }"
+        )
+
+    def test_drop_uses_name(self) -> None:
+        # Neo4j vector indexes share the index namespace, drop by name.
+        assert build_vector_index_drop("coco_vec_Doc__embedding") == (
+            "DROP INDEX `coco_vec_Doc__embedding` IF EXISTS"
+        )
+
+    def test_zero_dimension_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            build_vector_index_create("c", "Doc", "embedding", 0, "cosine")
+
+    def test_negative_dimension_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            build_vector_index_create("c", "Doc", "embedding", -1, "cosine")

--- a/python/tests/connectors/test_neo4j_target.py
+++ b/python/tests/connectors/test_neo4j_target.py
@@ -9,13 +9,15 @@ Unit tests run without a server. Integration tests require a running Neo4j
 
 from __future__ import annotations
 
+import os
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
 import pytest
+import pytest_asyncio
 
-# =============================================================================
-# Cypher builder unit tests — no DB needed, no driver needed
-# =============================================================================
-
-
+import cocoindex as coco
 from cocoindex.connectors.neo4j._cypher import (
     build_constraint_create,
     build_constraint_drop,
@@ -34,6 +36,41 @@ from cocoindex.connectors.neo4j._cypher import (
     validate_identifier,
     vector_index_name,
 )
+
+from tests import common
+
+coco_env = common.create_test_env(__file__)
+
+
+# =============================================================================
+# Skip gates
+# =============================================================================
+
+try:
+    import neo4j as _neo4j  # type: ignore[import-not-found]  # noqa: F401
+
+    HAS_NEO4J = True
+except ImportError:
+    HAS_NEO4J = False
+
+requires_neo4j = pytest.mark.skipif(not HAS_NEO4J, reason="neo4j is not installed")
+
+_HAS_NEO4J_SERVER = bool(os.environ.get("NEO4J_TEST_SERVER"))
+
+requires_neo4j_server = pytest.mark.skipif(
+    not (HAS_NEO4J and _HAS_NEO4J_SERVER),
+    reason="NEO4J_TEST_SERVER is not set",
+)
+
+if HAS_NEO4J:
+    from cocoindex.connectors import neo4j as neo  # type: ignore[attr-defined]
+
+    KG_DB: coco.ContextKey[Any] = coco.ContextKey("test_neo4j_kg")
+
+
+# =============================================================================
+# Cypher builder unit tests — no DB needed, no driver needed
+# =============================================================================
 
 
 class TestValidateIdentifier:
@@ -247,3 +284,424 @@ class TestVectorIndexCypher:
     def test_negative_dimension_rejected(self) -> None:
         with pytest.raises(ValueError):
             build_vector_index_create("c", "Doc", "embedding", -1, "cosine")
+
+
+# =============================================================================
+# Identifier-validation-at-API-entry tests (require neo4j package, no server)
+# =============================================================================
+
+
+@requires_neo4j
+class TestIdentifierValidationAtApiEntryPoints:
+    def test_table_schema_invalid_column(self) -> None:
+        with pytest.raises(ValueError, match="column name"):
+            neo.TableSchema(
+                columns={
+                    "id": neo.ColumnDef(type="STRING"),
+                    "bad-name": neo.ColumnDef(type="STRING"),
+                },
+                primary_key="id",
+            )
+
+    def test_table_schema_pk_must_exist_in_columns(self) -> None:
+        with pytest.raises(ValueError, match="primary_key"):
+            neo.TableSchema(
+                columns={"id": neo.ColumnDef(type="STRING")},
+                primary_key="missing",
+            )
+
+    def test_table_target_invalid_name(self) -> None:
+        with pytest.raises(ValueError, match="table name"):
+            neo.table_target(KG_DB, "bad-table")
+
+    def test_relation_target_invalid_name(self) -> None:
+        from typing import cast
+
+        with pytest.raises(ValueError, match="relation table name"):
+            neo.relation_target(
+                KG_DB,
+                "bad-rel",
+                cast(Any, None),
+                cast(Any, None),
+            )
+
+    def test_connection_factory_invalid_database_name(self) -> None:
+        with pytest.raises(ValueError, match="database name"):
+            neo.ConnectionFactory(uri="bolt://localhost:7687", database="bad name")
+
+
+# =============================================================================
+# TableSchema.from_class type mapping
+# =============================================================================
+
+
+@requires_neo4j
+class TestTableSchemaFromClass:
+    @pytest.mark.asyncio
+    async def test_basic_dataclass(self) -> None:
+        @dataclass
+        class Row:
+            id: str
+            count: int
+            score: float
+            flag: bool
+
+        schema = await neo.TableSchema.from_class(Row, primary_key="id")
+        assert schema.primary_key == "id"
+        assert schema.columns["id"].type == "STRING"
+        assert schema.columns["count"].type == "INTEGER"
+        assert schema.columns["score"].type == "FLOAT"
+        assert schema.columns["flag"].type == "BOOLEAN"
+        assert schema.value_field_names == ["count", "score", "flag"]
+
+    @pytest.mark.asyncio
+    async def test_custom_pk(self) -> None:
+        @dataclass
+        class Doc:
+            filename: str
+            title: str
+
+        schema = await neo.TableSchema.from_class(Doc, primary_key="filename")
+        assert schema.primary_key == "filename"
+        assert schema.value_field_names == ["title"]
+
+
+# =============================================================================
+# Integration tests — require running Neo4j (testcontainers spins one up)
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def neo4j_uri_auth() -> Iterator[tuple[str, tuple[str, str]]]:
+    """Spin up a Neo4j 5.13 container once per test module."""
+    if not (HAS_NEO4J and _HAS_NEO4J_SERVER):
+        pytest.skip("NEO4J_TEST_SERVER is not set")
+
+    from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-untyped]
+
+    container = Neo4jContainer(
+        "neo4j:5.26-community", username="neo4j", password="cocoindex"
+    )
+    container.start()
+    try:
+        uri = container.get_connection_url()
+        auth = ("neo4j", "cocoindex")
+        yield uri, auth
+    finally:
+        container.stop()
+
+
+@pytest_asyncio.fixture
+async def neo4j_clean(
+    neo4j_uri_auth: tuple[str, tuple[str, str]],
+) -> AsyncIterator[tuple[str, tuple[str, str]]]:
+    """Wipe the default `neo4j` database before each test.
+
+    Neo4j community has a single mutable database; isolation between tests
+    is by truncation rather than by separate database name.
+    """
+    uri, auth = neo4j_uri_auth
+    driver = _neo4j.AsyncGraphDatabase.driver(uri, auth=auth)
+    async with driver.session(database="neo4j") as session:
+        await session.run("MATCH (n) DETACH DELETE n")
+        # Drop any constraints/indexes the previous test left behind.
+        result = await session.run("SHOW CONSTRAINTS YIELD name")
+        names = [r["name"] async for r in result]
+        for n in names:
+            await session.run(f"DROP CONSTRAINT `{n}` IF EXISTS")
+        result = await session.run("SHOW INDEXES YIELD name, type")
+        idx = [(r["name"], r["type"]) async for r in result]
+        for n, t in idx:
+            if t == "LOOKUP":
+                continue  # auto-created, can't drop
+            await session.run(f"DROP INDEX `{n}` IF EXISTS")
+    await driver.close()
+    yield uri, auth
+
+
+async def _read_nodes(
+    uri: str, auth: tuple[str, str], label: str
+) -> list[dict[str, Any]]:
+    driver = _neo4j.AsyncGraphDatabase.driver(uri, auth=auth)
+    try:
+        async with driver.session(database="neo4j") as session:
+            result = await session.run(
+                f"MATCH (n:`{label}`) RETURN properties(n) AS props"
+            )
+            return [r["props"] async for r in result]
+    finally:
+        await driver.close()
+
+
+async def _read_relationships(
+    uri: str, auth: tuple[str, str], rel_type: str
+) -> list[tuple[dict[str, Any], dict[str, Any], dict[str, Any]]]:
+    driver = _neo4j.AsyncGraphDatabase.driver(uri, auth=auth)
+    try:
+        async with driver.session(database="neo4j") as session:
+            result = await session.run(
+                f"MATCH (s)-[r:`{rel_type}`]->(t) "
+                f"RETURN properties(s) AS s, properties(t) AS t, properties(r) AS r"
+            )
+            return [(row["s"], row["t"], row["r"]) async for row in result]
+    finally:
+        await driver.close()
+
+
+# Module-level state shared with declare functions (mirrors falkordb pattern).
+_node_rows: list[Any] = []
+_rel_pairs: list[tuple[Any, Any]] = []
+
+
+if HAS_NEO4J:
+
+    @dataclass
+    class Document:
+        filename: str
+        title: str
+        summary: str
+
+    @dataclass
+    class Entity:
+        value: str
+
+    @dataclass
+    class RelRow:
+        id: str
+        predicate: str
+
+    async def _declare_documents_only() -> None:
+        schema = await neo.TableSchema.from_class(Document, primary_key="filename")
+        table: Any = await coco.use_mount(  # type: ignore[call-overload]
+            coco.component_subpath("setup", "doc_table"),
+            neo.mount_table_target,  # type: ignore[arg-type]
+            KG_DB,
+            "Document",
+            schema,
+            primary_key="filename",
+        )
+        for row in _node_rows:
+            table.declare_record(row=row)
+
+    async def _declare_entities_and_relationships() -> None:
+        entity_schema = await neo.TableSchema.from_class(Entity, primary_key="value")
+        rel_schema = await neo.TableSchema.from_class(RelRow, primary_key="id")
+        entity_table: Any = await coco.use_mount(  # type: ignore[call-overload]
+            coco.component_subpath("setup", "entity_table"),
+            neo.mount_table_target,
+            KG_DB,
+            "Entity",
+            entity_schema,
+            primary_key="value",
+        )
+        rel_table: Any = await coco.use_mount(  # type: ignore[call-overload]
+            coco.component_subpath("setup", "rel_table"),
+            neo.mount_relation_target,
+            KG_DB,
+            "REL",
+            entity_table,
+            entity_table,
+            rel_schema,
+            primary_key="id",
+        )
+        seen_entities: set[str] = set()
+        for from_id, to_id in _rel_pairs:
+            for v in (from_id, to_id):
+                if v not in seen_entities:
+                    entity_table.declare_record(row=Entity(value=v))
+                    seen_entities.add(v)
+            rel_table.declare_relation(
+                from_id=from_id,
+                to_id=to_id,
+                record=RelRow(id=f"{from_id}->{to_id}", predicate="connects"),
+            )
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_node_upsert_and_readback(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    global _node_rows
+    uri, auth = neo4j_clean
+    _node_rows = [
+        Document(filename="a.md", title="A", summary="alpha"),
+        Document(filename="b.md", title="B", summary="beta"),
+    ]
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_node_upsert", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+
+    rows = await _read_nodes(uri, auth, "Document")
+    by_fn = {r["filename"]: r for r in rows}
+    assert set(by_fn) == {"a.md", "b.md"}
+    assert by_fn["a.md"]["title"] == "A"
+    assert by_fn["a.md"]["summary"] == "alpha"
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_reconcile_twice_is_noop(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    """Second update with identical input must not produce duplicate writes."""
+    global _node_rows
+    uri, auth = neo4j_clean
+    _node_rows = [Document(filename="a.md", title="A", summary="alpha")]
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_noop", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    rows1 = await _read_nodes(uri, auth, "Document")
+    await app.update()  # identical input
+    rows2 = await _read_nodes(uri, auth, "Document")
+    assert rows1 == rows2
+    assert len(rows2) == 1
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_modify_value_triggers_one_upsert(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    global _node_rows
+    uri, auth = neo4j_clean
+    _node_rows = [Document(filename="a.md", title="A", summary="alpha")]
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_modify", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    _node_rows[0] = Document(filename="a.md", title="A", summary="ALPHA-2")
+    await app.update()
+    rows = await _read_nodes(uri, auth, "Document")
+    assert len(rows) == 1
+    assert rows[0]["summary"] == "ALPHA-2"
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_delete_removes_node(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    global _node_rows
+    uri, auth = neo4j_clean
+    _node_rows = [
+        Document(filename="a.md", title="A", summary="alpha"),
+        Document(filename="b.md", title="B", summary="beta"),
+    ]
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_delete", environment=coco_env),
+        _declare_documents_only,
+    )
+    await app.update()
+    assert {r["filename"] for r in await _read_nodes(uri, auth, "Document")} == {
+        "a.md",
+        "b.md",
+    }
+    _node_rows.pop()  # drop b.md
+    await app.update()
+    assert {r["filename"] for r in await _read_nodes(uri, auth, "Document")} == {"a.md"}
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_relationship_upsert_with_endpoint_merge(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    """Verify three-MERGE relationship insert: source endpoint, target endpoint, edge."""
+    global _rel_pairs
+    uri, auth = neo4j_clean
+    _rel_pairs = [("alice", "bob"), ("bob", "carol")]
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_rel_upsert", environment=coco_env),
+        _declare_entities_and_relationships,
+    )
+    await app.update()
+
+    nodes = await _read_nodes(uri, auth, "Entity")
+    assert {n["value"] for n in nodes} == {"alice", "bob", "carol"}
+
+    edges = await _read_relationships(uri, auth, "REL")
+    assert len(edges) == 2
+    pairs = {(s["value"], t["value"]) for s, t, _ in edges}
+    assert pairs == {("alice", "bob"), ("bob", "carol")}
+    for _, _, rel in edges:
+        assert rel["predicate"] == "connects"
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_vector_index_attached(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    """declare_vector_index() should create a queryable vector index."""
+
+    @dataclass
+    class _DocWithVec:
+        filename: str
+        title: str
+        summary: str
+
+    async def _declare_doc_with_vector_index() -> None:
+        schema = await neo.TableSchema.from_class(_DocWithVec, primary_key="filename")
+        table: Any = await coco.use_mount(  # type: ignore[call-overload]
+            coco.component_subpath("setup", "doc_table"),
+            neo.mount_table_target,
+            KG_DB,
+            "VecDoc",
+            schema,
+            primary_key="filename",
+        )
+        # NOTE: in real flows the vector field would be a separate
+        # numpy-array column; this test only exercises that the DDL fires.
+        table.declare_vector_index(field="summary", metric="cosine", dimension=4)
+
+    uri, auth = neo4j_clean
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_vec_idx", environment=coco_env),
+        _declare_doc_with_vector_index,
+    )
+    await app.update()
+
+    driver = _neo4j.AsyncGraphDatabase.driver(uri, auth=auth)
+    try:
+        async with driver.session(database="neo4j") as session:
+            result = await session.run(
+                "SHOW INDEXES YIELD name, type, labelsOrTypes, properties"
+            )
+            rows = [dict(r) async for r in result]
+    finally:
+        await driver.close()
+
+    found = False
+    for row in rows:
+        if (
+            row["type"] == "VECTOR"
+            and "VecDoc" in (row["labelsOrTypes"] or [])
+            and "summary" in (row["properties"] or [])
+        ):
+            found = True
+            break
+    assert found, f"Expected vector index on VecDoc.summary; got {rows}"

--- a/uv.lock
+++ b/uv.lock
@@ -718,8 +718,8 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
-    { name = "neo4j", marker = "extra == 'all'", specifier = ">=5.13.0" },
-    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.13.0" },
+    { name = "neo4j", marker = "extra == 'all'", specifier = ">=5.18.0" },
+    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.18.0" },
     { name = "numpy", specifier = ">=1.23.2" },
     { name = "oci", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "oci", marker = "extra == 'oci'", specifier = ">=2.0" },
@@ -762,7 +762,7 @@ ci = [
     { name = "maturin", specifier = ">=1.10.0,<2.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
-    { name = "neo4j", specifier = ">=5.13.0" },
+    { name = "neo4j", specifier = ">=5.18.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
@@ -772,7 +772,7 @@ ci = [
 ]
 ci-enabled-optional-deps = [
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "neo4j", specifier = ">=5.13.0" },
+    { name = "neo4j", specifier = ">=5.18.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
 ]
 dev = [
@@ -782,7 +782,7 @@ dev = [
     { name = "maturin", specifier = ">=1.10.0,<2.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
-    { name = "neo4j", specifier = ">=5.13.0" },
+    { name = "neo4j", specifier = ">=5.18.0" },
     { name = "prek" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pytest", specifier = ">=9.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -550,6 +550,7 @@ all = [
     { name = "instructor" },
     { name = "lancedb" },
     { name = "litellm" },
+    { name = "neo4j" },
     { name = "oci" },
     { name = "pgvector" },
     { name = "pyarrow" },
@@ -597,6 +598,9 @@ lancedb = [
 litellm = [
     { name = "litellm" },
 ]
+neo4j = [
+    { name = "neo4j" },
+]
 oci = [
     { name = "oci" },
 ]
@@ -625,7 +629,7 @@ build-test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform != 'win32'" },
+    { name = "testcontainers", extra = ["neo4j"], marker = "sys_platform != 'win32'" },
 ]
 ci = [
     { name = "aiomoto", extra = ["s3"] },
@@ -634,15 +638,17 @@ ci = [
     { name = "maturin" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy" },
+    { name = "neo4j" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform != 'win32'" },
+    { name = "testcontainers", extra = ["neo4j"], marker = "sys_platform != 'win32'" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
     { name = "asyncpg" },
+    { name = "neo4j" },
     { name = "pydantic" },
 ]
 dev = [
@@ -652,12 +658,13 @@ dev = [
     { name = "maturin" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy" },
+    { name = "neo4j" },
     { name = "prek" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", marker = "sys_platform != 'win32'" },
+    { name = "testcontainers", extra = ["neo4j"], marker = "sys_platform != 'win32'" },
     { name = "types-psutil" },
 ]
 dev-local = [
@@ -711,6 +718,8 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "neo4j", marker = "extra == 'all'", specifier = ">=5.13.0" },
+    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.13.0" },
     { name = "numpy", specifier = ">=1.23.2" },
     { name = "oci", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "oci", marker = "extra == 'oci'", specifier = ">=2.0" },
@@ -733,7 +742,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchfiles", specifier = ">=1.1.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "kafka", "lancedb", "litellm", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb"]
+provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -744,7 +753,7 @@ build-test = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres", "neo4j"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
 ]
 ci = [
     { name = "aiomoto", extras = ["s3"], specifier = ">=0.3.0" },
@@ -753,15 +762,17 @@ ci = [
     { name = "maturin", specifier = ">=1.10.0,<2.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
+    { name = "neo4j", specifier = ">=5.13.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres", "neo4j"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "neo4j", specifier = ">=5.13.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
 ]
 dev = [
@@ -771,12 +782,13 @@ dev = [
     { name = "maturin", specifier = ">=1.10.0,<2.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
+    { name = "neo4j", specifier = ">=5.13.0" },
     { name = "prek" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
-    { name = "testcontainers", extras = ["postgres"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
+    { name = "testcontainers", extras = ["postgres", "neo4j"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
     { name = "types-psutil" },
 ]
 dev-local = [{ name = "prek" }]
@@ -2109,6 +2121,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "neo4j"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
 ]
 
 [[package]]
@@ -3715,6 +3739,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[package.optional-dependencies]
+neo4j = [
+    { name = "neo4j" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR 2 of the Neo4j-connector workstream. Lands the full connector under \`cocoindex/connectors/neo4j/\` with 45 cypher unit tests, 7 schema/identifier unit tests, and 6 end-to-end testcontainers integration tests.

Two commits:

1. \`neo4j: pure Cypher builders + unit tests\` — \`_cypher.py\` (Neo4j 5 dialect: named indexes with \`IF NOT EXISTS\`, real \`CREATE CONSTRAINT … IS UNIQUE\`, vector index DDL with \`indexConfig.vector.dimensions\`/\`vector.similarity_function\`), deterministic name builders, and unit tests covering every builder + identifier validation + edge cases. Adds \`neo4j>=5.18.0\` to \`[project.optional-dependencies]\` and \`testcontainers[neo4j]\` to the \`build-test\` group.

2. \`neo4j: full connector port + testcontainers integration tests\` — \`_target.py\` ports the FalkorDB engine layer to Neo4j: \`ConnectionFactory\` wrapping \`neo4j.AsyncGraphDatabase.driver\`, \`_SharedRecordApplier\` wraps each apply batch in one \`tx\` for atomic rollback, real Cypher DDL (no best-effort redis fallback), leaner \`_LEAF_TYPE_MAPPINGS\` (Bolt has native datetime/bytes/duration), deterministic index/constraint names so DROP can identify by name.

## Architecture decisions vs. FalkorDB

- Single PK field, configurable name (\`primary_key="id"\` default) — same as FalkorDB.
- Monomorphic endpoints — one \`from_table\`, one \`to_table\` per \`RelationTarget\`. Triple-MERGE auto-creates absent endpoints with just their PK.
- Auto-derived relation IDs: \`f"{from_table}_{from_id}_{to_table}_{to_id}"\` when not explicitly provided.
- Atomic transactions — Neo4j has multi-statement transactions, so each apply batch is one \`tx.commit()\` (or rollback on exception).
- Real CREATE CONSTRAINT — single-PK -> \`IS UNIQUE\`, compound -> \`IS NODE KEY\`.

## Test plan

### Unit (no Docker)
- [x] 52 unit tests pass (\`uv run pytest python/tests/connectors/test_neo4j_target.py -q\`)
- [x] \`uv run mypy\` clean (212 source files)
- [x] \`uv run ruff format --check\` clean
- [x] \`uv run ruff check\` clean

### Integration (testcontainers neo4j:5.26-community)
- [x] Node CRUD with PK upsert
- [x] Reconcile-twice idempotency (fingerprint short-circuit)
- [x] Property-only change -> single update, no duplicate
- [x] Source deletion -> node removed
- [x] Triple-MERGE relationship insert; endpoints auto-created
- [x] Vector index DDL fires; queryable via \`SHOW INDEXES\`

### Full suite regression
- [x] \`uv run pytest python/\` — 618 passed, 133 skipped (delta vs. baseline: 52 new tests, 6 new integration-skipped)

## Notes

- Targets Neo4j 5.18+ specifically because vector-index DDL (\`CREATE VECTOR INDEX … OPTIONS { indexConfig: { … } }\`) shipped in 5.18. Older 5.x versions need the \`db.index.vector.createNodeIndex\` procedure — out of scope for v1.
- \`Decimal\` and \`UUID\` are encoded as \`STRING\` since Neo4j has no native decimal and UUID-as-string is the convention; ndarray -> list paired with the vector-index DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)