### PR TITLE
`docs`: update stale `v1` branch links to main across docs

### DIFF
--- a/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
+++ b/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
@@ -592,7 +592,7 @@ pool = context_provider.get(key.db_key, asyncpg.Pool)
 
 This way, changing a password, switching replicas, or rotating credentials won't invalidate tracked states or break reconciliation.
 
-See `_TableKey` in [`cocoindex/connectors/postgres/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/v1/python/cocoindex/connectors/postgres/_target.py) and [`cocoindex/connectors/surrealdb/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/v1/python/cocoindex/connectors/surrealdb/_target.py) for reference implementations.
+See `_TableKey` in [`cocoindex/connectors/postgres/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/postgres/_target.py) and [`cocoindex/connectors/surrealdb/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/surrealdb/_target.py) for reference implementations.
 
 ### Idempotent actions
 
@@ -740,5 +740,5 @@ class _FileHandler(coco.TargetHandler[_FileContent, _FileTrackingRecord]):
 
 See the full implementations in:
 
-- [`cocoindex/connectors/localfs/target.py`](https://github.com/cocoindex-io/cocoindex/blob/v1/python/cocoindex/connectors/localfs/_target.py) — File system targets
-- [`cocoindex/connectors/postgres/target.py`](https://github.com/cocoindex-io/cocoindex/blob/v1/python/cocoindex/connectors/postgres/_target.py) — PostgreSQL tables and rows
+- [`cocoindex/connectors/localfs/target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/localfs/_target.py) — File system targets
+- [`cocoindex/connectors/postgres/target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/postgres/_target.py) — PostgreSQL tables and rows

--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -7,7 +7,7 @@ description: >
 ---
 CocoIndex ships an official **agent skill** that teaches AI coding agents how to build CocoIndex v1 pipelines correctly — core concepts, API surface, common patterns, connectors, and best practices, all in one place.
 
-The skill lives in the [`skills/cocoindex/`](https://github.com/cocoindex-io/cocoindex/tree/v1/skills/cocoindex) directory of the main repo.
+The skill lives in the [`skills/cocoindex/`](https://github.com/cocoindex-io/cocoindex/tree/main/skills/cocoindex) directory of the main repo.
 
 ## Why a skill?
 

--- a/docs/src/content/docs/getting_started/quickstart.mdx
+++ b/docs/src/content/docs/getting_started/quickstart.mdx
@@ -47,7 +47,7 @@ When your source data is updated, or your processing logic is changed (for examp
     ```bash
     mkdir pdf_files
     ```
-    You can download sample PDF files from the [git repo](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_to_markdown).
+    You can download sample PDF files from the [git repo](https://github.com/cocoindex-io/cocoindex/tree/main/examples/pdf_to_markdown).
 
 4. Create a `.env` file to configure the database path:
 
@@ -188,4 +188,4 @@ The corresponding Markdown file is automatically removed.
 
 - Read [Core Concepts](../programming_guide/core_concepts) to understand the mental model — state-driven programming, processing components, and memoization
 - Dive into the [Programming Guide](../programming_guide/app), starting with Apps, to learn how to build more complex pipelines
-- Browse more [examples](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) for real-world patterns (text embedding, RAG, knowledge graphs)
+- Browse more [examples](https://github.com/cocoindex-io/cocoindex/tree/main/examples) for real-world patterns (text embedding, RAG, knowledge graphs)

--- a/docs/src/content/docs/programming_guide/live_mode.mdx
+++ b/docs/src/content/docs/programming_guide/live_mode.mdx
@@ -87,7 +87,7 @@ app.update_blocking(live=True)
 
 **Catch-up compatibility:** `LiveMapView` sources also work without `live=True` — they do the initial full scan and exit cleanly. You can write your pipeline once and choose catch-up or live at run time.
 
-For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/files_transform).
+For a complete working example, see [`files_transform`](https://github.com/cocoindex-io/cocoindex/tree/main/examples/files_transform).
 
 ### `kafka` — consuming a topic with `LiveMapFeed`
 

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -11,7 +11,7 @@ last_reviewed: 2026-04-20
 
 Your code is the source of truth. In this tutorial, we'll build a pipeline that automatically generates a one-pager wiki for each project in a list, that never goes out-of-date with incremental processing. Think about building your own deep wiki that is always fresh.
 
-For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/v1/examples), we can have an auto-one-pager like this:
+For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/main/examples), we can have an auto-one-pager like this:
 
 
 ![markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.png)
@@ -118,11 +118,11 @@ app = coco.App(
 In the main function, we walk through each project in the subdirectories and process it.
 
 It is up to you to declare the process granularity. It can be
-- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding) is a project, each containing multiple files,
+- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding) is a project, each containing multiple files,
 - or at file level,
 - or at even smaller units (e.g., page level, or semantic unit level).
 
-In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
+In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/main/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
 
 ```python title="main.py"
 @coco.function

--- a/docs/src/content/example-posts/pdf-to-markdown.md
+++ b/docs/src/content/example-posts/pdf-to-markdown.md
@@ -48,7 +48,7 @@ When your source data is updated, or your processing logic is changed (for examp
     ```bash
     mkdir pdf_files
     ```
-    You can download sample PDF files from the [git repo](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_to_markdown).
+    You can download sample PDF files from the [git repo](https://github.com/cocoindex-io/cocoindex/tree/main/examples/pdf_to_markdown).
 
 4. Create a `.env` file to configure the database path:
 


### PR DESCRIPTION
Follow-up to #1958. The `v1` branch no longer exists after GA main branch merge, so several doc links were _404-ing_.
Updated all remaining `blob/v1` and `tree/v1` references to `main` across 6 files.

Also looking into why `lychee` didn't catch these earlier: the [latest CI run](https://github.com/cocoindex-io/cocoindex/actions/runs/25616104962) reports 10 broken links but still exits green. I feel that the issue is the exit code check in `links.yml`:

https://github.com/cocoindex-io/cocoindex/blob/ccfe37b258e2adca2d581321490a2ca183db6c2c/.github/workflows/links.yml#L52-L54


This is an exact string match, if lychee returns any other non-zero code, the step is skipped and CI passes. Also, --cache --max-cache-age 1d means if these URLs were valid when last cached (before v1 was deleted), they'd pass on subsequent runs within that window. Will follow up with a fix to the workflow.