### PR TITLE
refactor(examples): unify CLI to no-arg index + `query` subcommand

### DIFF
--- a/examples/amazon_s3_embedding/README.md
+++ b/examples/amazon_s3_embedding/README.md
@@ -27,10 +27,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres):
+Build/update the index (writes rows into Postgres). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/amazon_s3_embedding/main.py
+++ b/examples/amazon_s3_embedding/main.py
@@ -14,6 +14,7 @@ import asyncio
 import os
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 import aiobotocore.session
@@ -54,7 +55,7 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
 
@@ -173,7 +174,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -186,6 +187,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/amazon_s3_embedding/pyproject.toml
+++ b/examples/amazon_s3_embedding/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed S3 text files into Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[amazon_s3,postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[amazon_s3,postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/code_embedding/README.md
+++ b/examples/code_embedding/README.md
@@ -24,10 +24,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres):
+Build/update the index (writes rows into Postgres). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/code_embedding/main.py
+++ b/examples/code_embedding/main.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 import asyncpg
@@ -61,7 +62,7 @@ async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
     # Provide resources needed across the CocoIndex environment
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -185,7 +186,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -204,6 +205,11 @@ async def update_index() -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
-    asyncio.run(update_index())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/code_embedding/pyproject.toml
+++ b/examples/code_embedding/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed code files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/code_embedding_lancedb/README.md
+++ b/examples/code_embedding_lancedb/README.md
@@ -24,10 +24,16 @@ Install dependencies:
 pip install -e .
 ```
 
-Build/update the index (stores data in `./lancedb_data/`):
+Build/update the index (stores data in `./lancedb_data/`). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query interactively:

--- a/examples/code_embedding_lancedb/main.py
+++ b/examples/code_embedding_lancedb/main.py
@@ -15,6 +15,7 @@ import asyncio
 import pathlib
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 from numpy.typing import NDArray
@@ -181,6 +182,17 @@ async def query() -> None:
         await query_once(conn, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/code_embedding_lancedb/pyproject.toml
+++ b/examples/code_embedding_lancedb/pyproject.toml
@@ -3,7 +3,10 @@ name = "code-embedding-lancedb-v1"
 version = "0.1.0"
 description = "CocoIndex v1 example: embed code files and store in LanceDB."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.2"]
+dependencies = [
+    "cocoindex[sentence_transformers,lancedb]>=1.0.4",
+    "python-dotenv>=1.0.1",
+]
 
 [tool.setuptools]
 packages = []

--- a/examples/entire_session_search/README.md
+++ b/examples/entire_session_search/README.md
@@ -46,22 +46,28 @@ POSTGRES_URL=postgres://cocoindex:cocoindex@localhost/cocoindex
 
 ## Run
 
-Build the index:
+Build the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Search your sessions:
 
 ```sh
-python main.py "how did I fix the auth bug"
+python main.py query "how did I fix the auth bug"
 ```
 
 Or start an interactive search:
 
 ```sh
-python main.py
+python main.py query
 ```
 
 ## Configuration

--- a/examples/entire_session_search/main.py
+++ b/examples/entire_session_search/main.py
@@ -19,6 +19,7 @@ import os
 import pathlib
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 import asyncpg
@@ -63,7 +64,7 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -363,9 +364,9 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 1:
-            q = " ".join(sys.argv[1:])
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+        if len(sys.argv) > 2:
+            q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
             return
 
@@ -376,5 +377,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    asyncio.run(query())
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/entire_session_search/pyproject.toml
+++ b/examples/entire_session_search/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "Semantic search over AI coding sessions captured by Entire, powered by CocoIndex."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/gdrive_text_embedding/README.md
+++ b/examples/gdrive_text_embedding/README.md
@@ -27,10 +27,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/gdrive_text_embedding/main.py
+++ b/examples/gdrive_text_embedding/main.py
@@ -14,6 +14,7 @@ import asyncio
 import os
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 import asyncpg
@@ -47,7 +48,7 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -156,7 +157,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -169,6 +170,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/gdrive_text_embedding/pyproject.toml
+++ b/examples/gdrive_text_embedding/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed Google Drive text files into Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers,google_drive]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers,google_drive]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/hn_trending_topics/main.py
+++ b/examples/hn_trending_topics/main.py
@@ -13,6 +13,7 @@ import sys
 import pathlib
 from dataclasses import dataclass
 from datetime import datetime
+from dotenv import load_dotenv
 from typing import Any, AsyncIterator
 
 import aiohttp
@@ -190,7 +191,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
     # For CocoIndex internal states
     builder.settings.db_path = pathlib.Path("./cocoindex.db")
     # Provide resources needed across the CocoIndex environment
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         yield
 
@@ -406,6 +407,17 @@ async def query_demo() -> None:
         await pool.close()
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query_demo())
+    else:
+        print("Usage: main.py [query]")

--- a/examples/hn_trending_topics/pyproject.toml
+++ b/examples/hn_trending_topics/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "aiohttp>=3.9.0",
     "litellm>=1.40.0",
     "pydantic>=2.0.0",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/image_search/README.md
+++ b/examples/image_search/README.md
@@ -33,10 +33,16 @@ Install dependencies:
 pip install -e .
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/image_search/main.py
+++ b/examples/image_search/main.py
@@ -9,12 +9,14 @@ Image Search with Qdrant (v1) - CocoIndex pipeline example.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import io
 import os
 import pathlib
 import sys
 import uuid
+from dotenv import load_dotenv
 from typing import AsyncIterator
 
 import torch
@@ -140,8 +142,8 @@ def query_once(client: QdrantClient, query_text: str, *, top_k: int = TOP_K) -> 
 
 def query() -> None:
     client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 1:
-        q = " ".join(sys.argv[1:])
+    if len(sys.argv) > 2:
+        q = " ".join(sys.argv[2:])
         query_once(client, q)
         return
 
@@ -188,5 +190,17 @@ def _qdrant_search(
     raise RuntimeError("Unsupported qdrant-client version: no search method found.")
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    query()
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        query()
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/image_search/pyproject.toml
+++ b/examples/image_search/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "CocoIndex v1 example: image search with CLIP embeddings stored in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[qdrant]>=1.0.2",
+    "cocoindex[qdrant]>=1.0.4",
     "fastapi>=0.100.0",
     "torch>=2.0.0",
     "transformers>=4.29.0",
     "pillow>=10.0.0",
     "qdrant-client>=1.14.2",
     "uvicorn>=0.34.3",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/image_search_colpali/README.md
+++ b/examples/image_search_colpali/README.md
@@ -26,10 +26,16 @@ Install dependencies:
 pip install -e .
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```
+python main.py
 ```
 
 Query:

--- a/examples/image_search_colpali/main.py
+++ b/examples/image_search_colpali/main.py
@@ -9,12 +9,14 @@ Image Search with ColPali (v1) - CocoIndex pipeline example.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import io
 import os
 import pathlib
 import sys
 import uuid
+from dotenv import load_dotenv
 from typing import AsyncIterator
 
 import torch
@@ -163,8 +165,8 @@ def query_once(client: QdrantClient, query_text: str, *, top_k: int = TOP_K) -> 
 
 def query() -> None:
     client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 1:
-        q = " ".join(sys.argv[1:])
+    if len(sys.argv) > 2:
+        q = " ".join(sys.argv[2:])
         query_once(client, q)
         return
 
@@ -196,5 +198,17 @@ def _qdrant_search(
     return response.points
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    query()
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        query()
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/image_search_colpali/pyproject.toml
+++ b/examples/image_search_colpali/pyproject.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 description = "CocoIndex v1 example: image search with ColPali embeddings stored in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[colpali,qdrant]>=1.0.2",
+    "cocoindex[colpali,qdrant]>=1.0.4",
     "transformers>=4.45.0,<5",
     "fastapi>=0.100.0",
     "torch>=2.0.0",
     "pillow>=10.0.0",
     "qdrant-client>=1.14.2",
     "uvicorn>=0.34.3",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/oci_object_storage_embedding/README.md
+++ b/examples/oci_object_storage_embedding/README.md
@@ -30,16 +30,22 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index in catch-up mode (writes rows into Postgres and exits):
+Build/update the index in catch-up mode (writes rows into Postgres and exits). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Run in **live mode** — performs an initial scan, then keeps watching the OCI Streaming topic and applies incremental updates:
 
 ```sh
-cocoindex update -L main.py
+cocoindex update -L main
 ```
 
 Live mode requires `OCI_STREAMING_BOOTSTRAP_SERVERS`, `OCI_STREAMING_TOPIC`, `OCI_STREAMING_USERNAME`, and `OCI_STREAMING_AUTH_TOKEN` to be set in `.env`. With those unset, the connector skips live-stream subscription and just performs the catch-up scan.

--- a/examples/oci_object_storage_embedding/main.py
+++ b/examples/oci_object_storage_embedding/main.py
@@ -21,6 +21,7 @@ import asyncio
 import os
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import Annotated, AsyncIterator
 
 import asyncpg
@@ -113,7 +114,7 @@ def _build_streaming_consumer() -> AIOConsumer | None:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         builder.provide(OCI_CLIENT, _build_oci_client())
@@ -238,7 +239,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -251,6 +252,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/oci_object_storage_embedding/pyproject.toml
+++ b/examples/oci_object_storage_embedding/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed OCI Object Storage text files into Postgres/pgvector, with optional live updates via OCI Streaming."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[oci,kafka,postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[oci,kafka,postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/paper_metadata/README.md
+++ b/examples/paper_metadata/README.md
@@ -34,10 +34,16 @@ export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
 
 This example uses the `coco_examples_v1` schema by default to avoid clashing with the legacy example tables.
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/paper_metadata/main.py
+++ b/examples/paper_metadata/main.py
@@ -165,7 +165,7 @@ async def coco_lifespan(
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
 
-    async with await asyncpg.create_pool(database_url) as pool:
+    async with asyncpg.create_pool(database_url) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -324,7 +324,7 @@ async def query() -> None:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(database_url, init=register_vector) as pool:
+    async with asyncpg.create_pool(database_url, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -337,7 +337,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/paper_metadata/pyproject.toml
+++ b/examples/paper_metadata/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: extract paper metadata and embeddings from PDFs."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",

--- a/examples/pdf_embedding/README.md
+++ b/examples/pdf_embedding/README.md
@@ -28,10 +28,16 @@ Set a database URL (or use `.env`):
 export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/pdf_embedding/main.py
+++ b/examples/pdf_embedding/main.py
@@ -78,7 +78,7 @@ async def coco_lifespan(
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
 
-    async with await asyncpg.create_pool(database_url) as pool:
+    async with asyncpg.create_pool(database_url) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -184,7 +184,7 @@ async def query() -> None:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(database_url, init=register_vector) as pool:
+    async with asyncpg.create_pool(database_url, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -197,7 +197,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/pdf_embedding/pyproject.toml
+++ b/examples/pdf_embedding/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed local PDF files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",

--- a/examples/postgres_source/README.md
+++ b/examples/postgres_source/README.md
@@ -30,10 +30,16 @@ For simplicity, we use the same database for source and target. You can also set
 
 ## Run
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/postgres_source/main.py
+++ b/examples/postgres_source/main.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import Annotated, AsyncIterator
 
 import asyncpg
@@ -65,8 +66,8 @@ async def coco_lifespan(
 ) -> AsyncIterator[None]:
     # Provide resources needed across the CocoIndex environment
     async with (
-        await asyncpg.create_pool(DATABASE_URL) as target_pool,
-        await asyncpg.create_pool(SOURCE_DATABASE_URL) as source_pool,
+        asyncpg.create_pool(DATABASE_URL) as target_pool,
+        asyncpg.create_pool(SOURCE_DATABASE_URL) as source_pool,
     ):
         builder.provide(PG_DB, target_pool)
         builder.provide(SOURCE_POOL, source_pool)
@@ -163,7 +164,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -171,6 +172,17 @@ async def query() -> None:
         print('Usage: python main.py query "your search query"')
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/postgres_source/pyproject.toml
+++ b/examples/postgres_source/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: read from PostgreSQL source and write embeddings back to Postgres."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -24,10 +24,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres):
+Build/update the index (writes rows into Postgres). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/text_embedding/main.py
+++ b/examples/text_embedding/main.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 import asyncpg
@@ -50,7 +51,7 @@ async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
     # Provide resources needed across the CocoIndex environment
-    async with await asyncpg.create_pool(DATABASE_URL) as pool:
+    async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
         yield
@@ -163,7 +164,7 @@ async def query_once(
 
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
-    async with await asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
+    async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
         if len(sys.argv) > 2:
             q = " ".join(sys.argv[2:])
             await query_once(pool, embedder, q)
@@ -176,6 +177,17 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "query":
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
         asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/text_embedding/pyproject.toml
+++ b/examples/text_embedding/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed local markdown files and store in Postgres/pgvector."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[postgres,sentence_transformers]>=1.0.2",
+    "cocoindex[postgres,sentence_transformers]>=1.0.4",
     "asyncpg>=0.29.0",
     "pgvector>=0.4.1",
     "numpy",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/text_embedding_lancedb/README.md
+++ b/examples/text_embedding_lancedb/README.md
@@ -23,10 +23,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (stores data in `./lancedb_data/`):
+Build/update the index (stores data in `./lancedb_data/`). Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/text_embedding_lancedb/main.py
+++ b/examples/text_embedding_lancedb/main.py
@@ -14,6 +14,7 @@ import asyncio
 import pathlib
 import sys
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import AsyncIterator, Annotated
 
 from numpy.typing import NDArray
@@ -147,8 +148,8 @@ async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     conn = await lancedb.connect_async(LANCEDB_URI)
 
-    if len(sys.argv) > 1:
-        q = " ".join(sys.argv[1:])
+    if len(sys.argv) > 2:
+        q = " ".join(sys.argv[2:])
         await query_once(conn, embedder, q)
         return
 
@@ -159,5 +160,17 @@ async def query() -> None:
         await query_once(conn, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    asyncio.run(query())
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/text_embedding_lancedb/pyproject.toml
+++ b/examples/text_embedding_lancedb/pyproject.toml
@@ -3,7 +3,10 @@ name = "text-embedding-lancedb-v1"
 version = "0.1.0"
 description = "CocoIndex v1 example: embed markdown files and store in LanceDB."
 requires-python = ">=3.11"
-dependencies = ["cocoindex[sentence_transformers,lancedb]>=1.0.2"]
+dependencies = [
+    "cocoindex[sentence_transformers,lancedb]>=1.0.4",
+    "python-dotenv>=1.0.1",
+]
 
 [tool.setuptools]
 packages = []

--- a/examples/text_embedding_qdrant/README.md
+++ b/examples/text_embedding_qdrant/README.md
@@ -18,10 +18,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:

--- a/examples/text_embedding_qdrant/main.py
+++ b/examples/text_embedding_qdrant/main.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import pathlib
 import sys
+from dotenv import load_dotenv
 from typing import AsyncIterator
 
 from cocoindex.resources.id import IdGenerator
@@ -134,8 +135,8 @@ async def query_once(
 async def query() -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 1:
-        q = " ".join(sys.argv[1:])
+    if len(sys.argv) > 2:
+        q = " ".join(sys.argv[2:])
         await query_once(client, embedder, q)
         return
 
@@ -177,5 +178,17 @@ def _qdrant_search(
     raise RuntimeError("Unsupported qdrant-client version: no search method found.")
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
-    asyncio.run(query())
+    load_dotenv()
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/text_embedding_qdrant/pyproject.toml
+++ b/examples/text_embedding_qdrant/pyproject.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed markdown files and store in Qdrant."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[sentence_transformers,qdrant]>=1.0.2",
+    "cocoindex[sentence_transformers,qdrant]>=1.0.4",
     "numpy",
     "qdrant-client>=1.16.0",
+    "python-dotenv>=1.0.1",
 ]
 
 [tool.setuptools]

--- a/examples/text_embedding_turbopuffer/README.md
+++ b/examples/text_embedding_turbopuffer/README.md
@@ -21,20 +21,26 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index:
+Build/update the index. Either of the following works:
 
 ```sh
-cocoindex update main.py
+cocoindex update main
+```
+
+or
+
+```sh
+python main.py
 ```
 
 Query:
 
 ```sh
-python main.py "what is self-attention?"
+python main.py query "what is self-attention?"
 ```
 
 Or run interactively:
 
 ```sh
-python main.py
+python main.py query
 ```

--- a/examples/text_embedding_turbopuffer/main.py
+++ b/examples/text_embedding_turbopuffer/main.py
@@ -147,8 +147,8 @@ async def query() -> None:
     async with turbopuffer.AsyncTurbopuffer(
         region=TPUF_REGION, api_key=api_key
     ) as client:
-        if len(sys.argv) > 1:
-            q = " ".join(sys.argv[1:])
+        if len(sys.argv) > 2:
+            q = " ".join(sys.argv[2:])
             await query_once(client, embedder, q)
             return
 
@@ -159,6 +159,17 @@ async def query() -> None:
             await query_once(client, embedder, q)
 
 
+async def update_index() -> None:
+    async with coco.runtime():
+        await coco.show_progress(app.update())
+
+
 if __name__ == "__main__":
     load_dotenv()
-    asyncio.run(query())
+    if len(sys.argv) == 1:
+        # Update the index. Equivalent to running `cocoindex update main`.
+        asyncio.run(update_index())
+    elif sys.argv[1] == "query":
+        asyncio.run(query())
+    else:
+        print("Usage: main.py [query <search terms>]")

--- a/examples/text_embedding_turbopuffer/pyproject.toml
+++ b/examples/text_embedding_turbopuffer/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "CocoIndex v1 example: embed markdown files and store in Turbopuffer."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[sentence_transformers,turbopuffer]>=1.0.2",
+    "cocoindex[sentence_transformers,turbopuffer]>=1.0.4",
     "numpy",
     "python-dotenv>=1.0.1",
 ]


### PR DESCRIPTION
## Summary
- Unify the example CLI entrypoints: `python main.py` runs the index update (equivalent to `cocoindex update main`); `python main.py query [terms]` runs the query demo.
- Load `.env` via `python-dotenv` on entry, and drop the redundant `await` on `asyncpg.create_pool(...)` (the `async with` already awaits the coroutine).
- READMEs now show both `cocoindex update main` and `python main.py` for build/update.

Applied to: amazon_s3_embedding, code_embedding, code_embedding_lancedb, entire_session_search, gdrive_text_embedding, hn_trending_topics, image_search, image_search_colpali, oci_object_storage_embedding, paper_metadata, pdf_embedding, postgres_source, text_embedding, text_embedding_lancedb, text_embedding_qdrant, text_embedding_turbopuffer.

## Test plan
- CI
- Spot-checked: `python main.py` (no args) → indexes; `python main.py query "..."` → queries.
