### PR TITLE
refactor(examples): switch pdf_embedding from marker to docling

### DIFF
--- a/examples/pdf_embedding/main.py
+++ b/examples/pdf_embedding/main.py
@@ -13,18 +13,16 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import io
 import os
 import pathlib
 import sys
-import tempfile
 from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 from dotenv import load_dotenv
-from marker.config.parser import ConfigParser
-from marker.converters.pdf import PdfConverter
-from marker.models import create_model_dict
-from marker.output import text_from_rendered
+from docling.datamodel.base_models import DocumentStream
+from docling.document_converter import DocumentConverter
 from numpy.typing import NDArray
 import asyncpg
 
@@ -50,20 +48,14 @@ _splitter = RecursiveSplitter()
 
 
 @functools.cache
-def pdf_converter() -> PdfConverter:
-    config_parser = ConfigParser({})
-    return PdfConverter(
-        create_model_dict(), config=config_parser.generate_config_dict()
-    )
+def pdf_converter() -> DocumentConverter:
+    return DocumentConverter()
 
 
+@coco.fn.as_async(runner=coco.GPU)
 def pdf_to_markdown(content: bytes) -> str:
-    converter = pdf_converter()
-    with tempfile.NamedTemporaryFile(delete=True, suffix=".pdf") as temp_file:
-        temp_file.write(content)
-        temp_file.flush()
-        text_any, _, _ = text_from_rendered(converter(temp_file.name))
-        return text_any
+    source = DocumentStream(name="input.pdf", stream=io.BytesIO(content))
+    return pdf_converter().convert(source).document.export_to_markdown()
 
 
 @dataclass
@@ -115,8 +107,7 @@ async def process_file(
     file: FileLike,
     table: postgres.TableTarget[PdfEmbedding],
 ) -> None:
-    content = await file.read()
-    markdown = pdf_to_markdown(content)
+    markdown = await pdf_to_markdown(await file.read())
     chunks = _splitter.split(
         markdown, chunk_size=2000, chunk_overlap=500, language="markdown"
     )

--- a/examples/pdf_embedding/pyproject.toml
+++ b/examples/pdf_embedding/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
-    "marker-pdf>=1.8.5",
+    "docling>=2.0.0",
     "python-dotenv>=1.0.1",
 ]
 


### PR DESCRIPTION
## Summary
- Replace `marker-pdf` with `docling` for PDF→markdown conversion in the `pdf_embedding` example.
- Use `DocumentStream` with an in-memory `BytesIO` so no temp file is needed.
- Wrap `pdf_to_markdown` with `@coco.fn.as_async(runner=coco.GPU)` so the conversion runs off the event loop.

## Test plan
- CI
- `cocoindex update main.py` and `python main.py query "..."` from `examples/pdf_embedding/` after `uv sync`.
