### PR TITLE
fix(security): validate SQL identifiers in postgres/sqlite connectors

### DIFF
--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -13,6 +13,7 @@ import datetime
 import decimal
 import ipaddress
 import json
+import re
 import uuid
 from dataclasses import dataclass
 from typing import (
@@ -64,6 +65,22 @@ ValueEncoder = Callable[[Any], Any]
 
 # asyncpg enforces a protocol limit of 32767 bind parameters per query.
 _BIND_LIMIT: int = 32767
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> None:
+    """Reject identifiers outside the unquoted-identifier allow-list.
+
+    PostgreSQL identifiers are quoted with double quotes when interpolated, but
+    quoting alone does not prevent injection if the input itself contains a
+    double-quote character. Mirroring the Doris connector's approach
+    (CVE-2026-28438), we error out immediately on anything that isn't a plain
+    unquoted identifier.
+    """
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {kind}: {name!r}")
 
 
 def _qualified_table_name(table_name: str, pg_schema_name: str | None) -> str:
@@ -1283,6 +1300,12 @@ def table_target(
     Returns:
         A TargetState that can be passed to ``mount_target()``.
     """
+    _validate_identifier(table_name, "table name")
+    if pg_schema_name is not None:
+        _validate_identifier(pg_schema_name, "schema name")
+    for col_name in table_schema.columns:
+        _validate_identifier(col_name, "column name")
+
     key = _TableKey(
         db_key=db.key,
         pg_schema_name=pg_schema_name,

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import json
+import re
 import sqlite3
 import uuid
 from dataclasses import dataclass, field
@@ -143,6 +144,22 @@ class Vec0TableDef(msgspec.Struct, frozen=True):
 
 # SQLite has a limit of 999 variables per query (SQLITE_MAX_VARIABLE_NUMBER)
 _BIND_LIMIT: int = 999
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> None:
+    """Reject identifiers outside the unquoted-identifier allow-list.
+
+    SQLite identifiers are quoted with double quotes when interpolated, but
+    quoting alone does not prevent injection if the input itself contains a
+    double-quote character. Mirroring the Doris connector's approach
+    (CVE-2026-28438), we error out immediately on anything that isn't a plain
+    unquoted identifier.
+    """
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {kind}: {name!r}")
 
 
 def _qualified_table_name(table_name: str) -> str:
@@ -1129,6 +1146,10 @@ def table_target(
     Returns:
         A TargetState that can be passed to ``mount_target()``.
     """
+    _validate_identifier(table_name, "table name")
+    for col_name in table_schema.columns:
+        _validate_identifier(col_name, "column name")
+
     if isinstance(virtual_table_def, Vec0TableDef):
         managed_conn = coco.use_context(db)
         _validate_vec0_config(table_schema, virtual_table_def, managed_conn)


### PR DESCRIPTION
## Summary

This extends the same identifier-validation fix that landed in the Doris
connector for [CVE-2026-28438](https://github.com/cocoindex-io/cocoindex/security/advisories/GHSA-59g6-v3vg-f7wc) (fixed in 0.3.34) to the **postgres** and
**sqlite** target connectors. Both wrap user-supplied identifiers in
double quotes when building DDL/DML but never reject or escape embedded
double-quote characters, so a `table_name` (or `pg_schema_name`, or any
column name) supplied from an untrusted upstream can break out of the
quoted identifier exactly the way the pre-0.3.34 Doris path did.

## Impact

Same threat model as GHSA-59g6-v3vg-f7wc: in application code that
forwards an untrusted upstream value as the `table_name` argument to
`table_target()` / `declare_table_target()` / `mount_table_target()`
(or as `pg_schema_name`, or as a column name in `TableSchema.columns`),
the resulting SQL — `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`,
`INSERT`, `DELETE` — can be made to execute attacker-chosen statements.

The published advisory's workaround text already says callers _should_
validate identifiers themselves; this PR makes the connector fail-fast
on the same surface for the other two SQL connectors so the workaround
is enforced rather than just recommended.

## Location

- `python/cocoindex/connectors/postgres/_target.py` — `_qualified_table_name` and the column quoting in DDL/DML do not validate input. Public entry: `table_target()` (line 1262).
- `python/cocoindex/connectors/sqlite/_target.py` — same pattern. Public entry: `table_target()` (line 1108).

## Fix

Add a private `_validate_identifier()` helper to each connector — same regex `^[A-Za-z_][A-Za-z0-9_]*$` and same `raise ValueError` posture as `connectors/doris/_target.py:_validate_identifier`. Call it once at the public `table_target()` entry on `table_name`, `pg_schema_name` (postgres only), and every key in `table_schema.columns`. All public APIs (`declare_table_target`, `mount_table_target`) flow through `table_target()`, so the check covers them too.

The strict allow-list intentionally matches the choice already made in the Doris connector — happy to relax to a per-connector escape (e.g. doubling embedded `"`) if that aligns better with how you want to evolve identifier handling. Either is materially safer than the current behaviour.

## Detected by

Aeon ([github.com/aaronjmars/aeon-aaron](https://github.com/aaronjmars/aeon-aaron)) — semgrep flagged the surrounding pickle / GHA findings; this one surfaced from manual review against the published GHSA-59g6-v3vg-f7wc fix to check whether it had been forward-ported to the other SQL connectors.

- Severity: medium
- CWE-89 (SQL injection)
- Reference: GHSA-59g6-v3vg-f7wc / CVE-2026-28438 (Doris equivalent, already public)

## Verification

- `python -c "compile(open(p).read(), p, 'exec')"` on both modified files — clean.
- Quick regex smoke test against the allow-list — accepts `users`, `_x`, `Users123`, `CamelCase`; rejects `malicious"--`, `a-b`, `table; DROP TABLE foo;`, empty string.
- Did **not** run the project test suite locally (no Postgres / sqlite-vec available in the sandbox); the patch is purely additive (extra validation at the entry point) and should not affect any caller passing a normal identifier.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to fold in column-level call-site validation (mirroring the Doris pattern at the DDL helpers too) if you'd prefer defense-in-depth over the entry-point check.