### PR TITLE
refactor(examples): query-only `__main__`, index via `cocoindex update`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ examples/**/uv.lock
 
 # CocoIndex Code (ccc)
 /.cocoindex_code/
+
+# Claude Code local state
+.claude/*.lock

--- a/examples/amazon_s3_embedding/README.md
+++ b/examples/amazon_s3_embedding/README.md
@@ -27,22 +27,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres). Either of the following works:
+Build/update the index (one-shot catch-up; the amazon_s3 source does not support live mode):
 
 ```sh
 cocoindex update main
 ```
 
-or
-
-```sh
-python main.py
-```
-
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```
 
 Note: this example **does not create a vector index**; queries will do a sequential scan.

--- a/examples/amazon_s3_embedding/main.py
+++ b/examples/amazon_s3_embedding/main.py
@@ -1,11 +1,13 @@
 """
-Amazon S3 Text Embedding (v1) — CocoIndex pipeline example.
+Amazon S3 Text Embedding (v1) - CocoIndex pipeline example.
 
-- List markdown files from an S3 bucket
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column (no vector index)
-- Query demo using pgvector cosine distance (<=>)
+Index (one-shot catch-up; live mode is not supported for the amazon_s3 source):
+    cocoindex update main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: list markdown files from S3 -> chunk -> embed -> store in pgvector.
 """
 
 from __future__ import annotations
@@ -59,7 +61,6 @@ async def coco_lifespan(
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
 
-        # Create aiobotocore S3 client.
         # Set AWS_ENDPOINT_URL for S3-compatible services (e.g. MinIO).
         session = aiobotocore.session.get_session()
         async with session.create_client("s3") as s3_client:
@@ -137,11 +138,6 @@ app = coco.App(
 )
 
 
-# ============================================================================
-# Query demo (no vector index)
-# ============================================================================
-
-
 async def query_once(
     pool: asyncpg.Pool,
     embedder: SentenceTransformerEmbedder,
@@ -172,12 +168,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -187,17 +182,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/code_embedding/README.md
+++ b/examples/code_embedding/README.md
@@ -24,20 +24,22 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres). Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "embedding"
+python main.py "embedding"
 ```

--- a/examples/code_embedding/main.py
+++ b/examples/code_embedding/main.py
@@ -1,12 +1,13 @@
 """
 Code Embedding (v1) - CocoIndex pipeline example.
 
-- Walk local code files (Python, Rust, TOML, Markdown)
-- Detect programming language
-- Chunk code (RecursiveSplitter with syntax awareness)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column
-- Query demo using pgvector cosine distance (<=>)
+Index live (runs once and keeps watching for changes):
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk -> detect language -> chunk -> embed -> store in pgvector.
 """
 
 from __future__ import annotations
@@ -61,7 +62,6 @@ class CodeEmbedding:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
@@ -94,10 +94,7 @@ async def process_file(
     table: postgres.TableTarget[CodeEmbedding],
 ) -> None:
     text = await file.read_text()
-    # Detect programming language from filename
     language = detect_code_language(filename=str(file.file_path.path.name))
-
-    # Split with syntax awareness if language is detected
     chunks = _splitter.split(
         text,
         chunk_size=1000,
@@ -122,7 +119,6 @@ async def app_main(sourcedir: pathlib.Path) -> None:
     )
     target_table.declare_vector_index(column="embedding")
 
-    # Process multiple file types across the repository
     files = localfs.walk_dir(
         sourcedir,
         recursive=True,
@@ -136,6 +132,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
             ],
             excluded_patterns=["**/.*", "**/target", "**/node_modules"],
         ),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_table)
 
@@ -184,12 +181,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -199,17 +195,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/code_embedding_lancedb/README.md
+++ b/examples/code_embedding_lancedb/README.md
@@ -24,26 +24,22 @@ Install dependencies:
 pip install -e .
 ```
 
-Build/update the index (stores data in `./lancedb_data/`). Either of the following works:
+Build/update the index (writes rows into LanceDB). Pick one of the two modes:
+
+- **Catch-up run** — scan sources, sync changes, exit:
+
+  ```sh
+  cocoindex update main
+  ```
+
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
+
+Query:
 
 ```sh
-cocoindex update main
-```
-
-or
-
-```sh
-python main.py
-```
-
-Query interactively:
-
-```sh
-python main.py query
-```
-
-Or query with a specific search term:
-
-```sh
-python main.py query "embedding"
+python main.py "embedding"
 ```

--- a/examples/code_embedding_lancedb/main.py
+++ b/examples/code_embedding_lancedb/main.py
@@ -1,12 +1,14 @@
 """
 Code Embedding with LanceDB (v1) - CocoIndex pipeline example.
 
-- Walk local code files (Python, Rust, TOML, Markdown)
-- Detect programming language
-- Chunk code (RecursiveSplitter with syntax awareness)
-- Embed chunks (SentenceTransformers)
-- Store into LanceDB with vector column
-- Query demo using LanceDB native vector search
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk -> detect language -> chunk -> embed -> store in LanceDB.
 """
 
 from __future__ import annotations
@@ -55,7 +57,6 @@ class CodeEmbedding:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     conn = await lancedb.connect_async(LANCEDB_URI)
     builder.provide(LANCE_DB, conn)
     builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
@@ -87,10 +88,7 @@ async def process_file(
     table: lancedb.TableTarget[CodeEmbedding],
 ) -> None:
     text = await file.read_text()
-    # Detect programming language from filename
     language = detect_code_language(filename=str(file.file_path.path.name))
-
-    # Split with syntax awareness if language is detected
     chunks = _splitter.split(
         text,
         chunk_size=1000,
@@ -112,7 +110,6 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         ),
     )
 
-    # Process multiple file types across the repository
     files = localfs.walk_dir(
         sourcedir,
         recursive=True,
@@ -126,6 +123,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
             ],
             excluded_patterns=["**/.*", "**/target", "**/node_modules"],
         ),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_table)
 
@@ -166,13 +164,12 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     conn = await lancedb.connect_async(LANCEDB_URI)
 
-    if len(sys.argv) > 2:
-        q = " ".join(sys.argv[2:])
-        await query_once(conn, embedder, q)
+    if initial_query is not None:
+        await query_once(conn, embedder, initial_query)
         return
 
     while True:
@@ -182,17 +179,7 @@ async def query() -> None:
         await query_once(conn, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/entire_session_search/README.md
+++ b/examples/entire_session_search/README.md
@@ -46,28 +46,24 @@ POSTGRES_URL=postgres://cocoindex:cocoindex@localhost/cocoindex
 
 ## Run
 
-Build the index. Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
+
+- **Catch-up run** — scan sources, sync changes, exit:
+
+  ```sh
+  cocoindex update main
+  ```
+
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
+
+Query:
 
 ```sh
