### PR TITLE
docs: add gws CLI as alternative Google Drive authentication method

### DIFF
--- a/docs/src/content/docs/connectors/google_drive.mdx
+++ b/docs/src/content/docs/connectors/google_drive.mdx
@@ -36,6 +36,16 @@ Both require a Google service account with access to the target Drive folders.
 2. Download the JSON credential file
 3. Share the target Drive folders with the service account's email address
 
+:::tip[Alternative: using the `gws` CLI]
+In headless or server environments, the [`gws` CLI](https://github.com/nicholasgasior/gws) provides a convenient alternative for obtaining Google credentials:
+
+```bash
+gws auth login
+```
+
+This generates the necessary credential files that CocoIndex can use with the Google Drive connector.
+:::
+
 ### GoogleDriveSource
 
 The primary source class for iterating over Google Drive files.


### PR DESCRIPTION
Closes #1737

## Summary
Adds a tip callout to the Google Drive connector documentation mentioning `gws` CLI as an alternative authentication method, useful for headless or server environments where browser-based OAuth is not practical.

## Changes
- `docs/src/content/docs/connectors/google_drive.mdx` — adds `:::tip` block after the service account setup steps

## Test plan
- [ ] Tip block renders correctly in the docs site
- [ ] Link to gws CLI is accurate