### PR TITLE
fix(examples): register pgvector codec on asyncpg pool

### DIFF
--- a/examples/text_embedding/main.py
+++ b/examples/text_embedding/main.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 
 import cocoindex as coco
@@ -162,7 +163,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)


### PR DESCRIPTION
## Summary
- Register `pgvector.asyncpg.register_vector` as the asyncpg pool `init` callback in the standalone `query()` path of `examples/text_embedding/main.py` so NumPy ndarray embeddings encode as `vector` when bound as `$1`, instead of failing with `expected str, got ndarray`.
- The pipeline's lifespan pool doesn't need it — the cocoindex postgres target encodes vectors to text itself.

## Test plan
- Manual: run `python main.py query "<term>"` against a Postgres with pgvector and confirm results come back without the encoder error.
