### PR TITLE
feat(splitter): add Svelte and Vue tree-sitter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,11 @@ dependencies = [
  "tree-sitter-scala",
  "tree-sitter-sequel",
  "tree-sitter-solidity",
+ "tree-sitter-svelte-ng",
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-vue-next",
  "tree-sitter-xml",
  "tree-sitter-yaml",
  "unicase",
@@ -3793,6 +3795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-svelte-ng"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0a71f9cf5e94373cc86c64893630c8a29bb25d3390a248268d08af2165fa37"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-swift"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3829,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-vue-next"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ac89acaa8165aaabfa8ae9683aa423b0d2bf42c815dae5ca031a36a75525f1"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/python/tests/ops/test_text.py
+++ b/python/tests/ops/test_text.py
@@ -15,6 +15,8 @@ def test_detect_code_language_known_extensions() -> None:
     assert detect_code_language(filename="app.rs") == "rust"
     assert detect_code_language(filename="index.js") == "javascript"
     assert detect_code_language(filename="style.css") == "css"
+    assert detect_code_language(filename="App.svelte") == "svelte"
+    assert detect_code_language(filename="App.vue") == "vue"
 
 
 def test_detect_code_language_unknown_extension() -> None:
@@ -139,6 +141,49 @@ def test_recursive_splitter_with_language() -> None:
     splitter = RecursiveSplitter()
     code = "def foo():\n    pass\n\ndef bar():\n    pass"
     chunks = splitter.split(code, chunk_size=30, language="python")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_svelte() -> None:
+    """Test RecursiveSplitter with Svelte syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        '<script lang="ts">\n'
+        "  let count = 0;\n"
+        "  function increment() { count += 1; }\n"
+        "</script>\n\n"
+        "<button on:click={increment}>\n"
+        "  Clicked {count} times\n"
+        "</button>\n\n"
+        "<style>\n  button { color: red; }\n</style>\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="svelte")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_vue() -> None:
+    """Test RecursiveSplitter with Vue syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "<template>\n"
+        '  <div class="hello">\n'
+        "    <h1>{{ msg }}</h1>\n"
+        '    <button @click="increment">Count is: {{ count }}</button>\n'
+        "  </div>\n"
+        "</template>\n\n"
+        "<script>\n"
+        "export default {\n"
+        "  data() { return { msg: 'Hello', count: 0 } },\n"
+        "  methods: { increment() { this.count += 1 } },\n"
+        "}\n"
+        "</script>\n\n"
+        "<style scoped>\n.hello { color: blue; }\n</style>\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="vue")
 
     assert len(chunks) >= 1
     assert all(isinstance(c, Chunk) for c in chunks)

--- a/rust/ops_text/Cargo.toml
+++ b/rust/ops_text/Cargo.toml
@@ -41,5 +41,7 @@ tree-sitter-typescript = "0.23.2"
 tree-sitter-xml = "0.7.0"
 tree-sitter-yaml = "0.7.2"
 tree-sitter-solidity = "1.2.13"
+tree-sitter-svelte-ng = "1.0.2"
+tree-sitter-vue-next = "0.1.0"
 
 [dev-dependencies]

--- a/rust/ops_text/src/prog_langs.rs
+++ b/rust/ops_text/src/prog_langs.rs
@@ -427,7 +427,14 @@ static LANGUAGE_INFO_BY_NAME: LazyLock<
     );
     add("squirrel", &[".nut"], None);
     add("starlark", &[".star", ".bzl"], None);
