### PR TITLE
Add preview mode for update actions

### DIFF
--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -185,6 +185,7 @@ cocoindex update [OPTIONS] APP_TARGET
 | `--reset` | Drop existing setup before updating (equivalent to running 'cocoindex drop' first). |
 | `--full-reprocess` | Reprocess everything and invalidate existing caches. |
 | `-L, --live` | Run in live mode (live components continue processing after initial update). |
+| `--preview` | Compute target actions without applying them. Prints planned actions. |
 | `--help` | Show this message and exit. |
 
 ---

--- a/python/cocoindex/_internal/app.py
+++ b/python/cocoindex/_internal/app.py
@@ -59,10 +59,12 @@ class UpdateHandle(Generic[R]):
         self,
         init_coro: Any,  # Coroutine that returns core.UpdateHandle
         main_fn: Any = None,
+        preview: bool = False,
     ) -> None:
         self._init_coro = init_coro
         self._core_handle: core.UpdateHandle | None = None
         self._main_fn = main_fn  # used for return type inspection
+        self._preview = preview
 
     async def _ensure_started(self) -> core.UpdateHandle:
         if self._core_handle is None:
@@ -98,6 +100,8 @@ class UpdateHandle(Generic[R]):
 
         On error, raises the exception directly from the iterator.
         """
+        if self._preview:
+            raise TypeError("watch() is not supported when preview=True")
         handle = await self._ensure_started()
         last_version = 0
         while True:
@@ -130,6 +134,9 @@ class UpdateHandle(Generic[R]):
     async def result(self) -> R:
         """Await the update result. Raises on error."""
         handle = await self._ensure_started()
+        if self._preview:
+            await handle.result()
+            return handle.take_preview_actions()  # type: ignore[return-value]
         pyvalue: Any = await handle.result()
         return pyvalue.get(fn_ret_deserializer(self._main_fn))  # type: ignore[no-any-return]
 
@@ -269,6 +276,7 @@ class App(Generic[P, R]):
         *,
         full_reprocess: bool = False,
         live: bool = False,
+        preview: bool = False,
     ) -> UpdateHandle[R]:
         """
         Start an update and return a handle for tracking progress and awaiting the result.
@@ -280,6 +288,8 @@ class App(Generic[P, R]):
             full_reprocess: If True, reprocess everything and invalidate existing caches.
             live: If True, run in live mode (live components continue processing
                 after mark_ready).
+            preview: If True, compute target actions without applying them.
+                The handle's result will be a list of raw action objects.
 
         Returns:
             An UpdateHandle that provides access to stats(), watch(), and result().
@@ -295,10 +305,11 @@ class App(Generic[P, R]):
                 processor,
                 full_reprocess=full_reprocess,
                 live=live,
+                preview=preview,
                 host_ctx=env._context_provider,
             )
 
-        return UpdateHandle(_init(), main_fn=self._main_fn)
+        return UpdateHandle(_init(), main_fn=self._main_fn, preview=preview)
 
     def update_blocking(
         self,
@@ -306,7 +317,8 @@ class App(Generic[P, R]):
         report_to_stdout: bool | timedelta = False,
         full_reprocess: bool = False,
         live: bool = False,
-    ) -> R:
+        preview: bool = False,
+    ) -> R | list[Any]:
         """
         Update the app synchronously (run the app once to process all pending changes).
 
@@ -317,9 +329,11 @@ class App(Generic[P, R]):
             full_reprocess: If True, reprocess everything and invalidate existing caches.
             live: If True, run in live mode (live components continue processing
                 after mark_ready).
+            preview: If True, compute target actions without applying them.
+                Returns a list of raw action objects instead of the main function result.
 
         Returns:
-            The result of the main function.
+            The result of the main function, or a list of actions in preview mode.
         """
         env, core_app = self._get_core_env_app_sync()
         root_path = core.StablePath()
@@ -334,7 +348,10 @@ class App(Generic[P, R]):
             report_to_stdout=report,
             refresh_interval_secs=refresh_interval_secs,
             live=live,
