### PR TITLE
fix: resolve ruff format and lint issues (C408)

### DIFF
--- a/python/cocoindex/_internal/setting.py
+++ b/python/cocoindex/_internal/setting.py
@@ -65,7 +65,7 @@ class Settings:
     def from_env(cls, db_path: os.PathLike[str] | None = None) -> Self:
         """Load settings from environment variables."""
 
-        exec_kwargs: dict[str, Any] = dict()
+        exec_kwargs: dict[str, Any] = {}
         _load_field(
             exec_kwargs,
             "source_max_inflight_rows",
@@ -80,7 +80,7 @@ class Settings:
         )
         global_execution_options = GlobalExecutionOptions(**exec_kwargs)
 
-        lmdb_kwargs: dict[str, Any] = dict()
+        lmdb_kwargs: dict[str, Any] = {}
         _load_field(
             lmdb_kwargs,
             "lmdb_max_dbs",
@@ -114,7 +114,7 @@ class ServerSettings:
     @classmethod
     def from_env(cls) -> Self:
         """Load settings from environment variables."""
-        kwargs: dict[str, Any] = dict()
+        kwargs: dict[str, Any] = {}
         _load_field(kwargs, "address", "COCOINDEX_SERVER_ADDRESS")
         _load_field(
             kwargs,

--- a/python/cocoindex/setting.py
+++ b/python/cocoindex/setting.py
@@ -53,7 +53,7 @@ class Settings:
     def from_env(cls, db_path: os.PathLike[str] | None = None) -> Self:
         """Load settings from environment variables."""
 
-        exec_kwargs: dict[str, Any] = dict()
+        exec_kwargs: dict[str, Any] = {}
         _load_field(
             exec_kwargs,
             "source_max_inflight_rows",
@@ -68,7 +68,7 @@ class Settings:
         )
         global_execution_options = GlobalExecutionOptions(**exec_kwargs)
 
-        lmdb_kwargs: dict[str, Any] = dict()
+        lmdb_kwargs: dict[str, Any] = {}
         _load_field(
             lmdb_kwargs,
             "lmdb_max_dbs",
@@ -102,7 +102,7 @@ class ServerSettings:
     @classmethod
     def from_env(cls) -> Self:
         """Load settings from environment variables."""
-        kwargs: dict[str, Any] = dict()
+        kwargs: dict[str, Any] = {}
         _load_field(kwargs, "address", "COCOINDEX_SERVER_ADDRESS")
         _load_field(
             kwargs,

--- a/python/tests/connectors/test_kafka_target.py
+++ b/python/tests/connectors/test_kafka_target.py
@@ -80,8 +80,9 @@ def message_handler_with_deletion(producer: MockAIOProducer) -> _MessageHandler:
     return _MessageHandler(
         producer=_as_producer(producer),
         topic="test-topic",
-        deletion_value_fn=lambda k: b"deleted:"
-        + (k if isinstance(k, bytes) else k.encode()),
+        deletion_value_fn=lambda k: (
+            b"deleted:" + (k if isinstance(k, bytes) else k.encode())
+        ),
     )
 
 
@@ -268,8 +269,9 @@ class TestMessageHandlerSink:
         handler = _MessageHandler(
             producer=_as_producer(producer),
             topic="test-topic",
-            deletion_value_fn=lambda k: b"del:"
-            + (k if isinstance(k, bytes) else k.encode()),
+            deletion_value_fn=lambda k: (
+                b"del:" + (k if isinstance(k, bytes) else k.encode())
+            ),
         )
 
         action = _MessageAction(key=b"k1", value=b"del:k1")


### PR DESCRIPTION
## Summary

Fixes ruff formatting and lint issues found in the codebase:

1. **ruff format** in `python/tests/connectors/test_kafka_target.py`: Lambda expressions with multiline string concatenation were not properly parenthesized, causing `ruff format` to flag the file.

2. **ruff C408** in `python/cocoindex/setting.py` and `python/cocoindex/_internal/setting.py`: Replaced 6 unnecessary `dict()` calls with dict literal `{}` syntax, which is more idiomatic and consistent with the rest of the codebase.

## Changes

- `python/tests/connectors/test_kafka_target.py`: Wrap lambda expressions in parentheses for proper multiline formatting
- `python/cocoindex/setting.py`: `dict()` → `{}` in `Settings.from_env()` and `ServerSettings.from_env()`
- `python/cocoindex/_internal/setting.py`: Same `dict()` → `{}` fixes in the internal settings module

## Verification

```bash
ruff format --check .        # 219 files already formatted ✓
ruff check --select C408 .   # All checks passed ✓
```