### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.3] - 2026-05-05
+
+### Added
+- Turbopuffer target connector
+- Neo4j connector with meeting_notes_graph_neo4j example
+- Per-argument memoization support
+
+## [1.0.2] - 2026-04-29
+
+### Fixed
+- Google Drive connector: give each request its own Http to avoid socket races
+- Entity resolution: make ResolvedEntities a frozen+slots dataclass for improved performance
+
+## [0.3.39] - 2026-04-29
+
+### Fixed
+- Address dependency security vulnerabilities
+- Auto generation improvements
+
+### Changed
+- Documentation: point v1 to /docs-v1, v0 to /docs (legacy)
+
+## [1.0.1] - 2026-04-28
+
+### Added
+- OCI: live bucket watching via LiveStream + OCI Streaming events
+- FalkorDB target connector
+
+## [1.0.0] - 2026-04-22
+
+### Added
+- Stable 1.0 release
+- Updated documentation release environment
+
+### Fixed
+- URL in docusaurus config
+
+## [0.3.38] - 2026-04-20
+
+### Fixed
+- Make module name consistent
+- FTS documentation link in LanceDB
+
+### Changed
+- Clarify that collect() accepts plain Python values
+
+---
+
+For older releases and detailed changes, see the [GitHub Releases page](https://github.com/cocoindex-io/cocoindex/releases).


### PR DESCRIPTION
## Summary

This PR adds a CHANGELOG.md file following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format to the project.

## Changes

- Add CHANGELOG.md with entries for recent versions (1.0.3 through 0.3.38)
- Uses the widely adopted Keep a Changelog format
- Includes links to the full GitHub Releases page for older versions

## Why this matters

A changelog provides a clear, human-readable history of notable changes. While GitHub Releases exist, having a CHANGELOG.md in the repository root is a common convention that helps users quickly understand what changed between versions without navigating to GitHub's Releases page.

## Format

The changelog follows [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) with sections:
- **Added** for new features
- **Changed** for changes in existing functionality
- **Deprecated** for soon-to-be removed features
- **Removed** for now removed features
- **Fixed** for any bug fixes
- **Security** in case of vulnerabilities

## Checklist

- [x] CHANGELOG follows Keep a Changelog format
- [x] Recent version entries are accurate
- [x] Link to full GitHub Releases page included