### PR TITLE
fix(cli): share memo cache across script and CLI invocations

### DIFF
--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -38,7 +38,12 @@ from .component_ctx import (
     get_context_from_ctx,
 )
 from .context_keys import resolve_awaitables_sync
-from .memo_fingerprint import StateFnEntry, fingerprint_call, memo_fingerprint
+from .memo_fingerprint import (
+    StateFnEntry,
+    canonical_module_name,
+    fingerprint_call,
+    memo_fingerprint,
+)
 from .runner import Runner
 from .runner import in_subprocess as _in_subprocess
 from .serde import (
@@ -623,7 +628,7 @@ def _compute_logic_fingerprint(
             canonical = ast.dump(tree, include_attributes=False, annotate_fields=True)
         except (OSError, SyntaxError):
             canonical = f"<bytecode>{hashlib.sha256(fn.__code__.co_code).hexdigest()}"
-    payload = f"{fn.__module__}.{fn.__qualname__}\n{canonical}"
+    payload = f"{canonical_module_name(fn)}.{fn.__qualname__}\n{canonical}"
     if deps is not None:
         # Use an explicit stable encoding (hex of the 16-byte digest) rather
         # than Fingerprint.__str__ — the deps fingerprint ends up embedded in

--- a/python/cocoindex/_internal/memo_fingerprint.py
+++ b/python/cocoindex/_internal/memo_fingerprint.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import os
 import pickle
 import struct
+import sys
 import typing
 
 from . import core
@@ -88,6 +90,34 @@ def _make_state_fn_entry(
     return StateFnEntry(deserialize_prev=_deserialize_prev, call=state_fn)
 
 
+def canonical_module_name(obj: typing.Any) -> str:
+    """Return ``obj.__module__``, mapping ``"__main__"`` to the entry script's basename.
+
+    Why: ``fn.__module__`` is part of memoization keys, but the same script
+    produces different module names depending on how it's invoked:
+
+    * ``python main.py``           -> ``__main__``
+    * ``cocoindex update main.py`` -> ``main`` (basename, set by the loader)
+    * ``cocoindex update main``    -> ``main`` (importlib's module name)
+
+    Canonicalizing ``__main__`` to the script's basename collapses all three to
+    the same identity so memo caches are shared across them.
+
+    Callers must pass an object that has ``__module__`` (classes, regular
+    functions, lambdas, callable instances). If you're passing something looser
+    like a bound method or ``functools.partial`` produced by user code, wrap
+    with ``getattr(..., '__module__', None)`` at the call site instead.
+    """
+    mod: str = obj.__module__
+    if mod == "__main__":
+        main_mod = sys.modules.get("__main__")
+        if main_mod is not None:
+            main_file: str | None = getattr(main_mod, "__file__", None)
+            if main_file:
+                return os.path.splitext(os.path.basename(main_file))[0]
+    return mod
+
+
 def _is_dataclass_instance(obj: object) -> bool:
     """Check if obj is a dataclass instance (not a class)."""
     return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
@@ -108,7 +138,7 @@ def _canonicalize_dataclass(obj: object, _seen: dict[int, int]) -> Fingerprintab
     fields = dataclasses.fields(obj)  # type: ignore[arg-type]
     return (
         "dataclass",
-        typ.__module__,
+        canonical_module_name(typ),
         typ.__qualname__,
         tuple(
             (field.name, _canonicalize(getattr(obj, field.name), _seen))
@@ -127,7 +157,7 @@ def _canonicalize_pydantic(obj: object, _seen: dict[int, int]) -> Fingerprintabl
     field_names = obj.__pydantic_fields__.keys()  # type: ignore[attr-defined]
     return (
         "pydantic",
-        typ.__module__,
+        canonical_module_name(typ),
         typ.__qualname__,
         tuple((name, _canonicalize(getattr(obj, name), _seen)) for name in field_names),
     )
@@ -257,7 +287,7 @@ def _canonicalize(
                 state_methods.append(_make_state_fn_entry(state_hook, raw_fn))
         return (
             tag,
-            typ.__module__,
+            canonical_module_name(typ),
             typ.__qualname__,
             _canonicalize(k, _seen, state_methods),
         )
@@ -274,7 +304,7 @@ def _canonicalize(
                     state_methods.append(_make_state_fn_entry(bound, memo.state_fn))
             return (
                 tag,
-                base.__module__,
+                canonical_module_name(base),
                 base.__qualname__,
                 _canonicalize(k, _seen, state_methods),
             )
@@ -340,7 +370,7 @@ def _make_call_canonical(
     prefix_args: tuple[object, ...] = (),
 ) -> Fingerprintable:
     function_identity = (
-        getattr(func, "__module__", None),
+        canonical_module_name(func),
         getattr(func, "__qualname__", None),
     )
     canonical_args = tuple(
@@ -400,7 +430,7 @@ def fingerprint_call(
 # Register memo key for class types.
 register_memo_key_function(
     type,
-    lambda cls: (getattr(cls, "__module__", None), getattr(cls, "__qualname__", None)),
+    lambda cls: (canonical_module_name(cls), getattr(cls, "__qualname__", None)),
 )
 
 

--- a/python/cocoindex/user_app_loader.py
+++ b/python/cocoindex/user_app_loader.py
@@ -58,11 +58,11 @@ def load_user_app(app_target: str) -> types.ModuleType:
             raise Error(f"Application file path not found: {app_target}")
         app_path = os.path.abspath(app_target)
         app_dir = os.path.dirname(app_path)
-        # Use "__main__" as the module name so that functions defined in the loaded
-        # module have __module__ == "__main__", matching the behavior when running
-        # the script directly (python main.py). This keeps memoization cache keys
-        # consistent between direct execution and CLI-loaded execution.
-        module_name = "__main__"
+        # Use the file basename as the module name (e.g. main.py -> "main"). This
+        # matches the bare-module CLI form (`cocoindex update main`) so memo cache
+        # keys are consistent across both, and avoids triggering the user's
+        # `if __name__ == "__main__":` block during module loading.
+        module_name = os.path.splitext(os.path.basename(app_path))[0]
 
         # If the file lives inside a package (directory has __init__.py),
         # load it as a proper submodule so that relative imports work.


### PR DESCRIPTION
## Summary

- Two coordinated fixes so `python main.py`, `cocoindex update main.py`, and `cocoindex update main` produce identical memoization keys for the same function/type — no more cache-invalidation churn when switching between forms.
- Stops loading `.py` user apps under `__name__ = "__main__"`, which fixes `RuntimeError: environment already open in this program` when the user's `if __name__ == "__main__":` block runs the app during CLI loading (e.g. `examples/code_embedding/main.py`).
- Adds `canonical_module_name()` in `memo_fingerprint.py` that maps `"__main__"` → entry script basename, threaded through every place `__module__` participates in memo-key generation (logic fingerprint, dataclass/pydantic canonicalization, hook tags, call identity, class memo key).

## Test plan

- [x] `uv run mypy` — clean (217 files).
- [x] `uv run pytest python/tests/internal/test_memo_fingerprint.py` — 36 passed.
- [x] End-to-end on `examples/code_embedding`: after one warm run, all three forms hit the cache fully:
  - `cocoindex update main.py` → 550 `unchanged`
  - `cocoindex update main` → 550 `unchanged`
  - `python main.py` → 550 `unchanged`
- [x] CI.