-    add("svelte", &[".svelte"], None);
+    add(
+        "svelte",
+        &[".svelte"],
+        Some(TreeSitterLanguageInfo::new(
+            tree_sitter_svelte_ng::LANGUAGE,
+            [],
+        )),
+    );
     add(
         "swift",
         &[".swift"],
@@ -469,7 +476,14 @@ static LANGUAGE_INFO_BY_NAME: LazyLock<
     add("verilog", &[".vh"], None);
     add("vhdl", &[".vhd", ".vhdl"], None);
     add("vim", &[".vim"], None);
-    add("vue", &[".vue"], None);
+    add(
+        "vue",
+        &[".vue"],
+        Some(TreeSitterLanguageInfo::new(
+            tree_sitter_vue_next::LANGUAGE,
+            [],
+        )),
+    );
     add("wast", &[".wast"], None);
     add("wat", &[".wat"], None);
     add("wgsl", &[".wgsl"], None);
@@ -538,7 +552,20 @@ mod tests {
         assert_eq!(detect_language("test.rs"), Some("rust"));
         assert_eq!(detect_language("main.py"), Some("python"));
         assert_eq!(detect_language("app.js"), Some("javascript"));
+        assert_eq!(detect_language("App.svelte"), Some("svelte"));
+        assert_eq!(detect_language("App.vue"), Some("vue"));
         assert_eq!(detect_language("noextension"), None);
         assert_eq!(detect_language("unknown.xyz"), None);
+    }
+
+    #[test]
+    fn test_svelte_and_vue_have_treesitter() {
+        let svelte = get_language_info(".svelte").unwrap();
+        assert_eq!(svelte.name.as_ref(), "svelte");
+        assert!(svelte.treesitter_info.is_some());
+
+        let vue = get_language_info(".vue").unwrap();
+        assert_eq!(vue.name.as_ref(), "vue");
+        assert!(vue.treesitter_info.is_some());
     }
 }

--- a/rust/ops_text/src/split/recursive.rs
+++ b/rust/ops_text/src/split/recursive.rs
@@ -837,6 +837,63 @@ fn other() {
     }
 
     #[test]
+    fn test_split_with_svelte_language() {
+        let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
+        let text = r#"<script lang="ts">
+  let count = 0;
+  function increment() { count += 1; }
+</script>
+
+<button on:click={increment}>
+  Clicked {count} times
+</button>
+
+<style>
+  button { color: red; }
+</style>
+"#;
+        let config = RecursiveChunkConfig {
+            chunk_size: 80,
+            min_chunk_size: Some(20),
+            chunk_overlap: Some(0),
+            language: Some("svelte".to_string()),
+        };
+        let chunks = chunker.split(text, config);
+        assert!(!chunks.is_empty());
+    }
+
+    #[test]
+    fn test_split_with_vue_language() {
+        let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
+        let text = r#"<template>
+  <div class="hello">
+    <h1>{{ msg }}</h1>
+    <button @click="increment">Count is: {{ count }}</button>
+  </div>
+</template>
+
+<script>
+export default {
+  data() { return { msg: 'Hello', count: 0 } },
+  methods: { increment() { this.count += 1 } },
+}
+</script>
+
+<style scoped>
+.hello { color: blue; }
+</style>
+"#;
+        let config = RecursiveChunkConfig {
+            chunk_size: 80,
+            min_chunk_size: Some(20),
+            chunk_overlap: Some(0),
+            language: Some("vue".to_string()),
+        };
+        let chunks = chunker.split(text, config);
+        assert!(!chunks.is_empty());
+    }
+
+    #[test]
     fn test_split_positions() {
         let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
         let text = "Chunk1\n\nChunk2";


### PR DESCRIPTION
## Summary
- Wire up `tree-sitter-svelte-ng` and `tree-sitter-vue-next` so `RecursiveSplitter` performs syntax-aware chunking for `.svelte` and `.vue` files. Both languages were previously registered for name/extension lookup but fell back to the default regex separators because no tree-sitter parser was attached.
- Add Rust unit tests covering tree-sitter wiring + recursive splitting for both languages, and Python tests for `detect_code_language` + `RecursiveSplitter` on Svelte/Vue snippets.

See cocoindex-io/cocoindex-code#99

## Test plan
- CI (`cargo test -p cocoindex_ops_text`, `pytest python/tests/ops/test_text.py`)
