### PR TITLE
chore: bump trove classifier to Production/Stable for v1 launch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = "Apache-2.0"
 license-files = ["THIRD_PARTY_NOTICES.html"]
 urls = { Homepage = "https://cocoindex.io/" }
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Rust",


### PR DESCRIPTION
## Summary
- Bumps the trove classifier from `Development Status :: 3 - Alpha` to `5 - Production/Stable` to reflect that CocoIndex v1 is officially launched.

## Test plan
- CI (no behavior change; metadata only).
