### PR TITLE
fix: correct lychee exit code handling

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -2,14 +2,14 @@ name: Link Check
 
 on:
   pull_request:
-    branches: [main, v1]
+    branches: [main]
     paths:
       - "docs/**/*.md"
       - "docs/**/*.mdx"
       - ".lycheeignore"
       - ".github/workflows/links.yml"
   push:
-    branches: [main, v1]
+    branches: [main]
     paths:
       - "docs/**/*.md"
       - "docs/**/*.mdx"
@@ -33,6 +33,7 @@ jobs:
           fetch-depth: 1
 
       - name: Restore lychee cache
+        if: github.event_name != 'schedule'
         uses: actions/cache@v5
         with:
           path: .lycheecache
@@ -49,14 +50,14 @@ jobs:
           jobSummary: true
           output: ./lychee/out.md
 
-      - name: Fail on broken links
-        if: steps.lychee.outputs.exit_code == 1
-        run: exit 1
-
       - name: Create issue from report
-        if: steps.lychee.outputs.exit_code == 1
+        if: steps.lychee.outputs.exit_code == '2'
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
           labels: report, automated issue
+
+      - name: Fail on broken links
+        if: steps.lychee.outputs.exit_code != '0'
+        run: exit 1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -51,7 +51,7 @@ jobs:
           output: ./lychee/out.md
 
       - name: Create issue from report
-        if: steps.lychee.outputs.exit_code == '2'
+        if: steps.lychee.outputs.exit_code == '2' && github.event_name == 'schedule'
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report


### PR DESCRIPTION
Fixes the [link checker workflow](https://github.com/cocoindex-io/cocoindex/blob/main/.github/workflows/links.yml) that was silently passing despite broken links in the [latest run](https://github.com/cocoindex-io/cocoindex/actions/runs/25616104962).

Turned out there were a few compounding issues: `lychee` actually [exits with 2 for broken links](https://github.com/lycheeverse/lychee#exit-codes) (not 1), so the old `== 1` condition never _fired_. The issue creation step also needed to come **before** the fail step, otherwise it gets _skipped_.

And scheduled runs were restoring a stale cache, so URLs that were valid before the `v1` branch was deleted kept passing on daily checks; fixed by skipping cache restore on scheduled runs entirely. Also cleaned up v1 from the branch triggers since that branch no longer exists :)
