### PR TITLE
fix(examples): register pgvector codec on query asyncpg pools

### DIFF
--- a/examples/amazon_s3_embedding/main.py
+++ b/examples/amazon_s3_embedding/main.py
@@ -20,6 +20,7 @@ import aiobotocore.session
 import asyncpg
 from aiobotocore.client import AioBaseClient
 from numpy.typing import NDArray
+from pgvector.asyncpg import register_vector
 
 import cocoindex as coco
 from cocoindex.connectors import amazon_s3, postgres
@@ -172,7 +173,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)

--- a/examples/code_embedding/main.py
+++ b/examples/code_embedding/main.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 
 import cocoindex as coco
@@ -184,7 +185,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)

--- a/examples/entire_session_search/main.py
+++ b/examples/entire_session_search/main.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 
 import cocoindex as coco
@@ -362,7 +363,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 1:
             q = " ".join(sys.argv[1:])
             await query_once(pool, embedder, q)

--- a/examples/gdrive_text_embedding/main.py
+++ b/examples/gdrive_text_embedding/main.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 
 import cocoindex as coco
@@ -39,7 +40,6 @@ EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 PG_DB = coco.ContextKey[asyncpg.Pool]("gdrive_text_embedding_db")
 EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_change=True)
 
-_pool: asyncpg.Pool | None = None
 _splitter = RecursiveSplitter()
 
 
@@ -47,9 +47,7 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    global _pool
     async with await asyncpg.create_pool(DATABASE_URL) as pool:
-        _pool = pool
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -127,12 +125,13 @@ app = coco.App(
 
 
 async def query_once(
-    embedder: SentenceTransformerEmbedder, query: str, *, top_k: int = TOP_K
+    pool: asyncpg.Pool,
+    embedder: SentenceTransformerEmbedder,
+    query: str,
+    *,
+    top_k: int = TOP_K,
 ) -> None:
     query_vec = await embedder.embed(query)
-    pool = _pool
-    assert pool is not None
-
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             f"""
@@ -157,17 +156,17 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with coco.runtime():
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
-            await query_once(embedder, q)
+            await query_once(pool, embedder, q)
             return
 
         while True:
             q = input("Enter search query (or Enter to quit): ").strip()
             if not q:
                 break
-            await query_once(embedder, q)
+            await query_once(pool, embedder, q)
 
 
 if __name__ == "__main__":

--- a/examples/oci_object_storage_embedding/main.py
+++ b/examples/oci_object_storage_embedding/main.py
@@ -28,6 +28,7 @@ import oci  # type: ignore[import-not-found]
 from confluent_kafka.aio import AIOConsumer  # type: ignore[import-not-found]
 from numpy.typing import NDArray
 from oci.object_storage import ObjectStorageClient  # type: ignore[import-not-found]
+from pgvector.asyncpg import register_vector
 
 import cocoindex as coco
 from cocoindex.connectors import kafka, oci_object_storage, postgres
@@ -237,7 +238,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)

--- a/examples/paper_metadata/main.py
+++ b/examples/paper_metadata/main.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Annotated
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 from openai import OpenAI
 from dotenv import load_dotenv
@@ -323,7 +324,7 @@ async def query() -> None:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(database_url) as pool:
+    async with await asyncpg.create_pool(database_url, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)

--- a/examples/pdf_embedding/main.py
+++ b/examples/pdf_embedding/main.py
@@ -25,6 +25,7 @@ from docling.datamodel.base_models import DocumentStream
 from docling.document_converter import DocumentConverter
 from numpy.typing import NDArray
 import asyncpg
+from pgvector.asyncpg import register_vector
 
 import cocoindex as coco
 from cocoindex.connectors import localfs, postgres
@@ -183,7 +184,7 @@ async def query() -> None:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(database_url) as pool:
+    async with await asyncpg.create_pool(database_url, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)

--- a/examples/postgres_source/main.py
+++ b/examples/postgres_source/main.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Annotated, AsyncIterator
 
 import asyncpg
+from pgvector.asyncpg import register_vector
 from numpy.typing import NDArray
 
 import cocoindex as coco
@@ -162,7 +163,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)


### PR DESCRIPTION
## Summary
- Follow-up to #1975: apply the same pgvector codec fix to every other example whose query demo binds an `ndarray` embedding against a `vector` column via asyncpg (`amazon_s3_embedding`, `code_embedding`, `entire_session_search`, `gdrive_text_embedding`, `oci_object_storage_embedding`, `paper_metadata`, `pdf_embedding`, `postgres_source`).
- For `gdrive_text_embedding`, also switch the query path off the shared cocoindex lifespan pool to a dedicated query pool — cocoindex writes encode to text format, but pgvector's asyncpg codec is binary, so sharing a pool would break writes.

## Test plan
- CI (lint + type checks + pytest).
- Manual: each example's `query` subcommand requires a running Postgres with pgvector; ran the text_embedding one locally in #1975 and confirmed the fix; the others are mechanically identical.
