### PR TITLE
feat(splitter): add Julia tree-sitter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
+ "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
  "tree-sitter-md",
@@ -3673,6 +3674,16 @@ name = "tree-sitter-json"
 version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-julia"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4144731a178812ee867619b1e98b3b91e54c1652304b26e5ebe3175b701de323"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/python/tests/ops/test_text.py
+++ b/python/tests/ops/test_text.py
@@ -17,6 +17,7 @@ def test_detect_code_language_known_extensions() -> None:
     assert detect_code_language(filename="style.css") == "css"
     assert detect_code_language(filename="App.svelte") == "svelte"
     assert detect_code_language(filename="App.vue") == "vue"
+    assert detect_code_language(filename="script.jl") == "julia"
 
 
 def test_detect_code_language_unknown_extension() -> None:
@@ -160,6 +161,20 @@ def test_recursive_splitter_with_svelte() -> None:
         "<style>\n  button { color: red; }\n</style>\n"
     )
     chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="svelte")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_julia() -> None:
+    """Test RecursiveSplitter with Julia syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "function foo(x)\n    return x + 1\nend\n\n"
+        "struct Point\n    x::Int\n    y::Int\nend\n\n"
+        'module MyModule\n    export hello\n    hello() = println("hi")\nend\n'
+    )
+    chunks = splitter.split(code, chunk_size=60, min_chunk_size=20, language="julia")
 
     assert len(chunks) >= 1
     assert all(isinstance(c, Chunk) for c in chunks)

--- a/rust/ops_text/Cargo.toml
+++ b/rust/ops_text/Cargo.toml
@@ -24,6 +24,7 @@ tree-sitter-html = "0.23.2"
 tree-sitter-java = "0.23.5"
 tree-sitter-javascript = "0.23.1"
 tree-sitter-json = "0.24.8"
+tree-sitter-julia = "0.23.1"
 # The other more popular crate tree-sitter-kotlin requires tree-sitter < 0.23 for now
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-md = "0.5.3"

--- a/rust/ops_text/src/prog_langs.rs
+++ b/rust/ops_text/src/prog_langs.rs
@@ -266,7 +266,11 @@ static LANGUAGE_INFO_BY_NAME: LazyLock<
         Some(TreeSitterLanguageInfo::new(tree_sitter_json::LANGUAGE, [])),
     );
     add("jsonnet", &[".jsonnet"], None);
-    add("julia", &[".jl"], None);
+    add(
+        "julia",
+        &[".jl"],
+        Some(TreeSitterLanguageInfo::new(tree_sitter_julia::LANGUAGE, [])),
+    );
     add("kdl", &[".kdl"], None);
     add(
         "kotlin",
@@ -554,6 +558,7 @@ mod tests {
         assert_eq!(detect_language("app.js"), Some("javascript"));
         assert_eq!(detect_language("App.svelte"), Some("svelte"));
         assert_eq!(detect_language("App.vue"), Some("vue"));
+        assert_eq!(detect_language("script.jl"), Some("julia"));
         assert_eq!(detect_language("noextension"), None);
         assert_eq!(detect_language("unknown.xyz"), None);
     }
@@ -567,5 +572,12 @@ mod tests {
         let vue = get_language_info(".vue").unwrap();
         assert_eq!(vue.name.as_ref(), "vue");
         assert!(vue.treesitter_info.is_some());
+    }
+
+    #[test]
+    fn test_julia_has_treesitter() {
+        let julia = get_language_info(".jl").unwrap();
+        assert_eq!(julia.name.as_ref(), "julia");
+        assert!(julia.treesitter_info.is_some());
     }
 }

--- a/rust/ops_text/src/split/recursive.rs
+++ b/rust/ops_text/src/split/recursive.rs
@@ -863,6 +863,34 @@ fn other() {
     }
 
     #[test]
+    fn test_split_with_julia_language() {
+        let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
+        let text = r#"
+function foo(x)
+    return x + 1
+end
+
+struct Point
+    x::Int
+    y::Int
+end
+
+module MyModule
+    export hello
+    hello() = println("hi")
+end
+"#;
+        let config = RecursiveChunkConfig {
+            chunk_size: 60,
+            min_chunk_size: Some(20),
+            chunk_overlap: Some(0),
+            language: Some("julia".to_string()),
+        };
+        let chunks = chunker.split(text, config);
+        assert!(!chunks.is_empty());
+    }
+
+    #[test]
     fn test_split_with_vue_language() {
         let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
         let text = r#"<template>


### PR DESCRIPTION
## Summary
- Wire up `tree-sitter-julia` so `RecursiveSplitter` performs syntax-aware chunking for `.jl` files. Julia was previously registered for name/extension lookup but fell back to the default regex separators because no tree-sitter parser was attached.
- Add Rust unit tests covering tree-sitter wiring + recursive splitting for Julia, and Python tests for `detect_code_language` + `RecursiveSplitter` on a Julia snippet.

## Test plan
- CI (`cargo test -p cocoindex_ops_text`, `pytest python/tests/ops/test_text.py`)
