### PR TITLE
Molten Hub Code: Reduce Codebase And Centralize Classes

### DIFF
--- a/examples/meeting_notes_graph_common.py
+++ b/examples/meeting_notes_graph_common.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+import os
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import instructor
+import litellm
+import pydantic
+
+import cocoindex as coco
+from cocoindex.connectors import google_drive
+from cocoindex.ops.entity_resolution import ResolvedEntities
+from cocoindex.resources.id import IdGenerator
+
+litellm.drop_params = True
+
+
+@dataclass
+class Meeting:
+    id: int
+    note_file: str
+    time: datetime.date
+    note: str
+
+
+@dataclass
+class Person:
+    name: str
+
+
+@dataclass
+class Task:
+    description: str
+
+
+@dataclass
+class AttendedRel:
+    is_organizer: bool
+
+
+class ExtractedPerson(pydantic.BaseModel):
+    name: str = pydantic.Field(
+        description="Full name of the person, as written in the note."
+    )
+
+
+class ExtractedTask(pydantic.BaseModel):
+    description: str = pydantic.Field(
+        description="Concise, standalone description of the task or action item."
+    )
+    assigned_to: list[ExtractedPerson] = pydantic.Field(
+        default_factory=list,
+        description="People the task is assigned to.",
+    )
+
+
+class ExtractedMeeting(pydantic.BaseModel):
+    time: datetime.date = pydantic.Field(
+        description="Date of the meeting in ISO format (YYYY-MM-DD)."
+    )
+    note: str = pydantic.Field(
+        description="A brief summary or notes from the meeting section.",
+    )
+    organizer: ExtractedPerson = pydantic.Field(
+        description="The person who organized or led the meeting."
+    )
+    participants: list[ExtractedPerson] = pydantic.Field(
+        default_factory=list,
+        description=(
+            "People who attended the meeting other than the organizer. "
+            "Do not include the organizer here."
+        ),
+    )
+    tasks: list[ExtractedTask] = pydantic.Field(
+        default_factory=list,
+        description="Action items or tasks decided in the meeting.",
+    )
+
+
+EXTRACT_PROMPT = """\
+You are an expert at reading meeting notes and extracting structured information.
+
+Given a single meeting section (Markdown), extract:
+- The meeting date (look for a date in the heading or body; required).
+- A brief note summarizing what the meeting was about.
+- The organizer (the person who ran the meeting). If unclear, pick the person
+  who appears most central to the meeting.
+- Participants other than the organizer.
+- Tasks or action items decided, including who they are assigned to.
+
+Return only what is supported by the text. Use full names where available.
+"""
+
+
+async def extract_meeting_with_model(
+    section_text: str, model: str
+) -> ExtractedMeeting:
+    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
+    result = await client.chat.completions.create(
+        model=model,
+        response_model=ExtractedMeeting,
+        messages=[
+            {"role": "system", "content": EXTRACT_PROMPT},
+            {"role": "user", "content": section_text},
+        ],
+    )
+    return ExtractedMeeting.model_validate(result.model_dump())
+
+
+_HEADING_RE = re.compile(r"\n\n##?\s+")
+
+
+def _split_meetings(text: str) -> list[str]:
+    parts = _HEADING_RE.split("\n\n" + text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+@dataclass
+class MeetingExtraction:
+    meeting_id: int
+    organizer: str
+    participants: list[str]
+    task_assignees: list[tuple[str, list[str]]]
+
+
+ExtractMeetingFn = Callable[[str], Awaitable[ExtractedMeeting]]
+
+
+async def process_file_common(
+    file: google_drive.DriveFile,
+    meeting_table: Any,
+    task_table: Any,
+    decided_rel: Any,
+    extract_meeting: ExtractMeetingFn,
+) -> list[MeetingExtraction]:
+    text = await file.read_text()
+    note_file = file.file_path.path.as_posix()
+    id_generator = IdGenerator()
+    extractions = []
+    for section in _split_meetings(text):
+        extracted = await extract_meeting(section)
+        meeting_id = await id_generator.next_id(extracted.time)
+
+        meeting_table.declare_record(
+            row=Meeting(
+                id=meeting_id,
+                note_file=note_file,
+                time=extracted.time,
+                note=extracted.note,
+            )
+        )
+
+        for task in extracted.tasks:
+            task_table.declare_record(row=Task(description=task.description))
+            decided_rel.declare_relation(from_id=meeting_id, to_id=task.description)
+
+        extractions.append(
+            MeetingExtraction(
+                meeting_id=meeting_id,
+                organizer=extracted.organizer.name,
+                participants=[p.name for p in extracted.participants],
+                task_assignees=[
+                    (t.description, [a.name for a in t.assigned_to])
+                    for t in extracted.tasks
+                ],
+            )
+        )
+    return extractions
+
+
+def raw_person_names(meetings: list[MeetingExtraction]) -> set[str]:
+    raw_persons: set[str] = set()
+    for meeting in meetings:
+        raw_persons.add(meeting.organizer)
+        raw_persons.update(meeting.participants)
+        for _task_desc, assignees in meeting.task_assignees:
+            raw_persons.update(assignees)
+    return raw_persons
+
+
+async def collect_meeting_extractions(
+    process_file: Any,
+    meeting_table: Any,
+    task_table: Any,
+    decided_rel: Any,
+) -> list[MeetingExtraction]:
+    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
+    root_folder_ids = [
+        folder.strip()
+        for folder in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
+        if folder.strip()
+    ]
+    source = google_drive.GoogleDriveSource(
+        service_account_credential_path=credential_path,
+        root_folder_ids=root_folder_ids,
+    )
+
+    file_coros = []
+    async for path_key, file in source.items():
+        file_coros.append(
+            coco.use_mount(
+                coco.component_subpath("file", path_key),
+                process_file,
+                file,
+                meeting_table,
+                task_table,
+                decided_rel,
+            )
+        )
+
+    per_file: list[list[MeetingExtraction]] = list(await asyncio.gather(*file_coros))
+    return [meeting for meetings in per_file for meeting in meetings]
+
+
+def declare_person_relations(
+    meetings: list[MeetingExtraction],
+    persons: ResolvedEntities,
+    person_table: Any,
+    attended_rel: Any,
+    assigned_rel: Any,
+) -> None:
+    for canonical_name in persons.canonicals():
+        person_table.declare_record(row=Person(name=canonical_name))
+
+    for meeting in meetings:
+        attendees: dict[str, bool] = {
+            persons.canonical_of(meeting.organizer): True
+        }
+        for participant in meeting.participants:
+            attendees.setdefault(persons.canonical_of(participant), False)
+
+        for canonical, is_organizer in attendees.items():
+            attended_rel.declare_relation(
+                from_id=canonical,
+                to_id=meeting.meeting_id,
+                record=AttendedRel(is_organizer=is_organizer),
+            )
+
+        for task_desc, assignees in meeting.task_assignees:
+            seen: set[str] = set()
+            for raw in assignees:
+                canonical = persons.canonical_of(raw)
+                if canonical in seen:
+                    continue
+                seen.add(canonical)
+                assigned_rel.declare_relation(from_id=canonical, to_id=task_desc)

--- a/examples/meeting_notes_graph_falkordb/main.py
+++ b/examples/meeting_notes_graph_falkordb/main.py
@@ -1,64 +1,39 @@
 """
-Meeting Notes Graph (v1) — CocoIndex pipeline example.
-
-Ingest Markdown meeting notes from Google Drive, split each note into
-per-meeting sections at heading boundaries, extract structured information
-with LiteLLM + instructor, deduplicate person names with embedding-based
-entity resolution, and build a knowledge graph in FalkorDB:
-
-  Meeting nodes — one per meeting section
-  Person  nodes — canonical organizers, participants, and task assignees
-  Task    nodes — tasks decided in meetings
-
-  ATTENDED     Person -> Meeting (with is_organizer flag)
-  DECIDED      Meeting -> Task
-  ASSIGNED_TO  Person -> Task
-
-The pipeline runs in three phases:
-  1. Per-file extraction declares Meeting and Task nodes plus DECIDED edges,
-     and emits raw (un-resolved) person names for downstream resolution.
-  2. Person entity resolution maps raw names to canonical names.
-  3. A final pass declares canonical Person nodes and the person-touching
-     edges (ATTENDED, ASSIGNED_TO) using resolved names.
+Meeting Notes Graph (v1) - CocoIndex pipeline example, FalkorDB flavor.
 """
 
 from __future__ import annotations
 
-import asyncio
-import datetime
 import os
-import re
+import sys
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
-
-import instructor
-import litellm
-import pydantic
 
 import cocoindex as coco
 from cocoindex.connectors import falkordb, google_drive
 from cocoindex.ops.entity_resolution import ResolvedEntities, resolve_entities
 from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
-from cocoindex.resources.id import IdGenerator
 
-litellm.drop_params = True
-
-
-# ---------------------------------------------------------------------------
-# Context keys
-# ---------------------------------------------------------------------------
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from examples.meeting_notes_graph_common import (  # noqa: E402
+    ExtractedMeeting,
+    Meeting,
+    MeetingExtraction,
+    Person,
+    Task,
+    collect_meeting_extractions,
+    declare_person_relations,
+    extract_meeting_with_model,
+    process_file_common,
+    raw_person_names,
+)
 
 KG_DB = coco.ContextKey[falkordb.ConnectionFactory]("kg_db")
 LLM_MODEL = coco.ContextKey[str]("llm_model", detect_change=True)
 RESOLUTION_LLM_MODEL = coco.ContextKey[str]("resolution_llm_model", detect_change=True)
 EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_change=True)