+            preview=preview,
         )
+        if preview:
+            return pyvalue  # type: ignore[no-any-return]
         return pyvalue.get(fn_ret_deserializer(self._main_fn))  # type: ignore[no-any-return]
 
     async def drop(self) -> None:

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -195,6 +195,7 @@ class UpdateHandle:
     def stats_snapshot(self) -> tuple[int, bool, dict[str, dict[str, int]]]: ...
     def changed(self) -> Coroutine[Any, Any, int]: ...
     def result(self) -> Coroutine[Any, Any, StoredValue]: ...
+    def take_preview_actions(self) -> list[Any]: ...
 
 # --- DropHandle ---
 class DropHandle:
@@ -224,12 +225,14 @@ class App:
         report_to_stdout: bool = False,
         refresh_interval_secs: float | None = None,
         live: bool = False,
-    ) -> StoredValue: ...
+        preview: bool = False,
+    ) -> StoredValue | list[Any]: ...
     def update_async(
         self,
         root_processor: ComponentProcessor[T_co],
         full_reprocess: bool = False,
         live: bool = False,
+        preview: bool = False,
         host_ctx: Any = None,
     ) -> UpdateHandle: ...
     def drop(

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -708,6 +708,13 @@ async def _stop_all_environments() -> None:
     default=False,
     help="Run in live mode (live components continue processing after initial update).",
 )
