### PR TITLE
`docs`: fix broken URL

### DIFF
--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -118,7 +118,7 @@ app = coco.App(
 In the main function, we walk through each project in the subdirectories and process it.
 
 It is up to you to declare the process granularity. It can be
-- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding) is a project, each containing multiple files,
+- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding) is a project, each containing multiple files,
 - or at file level,
 - or at even smaller units (e.g., page level, or semantic unit level).
 


### PR DESCRIPTION
Fix broken link in [`multi-codebase-summarization doc webpage`](https://cocoindex.io/docs/examples/multi-codebase-summarization/#define-the-main-function): code_embedding example link is 404ing.
Updated to point to main.

Thanks to the community member (Unaimend) who flagged this in [Discord](https://discord.com/channels/1314801574169673738/1345480127491997736/1503077906073784402).

_PS: Wondering why this wasn't caught by lychee (should go through the actions running to see if this was flagged in a broken CI run)._