### PR TITLE
style: fix ruff format in postgres connector source

### DIFF
--- a/python/cocoindex/connectors/postgres/_source.py
+++ b/python/cocoindex/connectors/postgres/_source.py
@@ -28,7 +28,7 @@ from cocoindex.connectorkits.async_adapters import async_to_sync_iter
 
 
 # Valid SQL identifier pattern: starts with letter or underscore, contains only letters, digits, underscores, or $ (for temp tables)
-_VALID_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_$]*$')
+_VALID_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_$]*$")
 
 try:
     import asyncpg  # type: ignore


### PR DESCRIPTION
## Summary
- Fix ruff format failure in `python/cocoindex/connectors/postgres/_source.py` introduced by #1965 — switch the valid identifier regex literal from single to double quotes to match the formatter's expected style.

## Test plan
- CI (ruff format check + full test suite).