+@click.option(
+    "--preview",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Compute target actions without applying them. Prints planned actions.",
+)
 def update(
     app_target: str,
     force: bool,
@@ -715,12 +722,18 @@ def update(
     reset: bool,
     full_reprocess: bool,
     live: bool,
+    preview: bool,
 ) -> None:
     """
     Run an app in catch-up mode. With --live, run in live mode.
 
     `APP_TARGET`: `path/to/app.py`, `module`, `path/to/app.py:app_name`, or `module:app_name`.
     """
+    if preview and reset:
+        raise click.UsageError("--preview and --reset cannot be used together.")
+    if preview and live:
+        raise click.UsageError("--preview and --live cannot be used together.")
+
     app = _load_app(app_target)
 
     async def _do(cancelled: Any) -> None:
@@ -732,6 +745,20 @@ def update(
                 print(
                     f"Running app '{app._name}' from environment '{env.name}' (db path: {env.settings.db_path})"
                 )
+
+            if preview:
+                handle = app.update(
+                    full_reprocess=full_reprocess,
+                    preview=True,
+                )
+                actions: list[Any] = await handle.result()
+                click.echo("Preview: planned target actions")
+                if actions:
+                    for action in actions:
+                        click.echo(f"  {action!r}")
+                else:
+                    click.echo("  No target actions planned.")
+                return
 
             # --reset: drop existing state first (equivalent to `cocoindex drop ...`)
             if reset:

--- a/python/tests/cli/flat_target_app.py
+++ b/python/tests/cli/flat_target_app.py
@@ -1,0 +1,60 @@
+"""Test app with flat/leaf target states only (no child providers)."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any, Collection
+
+import cocoindex as coco
+
+_HERE = pathlib.Path(__file__).resolve().parent
+DB_PATH = _HERE / "cocoindex.db"
+
+env = coco.Environment(coco.Settings.from_env(db_path=DB_PATH))
+
+
+class _FlatStore:
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+
+    def _sink(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[str, Any | coco.NonExistenceType]],
+        /,
+    ) -> None:
+        for key, value in actions:
+            if coco.is_non_existence(value):
+                self.data.pop(key, None)
+            else:
+                self.data[key] = value
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: Any | coco.NonExistenceType,
+        prev_possible_records: Collection[Any],
+        prev_may_be_missing: bool,
+    ) -> (
+        coco.TargetReconcileOutput[tuple[str, Any | coco.NonExistenceType], Any] | None
+    ):
+        assert isinstance(key, str)
+        return coco.TargetReconcileOutput(
+            action=(key, desired_state),
+            sink=coco.TargetActionSink.from_fn(self._sink),
+            tracking_record=desired_state,
+        )
+
+
+_flat_store = _FlatStore()
+_provider = coco.register_root_target_states_provider(
+    "test_cli/flat_preview", _flat_store
+)
+
+
+@coco.fn
+def build() -> None:
+    coco.declare_target_state(_provider.target_state("x", 42))
+
+
+app = coco.App(coco.AppConfig(name="FlatPreviewApp", environment=env), build)

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -707,6 +707,32 @@ class TestDropQuiet:
 # =============================================================================
 
 
+class TestPreview:
+    """Tests for the --preview flag on update."""
+
+    def test_preview_prints_actions(self) -> None:
+        """update --preview should print planned actions without writing."""
+        result = run_cli("update", "./flat_target_app.py", "--preview")
+        assert "Preview: planned target actions" in result.stdout
+        assert "('x', 42)" in result.stdout
+
+    def test_preview_reset_rejected(self) -> None:
+        """--preview --reset should be rejected."""
+        result = run_cli(
+            "update", "./single_app.py", "--preview", "--reset", check=False
+        )
+        assert result.returncode != 0
+        assert "cannot be used together" in result.stderr.lower()
+
+    def test_preview_live_rejected(self) -> None:
+        """--preview --live should be rejected."""
+        result = run_cli(
+            "update", "./single_app.py", "--preview", "--live", check=False
+        )
+        assert result.returncode != 0
+        assert "cannot be used together" in result.stderr.lower()
+
+
 class TestShowTree:
     """Tests for the show command with --tree flag."""
 

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -1166,3 +1166,24 @@ def test_mount_target_delete() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": 2, "delete": 1}
     assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+
+
+##################################################################################
+# Test: preview rejects child target providers
+##################################################################################
+
+
+def test_preview_rejects_child_target_providers() -> None:
+    DictsTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_preview_rejects_child_target_providers", environment=coco_env
+        ),
+        _declare_dicts_data_together,
+    )
+
+    _source_data["D1"] = {"a": 1}
+    with pytest.raises(Exception, match="child target providers"):
+        app.update_blocking(preview=True)

--- a/python/tests/core/test_flat_target_states.py
+++ b/python/tests/core/test_flat_target_states.py
@@ -178,6 +178,52 @@ def test_async_global_dict_target_state_insert() -> None:
     assert AsyncGlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
 
 
+def test_global_dict_preview_returns_actions_without_writing() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_global_dict_preview_returns_actions", environment=coco_env
+        ),
+        declare_global_dict_entries,
+    )
+
+    _source_data["a"] = 1
+    _source_data["b"] = 2
+    actions = app.update_blocking(preview=True)
+
+    assert isinstance(actions, list)
+    assert len(actions) == 2
+    assert GlobalDictTarget.store.data == {}
+    assert GlobalDictTarget.store.metrics.collect() == {}
+
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+        "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 2}
+
+
+@pytest.mark.asyncio
+async def test_global_dict_preview_async() -> None:
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_global_dict_preview_async", environment=coco_env),
+        declare_global_dict_entries,
+    )
+
+    _source_data["a"] = 1
+    actions = await app.update(preview=True)
+
+    assert isinstance(actions, list)
+    assert len(actions) > 0
+    assert GlobalDictTarget.store.data == {}
+
+
 def test_global_dict_target_state_proceed_with_exception() -> None:
     GlobalDictTarget.store.clear()
     _source_data.clear()

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -3,7 +3,7 @@ use crate::engine::stats::{ProcessingStats, VersionedProcessingStats};
 use crate::prelude::*;
 
 use crate::engine::component::Component;
-use crate::engine::context::AppContext;
+use crate::engine::context::{AppContext, PreviewActionCollector};
 use crate::engine::live_component::{LIVE_COMPONENT_DRAIN_TIMEOUT_SECS, LiveComponentState};
 
 use crate::engine::environment::{AppRegistration, Environment};
@@ -101,7 +101,11 @@ impl<Prof: EngineProfile> App<Prof> {
         root_processor: Prof::ComponentProc,
         options: AppUpdateOptions,
         host_ctx: Arc<Prof::HostCtx>,
-    ) -> Result<AppOpHandle<Prof::FunctionData>> {
+        preview_collector: Option<PreviewActionCollector<Prof>>,
+    ) -> Result<(
+        AppOpHandle<Prof::FunctionData>,
+        Option<PreviewActionCollector<Prof>>,
+    )> {
         crate::telemetry::track("app_update");
         // Refresh the app token if a prior operation (e.g. drop_app) cancelled
         // it, so this update starts with a non-cancelled token.
@@ -113,6 +117,7 @@ impl<Prof: EngineProfile> App<Prof> {
             processing_stats.clone(),
             options.full_reprocess,
             options.live,
+            preview_collector.clone(),
             host_ctx,
             // Root has no installed on_error in Build mode — orphan-delete
             // failures from the root's GC sweep log + swallow. (Cascading
@@ -152,12 +157,15 @@ impl<Prof: EngineProfile> App<Prof> {
             .instrument(span),
         );
 
-        Ok(AppOpHandle {
-            task,
-            stats: processing_stats,
-            version_rx,
-            live,
-        })
+        Ok((
+            AppOpHandle {
+                task,
+                stats: processing_stats,
+                version_rx,
+                live,
+            },
+            preview_collector,
+        ))
     }
 
     /// Drop the app, reverting all target states and clearing the database.

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -7,7 +7,7 @@ use std::sync::Weak;
 use crate::engine::context::FnCallContext;
 use crate::engine::context::{
     AppContext, ComponentDeleteContext, ComponentProcessingAction, ComponentProcessingMode,
-    ComponentProcessorContext, MemoStatesPayload,
+    ComponentProcessorContext, MemoStatesPayload, PreviewActionCollector,
 };
 use crate::engine::execution::{
     cleanup_tombstone, eager_existence_upsert, post_submit_for_build, submit,
@@ -523,6 +523,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             parent_ctx.processing_stats().clone(),
             parent_ctx.full_reprocess(),
             parent_ctx.live(), // use_mount inherits live from parent
+            parent_ctx.preview_collector().cloned(),
             parent_ctx.host_ctx().clone(),
             // No build-mode on_error: use_mount is foreground; failures
             // propagate as `Err` to the awaiting parent via `.result()`.
@@ -551,6 +552,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             parent_ctx.processing_stats().clone(),
             parent_ctx.full_reprocess(),
             parent_ctx.live(), // mount inherits live from parent
+            parent_ctx.preview_collector().cloned(),
             parent_ctx.host_ctx().clone(),
             on_error.clone(),
         )?;
@@ -939,7 +941,9 @@ impl<Prof: EngineProfile> Component<Prof> {
                     // that existence ⊇ tracked state and eliminates the
                     // dual-writer conflict with the parent's commit-time
                     // existence reconciliation. See `internal_states.md` §3.1.
-                    if processor_context.mode() == ComponentProcessingMode::Build {
+                    if processor_context.mode() == ComponentProcessingMode::Build
+                        && !processor_context.preview()
+                    {
                         eager_existence_upsert(processor_context).await?;
                     }
 
@@ -1116,6 +1120,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         processing_stats: ProcessingStats,
         full_reprocess: bool,
         live: bool,
+        preview_collector: Option<PreviewActionCollector<Prof>>,
         host_ctx: Arc<Prof::HostCtx>,
         on_error: Option<OnError>,
     ) -> Result<ComponentProcessorContext<Prof>> {
@@ -1148,7 +1153,13 @@ impl<Prof: EngineProfile> Component<Prof> {
             parent_ctx.cloned(),
             processing_stats,
             host_ctx,
-            ComponentProcessingAction::new_build(providers, full_reprocess, live, on_error),
+            ComponentProcessingAction::new_build(
+                providers,
+                full_reprocess,
+                live,
+                on_error,
+                preview_collector,
+            ),
         ))
     }
 

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -457,17 +457,18 @@ pub(crate) struct ComponentBuildingState<Prof: EngineProfile> {
     pub fn_memos: FnMemoCache<Prof>,
 }
 
+/// Shared collector for preview actions across all components in a single update.
+pub(crate) type PreviewActionCollector<Prof> =
+    Arc<std::sync::Mutex<Vec<<Prof as EngineProfile>::TargetAction>>>;
+
 pub(crate) struct ComponentBuildContext<Prof: EngineProfile> {
     pub state: Mutex<Option<ComponentBuildingState<Prof>>>,
     pub full_reprocess: bool,
     pub live: bool,
-    /// Error handler routed to orphan-delete failures from this build's
-    /// commit-phase GC sweep. Same shape and meaning as
-    /// `ComponentDeleteContext::on_error` — see that doc for the
-    /// unified principle. `None` preserves the "log + swallow"
     /// default (e.g. root `App.update`, `use_mount`'s foreground path,
     /// `mount_inner_live`'s self-built parent context).
     pub on_error: Option<crate::engine::component::OnError>,
+    pub preview_collector: Option<PreviewActionCollector<Prof>>,
 }
 
 pub(crate) struct ComponentDeleteContext<Prof: EngineProfile> {
@@ -501,6 +502,7 @@ impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
         full_reprocess: bool,
         live: bool,
         on_error: Option<crate::engine::component::OnError>,
+        preview_collector: Option<PreviewActionCollector<Prof>>,
     ) -> Self {
         Self::Build(ComponentBuildContext {
             state: Mutex::new(Some(ComponentBuildingState {
@@ -514,6 +516,7 @@ impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
             full_reprocess,
             live,
             on_error,
+            preview_collector,
         })
     }
 }
@@ -789,6 +792,20 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         match &self.inner.processing_action {
             ComponentProcessingAction::Build(build_ctx) => build_ctx.full_reprocess,
             ComponentProcessingAction::Delete { .. } => false,
+        }
+    }
+
+    pub fn preview(&self) -> bool {
+        match &self.inner.processing_action {
+            ComponentProcessingAction::Build(build_ctx) => build_ctx.preview_collector.is_some(),
+            ComponentProcessingAction::Delete { .. } => false,
+        }
+    }
+
+    pub(crate) fn preview_collector(&self) -> Option<&PreviewActionCollector<Prof>> {
+        match &self.inner.processing_action {
+            ComponentProcessingAction::Build(build_ctx) => build_ctx.preview_collector.as_ref(),
+            ComponentProcessingAction::Delete { .. } => None,
         }
     }
 

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -1206,6 +1206,159 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     let stable_path = comp_ctx.stable_path().clone();
     let processor_name_owned: Option<Arc<str>> = processor_name.map(Arc::from);
 
+    if comp_ctx.preview() {
+        // Mirror normal precommit Phase 2 planning, but always return
+        // `Ok(None)` from the callback so AppStore applies/commits no
+        // tracking writes. Actions are collected in-memory only.
+        let collector = comp_ctx
+            .preview_collector()
+            .cloned()
+            .ok_or_else(|| internal_error!("preview mode requires a preview collector"))?;
+        let preview_result: Arc<Mutex<Option<(bool, Option<String>)>>> = Arc::new(Mutex::new(None));
+
+        let contained_target_state_paths = Arc::new(contained_target_state_paths);
+        let declared_target_states = Arc::new(tokio::sync::Mutex::new(declared_target_states));
+
+        let mut pending_backoff = std::time::Duration::from_millis(5);
+        const MAX_PENDING_RETRIES: u32 = 8;
+        let mut pending_attempt: u32 = 0;
+        loop {
+            let preview_result_capture = preview_result.clone();
+            let collector = collector.clone();
+            let captures: Arc<PreCommitCaptures<Prof>> = Arc::new(PreCommitCaptures {
+                app_store: app_store.clone(),
+                stable_path: stable_path.clone(),
+                processor_name: processor_name_owned.clone(),
+                contained_target_state_paths: Arc::clone(&contained_target_state_paths),
+                target_states_providers: target_states_providers.clone(),
+                declared_target_states: Arc::clone(&declared_target_states),
+            });
+
+            app_store
+                .precommit(&stable_path, move |wtxn, session| {
+                    let c = Arc::clone(&captures);
+                    let preview_result_capture = preview_result_capture.clone();
+                    let collector = collector.clone();
+                    Box::pin(async move {
+                        let declared_paths_all: Vec<TargetStatePath> = {
+                            let guard = c.declared_target_states.lock().await;
+                            guard.keys().cloned().collect()
+                        };
+                        let reads = session
+                            .precommit_read(
+                                wtxn,
+                                PrecommitReadPlan {
+                                    self_path: c.stable_path.clone(),
+                                    self_token: process_token,
+                                },
+                            )
+                            .await?;
+
+                        let existing_tracking_info_bytes = reads.existing_tracking_info;
+                        let tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'_>> =
+                            existing_tracking_info_bytes
+                                .as_deref()
+                                .map(from_msgpack_slice)
+                                .transpose()?;
+                        let existing_paths: std::collections::HashSet<TargetStatePath> =
+                            tracking_info
+                                .as_ref()
+                                .map(|info| {
+                                    info.target_state_items
+                                        .keys()
+                                        .map(|k| k.target_state_path.clone())
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                        let paths_to_claim: Vec<TargetStatePath> = declared_paths_all
+                            .iter()
+                            .filter(|p| !existing_paths.contains(*p))
+                            .cloned()
+                            .collect();
+
+                        let claim = session
+                            .precommit_claim_targets(
+                                wtxn,
+                                PrecommitClaimTargetsPlan {
+                                    self_path: c.stable_path.clone(),
+                                    paths_to_claim,
+                                },
+                            )
+                            .await?;
+
+                        let outcome = pre_commit(
+                            &c.app_store,
+                            wtxn,
+                            process_token,
+                            &c.stable_path,
+                            full_reprocess,
+                            c.processor_name.as_deref(),
+                            &c.contained_target_state_paths,
+                            &c.target_states_providers,
+                            Arc::clone(&c.declared_target_states),
+                            declared_paths_all,
+                            tracking_info,
+                            claim.prior_owners,
+                            claim.preempted_owner_states,
+                        )
+                        .await?;
+
+                        Ok(match outcome {
+                            PreCommitOutcome::Done { output, write_plan: _ } => {
+                                for input in output.actions_by_sinks.values() {
+                                    if input.child_providers.is_some() {
+                                        client_bail!(
+                                            "preview currently supports flat/leaf target actions only; \
+                                             target actions requiring child target providers are not supported yet"
+                                        );
+                                    }
+                                }
+                                let previously_exists = output.previously_exists;
+                                let processor_name_for_del = output.processor_name_for_del;
+                                let mut guard = collector.lock().unwrap();
+                                for (_sink, input) in output.actions_by_sinks {
+                                    guard.extend(input.actions);
+                                }
+                                *preview_result_capture.lock().unwrap() =
+                                    Some((previously_exists, processor_name_for_del));
+                                None::<(PrecommitWritePlan, PreCommitOutput<Prof>)>
+                            }
+                            PreCommitOutcome::PendingRetry => None,
+                        })
+                    })
+                })
+                .await?;
+
+            if preview_result.lock().unwrap().is_some() {
+                break;
+            }
+            pending_attempt += 1;
+            if pending_attempt >= MAX_PENDING_RETRIES {
+                client_bail!(
+                    "preview pre_commit gave up after {} retries waiting for concurrent ownership transfer at {}",
+                    MAX_PENDING_RETRIES,
+                    comp_ctx.stable_path(),
+                );
+            }
+            tokio::time::sleep(pending_backoff).await;
+            pending_backoff =
+                std::cmp::min(pending_backoff * 2, std::time::Duration::from_millis(200));
+        }
+
+        let (previously_exists, processor_name_for_del) = preview_result
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| internal_error!("preview pre_commit produced no output"))?;
+        if let Some(ref name) = processor_name_for_del {
+            collect_processor_name_name_for_del(name);
+        }
+        return Ok(SubmitOutput {
+            built_target_states_providers,
+            touched_previous_states: previously_exists,
+        });
+    }
+
     // Delete-mode preflight (was in `pre_commit` body pre-Session).
     // The early-return / `demote_component_only` decision needs to
     // happen before opening the submit session so the early-return

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -530,6 +530,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 self.full_reprocess,
                 self.live,
                 on_error.clone(),
+                None,
             ),
         );
 
@@ -829,6 +830,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 self.providers.clone(),
                 self.full_reprocess,
                 self.live,
+                None,
                 None,
             ),
         );
@@ -1134,6 +1136,7 @@ async fn run_op<Prof: EngineProfile>(
                     full_reprocess,
                     live,
                     on_error.clone(),
+                    None,
                 ),
             );
             let inner_handle = child

--- a/rust/py/src/app.rs
+++ b/rust/py/src/app.rs
@@ -31,6 +31,8 @@ fn snapshot_to_py<'py>(
     Ok(dict)
 }
 
+type PyPreviewCollector = Arc<std::sync::Mutex<Vec<Py<PyAny>>>>;
+
 #[pyclass(name = "UpdateHandle")]
 pub struct PyUpdateHandle {
     handle: Mutex<Option<AppOpHandle<PyStoredValue>>>,
@@ -38,6 +40,7 @@ pub struct PyUpdateHandle {
     /// Persistent receiver shared across `changed()` calls via Arc<tokio::Mutex>.
     /// Using tokio::Mutex so it can be held across .await points.
     version_rx: Arc<tokio::sync::Mutex<watch::Receiver<u64>>>,
+    preview_collector: Option<PyPreviewCollector>,
 }
 
 impl PyUpdateHandle {
@@ -48,6 +51,7 @@ impl PyUpdateHandle {
             handle: Mutex::new(Some(handle)),
             stats,
             version_rx,
+            preview_collector: None,
         }
     }
 }
@@ -93,6 +97,19 @@ impl PyUpdateHandle {
             let ret = handle.result().await.into_py_result()?;
             Ok(ret)
         })
+    }
+
+    /// Returns collected preview actions as a Python list. Call after result().
+    pub fn take_preview_actions<'py>(
+        &mut self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyList>> {
+        let actions = self
+            .preview_collector
+            .as_ref()
+            .map(|c| std::mem::take(&mut *c.lock().unwrap()))
+            .unwrap_or_default();
+        pyo3::types::PyList::new(py, actions.iter().map(|a| a.bind(py))).map_err(|e| e.into())
     }
 }
 
@@ -228,13 +245,14 @@ impl PyApp {
         Ok(Self(Arc::new(app)))
     }
 
-    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, live=false))]
+    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, live=false, preview=false))]
     pub fn update_async(
         &self,
         root_processor: PyComponentProcessor,
         full_reprocess: bool,
         host_ctx: Py<PyAny>,
         live: bool,
+        preview: bool,
     ) -> PyResult<PyUpdateHandle> {
         let app = self.0.clone();
         let options = AppUpdateOptions {
@@ -242,14 +260,21 @@ impl PyApp {
             live,
         };
         let host_ctx = Arc::new(host_ctx);
-        let handle = app
-            .update(root_processor, options, host_ctx)
+        let preview_collector = if preview {
+            Some(Arc::new(std::sync::Mutex::new(Vec::new())))
+        } else {
+            None
+        };
+        let (handle, preview_collector) = app
+            .update(root_processor, options, host_ctx, preview_collector)
             .context("failed to start app update")
             .into_py_result()?;
-        Ok(PyUpdateHandle::new(handle))
+        let mut uh = PyUpdateHandle::new(handle);
+        uh.preview_collector = preview_collector;
+        Ok(uh)
     }
 
-    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, report_to_stdout=false, refresh_interval_secs=None, live=false))]
+    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, report_to_stdout=false, refresh_interval_secs=None, live=false, preview=false))]
     pub fn update(
         &self,
         py: Python<'_>,
@@ -259,28 +284,46 @@ impl PyApp {
         report_to_stdout: bool,
         refresh_interval_secs: Option<f64>,
         live: bool,
-    ) -> PyResult<PyStoredValue> {
+        preview: bool,
+    ) -> PyResult<Py<PyAny>> {
         let app = self.0.clone();
         let options = AppUpdateOptions {
             full_reprocess,
             live,
         };
         let host_ctx = Arc::new(host_ctx);
+        let preview_collector = if preview {
+            Some(Arc::new(std::sync::Mutex::new(Vec::new())))
+        } else {
+            None
+        };
         py.detach(|| {
             get_runtime().block_on(async move {
-                let handle = app
-                    .update(root_processor, options, host_ctx)
+                let (handle, preview_collector) = app
+                    .update(root_processor, options, host_ctx, preview_collector)
                     .context("failed to start app update")
                     .into_py_result()?;
-                if report_to_stdout {
-                    rust_show_progress(
+                if preview {
+                    handle.result().await.into_py_result()?;
+                    let actions = preview_collector
+                        .map(|c| std::mem::take(&mut *c.lock().unwrap()))
+                        .unwrap_or_default();
+                    Python::attach(|py| {
+                        let list =
+                            pyo3::types::PyList::new(py, actions.iter().map(|a| a.bind(py)))?;
+                        Ok(list.unbind().into_any())
+                    })
+                } else if report_to_stdout {
+                    let ret: PyStoredValue = rust_show_progress(
                         handle,
                         ProgressDisplayOptions::from_refresh_secs(refresh_interval_secs),
                     )
                     .await
-                    .into_py_result()
+                    .into_py_result()?;
+                    Python::attach(|py| Ok(Py::new(py, ret)?.into_any()))
                 } else {
-                    handle.result().await.into_py_result()
+                    let ret: PyStoredValue = handle.result().await.into_py_result()?;
+                    Python::attach(|py| Ok(Py::new(py, ret)?.into_any()))
                 }
             })
         })

--- a/rust/sdk/cocoindex/src/app.rs
+++ b/rust/sdk/cocoindex/src/app.rs
@@ -272,10 +272,10 @@ impl App {
             live: false,
         };
 
-        let handle = self
+        let (handle, _preview_collector) = self
             .inner
             .core_app
-            .update(processor, options, Arc::new(()))
+            .update(processor, options, Arc::new(()), None)
             .map_err(|e| Error::engine(format!("{e}")))?;
         handle
             .result()


### PR DESCRIPTION
## Summary

Adds preview mode for update actions in both the Python API and CLI.

With preview enabled, CocoIndex computes the same target actions as a normal update, but does not apply them to real targets and does not commit internal tracking state.

Closes #1890.

## API and CLI

Preview is supported in:

- `App.update(..., preview=True)`
- `App.update_blocking(..., preview=True)`
- `cocoindex update --preview`

For the Python API, preview returns the planned action objects.
For the CLI, preview prints the planned actions.

## Implementation

This reuses the existing planning path instead of introducing a separate planner.

In preview mode:

- reconciliation still runs through `pre_commit(...)`
- planning runs in a standalone write transaction
- that transaction is dropped without commit
- `sink.apply(...)` is skipped
- the later commit phase is skipped

This keeps preview aligned with normal update behavior while remaining read-only.

## First pass scope

This first pass supports flat / leaf target actions only.

If a target requires child target providers, preview fails clearly instead of returning partial output.

## CLI behavior

Added:

- `cocoindex update ... --preview`

## Tests

Added coverage for:

- sync preview returns actions without writing
- async preview returns actions without writing
- preview rejects child target providers
- CLI preview prints planned actions

## Validation

Ran locally:

- `cargo fmt --check`
- `cargo test`
- `uv run mypy`
- `uv run pytest python/tests/core -q`
- `uv run pytest python/tests/internal -q`
- `uv run pytest python/tests/cli/test_cli.py -q`