### PR TITLE
feat: add Apache Iggy connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ doris = ["aiohttp>=3.9.0", "pymysql>=1.1.0", "aiomysql>=0.2.0"]
 falkordb = ["falkordb>=1.1.0"]
 neo4j = ["neo4j>=5.18.0"]
 kafka = ["confluent_kafka>=2.6"]
+iggy = ["apache-iggy>=0.8.0"]
 oci = ["oci>=2.0"]
 entity_resolution = ["faiss-cpu>=1.7"]
 entity_resolution_llm = [
@@ -120,6 +121,7 @@ all = [
     "falkordb>=1.1.0",
     "neo4j>=5.18.0",
     "confluent_kafka>=2.6",
+    "apache-iggy>=0.8.0",
     "oci>=2.0",
     "faiss-cpu>=1.7",
     "instructor>=1.0",

--- a/python/cocoindex/connectors/iggy/__init__.py
+++ b/python/cocoindex/connectors/iggy/__init__.py
@@ -1,0 +1,5 @@
+from . import _source, _target
+from ._source import *
+from ._target import *
+
+__all__ = _source.__all__ + _target.__all__

--- a/python/cocoindex/connectors/iggy/_source.py
+++ b/python/cocoindex/connectors/iggy/_source.py
@@ -1,0 +1,568 @@
+"""
+Iggy source for CocoIndex.
+
+Exposes an Iggy stream/topic/partition as a :class:`LiveStream` of raw
+``ReceiveMessage`` objects. It also provides a keyed-map adapter for payloads
+that carry an application-level key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from datetime import timedelta
+from typing import Any, Callable
+
+try:
+    from apache_iggy import AutoCommit  # type: ignore[import-not-found]
+    from apache_iggy import IggyClient  # type: ignore[import-not-found]
+    from apache_iggy import IggyConsumer  # type: ignore[import-not-found]
+    from apache_iggy import PollingStrategy  # type: ignore[import-not-found]
+    from apache_iggy import ReceiveMessage  # type: ignore[import-not-found]
+except ImportError as e:
+    raise ImportError(
+        "apache-iggy is required to use the Iggy connector. "
+        "Please install cocoindex[iggy]."
+    ) from e
+
+from cocoindex._internal.live_component import (
+    _IMMEDIATE_READY,
+    LiveMapSubscriber,
+    LiveStream,
+    LiveStreamSubscriber,
+    ReadyAwaitable,
+)
+from cocoindex._internal.typing import StableKey
+
+_logger = logging.getLogger(__name__)
+
+
+# --- Public type aliases ---
+
+IsDeleteFn = Callable[[ReceiveMessage], bool]
+KeyFn = Callable[[ReceiveMessage], StableKey | None]
+
+
+# --- Per-partition state ---
+
+
+class _PartitionState:
+    """Tracks inflight offsets and stores offsets when safe.
+
+    Iggy stores the last consumed offset, while Kafka commits the next offset.
+    Internally this class tracks ``_committed_next_offset`` so readiness uses the
+    same comparison as Kafka: caught up when the next offset to consume has
+    reached the initial high watermark.
+    """
+
+    __slots__ = (
+        "_consumer",
+        "_stream",
+        "_topic",
+        "_partition",
+        "_inflight",
+        "_completed",
+        "_tasks",
+        "_high_watermark",
+        "_committed_next_offset",
+        "_on_commit",
+    )
+
+    def __init__(
+        self,
+        consumer: IggyConsumer,
+        stream: str,
+        topic: str,
+        partition: int,
+        high_watermark: int,
+        committed_next_offset: int,
+        on_commit: Callable[[], None],
+    ) -> None:
+        self._consumer = consumer
+        self._stream = stream
+        self._topic = topic
+        self._partition = partition
+        self._inflight: deque[int] = deque()
+        self._completed: set[int] = set()
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._high_watermark = high_watermark
+        self._committed_next_offset = committed_next_offset
+        self._on_commit = on_commit
+
+    def is_caught_up(self) -> bool:
+        """Whether this partition has consumed up to its initial high watermark."""
+        return self._committed_next_offset >= self._high_watermark
+
+    def track(self, offset: int, handle: ReadyAwaitable) -> None:
+        """Register an inflight offset with its readiness handle."""
+        self._inflight.append(offset)
+        if handle is _IMMEDIATE_READY:
+            self._completed.add(offset)
+            self._try_drain_and_store()
+            return
+
+        task = asyncio.create_task(self._await_handle(offset, handle))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _await_handle(self, offset: int, handle: ReadyAwaitable) -> None:
+        """Await a readiness handle and mark the offset as completed."""
+        try:
+            await handle.ready()
+        except asyncio.CancelledError:
+            return
+        self._completed.add(offset)
+        self._try_drain_and_store()
+
+    def _try_drain_and_store(self) -> None:
+        """Drain contiguous completed offsets from the front and store the last."""
+        last_drained: int | None = None
+        while self._inflight and self._inflight[0] in self._completed:
+            offset = self._inflight.popleft()
+            self._completed.discard(offset)
+            last_drained = offset
+
+        if last_drained is not None:
+            self._committed_next_offset = last_drained + 1
+            self._on_commit()
+            asyncio.ensure_future(self._store_offset(last_drained))
+
+    async def _store_offset(self, offset: int) -> None:
+        """Store the given last-consumed offset in Iggy."""
+        try:
+            await self._consumer.store_offset(offset, self._partition)
+        except Exception:
+            _logger.exception(
+                "Failed to store offset %d for Iggy %s/%s partition %d",
+                offset,
+                self._stream,
+                self._topic,
+                self._partition,
+            )
+
+    def discard(self) -> None:
+        """Cancel background readiness tasks and clear state."""
+        for task in self._tasks:
+            task.cancel()
+        self._tasks.clear()
+        self._inflight.clear()
+        self._completed.clear()
+
+
+# --- Offset tracker ---
+
+
+class _OffsetTracker:
+    """Tracks all partitions this stream is consuming.
+
+    The current Python Iggy SDK does not expose Kafka-style assignment callbacks
+    or per-partition high watermarks. This connector therefore requires a known
+    initial high watermark for each consumed partition before watching starts.
+    """
+
+    __slots__ = ("_partitions", "_initialized", "ready_event")
+
+    def __init__(self) -> None:
+        self._partitions: dict[int, _PartitionState] = {}
+        self._initialized = False
+        self.ready_event = asyncio.Event()
+
+    def _check_ready(self) -> None:
+        if self._initialized and all(
+            state.is_caught_up() for state in self._partitions.values()
+        ):
+            self.ready_event.set()
+
+    def add(
+        self,
+        consumer: IggyConsumer,
+        stream: str,
+        topic: str,
+        partition: int,
+        high_watermark: int,
+        committed_next_offset: int,
+    ) -> _PartitionState:
+        """Create and register a partition state."""
+        state = _PartitionState(
+            consumer=consumer,
+            stream=stream,
+            topic=topic,
+            partition=partition,
+            high_watermark=high_watermark,
+            committed_next_offset=committed_next_offset,
+            on_commit=self._check_ready,
+        )
+        self._partitions[partition] = state
+        return state
+
+    def get(self, partition: int) -> _PartitionState:
+        """Get an initialized partition state."""
+        try:
+            return self._partitions[partition]
+        except KeyError as e:
+            raise RuntimeError(
+                "Received an Iggy message for an untracked partition. "
+                "Use an explicit partition_id per TopicStream instance."
+            ) from e
+
+    def mark_initialized(self) -> None:
+        """Mark initial partition state loaded and check readiness."""
+        self._initialized = True
+        self._check_ready()
+
+    def discard_all(self) -> None:
+        """Discard all partition states."""
+        for state in self._partitions.values():
+            state.discard()
+        self._partitions.clear()
+
+
+def _committed_next_offset(stored_offset: int | None) -> int:
+    """Convert Iggy's last-stored offset into the next offset to consume."""
+    return 0 if stored_offset is None else stored_offset + 1
+
+
+# --- TopicStream: LiveStream[ReceiveMessage] primitive ---
+
+
+class TopicStream:
+    """A :class:`LiveStream` of raw Iggy ``ReceiveMessage`` objects.
+
+    The stream creates an Iggy consumer group with auto-commit disabled, sends
+    messages to CocoIndex, and stores offsets only after the returned
+    ``ReadyAwaitable`` is ready. This mirrors the Kafka connector's at-least-once
+    processing contract.
+    """
+
+    __slots__ = (
+        "_client",
+        "_consumer_group",
+        "_stream",
+        "_topic",
+        "_partition_id",
+        "_batch_length",
+        "_poll_interval",
+        "_polling_retry_interval",
+        "_init_retries",
+        "_init_retry_interval",
+        "_allow_replay",
+        "_initial_high_watermark",
+    )
+
+    def __init__(
+        self,
+        client: IggyClient,
+        consumer_group: str,
+        stream: str,
+        topic: str,
+        *,
+        partition_id: int = 0,
+        batch_length: int = 100,
+        poll_interval: timedelta | None = None,
+        polling_retry_interval: timedelta | None = None,
+        init_retries: int | None = None,
+        init_retry_interval: timedelta | None = None,
+        allow_replay: bool = False,
+        initial_high_watermark: int | None = None,
+    ) -> None:
+        self._client = client
+        self._consumer_group = consumer_group
+        self._stream = stream
+        self._topic = topic
+        self._partition_id = partition_id
+        self._batch_length = batch_length
+        self._poll_interval = poll_interval
+        self._polling_retry_interval = polling_retry_interval
+        self._init_retries = init_retries
+        self._init_retry_interval = init_retry_interval
+        self._allow_replay = allow_replay
+        self._initial_high_watermark = initial_high_watermark
+
+    def payloads(self) -> LiveStream[bytes]:
+        """View of this stream yielding each message payload as bytes."""
+        return _TopicPayloadsStream(self)
+
+    async def _resolve_initial_high_watermark(self) -> int:
+        """Resolve the initial next-offset watermark for readiness."""
+        if self._initial_high_watermark is not None:
+            return self._initial_high_watermark
+
+        topic = await self._client.get_topic(self._stream, self._topic)
+        if topic is None:
+            raise RuntimeError(
+                f"Iggy topic {self._stream}/{self._topic} does not exist."
+            )
+        if topic.partitions_count != 1:
+            raise RuntimeError(
+                "The Python Iggy SDK does not expose per-partition high watermarks. "
+                "Pass initial_high_watermark for multi-partition topics, or consume "
+                "a single-partition topic."
+            )
+        return topic.messages_count
+
+    async def _create_consumer(self) -> IggyConsumer:
+        """Create an Iggy consumer group configured for manual offset storage."""
+        return await self._client.consumer_group(
+            name=self._consumer_group,
+            stream=self._stream,
+            topic=self._topic,
+            partition_id=self._partition_id,
+            polling_strategy=PollingStrategy.Next(),
+            batch_length=self._batch_length,
+            auto_commit=AutoCommit.Disabled(),
+            poll_interval=self._poll_interval,
+            polling_retry_interval=self._polling_retry_interval,
+            init_retries=self._init_retries,
+            init_retry_interval=self._init_retry_interval,
+            allow_replay=self._allow_replay,
+        )
+
+    async def watch(self, subscriber: LiveStreamSubscriber[ReceiveMessage]) -> None:
+        """Consume messages and deliver them to the subscriber."""
+        high_watermark = await self._resolve_initial_high_watermark()
+        consumer = await self._create_consumer()
+        tracker = _OffsetTracker()
+        tracker.add(
+            consumer=consumer,
+            stream=self._stream,
+            topic=self._topic,
+            partition=self._partition_id,
+            high_watermark=high_watermark,
+            committed_next_offset=_committed_next_offset(
+                consumer.get_last_stored_offset(self._partition_id)
+            ),
+        )
+        tracker.mark_initialized()
+
+        ready_signaled = False
+        active_next_task: asyncio.Future[ReceiveMessage] | None = None
+        iterator = consumer.iter_messages().__aiter__()
+
+        async def _process_message(message: ReceiveMessage) -> None:
+            partition = message.partition_id()
+            offset = message.offset()
+            part_state = tracker.get(partition)
+            handle = await subscriber.send(message)
+            part_state.track(offset, handle)
+
+        try:
+            while True:
+                if not ready_signaled:
+                    if active_next_task is None:
+                        active_next_task = asyncio.ensure_future(anext(iterator))
+                    ready_task: asyncio.Future[bool] = asyncio.ensure_future(
+                        tracker.ready_event.wait()
+                    )
+                    wait_set: set[asyncio.Future[Any]] = {
+                        active_next_task,
+                        ready_task,
+                    }
+                    done, _ = await asyncio.wait(
+                        wait_set,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+
+                    if ready_task in done:
+                        await subscriber.mark_ready()
+                        ready_signaled = True
+                    else:
+                        ready_task.cancel()
+
+                    if active_next_task in done:
+                        message = await active_next_task
+                        active_next_task = None
+                        await _process_message(message)
+                    continue
+
+                message = await anext(iterator)
+                await _process_message(message)
+        except StopAsyncIteration:
+            return
+        finally:
+            if active_next_task is not None:
+                active_next_task.cancel()
+            tracker.discard_all()
+
+
+class _TopicPayloadsStream:
+    """``LiveStream[bytes]`` view over a :class:`TopicStream`."""
+
+    __slots__ = ("_source",)
+
+    def __init__(self, source: TopicStream) -> None:
+        self._source = source
+
+    async def watch(self, subscriber: LiveStreamSubscriber[bytes]) -> None:
+        await self._source.watch(_PayloadsAdapter(subscriber))
+
+
+class _PayloadsAdapter:
+    """Adapts a ``LiveStreamSubscriber[bytes]`` to receive Iggy messages."""
+
+    __slots__ = ("_downstream",)
+
+    def __init__(self, downstream: LiveStreamSubscriber[bytes]) -> None:
+        self._downstream = downstream
+
+    async def send(self, message: ReceiveMessage) -> ReadyAwaitable:
+        return await self._downstream.send(message.payload())
+
+    async def mark_ready(self) -> None:
+        await self._downstream.mark_ready()
+
+
+# --- LiveMapFeed implementation ---
+
+
+class _StreamToMapSubscriber:
+    """Adapts a :class:`LiveMapSubscriber` to consume a ``LiveStream``."""
+
+    __slots__ = ("_map_sub", "_key", "_is_deletion")
+
+    def __init__(
+        self,
+        map_sub: LiveMapSubscriber[StableKey, ReceiveMessage],
+        key: KeyFn,
+        is_deletion: IsDeleteFn | None,
+    ) -> None:
+        self._map_sub = map_sub
+        self._key = key
+        self._is_deletion = is_deletion
+
+    async def send(self, message: ReceiveMessage) -> ReadyAwaitable:
+        key = self._key(message)
+        if key is None:
+            _logger.error(
+                "Skipping Iggy message without application key at partition %d "
+                "offset %d",
+                message.partition_id(),
+                message.offset(),
+            )
+            return _IMMEDIATE_READY
+        if self._is_deletion is not None and self._is_deletion(message):
+            return await self._map_sub.delete(key)
+        return await self._map_sub.update(key, message)
+
+    async def mark_ready(self) -> None:
+        await self._map_sub.mark_ready()
+
+
+class _TopicMapFeed:
+    """``LiveMapFeed`` view over a :class:`TopicStream`."""
+
+    __slots__ = ("_stream", "_key", "_is_deletion")
+
+    def __init__(
+        self,
+        stream: TopicStream,
+        key: KeyFn,
+        is_deletion: IsDeleteFn | None,
+    ) -> None:
+        self._stream = stream
+        self._key = key
+        self._is_deletion = is_deletion
+
+    async def watch(
+        self, subscriber: LiveMapSubscriber[StableKey, ReceiveMessage]
+    ) -> None:
+        await self._stream.watch(
+            _StreamToMapSubscriber(subscriber, self._key, self._is_deletion)
+        )
+
+
+# --- Public API ---
+
+
+def topic_as_stream(
+    client: IggyClient,
+    consumer_group: str,
+    stream: str,
+    topic: str,
+    *,
+    partition_id: int = 0,
+    batch_length: int = 100,
+    poll_interval: timedelta | None = None,
+    polling_retry_interval: timedelta | None = None,
+    init_retries: int | None = None,
+    init_retry_interval: timedelta | None = None,
+    allow_replay: bool = False,
+    initial_high_watermark: int | None = None,
+) -> TopicStream:
+    """
+    Treat an Iggy stream/topic/partition as a :class:`LiveStream`.
+
+    ``initial_high_watermark`` is the initial next offset for readiness. It is
+    optional for single-partition topics because the connector can use
+    ``TopicDetails.messages_count``. For multi-partition topics the Python SDK
+    does not currently expose per-partition watermarks, so callers must provide
+    the exact partition watermark to preserve Kafka-strength readiness semantics.
+    """
+    return TopicStream(
+        client,
+        consumer_group,
+        stream,
+        topic,
+        partition_id=partition_id,
+        batch_length=batch_length,
+        poll_interval=poll_interval,
+        polling_retry_interval=polling_retry_interval,
+        init_retries=init_retries,
+        init_retry_interval=init_retry_interval,
+        allow_replay=allow_replay,
+        initial_high_watermark=initial_high_watermark,
+    )
+
+
+def topic_as_map(
+    client: IggyClient,
+    consumer_group: str,
+    stream: str,
+    topic: str,
+    *,
+    key: KeyFn,
+    partition_id: int = 0,
+    batch_length: int = 100,
+    poll_interval: timedelta | None = None,
+    polling_retry_interval: timedelta | None = None,
+    init_retries: int | None = None,
+    init_retry_interval: timedelta | None = None,
+    allow_replay: bool = False,
+    initial_high_watermark: int | None = None,
+    is_deletion: IsDeleteFn | None = None,
+) -> _TopicMapFeed:
+    """
+    Treat an Iggy stream/topic/partition as a live keyed map.
+
+    Iggy Python messages do not expose Kafka-style message keys or tombstones,
+    so callers must provide ``key`` to extract an application-level key from the
+    message payload or metadata. Use ``is_deletion`` for application-level
+    delete events.
+    """
+    return _TopicMapFeed(
+        topic_as_stream(
+            client,
+            consumer_group,
+            stream,
+            topic,
+            partition_id=partition_id,
+            batch_length=batch_length,
+            poll_interval=poll_interval,
+            polling_retry_interval=polling_retry_interval,
+            init_retries=init_retries,
+            init_retry_interval=init_retry_interval,
+            allow_replay=allow_replay,
+            initial_high_watermark=initial_high_watermark,
+        ),
+        key,
+        is_deletion,
+    )
+
+
+__all__ = [
+    "IsDeleteFn",
+    "KeyFn",
+    "TopicStream",
+    "topic_as_map",
+    "topic_as_stream",
+]

--- a/python/cocoindex/connectors/iggy/_source.py
+++ b/python/cocoindex/connectors/iggy/_source.py
@@ -337,11 +337,25 @@ class TopicStream:
 
         ready_signaled = False
         active_next_task: asyncio.Future[ReceiveMessage] | None = None
+        last_delivered_offsets: dict[int, int] = {}
         iterator = consumer.iter_messages().__aiter__()
 
         async def _process_message(message: ReceiveMessage) -> None:
             partition = message.partition_id()
             offset = message.offset()
+            last_delivered_offset = last_delivered_offsets.get(partition)
+            if last_delivered_offset is not None and offset <= last_delivered_offset:
+                _logger.debug(
+                    "Skipping duplicate Iggy message for %s/%s partition %d "
+                    "offset %d; last delivered offset is %d",
+                    self._stream,
+                    self._topic,
+                    partition,
+                    offset,
+                    last_delivered_offset,
+                )
+                return
+            last_delivered_offsets[partition] = offset
             part_state = tracker.get(partition)
             handle = await subscriber.send(message)
             part_state.track(offset, handle)

--- a/python/cocoindex/connectors/iggy/_target.py
+++ b/python/cocoindex/connectors/iggy/_target.py
@@ -1,0 +1,373 @@
+"""
+Iggy target for CocoIndex.
+
+This module provides a two-level target state system for Iggy:
+1. Topic level: Lightweight container for generation tracking (user-managed stream/topic)
+2. Message level: Sends messages to the topic for upserts/deletes
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Collection, Generic, NamedTuple, Sequence
+
+try:
+    from apache_iggy import IggyClient  # type: ignore[import-not-found]
+    from apache_iggy import SendMessage as Message  # type: ignore[import-not-found]
+except ImportError as e:
+    raise ImportError(
+        "apache-iggy is required to use the Iggy connector. "
+        "Please install cocoindex[iggy]."
+    ) from e
+
+import cocoindex as coco
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+from cocoindex._internal.datatype import TypeChecker
+from cocoindex._internal.target_state import AsyncTargetActionSinkFn
+from cocoindex.connectorkits.fingerprint import fingerprint_bytes, fingerprint_str
+
+# --- Type aliases ---
+
+_MessageFingerprint = bytes
+
+# --- Internal types ---
+
+
+class _TopicKey(NamedTuple):
+    client_key: str
+    stream: str
+    topic: str
+    partition: int
+
+
+_TOPIC_KEY_CHECKER = TypeChecker(tuple[str, str, str, int])
+
+
+@dataclass
+class _TopicSpec:
+    deletion_value_fn: Callable[[bytes | str], bytes | str] | None
+
+
+class _TopicAction(NamedTuple):
+    key: _TopicKey
+    spec: _TopicSpec | coco.NonExistenceType
+
+
+class _MessageAction(NamedTuple):
+    key: bytes | str
+    value: bytes | str
+
+
+# --- Message handler (child level) ---
+
+
+class _MessageHandler(coco.TargetHandler[bytes | str, _MessageFingerprint, None]):
+    """Handler for message-level target states within a topic."""
+
+    __slots__ = (
+        "_client",
+        "_topic",
+        "_stream",
+        "_deletion_value_fn",
+        "_sink",
+        "_partition",
+    )
+
+    _client: IggyClient
+    _topic: str
+    _stream: str
+    _partition: int
+    _deletion_value_fn: Callable[[bytes | str], bytes | str] | None
+    _sink: coco.TargetActionSink[_MessageAction, None]
+
+    def __init__(
+        self,
+        client: IggyClient,
+        topic: str,
+        stream: str,
+        partition: int,
+        deletion_value_fn: Callable[[bytes | str], bytes | str] | None,
+    ) -> None:
+        self._client = client
+        self._topic = topic
+        self._stream = stream
+        self._partition = partition
+        self._deletion_value_fn = deletion_value_fn
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self,
+        context_provider: ContextProvider,
+        actions: Sequence[_MessageAction],
+        /,
+    ) -> None:
+        if not actions:
+            return
+        messages = [Message(action.value) for action in actions]
+        await self._client.send_messages(
+            stream=self._stream,
+            topic=self._topic,
+            partitioning=self._partition,
+            messages=messages,
+        )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_target_state: bytes | str | coco.NonExistenceType,
+        prev_possible_records: Collection[_MessageFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_MessageAction, _MessageFingerprint] | None:
+        assert isinstance(key, (bytes, str))
+
+        if coco.is_non_existence(desired_target_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            if self._deletion_value_fn is None:
+                raise ValueError(
+                    "Iggy does not support Kafka-style tombstones. "
+                    "Provide deletion_value_fn or encode deletes in the payload."
+                )
+            deletion_value = self._deletion_value_fn(key)
+            return coco.TargetReconcileOutput(
+                action=_MessageAction(key=key, value=deletion_value),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        # Upsert case
+        if isinstance(desired_target_state, bytes):
+            target_fp = fingerprint_bytes(desired_target_state)
+        else:
+            target_fp = fingerprint_str(desired_target_state)
+
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_MessageAction(key=key, value=desired_target_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# --- Topic handler (root level) ---
+
+
+class _TopicHandler(coco.TargetHandler[_TopicSpec, None, _MessageHandler]):
+    """Handler for topic-level target states. Always returns output for generation tracking."""
+
+    __slots__ = ("_sink",)
+
+    _sink: coco.TargetActionSink[_TopicAction, _MessageHandler]
+
+    def __init__(self) -> None:
+        sink_fn: AsyncTargetActionSinkFn[_TopicAction, _MessageHandler] = (
+            self._apply_actions
+        )
+        self._sink = coco.TargetActionSink.from_async_fn(sink_fn)
+
+    async def _apply_actions(
+        self,
+        context_provider: ContextProvider,
+        actions: Sequence[_TopicAction],
+        /,
+    ) -> list[coco.ChildTargetDef[_MessageHandler] | None]:
+        outputs: list[coco.ChildTargetDef[_MessageHandler] | None] = []
+        for action in actions:
+            if coco.is_non_existence(action.spec):
+                outputs.append(None)
+            else:
+                client = context_provider.get(action.key.client_key, IggyClient)
+                handler = _MessageHandler(
+                    client=client,
+                    topic=action.key.topic,
+                    stream=action.key.stream,
+                    partition=action.key.partition,
+                    deletion_value_fn=action.spec.deletion_value_fn,
+                )
+                outputs.append(coco.ChildTargetDef(handler=handler))
+        return outputs
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_target_state: _TopicSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[None],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_TopicAction, None, _MessageHandler]:
+        topic_key = _TopicKey(*_TOPIC_KEY_CHECKER.check(key))
+
+        tracking_record: None | coco.NonExistenceType
+        if coco.is_non_existence(desired_target_state):
+            tracking_record = coco.NON_EXISTENCE
+        else:
+            tracking_record = None
+
+        return coco.TargetReconcileOutput(
+            action=_TopicAction(key=topic_key, spec=desired_target_state),
+            sink=self._sink,
+            tracking_record=tracking_record,
+        )
+
+
+# --- Root provider registration ---
+
+_topic_provider = coco.register_root_target_states_provider(
+    "cocoindex/iggy/topic", _TopicHandler()
+)
+
+# --- Public API ---
+
+DeletionValueFn = Callable[[bytes | str], bytes | str]
+
+
+class IggyTopicTarget(Generic[coco.MaybePendingS], coco.ResolvesTo["IggyTopicTarget"]):
+    """
+    A target for sending messages to an Iggy stream/topic.
+
+    The stream and topic are user-managed (CocoIndex does not create/drop them).
+    Messages are sent for upserts and deletes of declared target states.
+    """
+
+    _provider: coco.TargetStateProvider[bytes | str, None, coco.MaybePendingS]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[bytes | str, None, coco.MaybePendingS],
+    ) -> None:
+        self._provider = provider
+
+    def declare_target_state(
+        self: "IggyTopicTarget", *, key: bytes | str, value: bytes | str
+    ) -> None:
+        """
+        Declare a target state backed by an Iggy message.
+
+        On commit, CocoIndex will send a message with the given value
+        if the state has changed since the last run.
+
+        Args:
+            key: The stable identity used by CocoIndex.
+            value: The message payload.
+        """
+        coco.declare_target_state(self._provider.target_state(key, value))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+def iggy_topic_target(
+    client: ContextKey[IggyClient],
+    stream: str,
+    topic: str,
+    *,
+    partition: int = 0,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> coco.TargetState[_MessageHandler]:
+    """
+    Create a TargetState for an Iggy stream/topic target.
+
+    Use with ``coco.mount_target()`` to mount and get a child provider,
+    or with ``mount_iggy_topic_target()`` for a convenience wrapper.
+
+    Args:
+        client: ContextKey for the IggyClient connection.
+        stream: The Iggy stream name or id.
+        topic: The Iggy topic name or id.
+        partition: The Iggy partition to send messages to.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            Required if declared target states are deleted.
+
+    Returns:
+        A TargetState that can be passed to ``mount_target()``.
+    """
+    key = _TopicKey(
+        client_key=client.key, stream=stream, topic=topic, partition=partition
+    )
+    spec = _TopicSpec(deletion_value_fn=deletion_value_fn)
+    return _topic_provider.target_state(key, spec)
+
+
+@coco.fn
+def declare_iggy_topic_target(
+    client: ContextKey[IggyClient],
+    stream: str,
+    topic: str,
+    *,
+    partition: int = 0,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> IggyTopicTarget[coco.PendingS]:
+    """
+    Declare an Iggy topic target and return an IggyTopicTarget for declaring messages.
+
+    Args:
+        client: ContextKey for the IggyClient connection.
+        stream: The Iggy stream name or id.
+        topic: The Iggy topic name or id.
+        partition: The Iggy partition to send messages to.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            Required if declared target states are deleted.
+
+    Returns:
+        An IggyTopicTarget that can be used to declare target states.
+    """
+    provider = coco.declare_target_state_with_child(
+        iggy_topic_target(
+            client,
+            stream,
+            topic,
+            partition=partition,
+            deletion_value_fn=deletion_value_fn,
+        )
+    )
+    return IggyTopicTarget(provider)
+
+
+async def mount_iggy_topic_target(
+    client: ContextKey[IggyClient],
+    stream: str,
+    topic: str,
+    *,
+    partition: int = 0,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> IggyTopicTarget[coco.ResolvedS]:
+    """
+    Mount an Iggy topic target and return a ready-to-use IggyTopicTarget.
+
+    Sugar over ``iggy_topic_target()`` + ``coco.mount_target()`` + wrapping.
+
+    Args:
+        client: ContextKey for the IggyClient connection.
+        stream: The Iggy stream name or id.
+        topic: The Iggy topic name or id.
+        partition: The Iggy partition to send messages to.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            Required if declared target states are deleted.
+
+    Returns:
+        An IggyTopicTarget that can be used to declare target states.
+    """
+    provider = await coco.mount_target(
+        iggy_topic_target(
+            client=client,
+            stream=stream,
+            topic=topic,
+            partition=partition,
+            deletion_value_fn=deletion_value_fn,
+        )
+    )
+    return IggyTopicTarget(provider)
+
+
+__all__ = [
+    "DeletionValueFn",
+    "IggyTopicTarget",
+    "declare_iggy_topic_target",
+    "iggy_topic_target",
+    "mount_iggy_topic_target",
+]

--- a/python/tests/connectors/test_iggy_source.py
+++ b/python/tests/connectors/test_iggy_source.py
@@ -1,0 +1,334 @@
+"""Tests for the Iggy source connector.
+
+These tests mock the Python Iggy SDK to verify CocoIndex source semantics
+without a real Iggy server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections import deque
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class MockAutoCommit:
+    class Disabled:
+        pass
+
+
+class MockPollingStrategy:
+    class Next:
+        pass
+
+
+class MockReceiveMessage:
+    def __init__(
+        self,
+        *,
+        payload: bytes,
+        offset: int,
+        partition_id: int = 0,
+    ) -> None:
+        self._payload = payload
+        self._offset = offset
+        self._partition_id = partition_id
+
+    def payload(self) -> bytes:
+        return self._payload
+
+    def offset(self) -> int:
+        return self._offset
+
+    def partition_id(self) -> int:
+        return self._partition_id
+
+
+class MockTopicDetails:
+    def __init__(self, *, messages_count: int, partitions_count: int = 1) -> None:
+        self.messages_count = messages_count
+        self.partitions_count = partitions_count
+
+
+class MockReadyHandle:
+    def __init__(self) -> None:
+        self._ready_event = asyncio.Event()
+
+    async def ready(self) -> None:
+        await self._ready_event.wait()
+
+    def set_ready(self) -> None:
+        self._ready_event.set()
+
+
+class MockMessageIterator:
+    def __init__(self, messages: deque[MockReceiveMessage]) -> None:
+        self._messages = messages
+
+    def __aiter__(self) -> "MockMessageIterator":
+        return self
+
+    async def __anext__(self) -> MockReceiveMessage:
+        if self._messages:
+            return self._messages.popleft()
+        raise StopAsyncIteration
+
+
+class MockIggyConsumer:
+    def __init__(
+        self,
+        messages: list[MockReceiveMessage],
+        *,
+        stored_offset: int | None = None,
+    ) -> None:
+        self._messages = deque(messages)
+        self._stored_offset = stored_offset
+        self.stored_offsets: list[tuple[int, int | None]] = []
+
+    def get_last_stored_offset(self, partition_id: int) -> int | None:
+        return self._stored_offset
+
+    async def store_offset(self, offset: int, partition_id: int | None) -> None:
+        self._stored_offset = offset
+        self.stored_offsets.append((offset, partition_id))
+
+    def iter_messages(self) -> MockMessageIterator:
+        return MockMessageIterator(self._messages)
+
+
+class MockIggyClient:
+    def __init__(
+        self,
+        consumer: MockIggyConsumer,
+        *,
+        messages_count: int,
+        partitions_count: int = 1,
+    ) -> None:
+        self.consumer = consumer
+        self.topic = MockTopicDetails(
+            messages_count=messages_count,
+            partitions_count=partitions_count,
+        )
+        self.consumer_group_calls: list[dict[str, Any]] = []
+
+    async def get_topic(self, stream: str, topic: str) -> MockTopicDetails:
+        return self.topic
+
+    async def consumer_group(self, **kwargs: Any) -> MockIggyConsumer:
+        self.consumer_group_calls.append(kwargs)
+        return self.consumer
+
+
+_mock_module = MagicMock()
+_mock_module.AutoCommit = MockAutoCommit
+_mock_module.IggyClient = MockIggyClient
+_mock_module.IggyConsumer = MockIggyConsumer
+_mock_module.PollingStrategy = MockPollingStrategy
+_mock_module.ReceiveMessage = MockReceiveMessage
+_mock_module.SendMessage = MagicMock()
+sys.modules["apache_iggy"] = _mock_module
+
+from cocoindex._internal.live_component import _IMMEDIATE_READY  # noqa: E402
+from cocoindex.connectors.iggy._source import (  # noqa: E402
+    TopicStream,
+    _PartitionState,
+    topic_as_map,
+    topic_as_stream,
+)
+
+
+class MockStreamSubscriber:
+    def __init__(self, *, auto_ready: bool = True) -> None:
+        self.messages: list[MockReceiveMessage] = []
+        self.ready_called = False
+        self._auto_ready = auto_ready
+
+    async def send(self, message: MockReceiveMessage) -> MockReadyHandle:
+        self.messages.append(message)
+        handle = MockReadyHandle()
+        if self._auto_ready:
+            handle.set_ready()
+        return handle
+
+    async def mark_ready(self) -> None:
+        self.ready_called = True
+
+
+class MockMapSubscriber:
+    def __init__(self) -> None:
+        self.updates: list[tuple[bytes | str, MockReceiveMessage]] = []
+        self.deletes: list[bytes | str] = []
+        self.ready_called = False
+
+    async def update(
+        self, key: bytes | str, value: MockReceiveMessage
+    ) -> MockReadyHandle:
+        self.updates.append((key, value))
+        handle = MockReadyHandle()
+        handle.set_ready()
+        return handle
+
+    async def delete(self, key: bytes | str) -> MockReadyHandle:
+        self.deletes.append(key)
+        handle = MockReadyHandle()
+        handle.set_ready()
+        return handle
+
+    async def update_all(self) -> None:
+        pass
+
+    async def mark_ready(self) -> None:
+        self.ready_called = True
+
+
+class TestPartitionState:
+    @pytest.mark.asyncio
+    async def test_stores_last_consumed_offset_after_contiguous_completion(self) -> None:
+        consumer = MockIggyConsumer([])
+        state = _PartitionState(
+            consumer,  # type: ignore[arg-type]
+            "stream",
+            "topic",
+            0,
+            high_watermark=3,
+            committed_next_offset=0,
+            on_commit=lambda: None,
+        )
+
+        handles = [MockReadyHandle() for _ in range(3)]
+        for offset, handle in enumerate(handles):
+            state.track(offset, handle)
+
+        handles[2].set_ready()
+        await asyncio.sleep(0.01)
+        assert consumer.stored_offsets == []
+
+        handles[0].set_ready()
+        handles[1].set_ready()
+        await asyncio.sleep(0.05)
+
+        assert consumer.stored_offsets[-1] == (2, 0)
+
+    @pytest.mark.asyncio
+    async def test_immediate_ready_fast_path(self) -> None:
+        consumer = MockIggyConsumer([])
+        state = _PartitionState(
+            consumer,  # type: ignore[arg-type]
+            "stream",
+            "topic",
+            0,
+            high_watermark=1,
+            committed_next_offset=0,
+            on_commit=lambda: None,
+        )
+
+        state.track(0, _IMMEDIATE_READY)
+        await asyncio.sleep(0.05)
+
+        assert consumer.stored_offsets == [(0, 0)]
+
+
+class TestTopicStream:
+    @pytest.mark.asyncio
+    async def test_stream_consumes_and_stores_offsets_after_ready(self) -> None:
+        consumer = MockIggyConsumer(
+            [
+                MockReceiveMessage(payload=b"v1", offset=0),
+                MockReceiveMessage(payload=b"v2", offset=1),
+            ]
+        )
+        client = MockIggyClient(consumer, messages_count=2)
+        stream = topic_as_stream(
+            client,  # type: ignore[arg-type]
+            "group",
+            "stream",
+            "topic",
+        )
+        subscriber = MockStreamSubscriber()
+
+        await stream.watch(subscriber)  # type: ignore[arg-type]
+        await asyncio.sleep(0.05)
+
+        assert [m.payload() for m in subscriber.messages] == [b"v1", b"v2"]
+        assert consumer.stored_offsets[-1] == (1, 0)
+        assert subscriber.ready_called
+        assert client.consumer_group_calls[0]["auto_commit"].__class__.__name__ == (
+            "Disabled"
+        )
+
+    @pytest.mark.asyncio
+    async def test_payloads_view_forwards_bytes(self) -> None:
+        consumer = MockIggyConsumer([MockReceiveMessage(payload=b"payload", offset=0)])
+        client = MockIggyClient(consumer, messages_count=1)
+        payloads = topic_as_stream(
+            client,  # type: ignore[arg-type]
+            "group",
+            "stream",
+            "topic",
+        ).payloads()
+
+        class BytesSubscriber:
+            def __init__(self) -> None:
+                self.payloads: list[bytes] = []
+                self.ready_called = False
+
+            async def send(self, payload: bytes) -> MockReadyHandle:
+                self.payloads.append(payload)
+                handle = MockReadyHandle()
+                handle.set_ready()
+                return handle
+
+            async def mark_ready(self) -> None:
+                self.ready_called = True
+
+        subscriber = BytesSubscriber()
+        await payloads.watch(subscriber)
+        await asyncio.sleep(0.05)
+
+        assert subscriber.payloads == [b"payload"]
+        assert subscriber.ready_called
+
+    @pytest.mark.asyncio
+    async def test_multi_partition_requires_explicit_watermark(self) -> None:
+        consumer = MockIggyConsumer([])
+        client = MockIggyClient(consumer, messages_count=10, partitions_count=2)
+        stream = TopicStream(
+            client,  # type: ignore[arg-type]
+            "group",
+            "stream",
+            "topic",
+        )
+
+        with pytest.raises(RuntimeError, match="per-partition high watermarks"):
+            await stream.watch(MockStreamSubscriber())  # type: ignore[arg-type]
+
+
+class TestTopicMap:
+    @pytest.mark.asyncio
+    async def test_map_uses_application_key_and_deletion_predicate(self) -> None:
+        consumer = MockIggyConsumer(
+            [
+                MockReceiveMessage(payload=b"k1:v1", offset=0),
+                MockReceiveMessage(payload=b"k1:DELETE", offset=1),
+            ]
+        )
+        client = MockIggyClient(consumer, messages_count=2)
+        feed = topic_as_map(
+            client,  # type: ignore[arg-type]
+            "group",
+            "stream",
+            "topic",
+            key=lambda msg: msg.payload().split(b":", 1)[0],
+            is_deletion=lambda msg: msg.payload().endswith(b"DELETE"),
+        )
+        subscriber = MockMapSubscriber()
+
+        await feed.watch(subscriber)  # type: ignore[arg-type]
+        await asyncio.sleep(0.05)
+
+        assert [(k, m.payload()) for k, m in subscriber.updates] == [(b"k1", b"k1:v1")]
+        assert subscriber.deletes == [b"k1"]
+        assert subscriber.ready_called

--- a/python/tests/connectors/test_iggy_source.py
+++ b/python/tests/connectors/test_iggy_source.py
@@ -262,6 +262,36 @@ class TestTopicStream:
         )
 
     @pytest.mark.asyncio
+    async def test_stream_skips_duplicate_offsets_from_live_consumer(self) -> None:
+        consumer = MockIggyConsumer(
+            [
+                MockReceiveMessage(payload=b"v1", offset=0),
+                MockReceiveMessage(payload=b"v2", offset=1),
+                MockReceiveMessage(payload=b"v2-duplicate", offset=1),
+                MockReceiveMessage(payload=b"v3", offset=2),
+            ]
+        )
+        client = MockIggyClient(consumer, messages_count=3)
+        stream = topic_as_stream(
+            client,  # type: ignore[arg-type]
+            "group",
+            "stream",
+            "topic",
+        )
+        subscriber = MockStreamSubscriber()
+
+        await stream.watch(subscriber)  # type: ignore[arg-type]
+        await asyncio.sleep(0.05)
+
+        assert [(m.offset(), m.payload()) for m in subscriber.messages] == [
+            (0, b"v1"),
+            (1, b"v2"),
+            (2, b"v3"),
+        ]
+        assert consumer.stored_offsets[-1] == (2, 0)
+        assert subscriber.ready_called
+
+    @pytest.mark.asyncio
     async def test_payloads_view_forwards_bytes(self) -> None:
         consumer = MockIggyConsumer([MockReceiveMessage(payload=b"payload", offset=0)])
         client = MockIggyClient(consumer, messages_count=1)

--- a/python/tests/connectors/test_iggy_source.py
+++ b/python/tests/connectors/test_iggy_source.py
@@ -186,7 +186,9 @@ class MockMapSubscriber:
 
 class TestPartitionState:
     @pytest.mark.asyncio
-    async def test_stores_last_consumed_offset_after_contiguous_completion(self) -> None:
+    async def test_stores_last_consumed_offset_after_contiguous_completion(
+        self,
+    ) -> None:
         consumer = MockIggyConsumer([])
         state = _PartitionState(
             consumer,  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -240,6 +240,32 @@ wheels = [
 ]
 
 [[package]]
+name = "apache-iggy"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/7a/890fcddcf7cc3f7a45a0675a935cfb69dbb0fa106e2157b79f407ef1a777/apache_iggy-0.8.0.tar.gz", hash = "sha256:f95e48eff23db962a290cbfe587dc7cc1bf2fe707c5462f39554c2741fd33c4e", size = 429484, upload-time = "2026-04-22T10:08:48.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/fb/615f997e3903362b392883344a5f521d8d6f54cf84a880e72867c333b0a5/apache_iggy-0.8.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f1617e6e1566de70a8fd769c5289d082e792b079e372f7c8d0c4f55676fd1bbc", size = 4985244, upload-time = "2026-04-22T10:09:07.611Z" },
+    { url = "https://files.pythonhosted.org/packages/90/55/853f82f7e4fbed8b50603512b6138296189a709b05ea4186c6600aef5c1a/apache_iggy-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1cc1b0c6df2fecae490cfb74d2c67b5c022e929cbf22b336440e67264187f30", size = 4837488, upload-time = "2026-04-22T10:08:55.382Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6e/2cdcad6415114b9f6fd2e52a1631ce2b86e6057324f8469049a7d4931765/apache_iggy-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32c399bdfc6541b0382989aa1bb47047fffae68fd182b12bdb8bfb0019a97812", size = 5238427, upload-time = "2026-04-22T10:09:06.147Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c1/8375cf8c899c58aba1086fc960cfec0cb4ee081f08b786b0c62720d3aedf/apache_iggy-0.8.0-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:e2734829c928331e94a5c6b7fe2dbab01e0a58e850fa37ba5d933558ee07e0f9", size = 5350766, upload-time = "2026-04-22T10:08:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2a/564406cceaa9b166f40518920c70d4ca62bfa4b5cc2d29ae671eb02c4e7e/apache_iggy-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cf609dd61f8dcd91e2bb4140af53e5a8c8f2619e478130efcf692960b5bb9dbd", size = 5412635, upload-time = "2026-04-22T10:09:00.213Z" },
+    { url = "https://files.pythonhosted.org/packages/84/76/47c2c7158dcd68d6bdbc0fab7f05f2268d490b514efcc31244a27953039a/apache_iggy-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dbe050ea2359e9706fbbe03c65280a271366395863d9c713b6302324ccdd5b2b", size = 5572601, upload-time = "2026-04-22T10:08:57.519Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2e/c78859c13c6429068e0977335246aeda03b58ec93de4c9d2c3941db1f714/apache_iggy-0.8.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:df06b870a0efaf1056bc1129c1e455dd52433364e03e1c2284977bc30b3d8c1d", size = 4982710, upload-time = "2026-04-22T10:09:04.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4a/84d4dad2c4dfd667869ae4fc493187bbce56e0bd0dc3f80c78df29013924/apache_iggy-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7ed7a449425ffd426bbfbe64d2c618c14e0fae99fc275adf3a8d98ef16fcdf3c", size = 4836098, upload-time = "2026-04-22T10:09:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/4e/7156a034705a1af5146547e9ee25e8c159a313fb6800e1cb5fc39306f6b9/apache_iggy-0.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e8700ffe6dc0602d874d4d54f148f1093109012421138721fa8a1da0e2e7aa0", size = 5233334, upload-time = "2026-04-22T10:08:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/28/2963cdef38b5b0eae2ce950ca3530b8bfeff9c729088831fcd4d5cb83473/apache_iggy-0.8.0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:198c9ed00d90ab279494aed0fe538a5d5890b5549d92937ed3d99f39beab2d47", size = 5342600, upload-time = "2026-04-22T10:08:33.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b1/a3200ed7b4e2f666fcf076d494bbf10a94ff01095dab6b1c8aa57f09fb01/apache_iggy-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:55a8681d43f40d6e1bf1ba937bb0a867fbe43b361d885ca96abe0f1b4d3ba171", size = 5407815, upload-time = "2026-04-22T10:08:42.66Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/04/789406935af89fe8a1570c40841281937a29d9486f8a5167d34c5da99868/apache_iggy-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff6c1c4a2219986baea25acc055f9adb159da8171cbe5a85105829cf41fb828f", size = 5565518, upload-time = "2026-04-22T10:08:53.5Z" },
+    { url = "https://files.pythonhosted.org/packages/23/53/8880bac8e972f437ee55bf54ec75f89d1adcd736e40e3a2f66367ea931d3/apache_iggy-0.8.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:247b7fad1bfb98d533c79b2a4c4d1d337f35918b9591480489de3b3365e09bc1", size = 4982324, upload-time = "2026-04-22T10:08:39.556Z" },
+    { url = "https://files.pythonhosted.org/packages/85/21/39d8d0c429cbe2e2f203b42a542aae50add7cff8d01ad7d1ef1874696cf6/apache_iggy-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bd4aedf9ad5af8192d51122ad4122a267927f13f7bdc72515d2956be2208484e", size = 4836015, upload-time = "2026-04-22T10:08:44.078Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/3e/ad2f7b041b1c6f75b1a0dec953050a154fd352e093c782470ee884468b65/apache_iggy-0.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0161acc29310dcb084381caa57dc3e912a23b70fae45944318d8e9449b8d42d7", size = 5233947, upload-time = "2026-04-22T10:09:09.001Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/fc/0a63ac51e7d0c4e80eb77c1d5286a8d447f3f25803c6d62cee06661442e4/apache_iggy-0.8.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:e10863db5863309a1564d489d8c33765513bcb1841717bacb2834ab362c2388c", size = 5342330, upload-time = "2026-04-22T10:08:50.363Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/0b9fa52eccc93736cc6429c41c13b78652d056c62207a1e48c37ff390d26/apache_iggy-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:96b863008503685c4c21b07641af758ead10ccdf0e1e48e8520466c4dc5d48c3", size = 5408022, upload-time = "2026-04-22T10:08:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/c4d6607704e2ad524d285c126aefe696f1b55d51c8856a5fecb40cc63481/apache_iggy-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:73be0d5d9f1bdf582527eb7cdea2fc9a8111ca2adea4e8a02e89f4a6a137da80", size = 5565128, upload-time = "2026-04-22T10:08:38.07Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -538,6 +564,7 @@ all = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
     { name = "aiomysql" },
+    { name = "apache-iggy" },
     { name = "asyncpg" },
     { name = "colpali-engine" },
     { name = "confluent-kafka" },
@@ -588,6 +615,9 @@ google-drive = [
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "httplib2" },
+]
+iggy = [
+    { name = "apache-iggy" },
 ]
 kafka = [
     { name = "confluent-kafka" },
@@ -694,6 +724,8 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'doris'", specifier = ">=3.9.0" },
     { name = "aiomysql", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "aiomysql", marker = "extra == 'doris'", specifier = ">=0.2.0" },
+    { name = "apache-iggy", marker = "extra == 'all'", specifier = ">=0.8.0" },
+    { name = "apache-iggy", marker = "extra == 'iggy'", specifier = ">=0.8.0" },
     { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.31.0" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.31.0" },
     { name = "click", specifier = ">=8.1.8" },
@@ -748,7 +780,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer"]
+provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer"]
 
 [package.metadata.requires-dev]
 build-test = [


### PR DESCRIPTION
## Summary

- add an Apache Iggy connector package with source and target support
- map Iggy stream/topic/partition addressing into CocoIndex live streams and target states
- preserve source at-least-once behavior by storing Iggy offsets only after downstream readiness
- add mocked source tests covering offset storage, payload streams, keyed map adaptation, and readiness safeguards
- add the `cocoindex[iggy]` optional dependency and lockfile entries

## Notes

- Iggy Python messages do not expose Kafka-style keys or tombstones, so `topic_as_map()` requires an application-level `key` extractor and optional deletion predicate.
- Multi-partition readiness requires an explicit `initial_high_watermark` until the Python SDK exposes per-partition watermarks.
- Live testing against `apache/iggy:latest` found that `iter_messages().__anext__()` returns a Future, so the connector uses `asyncio.ensure_future()` for SDK compatibility.

## Validation

- `uv run pytest python/tests/connectors/test_iggy_source.py`
- `uv run ruff check python/cocoindex/connectors/iggy/_source.py python/cocoindex/connectors/iggy/_target.py python/tests/connectors/test_iggy_source.py`
- `uv run mypy python/cocoindex/connectors/iggy/_source.py python/cocoindex/connectors/iggy/_target.py python/tests/connectors/test_iggy_source.py`
- Live smoke test against local `apache/iggy:latest` on `127.0.0.1:8090`: created stream/topic, sent via Iggy target handler, consumed via `topic_as_stream()`, observed readiness, and verified the same consumer group did not replay messages after offset storage.