-cocoindex update main
-```
-
-or
-
-```sh
-python main.py
-```
-
-Search your sessions:
-
-```sh
-python main.py query "how did I fix the auth bug"
-```
-
-Or start an interactive search:
-
-```sh
-python main.py query
+python main.py "how did I fix the auth bug"
 ```
 
 ## Configuration

--- a/examples/entire_session_search/main.py
+++ b/examples/entire_session_search/main.py
@@ -1,14 +1,14 @@
 """
 Entire Session Search - CocoIndex pipeline example.
 
-Indexes AI coding session data captured by Entire (https://entire.io)
-into Postgres with pgvector for semantic search.
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
 
-Handles four file types from Entire's checkpoint format:
-- full.jsonl:  conversation transcript (chunked + embedded)
-- prompt.txt:  user's initial prompt (embedded directly)
-- context.md:  AI-generated session summary (chunked + embedded)
-- metadata.json: token counts, files touched, timestamps (stored as metadata)
+Query the index:
+    python main.py "your query"
+
+Pipeline: indexes AI coding session checkpoints from Entire (https://entire.io) — transcripts, prompts, context summaries, and metadata — into Postgres with pgvector for semantic search.
 """
 
 from __future__ import annotations
@@ -310,6 +310,7 @@ async def app_main(checkpoints_dir: pathlib.Path) -> None:
             ],
             excluded_patterns=["**/content_hash.txt"],
         ),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), emb_table, meta_table)
 
@@ -362,12 +363,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -377,17 +377,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/gdrive_text_embedding/README.md
+++ b/examples/gdrive_text_embedding/README.md
@@ -27,22 +27,16 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index. Either of the following works:
+Build/update the index (one-shot catch-up; the google_drive source does not support live mode):
 
 ```sh
 cocoindex update main
 ```
 
-or
-
-```sh
-python main.py
-```
-
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```
 
 Note: this example does not create a vector index; queries do a sequential scan.

--- a/examples/gdrive_text_embedding/main.py
+++ b/examples/gdrive_text_embedding/main.py
@@ -1,11 +1,13 @@
 """
 Google Drive Text Embedding (v1) - CocoIndex pipeline example.
 
-- Read text files from Google Drive
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column (no vector index)
-- Query demo using pgvector cosine distance (<=>)
+Index (one-shot catch-up; live mode is not supported for the google_drive source):
+    cocoindex update main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: read text files from Google Drive -> chunk -> embed -> store in pgvector.
 """
 
 from __future__ import annotations