-
-
-# ---------------------------------------------------------------------------
-# Lifespan
-# ---------------------------------------------------------------------------
 
 
 @coco.lifespan
@@ -84,156 +59,9 @@ async def coco_lifespan(
     yield
 
 
-# ---------------------------------------------------------------------------
-# FalkorDB row schemas (dataclasses for declare_record / declare_relation)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Meeting:
-    id: int  # Generated via generate_id((note_file, time_iso))
-    note_file: str
-    time: datetime.date
-    note: str
-
-
-@dataclass
-class Person:
-    name: str  # canonical
-
-
-@dataclass
-class Task:
-    description: str
-
-
-@dataclass
-class AttendedRel:
-    """ATTENDED edge payload. The relation PK is auto-derived from
-    (from_id=person, to_id=meeting_id) by the FalkorDB connector — we mount
-    this relation without a TableSchema so the connector's endpoint-based
-    fallback supplies the PK, giving exactly one edge per (person, meeting).
-    """
-
-    is_organizer: bool
-
-
-# DECIDED and ASSIGNED_TO carry no payload — declared without schema or
-# record, with the connector deriving PKs from (from_id, to_id).
-
-
-# ---------------------------------------------------------------------------
-# LLM extraction schemas (Pydantic, for instructor)
-# ---------------------------------------------------------------------------
-
-
-class ExtractedPerson(pydantic.BaseModel):
-    name: str = pydantic.Field(
-        description="Full name of the person, as written in the note."
-    )
-
-
-class ExtractedTask(pydantic.BaseModel):
-    description: str = pydantic.Field(
-        description="Concise, standalone description of the task or action item."
-    )
-    assigned_to: list[ExtractedPerson] = pydantic.Field(
-        default_factory=list,
-        description="People the task is assigned to.",
-    )
-
-
-class ExtractedMeeting(pydantic.BaseModel):
-    time: datetime.date = pydantic.Field(
-        description="Date of the meeting in ISO format (YYYY-MM-DD)."
-    )
-    note: str = pydantic.Field(
-        description="A brief summary or notes from the meeting section.",
-    )
-    organizer: ExtractedPerson = pydantic.Field(
-        description="The person who organized or led the meeting."
-    )
-    participants: list[ExtractedPerson] = pydantic.Field(
-        default_factory=list,
-        description=(
-            "People who attended the meeting other than the organizer. "
-            "Do not include the organizer here."
-        ),
-    )
-    tasks: list[ExtractedTask] = pydantic.Field(
-        default_factory=list,
-        description="Action items or tasks decided in the meeting.",
-    )
-
-
-EXTRACT_PROMPT = """\
-You are an expert at reading meeting notes and extracting structured information.
-
-Given a single meeting section (Markdown), extract:
-- The meeting date (look for a date in the heading or body; required).
-- A brief note summarizing what the meeting was about.
-- The organizer (the person who ran the meeting). If unclear, pick the person
-  who appears most central to the meeting.
-- Participants other than the organizer.
-- Tasks or action items decided, including who they are assigned to.
-
-Return only what is supported by the text. Use full names where available.
-"""
-
-
-# ---------------------------------------------------------------------------
-# LLM extraction
-# ---------------------------------------------------------------------------
-
-
 @coco.fn(memo=True)
 async def extract_meeting(section_text: str) -> ExtractedMeeting:
-    """Extract a structured Meeting from a Markdown section via LiteLLM + instructor."""
-    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
-    result = await client.chat.completions.create(
-        model=coco.use_context(LLM_MODEL),
-        response_model=ExtractedMeeting,
-        messages=[
-            {"role": "system", "content": EXTRACT_PROMPT},
-            {"role": "user", "content": section_text},
-        ],
-    )
-    # Re-validate to restore class identity for pickling.
-    return ExtractedMeeting.model_validate(result.model_dump())
-
-
-# ---------------------------------------------------------------------------
-# Splitting — match v0's `\n\n##? ` heading regex
-# ---------------------------------------------------------------------------
-
-_HEADING_RE = re.compile(r"\n\n##?\s+")
-
-
-def _split_meetings(text: str) -> list[str]:
-    parts = _HEADING_RE.split("\n\n" + text)
-    return [p.strip() for p in parts if p.strip()]
-
-
-# ---------------------------------------------------------------------------
-# Internal transfer types (Phase 1 → Phase 3)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class MeetingExtraction:
-    """Raw per-meeting data carried forward to entity resolution + relation declaration."""
-
-    meeting_id: int
-    organizer: str  # raw name
-    participants: list[str]  # raw names
-    task_assignees: list[
-        tuple[str, list[str]]
-    ]  # (task_description, [raw assignee names])
-
-
-# ---------------------------------------------------------------------------
-# Phase 1: per-meeting and per-file processing
-# ---------------------------------------------------------------------------
+    return await extract_meeting_with_model(section_text, coco.use_context(LLM_MODEL))
 
 
 @coco.fn(memo=True)
@@ -243,44 +71,9 @@ async def process_file(
     task_table: falkordb.TableTarget[Task],
     decided_rel: falkordb.RelationTarget[Any],
 ) -> list[MeetingExtraction]:
-    text = await file.read_text()
-    note_file = file.file_path.path.as_posix()
-    id_generator = IdGenerator()
-    extractions = []
-    for section in _split_meetings(text):
-        extracted = await extract_meeting(section)
-        meeting_id = await id_generator.next_id(extracted.time)
-
-        meeting_table.declare_record(
-            row=Meeting(
-                id=meeting_id,
-                note_file=note_file,
-                time=extracted.time,
-                note=extracted.note,
-            )
-        )
-
-        for task in extracted.tasks:
-            task_table.declare_record(row=Task(description=task.description))
-            decided_rel.declare_relation(from_id=meeting_id, to_id=task.description)
-
-        extractions.append(
-            MeetingExtraction(
-                meeting_id=meeting_id,
-                organizer=extracted.organizer.name,
-                participants=[p.name for p in extracted.participants],
-                task_assignees=[
-                    (t.description, [a.name for a in t.assigned_to])
-                    for t in extracted.tasks
-                ],
-            )
-        )
-    return extractions
-
-
-# ---------------------------------------------------------------------------
-# Phase 2: Person entity resolution
-# ---------------------------------------------------------------------------
+    return await process_file_common(
+        file, meeting_table, task_table, decided_rel, extract_meeting
+    )
 
 
 @coco.fn(memo=True)
@@ -292,11 +85,6 @@ async def _resolve_persons(raw_persons: set[str]) -> ResolvedEntities:
     )
 
 
