### PR TITLE
docs: drop /review-changes pointer from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,8 +186,6 @@ app.update_blocking(report_to_stdout=True)
 
 ## Code Conventions
 
-The full review-time detection checklist (with worked examples and post-hoc smell patterns) lives in the [`/review-changes`](~/.claude/skills/review-changes/SKILL.md) skill — run it on uncommitted changes before landing a non-trivial PR. The rules below are write-time mnemonics; project-specific ones (Internal/External modules, Minimize API surface, Sync vs Async, Test Environment Setup) stay here in full.
-
 ### Internal vs External Modules
 
 We distinguish between **internal modules** (under packages with `_` prefix, e.g. `_internal.*` or `connectors.*._source`) and **external modules** (which users can directly import).


### PR DESCRIPTION
## Summary
- Removes the pointer to the personal `/review-changes` Claude skill from `CLAUDE.md`. That skill isn't part of this repo, so the "run it before landing a non-trivial PR" instruction only applied to users with that local skill installed.

## Test plan
- Docs-only change; CI.
