### PR TITLE
docs(examples): add Postgres dev install snippet to example READMEs

### DIFF
--- a/examples/amazon_s3_embedding/README.md
+++ b/examples/amazon_s3_embedding/README.md
@@ -4,7 +4,12 @@ This example embeds markdown files from an S3 bucket, stores the chunks + embedd
 
 ## Prerequisites
 
-- A running Postgres with the pgvector extension available
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - An S3 bucket (or S3-compatible service like MinIO) with markdown files
 - AWS credentials configured (e.g. via `aws configure`, env vars, or IAM role)
 

--- a/examples/audio_to_text/README.md
+++ b/examples/audio_to_text/README.md
@@ -4,14 +4,19 @@ This example transcribes local audio files with LiteLLM and stores one row per f
 
 ## Prerequisites
 
-- A running Postgres database.
+- A running Postgres database. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - LiteLLM credentials for the transcription model. For the default `whisper-1` model, set `OPENAI_API_KEY`.
 - `POSTGRES_URL` set, e.g.
 
-```sh
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-export OPENAI_API_KEY="..."
-```
+  ```sh
+  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+  export OPENAI_API_KEY="..."
+  ```
 
 ## Input Files
 

--- a/examples/code_embedding/README.md
+++ b/examples/code_embedding/README.md
@@ -4,12 +4,17 @@ This example extracts code chunks from local Python files, stores the code and t
 
 ## Prerequisites
 
-- A running Postgres with the pgvector extension available
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - `POSTGRES_URL` set, e.g.
 
-```sh
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-```
+  ```sh
+  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+  ```
 
 ## Run
 

--- a/examples/entire_session_search/README.md
+++ b/examples/entire_session_search/README.md
@@ -12,7 +12,12 @@ Because CocoIndex is incremental, re-running after new sessions only processes w
 
 ## Prerequisites
 
-- Postgres with pgvector extension
+- Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - [Entire](https://entire.io) installed with some captured sessions
 - Python 3.11+
 

--- a/examples/gdrive_text_embedding/README.md
+++ b/examples/gdrive_text_embedding/README.md
@@ -4,15 +4,20 @@ This example embeds text files from Google Drive, stores chunk embeddings in Pos
 
 ## Prerequisites
 
-- A running Postgres with the pgvector extension available
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - A Google Cloud service account with Drive access
 - Environment variables:
 
-```sh
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL="/path/to/service-account.json"
-export GOOGLE_DRIVE_ROOT_FOLDER_IDS="folder_id_1,folder_id_2"
-```
+  ```sh
+  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+  export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL="/path/to/service-account.json"
+  export GOOGLE_DRIVE_ROOT_FOLDER_IDS="folder_id_1,folder_id_2"
+  ```
 
 ## Run
 

--- a/examples/image_search/README.md
+++ b/examples/image_search/README.md
@@ -13,10 +13,15 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 - Qdrant for vector storage
 
 ## Setup
-- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+- A running Postgres. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
 
 - Make sure Qdrant is running
-  ```
+
+  ```sh
   docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
   ```
 

--- a/examples/image_search_colpali/README.md
+++ b/examples/image_search_colpali/README.md
@@ -6,12 +6,17 @@ This example builds an image search index using the ColPali embedding model and 
 We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
 
 ## Setup
-- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+- A running Postgres. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - Make sure Qdrant is running
 
-```
-docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
-```
+  ```sh
+  docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
+  ```
 
 ## Run (CLI)
 

--- a/examples/oci_object_storage_embedding/README.md
+++ b/examples/oci_object_storage_embedding/README.md
@@ -6,7 +6,12 @@ It optionally subscribes to **OCI Streaming** (Kafka-protocol-compatible) for li
 
 ## Prerequisites
 
-- A running Postgres with the pgvector extension available
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - An OCI Object Storage bucket with markdown files
 - An OCI config file (default `~/.oci/config`) with API-key auth set up — see [OCI SDK config docs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm)
 - *(Optional, for live mode)* An OCI Streaming stream pool with object events from the bucket published to a topic, plus a streaming auth token

--- a/examples/paper_metadata/README.md
+++ b/examples/paper_metadata/README.md
@@ -8,7 +8,12 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 
 ## Prerequisites
 
-- [Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres)
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - Set `OPENAI_API_KEY` for metadata extraction
 - Set `POSTGRES_URL` for Postgres access
 

--- a/examples/pdf_embedding/README.md
+++ b/examples/pdf_embedding/README.md
@@ -8,7 +8,11 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 
 ## Prerequisite
 
-[Install Postgres](https://cocoindex.io/docs/getting_started/installation#-install-postgres) if you don't have one.
+A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
 
 ## Run
 

--- a/examples/postgres_source/README.md
+++ b/examples/postgres_source/README.md
@@ -14,7 +14,11 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
 pip install -e .
 ```
 
-2. Follow the [CocoIndex PostgreSQL setup guide](https://cocoindex.io/docs/getting_started/quickstart) to install and configure PostgreSQL with pgvector extension.
+2. A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+   ```sh
+   docker compose -f ../../dev/postgres.yaml up -d
+   ```
 
 3. Create source table `source_products` with sample data:
 

--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -4,12 +4,17 @@ This example embeds local markdown files, stores the chunks + embeddings in Post
 
 ## Prerequisites
 
-- A running Postgres with the pgvector extension available
+- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
 - `POSTGRES_URL` set, e.g.
 
-```sh
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-```
+  ```sh
+  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+  ```
 
 ## Run
 


### PR DESCRIPTION
## Summary
- Replace the vague "running Postgres with pgvector" line (and several broken `cocoindex.io/docs/getting_started/installation#-install-postgres` anchors) with a concrete docker-compose snippet across the 12 example READMEs that need Postgres.
- Use `../../dev/postgres.yaml` so the command runs from the example's own directory, matching the cwd used by every other command in those READMEs (`pip install -e .`, `cocoindex update main.py`, etc.).

## Test plan
- Renders fine on GitHub — pure docs change, no code touched. CI doc/lint hooks pass.
