### PR TITLE
examples: drop CocoInsight section from meeting_notes READMEs

### DIFF
--- a/examples/meeting_notes_graph_falkordb/README.md
+++ b/examples/meeting_notes_graph_falkordb/README.md
@@ -127,15 +127,3 @@ You can also use `redis-cli`:
 redis-cli GRAPH.QUERY meeting_notes \
   "MATCH (p:Person)-[:ATTENDED]->(m:Meeting) RETURN p.name, m.note_file, m.time"
 ```
-
-## CocoInsight
-
-Use [CocoInsight](https://cocoindex.io/cocoinsight) to inspect data lineage and
-debug the pipeline. It connects to your local CocoIndex server with zero
-pipeline data retention.
-
-```sh
-cocoindex server -ci main
-```
-
-Then open <https://cocoindex.io/cocoinsight>.

--- a/examples/meeting_notes_graph_neo4j/README.md
+++ b/examples/meeting_notes_graph_neo4j/README.md
@@ -145,15 +145,3 @@ You can also use `cypher-shell` from the command line:
 docker exec -it cocoindex-neo4j cypher-shell -u neo4j -p cocoindex \
   "MATCH (p:Person)-[:ATTENDED]->(m:Meeting) RETURN p.name, m.note_file, m.time"
 ```
-
-## CocoInsight
-
-Use [CocoInsight](https://cocoindex.io/cocoinsight) to inspect data lineage and
-debug the pipeline. It connects to your local CocoIndex server with zero
-pipeline data retention.
-
-```sh
-cocoindex server -ci main
-```
-
-Then open <https://cocoindex.io/cocoinsight>.


### PR DESCRIPTION
Removes the trailing CocoInsight `## CocoInsight` block from both `examples/meeting_notes_graph_falkordb/README.md` and `examples/meeting_notes_graph_neo4j/README.md` (24 lines total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)