@@ -155,12 +157,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -170,17 +171,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/hn_trending_topics/README.md
+++ b/examples/hn_trending_topics/README.md
@@ -1,0 +1,51 @@
+# HackerNews Trending Topics (v1)
+
+[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+
+This example scrapes recent HackerNews threads (and their comments) via the [Algolia HN API](https://hn.algolia.com/api), uses an LLM to extract topics from each message, and stores everything in Postgres. A small CLI demo prints trending topics ranked by mention score and lets you search messages by topic.
+
+## Prerequisites
+
+- A running Postgres. If you don't have one, start a local instance with the compose file in this repo:
+
+  ```sh
+  docker compose -f ../../dev/postgres.yaml up -d
+  ```
+
+- `POSTGRES_URL` set, e.g.
+
+  ```sh
+  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+  ```
+
+- An API key for the LLM. The default model is `gemini/gemini-2.5-flash` (set `GEMINI_API_KEY`). Any provider supported by [litellm](https://docs.litellm.ai/docs/providers) works — change `LLM_MODEL` in `main.py` and set the matching credential.
+
+You can put these in a `.env` file in this directory; `python main.py` loads it automatically.
+
+## Run
+
+Install deps:
+
+```sh
+pip install -e .
+```
+
+Build/update the index (one-shot catch-up; this example doesn't use a live source):
+
+```sh
+cocoindex update main
+```
+
+Each run fetches the latest `MAX_THREADS` (default 10) threads, runs LLM topic extraction on the thread + each comment, and writes rows into `coco_examples.hn_messages` and `coco_examples.hn_topics`. CocoIndex memoizes per-message extraction, so re-running is incremental.
+
+Query — show top trending topics, then enter a search loop:
+
+```sh
+python main.py
+```
+
+Or jump straight to a topic search:
+
+```sh
+python main.py "rust"
+```

--- a/examples/hn_trending_topics/main.py
+++ b/examples/hn_trending_topics/main.py
@@ -1,10 +1,13 @@
 """
-HackerNews Trending Topics - CocoIndex Pipeline Example
+HackerNews Trending Topics - CocoIndex pipeline example.
 
-This example demonstrates a CocoIndex pipeline that:
-1. Scrapes HackerNews threads and comments via API
-2. Extracts topics using LLM (Gemini 2.5 Flash via LiteLLM)
-3. Stores everything in PostgreSQL using the cocoindex postgres target
+Index (one-shot catch-up; live mode is not supported for the postgres source):
+    cocoindex update main
+
+Query the index:
+    python main.py "your topic"
+
+Pipeline: scrape HN threads + comments -> extract topics via LLM -> store in Postgres.
 """
 
 import asyncio
@@ -187,10 +190,7 @@ async def fetch_thread(session: aiohttp.ClientSession, thread_id: str) -> Thread
 
 @coco.lifespan
 async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
-    """Set up CocoIndex environment with PostgreSQL database."""
-    # For CocoIndex internal states
     builder.settings.db_path = pathlib.Path("./cocoindex.db")
-    # Provide resources needed across the CocoIndex environment
     async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         yield
@@ -379,13 +379,24 @@ async def search_by_topic(pool: asyncpg.Pool, topic: str) -> list[dict[str, Any]
         ]
 
 
-async def query_demo() -> None:
-    """Demo querying the database."""
+async def _print_topic_search(pool: asyncpg.Pool, topic: str) -> None:
+    print(f"Searching for '{topic}' related content:")
+    print("-" * 60)
+    results = await search_by_topic(pool, topic)
+    for result in results[:5]:
+        print(f"[{result['type']}] by {result['author']}: {result['text'][:100]}...")
+
+
+async def query_demo(initial_query: str | None = None) -> None:
     pool = await asyncpg.create_pool(DATABASE_URL)
     if not pool:
         raise RuntimeError("Failed to create database pool")
 
     try:
+        if initial_query is not None:
+            await _print_topic_search(pool, initial_query)
+            return
+
         print("Top 20 Trending Topics:")
         print("-" * 60)
         topics = await get_trending_topics(pool, limit=20)
@@ -393,31 +404,18 @@ async def query_demo() -> None:
             print(
                 f"{i:2}. {topic['topic']:<30} (score: {topic['score']}, threads: {topic['thread_count']})"
             )
-
         print()
-        print("Searching for 'AI' related content:")
-        print("-" * 60)
-        results = await search_by_topic(pool, "AI")
-        for result in results[:5]:
-            print(
-                f"[{result['type']}] by {result['author']}: {result['text'][:100]}..."
-            )
 
+        while True:
+            q = input("Enter topic to search (or Enter to quit): ").strip()
+            if not q:
+                break
+            await _print_topic_search(pool, q)
     finally:
         await pool.close()
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query_demo())
-    else:
-        print("Usage: main.py [query]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query_demo(initial))

--- a/examples/image_search/README.md
+++ b/examples/image_search/README.md
@@ -1,7 +1,7 @@
 # Image Search with CocoIndex (v1)
 [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
 
-This example builds an image search index with CLIP embeddings and Qdrant, then queries it with natural language.
+This example builds an image search index with CLIP embeddings and Qdrant, then queries it with natural language via a small FastAPI server and React frontend.
 
 We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
 
@@ -25,7 +25,7 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
   docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
   ```
 
-## Run (CLI)
+## Run
 
 Install dependencies:
 
@@ -33,33 +33,15 @@ Install dependencies:
 pip install -e .
 ```
 
-Build/update the index. Either of the following works:
-
-```sh
-cocoindex update main
-```
-
-or
-
-```sh
-python main.py
-```
-
-Query:
-
-```sh
-python main.py query "a red car"
-```
-
-## Frontend (optional)
-
-If you want a UI, start the FastAPI wrapper and the frontend:
+Start the FastAPI server:
 
 ```sh
 python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
 ```
 
-Then in another terminal:
+The server runs the index in **live mode** in the background — startup blocks until the initial sweep over `img/` finishes (so the collection is queryable), then file changes keep flowing into Qdrant while requests are served. There is no separate "build the index" step.
+
+Then in another terminal, start the frontend:
 
 ```sh
 cd frontend
@@ -68,3 +50,8 @@ npm run dev
 ```
 
 Then open `http://localhost:5173`.
+
+## Code layout
+
+- `pipeline.py` — defines the CocoIndex `app`, the CLIP embedder helpers, and a small `_qdrant_search` shim. Library only — not an entry point.
+- `api.py` — FastAPI server. Imports `pipeline`, runs `pipeline.app.update(live=True)` in the background, and exposes `/search`.

--- a/examples/image_search/api.py
+++ b/examples/image_search/api.py
@@ -1,12 +1,18 @@
 """
 FastAPI wrapper for the v1 image search pipeline.
+
+Runs the index in live mode in the background, so the FastAPI server keeps
+the Qdrant collection in sync with `img/` while serving search requests.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -15,15 +21,11 @@ from qdrant_client import QdrantClient
 import cocoindex as coco
 from cocoindex.connectors import qdrant
 
-try:
-    from . import main as image_search
-except ImportError:
-    import importlib
+import pipeline
 
-    image_search = importlib.import_module("main")
+load_dotenv()
 
 
-# Module-level client reference for API endpoints
 _client: QdrantClient | None = None
 
 
@@ -31,12 +33,23 @@ _client: QdrantClient | None = None
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[override]
     global _client
     async with coco.runtime():
-        # Initialize client for API endpoints
-        _client = qdrant.create_client(image_search.QDRANT_URL, prefer_grpc=True)
-        # Build/update the index once on startup so the collection exists.
-        await coco.show_progress(image_search.app.update())
-        yield
-        _client = None
+        _client = qdrant.create_client(pipeline.qdrant_url(), prefer_grpc=True)
+
+        # Start a live update; block startup until the initial sweep finishes so
+        # the collection is queryable, then keep it running in the background.
+        update_handle = pipeline.app.update(live=True)
+        async for snap in update_handle.watch():
+            if snap.status is coco.UpdateStatus.READY:
+                break
+        update_task = asyncio.create_task(update_handle.result())
+
+        try:
+            yield
+        finally:
+            update_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await update_task
+            _client = None
 
 
 app = FastAPI(lifespan=lifespan)
@@ -58,14 +71,14 @@ async def search(
     q: str = Query(..., description="Search query"),
     limit: int = Query(5, description="Number of results"),
 ) -> dict[str, Any]:
-    query_embedding = image_search.embed_query(q)
+    query_embedding = pipeline.embed_query(q)
 
     if _client is None:
         raise RuntimeError("Qdrant client is not initialized.")
 
-    results = image_search._qdrant_search(
+    results = pipeline._qdrant_search(
         _client,
-        image_search.QDRANT_COLLECTION,
+        pipeline.QDRANT_COLLECTION,
         query_embedding,
         limit,
     )

--- a/examples/image_search/frontend/src/App.jsx
+++ b/examples/image_search/frontend/src/App.jsx
@@ -42,7 +42,7 @@ export default function App() {
         {results.length === 0 && !loading && <div>No results</div>}
         {results.map((result, idx) => (
           <div key={idx} className="result-card">
-            <img src={`http://${window.location.hostname}:8000/img/${result.filename}`} alt={result.filename} className="result-img" />
+            <img src={`http://${window.location.hostname}:8000/${result.filename}`} alt={result.filename} className="result-img" />
             <div className="score">Score: {result.score?.toFixed(3)}</div>
           </div>
         ))}

--- a/examples/image_search/pipeline.py
+++ b/examples/image_search/pipeline.py
@@ -1,23 +1,24 @@
 """
-Image Search with Qdrant (v1) - CocoIndex pipeline example.
+Image Search with Qdrant (v1) - CocoIndex pipeline definition.
 
-- Walk local image files
-- Embed images with CLIP
-- Store embeddings in Qdrant
-- Query by text using CLIP text embeddings
+Defines the CocoIndex `app` (walk local images -> embed with CLIP -> store in Qdrant)
+and the helper functions (`embed_query`, `_qdrant_search`) used by `api.py`.
+
+This module is not an entry point. To run the example, start the FastAPI server:
+
+    python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
+
+The server runs the index in live mode in the background and serves search requests.
 """
 
 from __future__ import annotations
 
-import asyncio
 import functools
 import io
 import os
 import pathlib
-import sys
 import uuid
-from dotenv import load_dotenv
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 import torch
 from PIL import Image
@@ -31,10 +32,13 @@ from cocoindex.connectors import localfs, qdrant
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 from cocoindex.resources.schema import VectorSchema
 
-QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6334/")
 QDRANT_COLLECTION = "ImageSearch"
 CLIP_MODEL_NAME = "openai/clip-vit-large-patch14"
 TOP_K = 5
+
+
+def qdrant_url() -> str:
+    return os.getenv("QDRANT_URL", "http://localhost:6334/")
 
 
 QDRANT_DB = coco.ContextKey[QdrantClient]("image_search_qdrant")
@@ -48,12 +52,18 @@ def get_clip_model() -> tuple[CLIPModel, CLIPProcessor]:
     return model, processor
 
 
+def _projected_features(out: Any) -> torch.Tensor:
+    # transformers >=5 returns BaseModelOutputWithPooling with the projected features in pooler_output;
+    # transformers <5 returns the projected features tensor directly.
+    return out.pooler_output if hasattr(out, "pooler_output") else out
+
+
 def embed_query(text: str) -> list[float]:
     model, processor = get_clip_model()
     inputs = processor(text=[text], return_tensors="pt", padding=True)
     with torch.no_grad():
-        features = model.get_text_features(**inputs)
-    return features[0].tolist()
+        out = model.get_text_features(**inputs)
+    return _projected_features(out)[0].tolist()
 
 
 def embed_image_bytes(img_bytes: bytes) -> list[float]:
@@ -61,16 +71,15 @@ def embed_image_bytes(img_bytes: bytes) -> list[float]:
     image = Image.open(io.BytesIO(img_bytes)).convert("RGB")
     inputs = processor(images=image, return_tensors="pt")
     with torch.no_grad():
-        features = model.get_image_features(**inputs)
-    return features[0].tolist()
+        out = model.get_image_features(**inputs)
+    return _projected_features(out)[0].tolist()
 
 
 @coco.lifespan
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
-    client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
+    client = qdrant.create_client(qdrant_url(), prefer_grpc=True)
     builder.provide(QDRANT_DB, client)
     builder.provide(QDRANT_CLIENT, client)
     yield
@@ -114,6 +123,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         path_matcher=PatternFilePathMatcher(
             included_patterns=["**/*.jpg", "**/*.jpeg", "**/*.png"]
         ),
+        live=True,  # source supports live watch; api.py runs the app with live=True
     )
     await coco.mount_each(process_file, files.items(), target_collection)
 
@@ -123,35 +133,6 @@ app = coco.App(
     app_main,
     sourcedir=pathlib.Path("./img"),
 )
-
-
-# ============================================================================
-# Query demo
-# ============================================================================
-
-
-def query_once(client: QdrantClient, query_text: str, *, top_k: int = TOP_K) -> None:
-    query_vec = embed_query(query_text)
-    results = _qdrant_search(client, QDRANT_COLLECTION, query_vec, top_k)
-
-    for r in results:
-        payload = r.payload or {}
-        print(f"[{r.score:.3f}] {payload.get('filename', '<unknown>')}")
-        print("---")
-
-
-def query() -> None:
-    client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 2:
-        q = " ".join(sys.argv[2:])
-        query_once(client, q)
-        return
-
-    while True:
-        q = input("Enter search query (or Enter to quit): ").strip()
-        if not q:
-            break
-        query_once(client, q)
 
 
 def _image_id(path: pathlib.PurePath) -> str:
@@ -188,19 +169,3 @@ def _qdrant_search(
         )
         return response.result
     raise RuntimeError("Unsupported qdrant-client version: no search method found.")
-
-
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
-if __name__ == "__main__":
-    load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        query()
-    else:
-        print("Usage: main.py [query <search terms>]")

--- a/examples/image_search_colpali/README.md
+++ b/examples/image_search_colpali/README.md
@@ -1,7 +1,7 @@
 # Image Search with ColPali (v1)
 [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
 
-This example builds an image search index using the ColPali embedding model and stores vectors in Qdrant. It supports both CLI queries and a FastAPI backend for the included frontend.
+This example builds an image search index using the ColPali multi-vector embedding model and stores vectors in Qdrant (MaxSim multivector config), then queries it with natural language via a small FastAPI server and React frontend.
 
 We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
 
@@ -18,44 +18,33 @@ We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/c
   docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
   ```
 
-## Run (CLI)
+## Run
 
 Install dependencies:
 
-```
+```sh
 pip install -e .
 ```
 
-Build/update the index. Either of the following works:
+Start the FastAPI server:
 
-```
-cocoindex update main
-```
-
-or
-
-```
-python main.py
-```
-
-Query:
-
-```
-python main.py query "a red car"
-```
-
-## Run (API)
-
-```
+```sh
 python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
 ```
 
-## Frontend
+The server runs the index in **live mode** in the background — startup blocks until the initial sweep over `img/` finishes (so the collection is queryable), then file changes keep flowing into Qdrant while requests are served. There is no separate "build the index" step.
 
-```
+Then in another terminal, start the frontend:
+
+```sh
 cd frontend
 npm install
 npm run dev
 ```
 
 Go to `http://localhost:5173` to search.
+
+## Code layout
+
+- `pipeline.py` — defines the CocoIndex `app`, the ColPali embedder helpers, and a small `_qdrant_search` shim. Library only — not an entry point.
+- `api.py` — FastAPI server. Imports `pipeline`, runs `pipeline.app.update(live=True)` in the background, and exposes `/search`.

--- a/examples/image_search_colpali/api.py
+++ b/examples/image_search_colpali/api.py
@@ -1,12 +1,18 @@
 """
 FastAPI wrapper for the v1 ColPali image search pipeline.
+
+Runs the index in live mode in the background, so the FastAPI server keeps
+the Qdrant collection in sync with `img/` while serving search requests.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -15,15 +21,11 @@ from qdrant_client import QdrantClient
 import cocoindex as coco
 from cocoindex.connectors import qdrant
 
-try:
-    from . import main as image_search
-except ImportError:
-    import importlib
+import pipeline
 
-    image_search = importlib.import_module("main")
+load_dotenv()
 
 
-# Module-level client reference for API endpoints
 _client: QdrantClient | None = None
 
 
@@ -31,11 +33,23 @@ _client: QdrantClient | None = None
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # type: ignore[override]
     global _client
     async with coco.runtime():
-        # Initialize client for API endpoints
-        _client = qdrant.create_client(image_search.QDRANT_URL, prefer_grpc=True)
-        await coco.show_progress(image_search.app.update())
-        yield
-        _client = None
+        _client = qdrant.create_client(pipeline.qdrant_url(), prefer_grpc=True)
+
+        # Start a live update; block startup until the initial sweep finishes so
+        # the collection is queryable, then keep it running in the background.
+        update_handle = pipeline.app.update(live=True)
+        async for snap in update_handle.watch():
+            if snap.status is coco.UpdateStatus.READY:
+                break
+        update_task = asyncio.create_task(update_handle.result())
+
+        try:
+            yield
+        finally:
+            update_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await update_task
+            _client = None
 
 
 app = FastAPI(lifespan=lifespan)
@@ -57,14 +71,14 @@ async def search(
     q: str = Query(..., description="Search query"),
     limit: int = Query(5, description="Number of results"),
 ) -> dict[str, Any]:
-    query_embedding = image_search.embed_query(q)
+    query_embedding = pipeline.embed_query(q)
 
     if _client is None:
         raise RuntimeError("Qdrant client is not initialized.")
 
-    results = image_search._qdrant_search(
+    results = pipeline._qdrant_search(
         _client,
-        image_search.QDRANT_COLLECTION,
+        pipeline.QDRANT_COLLECTION,
         query_embedding,
         limit,
     )

--- a/examples/image_search_colpali/frontend/src/App.jsx
+++ b/examples/image_search_colpali/frontend/src/App.jsx
@@ -42,7 +42,7 @@ export default function App() {
         {results.length === 0 && !loading && <div>No results</div>}
         {results.map((result, idx) => (
           <div key={idx} className="result-card">
-            <img src={`http://${window.location.hostname}:8000/img/${result.filename}`} alt={result.filename} className="result-img" />
+            <img src={`http://${window.location.hostname}:8000/${result.filename}`} alt={result.filename} className="result-img" />
             <div className="score">Score: {result.score?.toFixed(3)}</div>
           </div>
         ))}

--- a/examples/image_search_colpali/pipeline.py
+++ b/examples/image_search_colpali/pipeline.py
@@ -1,22 +1,24 @@
 """
-Image Search with ColPali (v1) - CocoIndex pipeline example.
+Image Search with ColPali (v1) - CocoIndex pipeline definition.
 
-- Walk local image files
-- Embed images with ColPali (multi-vector)
-- Store embeddings in Qdrant with MaxSim multivector config
-- Query by text using ColPali query embeddings
+Defines the CocoIndex `app` (walk local images -> embed with ColPali multi-vector ->
+store in Qdrant with MaxSim multivector config) and the helper functions
+(`embed_query`, `_qdrant_search`) used by `api.py`.
+
+This module is not an entry point. To run the example, start the FastAPI server:
+
+    python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
+
+The server runs the index in live mode in the background and serves search requests.
 """
 
 from __future__ import annotations
 
-import asyncio
 import functools
 import io
 import os
 import pathlib
-import sys
 import uuid
-from dotenv import load_dotenv
 from typing import AsyncIterator
 
 import torch
@@ -36,10 +38,13 @@ from cocoindex.connectors import localfs, qdrant
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 from cocoindex.resources.schema import MultiVectorSchema, VectorSchema
 
-QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6334/")
 QDRANT_COLLECTION = "ImageSearchColpali"
 COLPALI_MODEL_NAME = os.getenv("COLPALI_MODEL", "vidore/colpali-v1.2")
 TOP_K = 5
+
+
+def qdrant_url() -> str:
+    return os.getenv("QDRANT_URL", "http://localhost:6334/")
 
 
 QDRANT_DB = coco.ContextKey[QdrantClient]("image_search_colpali")
@@ -89,8 +94,7 @@ def embed_image_bytes(img_bytes: bytes) -> list[list[float]]:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
-    client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
+    client = qdrant.create_client(qdrant_url(), prefer_grpc=True)
     builder.provide(QDRANT_DB, client)
     builder.provide(QDRANT_CLIENT, client)
     yield
@@ -137,6 +141,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         path_matcher=PatternFilePathMatcher(
             included_patterns=["**/*.jpg", "**/*.jpeg", "**/*.png"]
         ),
+        live=True,  # source supports live watch; api.py runs the app with live=True
     )
     await coco.mount_each(process_file, files.items(), target_collection)
 
@@ -146,35 +151,6 @@ app = coco.App(
     app_main,
     sourcedir=pathlib.Path("./img"),
 )
-
-
-# ============================================================================
-# Query demo
-# ============================================================================
-
-
-def query_once(client: QdrantClient, query_text: str, *, top_k: int = TOP_K) -> None:
-    query_vec = embed_query(query_text)
-    results = _qdrant_search(client, QDRANT_COLLECTION, query_vec, top_k)
-
-    for r in results:
-        payload = r.payload or {}
-        print(f"[{r.score:.3f}] {payload.get('filename', '<unknown>')}")
-        print("---")
-
-
-def query() -> None:
-    client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 2:
-        q = " ".join(sys.argv[2:])
-        query_once(client, q)
-        return
-
-    while True:
-        q = input("Enter search query (or Enter to quit): ").strip()
-        if not q:
-            break
-        query_once(client, q)
 
 
 def _image_id(path: pathlib.PurePath) -> str:
@@ -196,19 +172,3 @@ def _qdrant_search(
         with_payload=True,
     )
     return response.points
-
-
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
-if __name__ == "__main__":
-    load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        query()
-    else:
-        print("Usage: main.py [query <search terms>]")

--- a/examples/oci_object_storage_embedding/README.md
+++ b/examples/oci_object_storage_embedding/README.md
@@ -30,23 +30,19 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index in catch-up mode (writes rows into Postgres and exits). Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan the bucket, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching the OCI Streaming topic for change events and apply incremental updates:
 
-Run in **live mode** — performs an initial scan, then keeps watching the OCI Streaming topic and applies incremental updates:
-
-```sh
-cocoindex update -L main
-```
+  ```sh
+  cocoindex update -L main
+  ```
 
 Live mode requires `OCI_STREAMING_BOOTSTRAP_SERVERS`, `OCI_STREAMING_TOPIC`, `OCI_STREAMING_USERNAME`, and `OCI_STREAMING_AUTH_TOKEN` to be set in `.env`. With those unset, the connector skips live-stream subscription and just performs the catch-up scan.
 
@@ -67,7 +63,7 @@ This is a per-user "Auth Token" — a one-shot credential, distinct from your Co
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```
 
 Note: this example **does not create a vector index**; queries will do a sequential scan.

--- a/examples/oci_object_storage_embedding/main.py
+++ b/examples/oci_object_storage_embedding/main.py
@@ -1,13 +1,14 @@
 """
-OCI Object Storage Text Embedding (v1) — CocoIndex pipeline example.
+OCI Object Storage Text Embedding (v1) - CocoIndex pipeline example.
 
-- List markdown files from an OCI Object Storage bucket
-- Optionally subscribe to OCI Streaming (Kafka-compatible) for change events,
-  enabling live-mode updates via the connector's ``LiveMapView``
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column (no vector index)
-- Query demo using pgvector cosine distance (<=>)
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: list markdown objects from an OCI Object Storage bucket -> chunk -> embed -> store in Postgres pgvector.
 
 Live mode is opt-in via the ``OCI_STREAMING_BOOTSTRAP_SERVERS`` env var
 (plus ``OCI_STREAMING_TOPIC`` and credentials). When set, the example
@@ -237,12 +238,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -252,17 +252,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/paper_metadata/README.md
+++ b/examples/paper_metadata/README.md
@@ -34,22 +34,24 @@ export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
 
 This example uses the `coco_examples_v1` schema by default to avoid clashing with the legacy example tables.
 
-Build/update the index. Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "graph neural networks"
+python main.py "graph neural networks"
 ```
 
 Note: this example **does not create a vector index**; queries will do a sequential scan.

--- a/examples/paper_metadata/main.py
+++ b/examples/paper_metadata/main.py
@@ -1,12 +1,14 @@
 """
 Paper Metadata (v1) - CocoIndex pipeline example.
 
-- Walk local PDF files
-- Extract the first page text
-- Use an LLM to extract title/authors/abstract
-- Embed title and abstract chunks (SentenceTransformers)
-- Store metadata and embeddings in Postgres (pgvector)
-- Query demo using pgvector cosine distance (<=>)
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk local PDFs -> extract first-page text -> LLM-extract title/authors/abstract -> embed title and abstract chunks -> store in Postgres pgvector.
 """
 
 from __future__ import annotations
@@ -160,7 +162,6 @@ def extract_metadata(markdown: str) -> PaperMetadataModel:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     database_url = os.getenv("POSTGRES_URL")
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
@@ -269,6 +270,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.pdf"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(
         process_file, files.items(), metadata_table, author_table, embedding_table
@@ -318,16 +320,15 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     database_url = os.getenv("POSTGRES_URL")
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(database_url, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -337,17 +338,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/pdf_embedding/README.md
+++ b/examples/pdf_embedding/README.md
@@ -28,22 +28,24 @@ Set a database URL (or use `.env`):
 export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
 ```
 
-Build/update the index. Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "what is attention?"
+python main.py "what is attention?"
 ```
 
 Note: this example **does not create a vector index**; queries will do a sequential scan.

--- a/examples/pdf_embedding/main.py
+++ b/examples/pdf_embedding/main.py
@@ -1,12 +1,14 @@
 """
 PDF Embedding (v1) - CocoIndex pipeline example.
 
-- Walk local PDF files
-- Convert PDFs to markdown
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column (no vector index)
-- Query demo using pgvector cosine distance (<=>)
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk local PDFs -> convert to markdown -> chunk -> embed -> store in Postgres pgvector.
 """
 
 from __future__ import annotations
@@ -73,7 +75,6 @@ class PdfEmbedding:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     database_url = os.getenv("POSTGRES_URL")
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
@@ -132,6 +133,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.pdf"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_table)
 
@@ -178,16 +180,15 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     database_url = os.getenv("POSTGRES_URL")
     if not database_url:
         raise ValueError("POSTGRES_URL is not set")
 
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(database_url, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -197,17 +198,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/postgres_source/README.md
+++ b/examples/postgres_source/README.md
@@ -30,20 +30,14 @@ For simplicity, we use the same database for source and target. You can also set
 
 ## Run
 
-Build/update the index. Either of the following works:
+Build/update the index (one-shot catch-up; the postgres source does not support live mode):
 
 ```sh
 cocoindex update main
 ```
 
-or
-
-```sh
-python main.py
-```
-
 Query:
 
 ```sh
-python main.py query "wireless headphones"
+python main.py "wireless headphones"
 ```

--- a/examples/postgres_source/main.py
+++ b/examples/postgres_source/main.py
@@ -1,10 +1,13 @@
 """
 PostgreSQL Source (v1) - CocoIndex pipeline example.
 
-- Read product rows from a source PostgreSQL table
-- Compute derived fields and embeddings
-- Store results into a target PostgreSQL table with pgvector
-- Query demo using pgvector cosine distance (<=>)
+Index (one-shot catch-up; live mode is not supported for the postgres source):
+    cocoindex update main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: read product rows -> compute derived fields + embeddings -> store in pgvector.
 """
 
 from __future__ import annotations
@@ -64,7 +67,6 @@ class OutputProduct:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     async with (
         asyncpg.create_pool(DATABASE_URL) as target_pool,
         asyncpg.create_pool(SOURCE_DATABASE_URL) as source_pool,
@@ -162,27 +164,21 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
-        print('Usage: python main.py query "your search query"')
 
-
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
+        while True:
+            q = input("Enter search query (or Enter to quit): ").strip()
+            if not q:
+                break
+            await query_once(pool, embedder, q)
 
 
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -24,22 +24,24 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres). Either of the following works:
+Build/update the index (writes rows into Postgres). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```
 
 Note: this example **does not create a vector index**; queries will do a sequential scan.

--- a/examples/text_embedding/main.py
+++ b/examples/text_embedding/main.py
@@ -1,11 +1,14 @@
 """
 Text Embedding (v1) - CocoIndex pipeline example.
 
-- Walk local markdown files
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Postgres with pgvector column (no vector index)
-- Query demo using pgvector cosine distance (<=>)
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk markdown files -> chunk -> embed -> store in pgvector (no vector index).
 """
 
 from __future__ import annotations
@@ -50,7 +53,6 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     async with asyncpg.create_pool(DATABASE_URL) as pool:
         builder.provide(PG_DB, pool)
         builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
@@ -116,6 +118,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_table)
 
@@ -162,12 +165,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     async with asyncpg.create_pool(DATABASE_URL, init=register_vector) as pool:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(pool, embedder, q)
+        if initial_query is not None:
+            await query_once(pool, embedder, initial_query)
             return
 
         while True:
@@ -177,17 +179,7 @@ async def query() -> None:
             await query_once(pool, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/text_embedding_lancedb/README.md
+++ b/examples/text_embedding_lancedb/README.md
@@ -23,20 +23,22 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index (stores data in `./lancedb_data/`). Either of the following works:
+Build/update the index (writes rows into LanceDB). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```

--- a/examples/text_embedding_lancedb/main.py
+++ b/examples/text_embedding_lancedb/main.py
@@ -1,11 +1,14 @@
 """
 Text Embedding with LanceDB (v1) - CocoIndex pipeline example.
 
-- Walk local markdown files
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into LanceDB with vector column
-- Query demo using LanceDB native vector search
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk local markdown files -> chunk -> embed -> store in LanceDB.
 """
 
 from __future__ import annotations
@@ -54,7 +57,6 @@ class DocEmbedding:
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     conn = await lancedb.connect_async(LANCEDB_URI)
     builder.provide(LANCE_DB, conn)
     builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
@@ -107,6 +109,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_table)
 
@@ -144,13 +147,12 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     conn = await lancedb.connect_async(LANCEDB_URI)
 
-    if len(sys.argv) > 2:
-        q = " ".join(sys.argv[2:])
-        await query_once(conn, embedder, q)
+    if initial_query is not None:
+        await query_once(conn, embedder, initial_query)
         return
 
     while True:
@@ -160,17 +162,7 @@ async def query() -> None:
         await query_once(conn, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/text_embedding_qdrant/README.md
+++ b/examples/text_embedding_qdrant/README.md
@@ -18,22 +18,24 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index. Either of the following works:
+Build/update the index (writes points into Qdrant). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
+python main.py "what is self-attention?"
 ```
 
 You can also open the Qdrant dashboard at <http://localhost:6333/dashboard>.

--- a/examples/text_embedding_qdrant/main.py
+++ b/examples/text_embedding_qdrant/main.py
@@ -1,11 +1,14 @@
 """
 Text Embedding with Qdrant (v1) - CocoIndex pipeline example.
 
-- Walk local markdown files
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into Qdrant collection
-- Query demo using Qdrant vector search
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk local markdown files -> chunk -> embed -> store in a Qdrant collection.
 """
 
 from __future__ import annotations
@@ -44,7 +47,6 @@ _splitter = RecursiveSplitter()
 async def coco_lifespan(
     builder: coco.EnvironmentBuilder,
 ) -> AsyncIterator[None]:
-    # Provide resources needed across the CocoIndex environment
     client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
     builder.provide(QDRANT_DB, client)
     builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
@@ -99,6 +101,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_collection)
 
@@ -132,12 +135,11 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     embedder = SentenceTransformerEmbedder(EMBED_MODEL)
     client = qdrant.create_client(QDRANT_URL, prefer_grpc=True)
-    if len(sys.argv) > 2:
-        q = " ".join(sys.argv[2:])
-        await query_once(client, embedder, q)
+    if initial_query is not None:
+        await query_once(client, embedder, initial_query)
         return
 
     while True:
@@ -178,17 +180,7 @@ def _qdrant_search(
     raise RuntimeError("Unsupported qdrant-client version: no search method found.")
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))

--- a/examples/text_embedding_turbopuffer/README.md
+++ b/examples/text_embedding_turbopuffer/README.md
@@ -21,26 +21,22 @@ Install deps:
 pip install -e .
 ```
 
-Build/update the index. Either of the following works:
+Build/update the index (writes rows into Turbopuffer). Pick one of the two modes:
 
-```sh
-cocoindex update main
-```
+- **Catch-up run** — scan sources, sync changes, exit:
 
-or
+  ```sh
+  cocoindex update main
+  ```
 
-```sh
-python main.py
-```
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
 
 Query:
 
 ```sh
-python main.py query "what is self-attention?"
-```
-
-Or run interactively:
-
-```sh
-python main.py query
+python main.py "what is self-attention?"
 ```

--- a/examples/text_embedding_turbopuffer/main.py
+++ b/examples/text_embedding_turbopuffer/main.py
@@ -1,11 +1,14 @@
 """
 Text Embedding with Turbopuffer (v1) - CocoIndex pipeline example.
 
-- Walk local markdown files
-- Chunk text (RecursiveSplitter)
-- Embed chunks (SentenceTransformers)
-- Store into a Turbopuffer namespace
-- Query demo using Turbopuffer ANN search
+Index (use `-L` for live mode, omit for one-shot catch-up):
+    cocoindex update main
+    cocoindex update -L main
+
+Query the index:
+    python main.py "your query"
+
+Pipeline: walk local markdown files -> chunk -> embed -> store in a Turbopuffer namespace.
 """
 
 from __future__ import annotations
@@ -99,6 +102,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         sourcedir,
         recursive=True,
         path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,  # source supports live watch; pass -L to `cocoindex update` to actually run live
     )
     await coco.mount_each(process_file, files.items(), target_namespace)
 
@@ -138,7 +142,7 @@ async def query_once(
         print("---")
 
 
-async def query() -> None:
+async def query(initial_query: str | None = None) -> None:
     api_key = os.environ.get("TURBOPUFFER_API_KEY")
     if not api_key:
         print("TURBOPUFFER_API_KEY is not set", file=sys.stderr)
@@ -147,9 +151,8 @@ async def query() -> None:
     async with turbopuffer.AsyncTurbopuffer(
         region=TPUF_REGION, api_key=api_key
     ) as client:
-        if len(sys.argv) > 2:
-            q = " ".join(sys.argv[2:])
-            await query_once(client, embedder, q)
+        if initial_query is not None:
+            await query_once(client, embedder, initial_query)
             return
 
         while True:
@@ -159,17 +162,7 @@ async def query() -> None:
             await query_once(client, embedder, q)
 
 
-async def update_index() -> None:
-    async with coco.runtime():
-        await coco.show_progress(app.update())
-
-
 if __name__ == "__main__":
     load_dotenv()
-    if len(sys.argv) == 1:
-        # Update the index. Equivalent to running `cocoindex update main`.
-        asyncio.run(update_index())
-    elif sys.argv[1] == "query":
-        asyncio.run(query())
-    else:
-        print("Usage: main.py [query <search terms>]")
+    initial = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else None
+    asyncio.run(query(initial))


### PR DESCRIPTION
## Summary

- **Unify example CLI:** `python main.py [<query>]` is query-only; indexing is `cocoindex update [-L] main`. The catch-up vs. live decision lives on the CLI flag, not in the script. READMEs explicitly call out which sources support live mode.
- **Refactor `image_search` and `image_search_colpali`:** rename `main.py` → `pipeline.py` (library only). `api.py` is the sole entry point — its lifespan starts `app.update(live=True)` in the background, blocks startup until the initial sweep is `READY`, then cancels on shutdown. Drop the dead `try: from . import …` import branch.
- **Fix `embed_query`/`embed_image_bytes` for transformers ≥5:** new `CLIPModel.get_text_features` returns a `BaseModelOutputWithPooling`; projected features now live on `.pooler_output`. Old code's `features[0]` fell back to `last_hidden_state` (3D), producing triply-nested vectors that crashed `client.query_points`.
- **Frontend URL fix in `App.jsx`:** `result.filename` already contains `img/`, so `/img/${filename}` produced `/img/img/…`.
- Add missing `examples/hn_trending_topics/README.md`. Gitignore `.claude/*.lock`.

Touched 16 example directories.

## Test plan

- CI (mypy, ruff, pytest, pre-commit hooks)
- Manual smoke tests already done locally on `image_search/api.py`: `embed_query("a red car")` returns a flat `list[float]` of 768 floats; mypy clean across 220 source files.