-# ---------------------------------------------------------------------------
-# Phase 3: declare canonical Person nodes + person-touching relations
-# ---------------------------------------------------------------------------
-
-
 @coco.fn
 async def create_person_relations(
     meetings: list[MeetingExtraction],
@@ -305,45 +93,13 @@ async def create_person_relations(
     attended_rel: falkordb.RelationTarget[Any],
     assigned_rel: falkordb.RelationTarget[Any],
 ) -> None:
-    # Declare canonical Person nodes.
-    for canonical_name in persons.canonicals():
-        person_table.declare_record(row=Person(name=canonical_name))
-
-    for m in meetings:
-        # ATTENDED — aggregate organizer + participants. Organizer flag wins
-        # on collision so a person listed as both gets a single edge with
-        # is_organizer=true. Resolution happens before aggregation so two
-        # raw names that resolve to the same person also collapse.
-        attendees: dict[str, bool] = {persons.canonical_of(m.organizer): True}
-        for p in m.participants:
-            attendees.setdefault(persons.canonical_of(p), False)
-
-        for canonical, is_organizer in attendees.items():
-            attended_rel.declare_relation(
-                from_id=canonical,
-                to_id=m.meeting_id,
-                record=AttendedRel(is_organizer=is_organizer),
-            )
-
-        # ASSIGNED_TO — dedup per (canonical person, task description).
-        for task_desc, assignees in m.task_assignees:
-            seen: set[str] = set()
-            for raw in assignees:
-                canonical = persons.canonical_of(raw)
-                if canonical in seen:
-                    continue
-                seen.add(canonical)
-                assigned_rel.declare_relation(from_id=canonical, to_id=task_desc)
-
-
-# ---------------------------------------------------------------------------
-# App main
-# ---------------------------------------------------------------------------
+    declare_person_relations(
+        meetings, persons, person_table, attended_rel, assigned_rel
+    )
 
 
 @coco.fn
 async def app_main() -> None:
-    # --- Mount node tables ---
     meeting_table = await falkordb.mount_table_target(
         KG_DB,
         "Meeting",
@@ -363,9 +119,6 @@ async def app_main() -> None:
         primary_key="description",
     )
 
-    # --- Mount relation targets ---
-    # ATTENDED carries is_organizer; mounted without a schema so the connector
-    # auto-derives the relation PK from (from_id, to_id).
     attended_rel = await falkordb.mount_relation_target(
         KG_DB, "ATTENDED", person_table, meeting_table
     )
@@ -376,48 +129,16 @@ async def app_main() -> None:
         KG_DB, "ASSIGNED_TO", person_table, task_table
     )
 
-    # --- Phase 1: per-file extraction ---
-    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
-    root_folder_ids = [
-        folder.strip()
-        for folder in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
-        if folder.strip()
-    ]
-    source = google_drive.GoogleDriveSource(
-        service_account_credential_path=credential_path,
-        root_folder_ids=root_folder_ids,
+    all_meetings = await collect_meeting_extractions(
+        process_file, meeting_table, task_table, decided_rel
     )
-
-    file_coros = []
-    async for path_key, file in source.items():
-        file_coros.append(
-            coco.use_mount(
-                coco.component_subpath("file", path_key),
-                process_file,
-                file,
-                meeting_table,
-                task_table,
-                decided_rel,
-            )
-        )
-    per_file: list[list[MeetingExtraction]] = list(await asyncio.gather(*file_coros))
-    all_meetings: list[MeetingExtraction] = [m for ms in per_file for m in ms]
-
-    # --- Phase 2: Person entity resolution ---
-    raw_persons: set[str] = set()
-    for m in all_meetings:
-        raw_persons.add(m.organizer)
-        raw_persons.update(m.participants)
-        for _task_desc, assignees in m.task_assignees:
-            raw_persons.update(assignees)
 
     persons = await coco.use_mount(
         coco.component_subpath("resolve_persons"),
         _resolve_persons,
-        raw_persons,
+        raw_person_names(all_meetings),
     )
 
-    # --- Phase 3: declare Person nodes + person-touching relations ---
     await coco.mount(
         coco.component_subpath("person_relations"),
         create_person_relations,

--- a/examples/meeting_notes_graph_neo4j/main.py
+++ b/examples/meeting_notes_graph_neo4j/main.py
@@ -1,69 +1,39 @@
 """
-Meeting Notes Graph (v1) — CocoIndex pipeline example, Neo4j flavor.
-
-Ingest Markdown meeting notes from Google Drive, split each note into
-per-meeting sections at heading boundaries, extract structured information
-with LiteLLM + instructor, deduplicate person names with embedding-based
-entity resolution, and build a knowledge graph in Neo4j:
-
-  Meeting nodes — one per meeting section
-  Person  nodes — canonical organizers, participants, and task assignees
-  Task    nodes — tasks decided in meetings
-
-  ATTENDED     Person -> Meeting (with is_organizer flag)
-  DECIDED      Meeting -> Task
-  ASSIGNED_TO  Person -> Task
-
-The pipeline runs in three phases:
-  1. Per-file extraction declares Meeting and Task nodes plus DECIDED edges,
-     and emits raw (un-resolved) person names for downstream resolution.
-  2. Person entity resolution maps raw names to canonical names.
-  3. A final pass declares canonical Person nodes and the person-touching
-     edges (ATTENDED, ASSIGNED_TO) using resolved names.
-
-Side-by-side diff with examples/meeting_notes_graph_falkordb/main.py: the
-flow is identical; the only differences are the connector import, the
-ConnectionFactory arguments (uri + auth + database vs uri + graph), and
-the AppConfig name.
+Meeting Notes Graph (v1) - CocoIndex pipeline example, Neo4j flavor.
 """
 
 from __future__ import annotations
 
-import asyncio
-import datetime
 import os
-import re
+import sys
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
-
-import instructor
-import litellm
-import pydantic
 
 import cocoindex as coco
 from cocoindex.connectors import google_drive, neo4j
 from cocoindex.ops.entity_resolution import ResolvedEntities, resolve_entities
 from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
-from cocoindex.resources.id import IdGenerator
 
-litellm.drop_params = True
-
-
-# ---------------------------------------------------------------------------
-# Context keys
-# ---------------------------------------------------------------------------
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from examples.meeting_notes_graph_common import (  # noqa: E402
+    ExtractedMeeting,
+    Meeting,
+    MeetingExtraction,
+    Person,
+    Task,
+    collect_meeting_extractions,
+    declare_person_relations,
+    extract_meeting_with_model,
+    process_file_common,
+    raw_person_names,
+)
 
 KG_DB = coco.ContextKey[neo4j.ConnectionFactory]("kg_db")
 LLM_MODEL = coco.ContextKey[str]("llm_model", detect_change=True)
 RESOLUTION_LLM_MODEL = coco.ContextKey[str]("resolution_llm_model", detect_change=True)
 EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_change=True)
-
-
-# ---------------------------------------------------------------------------
-# Lifespan
-# ---------------------------------------------------------------------------
 
 
 @coco.lifespan
@@ -93,156 +63,9 @@ async def coco_lifespan(
     yield
 
 
-# ---------------------------------------------------------------------------
-# Neo4j row schemas (dataclasses for declare_record / declare_relation)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Meeting:
-    id: int  # Generated via generate_id((note_file, time_iso))
-    note_file: str
-    time: datetime.date
-    note: str
-
-
-@dataclass
-class Person:
-    name: str  # canonical
-
-
-@dataclass
-class Task:
-    description: str
-
-
-@dataclass
-class AttendedRel:
-    """ATTENDED edge payload. The relation PK is auto-derived from
-    (from_id=person, to_id=meeting_id) by the Neo4j connector — we mount
-    this relation without a TableSchema so the connector's endpoint-based
-    fallback supplies the PK, giving exactly one edge per (person, meeting).
-    """
-
-    is_organizer: bool
-
-
-# DECIDED and ASSIGNED_TO carry no payload — declared without schema or
-# record, with the connector deriving PKs from (from_id, to_id).
-
-
-# ---------------------------------------------------------------------------
-# LLM extraction schemas (Pydantic, for instructor)
-# ---------------------------------------------------------------------------
-
-
-class ExtractedPerson(pydantic.BaseModel):
-    name: str = pydantic.Field(
-        description="Full name of the person, as written in the note."
-    )
-
-
-class ExtractedTask(pydantic.BaseModel):
-    description: str = pydantic.Field(
-        description="Concise, standalone description of the task or action item."
-    )
-    assigned_to: list[ExtractedPerson] = pydantic.Field(
-        default_factory=list,
-        description="People the task is assigned to.",
-    )
-
-
-class ExtractedMeeting(pydantic.BaseModel):
-    time: datetime.date = pydantic.Field(
-        description="Date of the meeting in ISO format (YYYY-MM-DD)."
-    )
-    note: str = pydantic.Field(
-        description="A brief summary or notes from the meeting section.",
-    )
-    organizer: ExtractedPerson = pydantic.Field(
-        description="The person who organized or led the meeting."
-    )
-    participants: list[ExtractedPerson] = pydantic.Field(
-        default_factory=list,
-        description=(
-            "People who attended the meeting other than the organizer. "
-            "Do not include the organizer here."
-        ),
-    )
-    tasks: list[ExtractedTask] = pydantic.Field(
-        default_factory=list,
-        description="Action items or tasks decided in the meeting.",
-    )
-
-
-EXTRACT_PROMPT = """\
-You are an expert at reading meeting notes and extracting structured information.
-
-Given a single meeting section (Markdown), extract:
-- The meeting date (look for a date in the heading or body; required).
-- A brief note summarizing what the meeting was about.
-- The organizer (the person who ran the meeting). If unclear, pick the person
-  who appears most central to the meeting.
-- Participants other than the organizer.
-- Tasks or action items decided, including who they are assigned to.
-
-Return only what is supported by the text. Use full names where available.
-"""
-
-
-# ---------------------------------------------------------------------------
-# LLM extraction
-# ---------------------------------------------------------------------------
-
-
 @coco.fn(memo=True)
 async def extract_meeting(section_text: str) -> ExtractedMeeting:
-    """Extract a structured Meeting from a Markdown section via LiteLLM + instructor."""
-    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
-    result = await client.chat.completions.create(
-        model=coco.use_context(LLM_MODEL),
-        response_model=ExtractedMeeting,
-        messages=[
-            {"role": "system", "content": EXTRACT_PROMPT},
-            {"role": "user", "content": section_text},
-        ],
-    )
-    # Re-validate to restore class identity for pickling.
-    return ExtractedMeeting.model_validate(result.model_dump())
-
-
-# ---------------------------------------------------------------------------
-# Splitting — match v0's `\n\n##? ` heading regex
-# ---------------------------------------------------------------------------
-
-_HEADING_RE = re.compile(r"\n\n##?\s+")
-
-
-def _split_meetings(text: str) -> list[str]:
-    parts = _HEADING_RE.split("\n\n" + text)
-    return [p.strip() for p in parts if p.strip()]
-
-
-# ---------------------------------------------------------------------------
-# Internal transfer types (Phase 1 → Phase 3)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class MeetingExtraction:
-    """Raw per-meeting data carried forward to entity resolution + relation declaration."""
-
-    meeting_id: int
-    organizer: str  # raw name
-    participants: list[str]  # raw names
-    task_assignees: list[
-        tuple[str, list[str]]
-    ]  # (task_description, [raw assignee names])
-
-
-# ---------------------------------------------------------------------------
-# Phase 1: per-meeting and per-file processing
-# ---------------------------------------------------------------------------
+    return await extract_meeting_with_model(section_text, coco.use_context(LLM_MODEL))
 
 
 @coco.fn(memo=True)
@@ -252,44 +75,9 @@ async def process_file(
     task_table: neo4j.TableTarget[Task],
     decided_rel: neo4j.RelationTarget[Any],
 ) -> list[MeetingExtraction]:
-    text = await file.read_text()
-    note_file = file.file_path.path.as_posix()
-    id_generator = IdGenerator()
-    extractions = []
-    for section in _split_meetings(text):
-        extracted = await extract_meeting(section)
-        meeting_id = await id_generator.next_id(extracted.time)
-
-        meeting_table.declare_record(
-            row=Meeting(
-                id=meeting_id,
-                note_file=note_file,
-                time=extracted.time,
-                note=extracted.note,
-            )
-        )
-
-        for task in extracted.tasks:
-            task_table.declare_record(row=Task(description=task.description))
-            decided_rel.declare_relation(from_id=meeting_id, to_id=task.description)
-
-        extractions.append(
-            MeetingExtraction(
-                meeting_id=meeting_id,
-                organizer=extracted.organizer.name,
-                participants=[p.name for p in extracted.participants],
-                task_assignees=[
-                    (t.description, [a.name for a in t.assigned_to])
-                    for t in extracted.tasks
-                ],
-            )
-        )
-    return extractions
-
-
-# ---------------------------------------------------------------------------
-# Phase 2: Person entity resolution
-# ---------------------------------------------------------------------------
+    return await process_file_common(
+        file, meeting_table, task_table, decided_rel, extract_meeting
+    )
 
 
 @coco.fn(memo=True)
@@ -301,11 +89,6 @@ async def _resolve_persons(raw_persons: set[str]) -> ResolvedEntities:
     )
 
 
-# ---------------------------------------------------------------------------
-# Phase 3: declare canonical Person nodes + person-touching relations
-# ---------------------------------------------------------------------------
-
-
 @coco.fn
 async def create_person_relations(
     meetings: list[MeetingExtraction],
@@ -314,45 +97,13 @@ async def create_person_relations(
     attended_rel: neo4j.RelationTarget[Any],
     assigned_rel: neo4j.RelationTarget[Any],
 ) -> None:
-    # Declare canonical Person nodes.
-    for canonical_name in persons.canonicals():
-        person_table.declare_record(row=Person(name=canonical_name))
-
-    for m in meetings:
-        # ATTENDED — aggregate organizer + participants. Organizer flag wins
-        # on collision so a person listed as both gets a single edge with
-        # is_organizer=true. Resolution happens before aggregation so two
-        # raw names that resolve to the same person also collapse.
-        attendees: dict[str, bool] = {persons.canonical_of(m.organizer): True}
-        for p in m.participants:
-            attendees.setdefault(persons.canonical_of(p), False)
-
-        for canonical, is_organizer in attendees.items():
-            attended_rel.declare_relation(
-                from_id=canonical,
-                to_id=m.meeting_id,
-                record=AttendedRel(is_organizer=is_organizer),
-            )
-
-        # ASSIGNED_TO — dedup per (canonical person, task description).
-        for task_desc, assignees in m.task_assignees:
-            seen: set[str] = set()
-            for raw in assignees:
-                canonical = persons.canonical_of(raw)
-                if canonical in seen:
-                    continue
-                seen.add(canonical)
-                assigned_rel.declare_relation(from_id=canonical, to_id=task_desc)
-
-
-# ---------------------------------------------------------------------------
-# App main
-# ---------------------------------------------------------------------------
+    declare_person_relations(
+        meetings, persons, person_table, attended_rel, assigned_rel
+    )
 
 
 @coco.fn
 async def app_main() -> None:
-    # --- Mount node tables ---
     meeting_table = await neo4j.mount_table_target(
         KG_DB,
         "Meeting",
@@ -372,9 +123,6 @@ async def app_main() -> None:
         primary_key="description",
     )
 
-    # --- Mount relation targets ---
-    # ATTENDED carries is_organizer; mounted without a schema so the connector
-    # auto-derives the relation PK from (from_id, to_id).
     attended_rel = await neo4j.mount_relation_target(
         KG_DB, "ATTENDED", person_table, meeting_table
     )
@@ -385,48 +133,16 @@ async def app_main() -> None:
         KG_DB, "ASSIGNED_TO", person_table, task_table
     )
 
-    # --- Phase 1: per-file extraction ---
-    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
-    root_folder_ids = [
-        folder.strip()
-        for folder in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
-        if folder.strip()
-    ]
-    source = google_drive.GoogleDriveSource(
-        service_account_credential_path=credential_path,
-        root_folder_ids=root_folder_ids,
+    all_meetings = await collect_meeting_extractions(
+        process_file, meeting_table, task_table, decided_rel
     )
-
-    file_coros = []
-    async for path_key, file in source.items():
-        file_coros.append(
-            coco.use_mount(
-                coco.component_subpath("file", path_key),
-                process_file,
-                file,
-                meeting_table,
-                task_table,
-                decided_rel,
-            )
-        )
-    per_file: list[list[MeetingExtraction]] = list(await asyncio.gather(*file_coros))
-    all_meetings: list[MeetingExtraction] = [m for ms in per_file for m in ms]
-
-    # --- Phase 2: Person entity resolution ---
-    raw_persons: set[str] = set()
-    for m in all_meetings:
-        raw_persons.add(m.organizer)
-        raw_persons.update(m.participants)
-        for _task_desc, assignees in m.task_assignees:
-            raw_persons.update(assignees)
 
     persons = await coco.use_mount(
         coco.component_subpath("resolve_persons"),
         _resolve_persons,
-        raw_persons,
+        raw_person_names(all_meetings),
     )
 
-    # --- Phase 3: declare Person nodes + person-touching relations ---
     await coco.mount(
         coco.component_subpath("person_relations"),
         create_person_relations,


### PR DESCRIPTION
Proposed changes from Molten.Bot

This PR implements the requested changes described below.
Built using an AI augmented engineering and reviewed before submission.
Only relevant files were modified.

Original task prompt:
```text
Refactor this repository to reduce the codebase size and centralize duplicated classes, types, and shared logic.

Task:
- Use the most appropriate existing abstractions.
- Remove redundancy instead of layering new wrappers.
- Preserve behavior.
- Avoid regressions.
- Keep the diff focused on the reduction/centralization goal.

Validation:
- Validate the result with focused tests and any existing local verification the repository supports before finishing.
- If local test or validation tooling is unavailable in this runtime, for example `command not found`, do not fail solely for that. Continue with any alternative checks available and clearly report the validation gap.

Failure reporting:
- If failures occur, send a response back to the calling agent with these fields:
  `Failure:` <short failure summary>
  `Error details:` <failing command, log detail, or concrete blocker>.
```

Curious how this was built? See how AI agents can help with your own projects: [MoltenBot Code](https://molten.bot/code?source=pr)