### PR TITLE
refactor(state_store): isolate LMDB-specific code in one module

### DIFF
--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -72,14 +72,9 @@ impl<Prof: EngineProfile> App<Prof> {
         let app_reg = AppRegistration::new(name, &env)?;
 
         // TODO: This database initialization logic should happen lazily on first call to `update()`.
-        let db = {
-            let mut wtxn = env.db_env().write_txn()?;
-            let db = env.db_env().create_database(&mut wtxn, Some(name))?;
-            wtxn.commit()?;
-            db
-        };
+        let store = env.create_app_store(name)?;
 
-        let app_ctx = AppContext::new(env, db, app_reg, max_inflight_components);
+        let app_ctx = AppContext::new(env, store, app_reg, max_inflight_components);
         let root_component = Component::new(app_ctx, StablePath::root(), None);
         crate::telemetry::track("app_create");
         Ok(Self { root_component })
@@ -216,12 +211,12 @@ impl<Prof: EngineProfile> App<Prof> {
                 handle.ready().await?;
 
                 // Clear the database
-                let db = root_component.app_ctx().db().clone();
+                let store = root_component.app_ctx().store().clone();
                 root_component
                     .app_ctx()
                     .env()
                     .txn_batcher()
-                    .run(move |wtxn| Ok(db.clear(wtxn)?))
+                    .run(move |wtxn| crate::state_store::ops::clear_all(wtxn, &store))
                     .await?;
 
                 info!("App dropped successfully");

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -18,11 +18,12 @@ use crate::state::target_state_path::TargetStatePath;
 use crate::{
     engine::environment::{AppRegistration, Environment},
     state::stable_path::StablePath,
+    state_store::Store,
 };
 
 struct AppContextInner<Prof: EngineProfile> {
     env: Environment<Prof>,
-    db: db_schema::Database,
+    store: Store,
     app_reg: AppRegistration<Prof>,
     id_sequencer_manager: IdSequencerManager,
     inflight_semaphore: Option<Arc<tokio::sync::Semaphore>>,
@@ -53,7 +54,7 @@ pub struct AppContext<Prof: EngineProfile> {
 impl<Prof: EngineProfile> AppContext<Prof> {
     pub fn new(
         env: Environment<Prof>,
-        db: db_schema::Database,
+        store: Store,
         app_reg: AppRegistration<Prof>,
         max_inflight_components: Option<usize>,
     ) -> Self {
@@ -62,7 +63,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         Self {
             inner: Arc::new(AppContextInner {
                 env,
-                db,
+                store,
                 app_reg,
                 id_sequencer_manager: IdSequencerManager::new(),
                 inflight_semaphore,
@@ -113,8 +114,8 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         &self.inner.env
     }
 
-    pub fn db(&self) -> &db_schema::Database {
-        &self.inner.db
+    pub fn store(&self) -> &Store {
+        &self.inner.store
     }
 
     pub fn app_reg(&self) -> &AppRegistration<Prof> {
@@ -152,7 +153,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         let key = key.unwrap_or(&default_key);
         self.inner
             .id_sequencer_manager
-            .next_id(self.inner.env.txn_batcher(), &self.inner.db, key)
+            .next_id(self.inner.env.txn_batcher(), &self.inner.store, key)
             .await
     }
 }

--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -1,6 +1,8 @@
 use crate::{
-    engine::profile::EngineProfile, engine::target_state::TargetStateProviderRegistry,
-    engine::txn_batcher::TxnBatcher, prelude::*,
+    engine::profile::EngineProfile,
+    engine::target_state::TargetStateProviderRegistry,
+    prelude::*,
+    state_store::{ReadTxn, TxnBatcher},
 };
 
 use cocoindex_utils::fingerprint::Fingerprint;
@@ -133,13 +135,26 @@ impl<Prof: EngineProfile> Environment<Prof> {
         &self.inner.db_env
     }
 
+    /// Create the per-app sub-database for this environment and wrap it in a
+    /// `Store`. Hides the underlying LMDB sub-database creation from
+    /// `App::new`.
+    pub fn create_app_store(&self, app_name: &str) -> Result<crate::state_store::Store> {
+        let mut wtxn = self.inner.db_env.write_txn()?;
+        let db = self
+            .inner
+            .db_env
+            .create_database(&mut wtxn, Some(app_name))?;
+        wtxn.commit()?;
+        Ok(crate::state_store::Store::new(db))
+    }
+
     /// Open an LMDB read transaction with automatic retry on `MDB_READERS_FULL`.
     ///
     /// Two-phase strategy:
     /// 1. Retry with a short timeout — handles transient reader slot contention.
     /// 2. If phase 1 times out, call `clear_stale_readers()` to reclaim slots
     ///    from dead processes, then retry indefinitely.
-    pub async fn read_txn(&self) -> Result<heed::RoTxn<'_, heed::WithoutTls>> {
+    pub async fn read_txn(&self) -> Result<ReadTxn<'_>> {
         let db_env = self.db_env();
         let try_read_txn = || async {
             match db_env.read_txn() {
@@ -156,7 +171,7 @@ impl<Prof: EngineProfile> Environment<Prof> {
 
         // Phase 1: short timeout for transient concurrency.
         match retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE1).await {
-            Ok(txn) => return Ok(txn),
+            Ok(txn) => return Ok(ReadTxn::new(txn)),
             Err(e) if !e.is_retryable => return Err(e.into()),
             Err(_) => {}
         }
@@ -168,6 +183,7 @@ impl<Prof: EngineProfile> Environment<Prof> {
         }
         retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE2)
             .await
+            .map(ReadTxn::new)
             .map_err(Into::into)
     }
 

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -23,7 +23,6 @@ use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
 use crate::state_store::{AnyTxn, Store, WriteTxn, ops};
-use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
 /// Deserialize a `Vec<MemoizedValue>` into a `Vec<Prof::FunctionData>`.
@@ -345,21 +344,12 @@ struct ChildrenPathInfo {
     child_path_set: Option<ChildStablePathSet>,
 }
 
-struct ChildPathInfo {
-    encoded_db_key: Vec<u8>,
-    encoded_db_value: Vec<u8>,
-    stable_key: StableKey,
-    path_set: StablePathSet,
-}
-
 struct Committer<Prof: EngineProfile> {
     component_ctx: ComponentProcessorContext<Prof>,
     store: Store,
     target_states_providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
 
     component_path: StablePath,
-
-    encoded_tombstone_key_prefix: Vec<u8>,
 
     existence_processing_queue: VecDeque<ChildrenPathInfo>,
     buffered_paths_for_tombstone: Vec<StablePath>,
@@ -374,17 +364,11 @@ impl<Prof: EngineProfile> Committer<Prof> {
         demote_component_only: bool,
     ) -> Result<Self> {
         let component_path = component_ctx.stable_path().clone();
-        let tombstone_key_prefix = db_schema::DbEntryKey::StablePath(
-            component_path.clone(),
-            db_schema::StablePathEntryKey::ChildComponentTombstonePrefix,
-        );
-        let encoded_tombstone_key_prefix = tombstone_key_prefix.encode()?;
         Ok(Self {
             component_ctx: component_ctx.clone(),
             store: component_ctx.app_ctx().store().clone(),
             target_states_providers: target_states_providers.clone(),
             component_path,
-            encoded_tombstone_key_prefix,
             existence_processing_queue: VecDeque::new(),
             buffered_paths_for_tombstone: Vec::new(),
             demote_component_only,
@@ -397,24 +381,19 @@ impl<Prof: EngineProfile> Committer<Prof> {
         mut self,
         wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
-        encoded_target_state_info_key: &[u8],
         all_memo_fps: &HashSet<Fingerprint>,
         memos_without_mounts_to_store: Vec<(Fingerprint, FnCallMemo<Prof>)>,
         curr_version: Option<u64>,
     ) -> Result<Self> {
         {
             if self.component_ctx.mode() == ComponentProcessingMode::Delete {
-                self.store
-                    .db()
-                    .delete(&mut *wtxn, encoded_target_state_info_key.as_ref())?;
+                ops::delete_tracking_info(wtxn, &self.store, &self.component_path)?;
             } else {
                 let curr_version = curr_version
                     .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;
-                let mut tracking_info: db_schema::StablePathEntryTrackingInfo = wtxn
-                    .db_get_bytes(self.store.db(), encoded_target_state_info_key.as_ref())?
-                    .map(|data| from_msgpack_slice(data))
-                    .transpose()?
-                    .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
+                let mut tracking_info: db_schema::StablePathEntryTrackingInfo =
+                    ops::read_tracking_info(&*wtxn, &self.store, &self.component_path)?
+                        .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
 
                 for item in tracking_info.target_state_items.values_mut() {
                     item.states.retain(|(version, state)| {
@@ -470,11 +449,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
                 let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
                 drop(tracking_info); // Release borrow before mutable operations.
-                self.store.db().put(
-                    &mut *wtxn,
-                    encoded_target_state_info_key.as_ref(),
-                    data_bytes.as_slice(),
-                )?;
+                ops::write_tracking_info_raw(wtxn, &self.store, &self.component_path, &data_bytes)?;
 
                 // Clean up inverted tracking for pruned entries.
                 for path in &pruned_paths {
@@ -501,12 +476,10 @@ impl<Prof: EngineProfile> Committer<Prof> {
     async fn commit(
         self,
         child_path_set: Option<ChildStablePathSet>,
-        target_state_info_key: db_schema::DbEntryKey<'_>,
         all_memo_fps: HashSet<Fingerprint>,
         memos_without_mounts_to_store: Vec<(Fingerprint, FnCallMemo<Prof>)>,
         curr_version: Option<u64>,
     ) -> Result<()> {
-        let encoded_target_state_info_key = target_state_info_key.encode()?;
         // Single cheap Arc clone so we can call txn_batcher() / db_env() after self moves into the closure.
         let app_ctx = self.component_ctx.app_ctx().clone();
         let committer = app_ctx
@@ -516,7 +489,6 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 self.commit_in_txn(
                     wtxn,
                     child_path_set,
-                    &encoded_target_state_info_key,
                     &all_memo_fps,
                     memos_without_mounts_to_store,
                     curr_version,
@@ -538,140 +510,125 @@ impl<Prof: EngineProfile> Committer<Prof> {
             child_path_set,
         });
         while let Some(path_info) = self.existence_processing_queue.pop_front() {
-            let mut children_to_add: Vec<ChildPathInfo> = Vec::new();
-            {
-                let mut curr_iter = path_info
-                    .child_path_set
-                    .into_iter()
-                    .flat_map(|set| set.children.into_iter());
+            // Sorted merge between the declared children (in-memory BTreeMap
+            // iteration, sorted by StableKey) and the existing on-disk
+            // entries (storekey-encoded byte order matches StableKey Ord).
+            let mut curr_iter = path_info
+                .child_path_set
+                .into_iter()
+                .flat_map(|set| set.children.into_iter());
+            let existing_children = ops::list_child_existence(wtxn, &self.store, &path_info.path)?;
+            let mut existing_iter = existing_children.into_iter();
 
-                let mut curr_iter_next = || -> Result<Option<ChildPathInfo>> {
-                    let v = if let Some((stable_key, path_set)) = curr_iter.next() {
-                        let db_key = db_schema::DbEntryKey::StablePath(
-                            path_info.path.clone(),
-                            db_schema::StablePathEntryKey::ChildExistence(stable_key.clone()),
-                        );
-                        Some(ChildPathInfo {
-                            encoded_db_key: db_key.encode()?,
-                            encoded_db_value: Self::encode_child_existence_info(&path_set)?,
-                            stable_key,
-                            path_set,
-                        })
-                    } else {
-                        None
-                    };
-                    Ok(v)
-                };
+            let mut curr_next = curr_iter.next();
+            let mut existing_next = existing_iter.next();
+            let mut children_to_add: Vec<(StableKey, StablePathSet)> = Vec::new();
 
-                let mut curr_next = curr_iter_next()?;
-
-                let db_key_prefix = db_schema::DbEntryKey::StablePath(
-                    path_info.path.clone(),
-                    db_schema::StablePathEntryKey::ChildExistencePrefix,
-                );
-                let encoded_db_key_prefix = db_key_prefix.encode()?;
-                let mut db_prefix_iter = self
-                    .store
-                    .db()
-                    .prefix_iter_mut(&mut **wtxn, encoded_db_key_prefix.as_ref())?;
-                let mut db_next = db_prefix_iter.next().transpose()?;
-
-                loop {
-                    let Some(db_next_entry) = db_next else {
-                        // All remaining children are new.
-                        curr_next.map(|v| children_to_add.push(v));
-                        while let Some(entry) = curr_iter_next()? {
+            loop {
+                match (&curr_next, &existing_next) {
+                    (None, None) => break,
+                    (Some(_), None) => {
+                        // All remaining declared children are new.
+                        if let Some(entry) = curr_next.take() {
                             children_to_add.push(entry);
                         }
+                        children_to_add.extend(curr_iter.by_ref());
                         break;
-                    };
-                    let Some(curr_next_v) = &curr_next else {
-                        // All remaining children should be deleted.
-                        let mut db_next_entry = db_next_entry;
-                        loop {
-                            self.del_child(db_next_entry, &path_info.path, &encoded_db_key_prefix)?;
-                            unsafe {
-                                db_prefix_iter.del_current()?;
-                            }
-                            db_next_entry =
-                                if let Some(entry) = db_prefix_iter.next().transpose()? {
-                                    entry
-                                } else {
-                                    break;
-                                };
+                    }
+                    (None, Some(_)) => {
+                        // All remaining existing children should be deleted.
+                        if let Some((key, info)) = existing_next.take() {
+                            ops::delete_child_existence(wtxn, &self.store, &path_info.path, &key)?;
+                            self.del_child(&key, &info, &path_info.path)?;
+                        }
+                        for (key, info) in existing_iter.by_ref() {
+                            ops::delete_child_existence(wtxn, &self.store, &path_info.path, &key)?;
+                            self.del_child(&key, &info, &path_info.path)?;
                         }
                         break;
-                    };
-                    match Ord::cmp(curr_next_v.encoded_db_key.as_slice(), db_next_entry.0) {
-                        Ordering::Less => {
-                            // New child.
-                            children_to_add.push(curr_next.ok_or_else(invariance_violation)?);
-                            curr_next = curr_iter_next()?;
-                        }
-                        Ordering::Greater => {
-                            // Child to delete.
-                            self.del_child(db_next_entry, &path_info.path, &encoded_db_key_prefix)?;
-                            unsafe {
-                                db_prefix_iter.del_current()?;
+                    }
+                    (Some((curr_key, _)), Some((existing_key, _))) => {
+                        match curr_key.cmp(existing_key) {
+                            Ordering::Less => {
+                                // New child.
+                                children_to_add
+                                    .push(curr_next.take().ok_or_else(invariance_violation)?);
+                                curr_next = curr_iter.next();
                             }
-                            db_next = db_prefix_iter.next().transpose()?;
-                        }
-                        Ordering::Equal => {
-                            let curr_next_v = curr_next.ok_or_else(invariance_violation)?;
+                            Ordering::Greater => {
+                                // Existing child no longer declared — delete.
+                                let (key, info) =
+                                    existing_next.take().ok_or_else(invariance_violation)?;
+                                ops::delete_child_existence(
+                                    wtxn,
+                                    &self.store,
+                                    &path_info.path,
+                                    &key,
+                                )?;
+                                self.del_child(&key, &info, &path_info.path)?;
+                                existing_next = existing_iter.next();
+                            }
+                            Ordering::Equal => {
+                                let (curr_key, curr_path_set) =
+                                    curr_next.take().ok_or_else(invariance_violation)?;
+                                let (_, existing_info) =
+                                    existing_next.take().ok_or_else(invariance_violation)?;
+                                let new_node_type = node_type_for(&curr_path_set);
 
-                            // Update the child existence info if it has changed.
-                            if curr_next_v.encoded_db_value.as_slice() != db_next_entry.1 {
-                                unsafe {
-                                    db_prefix_iter.put_current(
-                                        curr_next_v.encoded_db_key.as_slice(),
-                                        curr_next_v.encoded_db_value.as_slice(),
+                                // Update the child existence info if the node type changed.
+                                if existing_info.node_type != new_node_type {
+                                    ops::write_child_existence(
+                                        wtxn,
+                                        &self.store,
+                                        &path_info.path,
+                                        &curr_key,
+                                        &db_schema::ChildExistenceInfo {
+                                            node_type: new_node_type,
+                                        },
                                     )?;
                                 }
-                            }
 
-                            match curr_next_v.path_set {
-                                StablePathSet::Directory(curr_dir_set) => {
-                                    let db_value: db_schema::ChildExistenceInfo =
-                                        from_msgpack_slice(db_next_entry.1)?;
-                                    if db_value.node_type
+                                if let StablePathSet::Directory(curr_dir_set) = curr_path_set {
+                                    // Demotion: existing was a Component, now becoming a Directory
+                                    // (its descendants have replaced the leaf). The old component
+                                    // needs a tombstone so its target states get cleaned up.
+                                    if existing_info.node_type
                                         == db_schema::StablePathNodeType::Component
                                     {
                                         self.buffered_paths_for_tombstone.push(
                                             self.relative_path(path_info.path.as_ref())?
-                                                .concat_part(curr_next_v.stable_key.clone()),
+                                                .concat_part(curr_key.clone()),
                                         );
                                     }
                                     self.existence_processing_queue.push_back(ChildrenPathInfo {
-                                        path: path_info
-                                            .path
-                                            .concat_part(curr_next_v.stable_key.clone()),
+                                        path: path_info.path.concat_part(curr_key),
                                         child_path_set: Some(curr_dir_set),
                                     });
                                 }
-                                StablePathSet::Component => {
-                                    // No-op. Everything should be handled by the sub component.
-                                }
+                                // StablePathSet::Component case: no-op (sub-component handles itself).
+                                curr_next = curr_iter.next();
+                                existing_next = existing_iter.next();
                             }
-
-                            curr_next = curr_iter_next()?;
-                            db_next = db_prefix_iter.next().transpose()?;
                         }
                     }
                 }
             }
 
-            for child_to_add in children_to_add {
-                if let StablePathSet::Directory(child_path_set) = child_to_add.path_set {
+            for (stable_key, path_set) in children_to_add {
+                let node_type = node_type_for(&path_set);
+                ops::write_child_existence(
+                    wtxn,
+                    &self.store,
+                    &path_info.path,
+                    &stable_key,
+                    &db_schema::ChildExistenceInfo { node_type },
+                )?;
+                if let StablePathSet::Directory(child_path_set) = path_set {
                     self.existence_processing_queue.push_back(ChildrenPathInfo {
-                        path: path_info.path.concat_part(child_to_add.stable_key),
+                        path: path_info.path.concat_part(stable_key),
                         child_path_set: Some(child_path_set),
                     });
                 }
-                self.store.db().put(
-                    &mut **wtxn,
-                    child_to_add.encoded_db_key.as_slice(),
-                    child_to_add.encoded_db_value.as_slice(),
-                )?;
             }
 
             self.flush_component_tombstones(wtxn)?;
@@ -680,12 +637,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
     }
 
     fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &T) -> Result<()> {
-        let tombstone_key_prefix_iter =
-            rtxn.db_prefix_iter(self.store.db(), self.encoded_tombstone_key_prefix.as_ref())?;
-        for tombstone_entry in tombstone_key_prefix_iter {
-            let (ts_key, _) = tombstone_entry?;
-            let relative_path: StablePath =
-                storekey::decode(&ts_key[self.encoded_tombstone_key_prefix.len()..])?;
+        for relative_path in ops::list_tombstones(rtxn, &self.store, &self.component_path)? {
             let stable_path = self.component_path.concat(relative_path.as_ref());
             let component = self.component_ctx.component().get_child(stable_path);
             let delete_ctx = component.new_processor_context_for_delete(
@@ -701,59 +653,43 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
     fn del_child(
         &mut self,
-        db_entry: (&[u8], &[u8]),
-        path: &StablePath,
-        encoded_db_key_prefix: &[u8],
+        stable_key: &StableKey,
+        info: &db_schema::ChildExistenceInfo,
+        parent_path: &StablePath,
     ) -> Result<()> {
-        let (raw_db_key, raw_db_value) = db_entry;
-        let stable_key: StableKey =
-            storekey::decode(raw_db_key[encoded_db_key_prefix.len()..].as_ref())?;
-        let db_value: db_schema::ChildExistenceInfo = from_msgpack_slice(raw_db_value)?;
-        match db_value.node_type {
+        match info.node_type {
             db_schema::StablePathNodeType::Directory => {
                 self.existence_processing_queue.push_back(ChildrenPathInfo {
-                    path: path.concat_part(stable_key),
+                    path: parent_path.concat_part(stable_key.clone()),
                     child_path_set: None,
                 });
             }
             db_schema::StablePathNodeType::Component => {
-                self.buffered_paths_for_tombstone
-                    .push(self.relative_path(path.as_ref())?.concat_part(stable_key));
+                self.buffered_paths_for_tombstone.push(
+                    self.relative_path(parent_path.as_ref())?
+                        .concat_part(stable_key.clone()),
+                );
             }
         }
         Ok(())
     }
 
     fn flush_component_tombstones(&mut self, wtxn: &mut WriteTxn<'_>) -> Result<()> {
-        if self.buffered_paths_for_tombstone.is_empty() {
-            return Ok(());
-        }
-        let mut encoded_tombstone_key = self.encoded_tombstone_key_prefix.clone();
-        let prefix_len = encoded_tombstone_key.len();
-        for stable_path in std::mem::take(&mut self.buffered_paths_for_tombstone) {
-            encoded_tombstone_key.truncate(prefix_len);
-            storekey::encode(&mut encoded_tombstone_key, &stable_path)?;
-            self.store
-                .db()
-                .put(&mut **wtxn, encoded_tombstone_key.as_slice(), &[])?;
+        for relative_path in std::mem::take(&mut self.buffered_paths_for_tombstone) {
+            ops::write_tombstone(wtxn, &self.store, &self.component_path, &relative_path)?;
         }
         Ok(())
     }
 
-    fn encode_child_existence_info(path_set: &StablePathSet) -> Result<Vec<u8>> {
-        let existence_info = match path_set {
-            StablePathSet::Directory(_) => db_schema::ChildExistenceInfo {
-                node_type: db_schema::StablePathNodeType::Directory,
-            },
-            StablePathSet::Component => db_schema::ChildExistenceInfo {
-                node_type: db_schema::StablePathNodeType::Component,
-            },
-        };
-        Ok(rmp_serde::to_vec_named(&existence_info)?)
-    }
-
     fn relative_path<'p>(&self, path: StablePathRef<'p>) -> Result<StablePathRef<'p>> {
         path.strip_parent(self.component_path.as_ref())
+    }
+}
+
+fn node_type_for(path_set: &StablePathSet) -> db_schema::StablePathNodeType {
+    match path_set {
+        StablePathSet::Directory(_) => db_schema::StablePathNodeType::Directory,
+        StablePathSet::Component => db_schema::StablePathNodeType::Component,
     }
 }
 
@@ -798,23 +734,38 @@ struct PreCommitOutput<Prof: EngineProfile> {
     processor_name_for_del: Option<String>,
 }
 
-// --- Inverted tracking (TargetStatePath → owning component) helpers ---
-
-/// Encode an inverted tracking upsert as a deferred write (key, Some(value)).
+/// Write deferred to after `pre_commit` finishes inspecting `tracking_info`.
 ///
-/// Still uses raw key+value bytes because `deferred_writes` mixes
-/// `TrackingInfo` writes and `TargetStateOwner` upserts in the same
-/// `Vec<(Vec<u8>, Vec<u8>)>`. See `specs/core/state_store_refactor.md` §10
-/// for the deferred typed-enum refactor.
-fn encode_owner_upsert(
-    target_state_path: &TargetStatePath,
-    component_path: &StablePath,
-) -> Result<(Vec<u8>, Vec<u8>)> {
-    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
-    let value = rmp_serde::to_vec_named(&db_schema::TargetStateOwnerInfo {
-        component_path: component_path.clone(),
-    })?;
-    Ok((key, value))
+/// The two cases mix in one queue because both arise during the ownership
+/// preemption flow: when a target state moves from component A to B, we
+/// need to (a) rewrite A's tracking info with the entry removed, and (b)
+/// point the inverted index at B. Both writes must happen after the
+/// borrowed `tracking_info` in `pre_commit` is dropped — hence "deferred".
+enum DeferredWrite {
+    /// Pre-serialized tracking info. Stored as bytes because the typed
+    /// value borrows from the write txn (the read returns `*Info<'txn>`);
+    /// serializing at deferral time releases that borrow so the eventual
+    /// flush can take `&mut WriteTxn` for the write.
+    TrackingInfoRaw { path: StablePath, encoded: Vec<u8> },
+    /// Inverted-index upsert pointing `target_state_path` at `component_path`.
+    OwnerUpsert {
+        target_state_path: TargetStatePath,
+        component_path: StablePath,
+    },
+}
+
+impl DeferredWrite {
+    fn flush(self, wtxn: &mut WriteTxn<'_>, store: &Store) -> Result<()> {
+        match self {
+            DeferredWrite::TrackingInfoRaw { path, encoded } => {
+                ops::write_tracking_info_raw(wtxn, store, &path, &encoded)
+            }
+            DeferredWrite::OwnerUpsert {
+                target_state_path,
+                component_path,
+            } => ops::upsert_target_state_owner(wtxn, store, &target_state_path, &component_path),
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -825,8 +776,6 @@ fn pre_commit<Prof: EngineProfile>(
     stable_path: &StablePath,
     full_reprocess: bool,
     processor_name: Option<&str>,
-    encoded_target_state_info_key: &[u8],
-    memo_del_key: &[u8],
     contained_target_state_paths: &HashSet<TargetStatePath>,
     target_states_providers: &rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
     declared_target_states: BTreeMap<TargetStatePath, DeclaredTargetState<Prof>>,
@@ -836,7 +785,7 @@ fn pre_commit<Prof: EngineProfile>(
     let mut processor_name_for_del: Option<String> = None;
 
     if comp_mode == ComponentProcessingMode::Delete {
-        store.db().delete(&mut **wtxn, memo_del_key)?;
+        ops::delete_component_memo(wtxn, store, stable_path)?;
     }
 
     if let Some((parent_path, key)) = stable_path.as_ref().split_parent() {
@@ -866,14 +815,11 @@ fn pre_commit<Prof: EngineProfile>(
     }
 
     let mut id_reservation = IdReservation::new(&TARGET_ID_KEY);
-    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> = wtxn
-        .db_get_bytes(store.db(), encoded_target_state_info_key)?
-        .map(|data| from_msgpack_slice(data))
-        .transpose()?;
+    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> =
+        ops::read_tracking_info(wtxn, store, stable_path)?;
     // Deferred DB writes that will be flushed after tracking_info is dropped,
     // since tracking_info borrows from wtxn and prevents mutable DB operations.
-    // Each entry is (encoded_key, optional_encoded_value); None value means delete.
-    let mut deferred_writes: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
     let previously_exists = tracking_info.is_some();
     if let Some(tracking_info) = &mut tracking_info {
         if let Some(processor_name) = processor_name {
@@ -925,16 +871,10 @@ fn pre_commit<Prof: EngineProfile>(
                 // Insert path: check inverted tracking for ownership preempt.
                 match ops::read_target_state_owner(wtxn, store, &target_state_path)? {
                     Some(owner_info) if owner_info.component_path != *stable_path => {
-                        let old_owner_key = db_schema::DbEntryKey::StablePath(
-                            owner_info.component_path.clone(),
-                            db_schema::StablePathEntryKey::TrackingInfo,
-                        )
-                        .encode()?;
-                        if let Some(data) =
-                            wtxn.db_get_bytes(store.db(), old_owner_key.as_slice())?
+                        let old_owner_path = owner_info.component_path.clone();
+                        if let Some(mut old_tracking) =
+                            ops::read_tracking_info(wtxn, store, &old_owner_path)?
                         {
-                            let mut old_tracking: db_schema::StablePathEntryTrackingInfo =
-                                from_msgpack_slice(data)?;
                             let len_before = old_tracking.target_state_items.len();
                             // Look up the entry matching current provider_id.
                             let prev_item = old_tracking
@@ -956,9 +896,13 @@ fn pre_commit<Prof: EngineProfile>(
                                 .target_state_items
                                 .retain(|k, _| k.target_state_path != target_state_path);
                             if old_tracking.target_state_items.len() < len_before {
-                                // Write back old owner's modified tracking info — deferred.
+                                // Write back old owner's modified tracking info — deferred
+                                // because the deserialized struct borrows from wtxn.
                                 let old_data = rmp_serde::to_vec_named(&old_tracking)?;
-                                deferred_writes.push((old_owner_key, old_data));
+                                deferred_writes.push(DeferredWrite::TrackingInfoRaw {
+                                    path: old_owner_path,
+                                    encoded: old_data,
+                                });
                             }
                             prev_item
                         } else {
@@ -1082,7 +1026,10 @@ fn pre_commit<Prof: EngineProfile>(
             if let Some(item) = prev_item {
                 // Write inverted tracking for entries new to this component — deferred.
                 if is_new_to_component {
-                    deferred_writes.push(encode_owner_upsert(&target_state_path, stable_path)?);
+                    deferred_writes.push(DeferredWrite::OwnerUpsert {
+                        target_state_path: target_state_path.clone(),
+                        component_path: stable_path.clone(),
+                    });
                 }
                 items_to_insert.push((lookup_key, item));
             }
@@ -1176,21 +1123,15 @@ fn pre_commit<Prof: EngineProfile>(
 
         let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
         drop(tracking_info); // Release borrow before mutable operations.
-        store.db().put(
-            &mut **wtxn,
-            encoded_target_state_info_key,
-            data_bytes.as_slice(),
-        )?;
+        ops::write_tracking_info_raw(wtxn, store, stable_path, &data_bytes)?;
         Some(curr_version)
     } else {
         None
     };
 
     // Flush deferred writes now that tracking_info is dropped.
-    for (key, value) in &deferred_writes {
-        store
-            .db()
-            .put(&mut **wtxn, key.as_slice(), value.as_slice())?;
+    for dw in deferred_writes {
+        dw.flush(wtxn, store)?;
     }
 
     id_reservation.commit(wtxn, store)?;
@@ -1262,16 +1203,6 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     let full_reprocess = comp_ctx.full_reprocess();
     let processor_name_owned: Option<String> = processor_name.map(|s| s.to_owned());
 
-    let target_state_info_key = db_schema::DbEntryKey::StablePath(
-        stable_path.clone(),
-        db_schema::StablePathEntryKey::TrackingInfo,
-    );
-    let encoded_target_state_info_key = target_state_info_key.encode()?;
-    let memo_del_key = db_schema::DbEntryKey::StablePath(
-        stable_path.clone(),
-        db_schema::StablePathEntryKey::ComponentMemoization,
-    )
-    .encode()?;
     let contained_target_state_paths =
         std::mem::take(&mut finalized_fn_call_memos.contained_target_state_paths);
 
@@ -1291,8 +1222,6 @@ pub(crate) async fn submit<Prof: EngineProfile>(
                 &stable_path,
                 full_reprocess,
                 processor_name_owned.as_deref(),
-                &encoded_target_state_info_key,
-                &memo_del_key,
                 &contained_target_state_paths,
                 &target_states_providers_owned,
                 declared_target_states,
@@ -1353,7 +1282,6 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     committer
         .commit(
             child_path_set,
-            target_state_info_key,
             finalized_fn_call_memos.all_memos_fps,
             finalized_fn_call_memos.memos_without_mounts_to_store,
             curr_version,

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -5,8 +5,6 @@ use std::borrow::Cow;
 use std::cmp::{Ord, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque, btree_map};
 
-use heed::{RoTxn, RwTxn};
-
 use crate::engine::context::{
     ComponentProcessingAction, ComponentProcessingMode, ComponentProcessorContext,
     DeclaredTargetState, FnCallMemo, MemoStatesPayload, TARGET_ID_KEY,
@@ -24,6 +22,7 @@ use crate::state::stable_path_set::{ChildStablePathSet, StablePathSet};
 use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
+use crate::state_store::{AnyTxn, Store, WriteTxn, ops};
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
@@ -86,20 +85,14 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
         return Ok(None);
     }
 
-    let key = db_schema::DbEntryKey::StablePath(
-        comp_ctx.stable_path().clone(),
-        db_schema::StablePathEntryKey::ComponentMemoization,
-    )
-    .encode()?;
-
-    let db = comp_ctx.app_ctx().db();
+    let store = comp_ctx.app_ctx().store();
+    let path = comp_ctx.stable_path();
     {
         let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let Some(data) = db.get(&rtxn, key.as_slice())? else {
+        let Some(memo_info) = ops::read_component_memo(&rtxn, store, path)? else {
             return Ok(None);
         };
         if let Some(processor_fp) = processor_fp {
-            let memo_info: db_schema::ComponentMemoizationInfo<'_> = from_msgpack_slice(&data)?;
             if memo_info.processor_fp == processor_fp
                 && logic_registry::all_contained_with_env(
                     &memo_info.logic_deps,
@@ -137,15 +130,13 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
 
     // Invalidate the memoization.
     {
-        let db = comp_ctx.app_ctx().db().clone();
+        let store = comp_ctx.app_ctx().store().clone();
+        let path = path.clone();
         comp_ctx
             .app_ctx()
             .env()
             .txn_batcher()
-            .run(move |wtxn| {
-                db.delete(wtxn, key.as_slice())?;
-                Ok(())
-            })
+            .run(move |wtxn| ops::delete_component_memo(wtxn, &store, &path))
             .await?;
     }
 
@@ -162,56 +153,50 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     new_states: &MemoStatesPayload<Prof>,
 ) -> Result<()> {
-    let key = db_schema::DbEntryKey::StablePath(
-        comp_ctx.stable_path().clone(),
-        db_schema::StablePathEntryKey::ComponentMemoization,
-    )
-    .encode()?;
-
-    let db = comp_ctx.app_ctx().db().clone();
+    let store = comp_ctx.app_ctx().store().clone();
+    let path = comp_ctx.stable_path().clone();
 
     // Serialize new states
     let memo_states_serialized = serialize_memo_values::<Prof>(&new_states.positional)?;
     let context_memo_states_serialized =
         serialize_context_memo_states::<Prof>(&new_states.by_context_fp)?;
 
-    // Read existing entry and write back with updated states in one transaction
+    // Read existing entry and write back with updated states in one
+    // transaction. The deserialized memo_info borrows from wtxn, so we
+    // serialize the modified struct to bytes (releasing the borrow) before
+    // writing back.
     comp_ctx
         .app_ctx()
         .env()
         .txn_batcher()
         .run(move |wtxn| {
-            let Some(data) = db.get(wtxn, key.as_slice())? else {
-                return Ok(());
+            let encoded = {
+                let Some(existing) = ops::read_component_memo(&*wtxn, &store, &path)? else {
+                    return Ok(());
+                };
+                let new_info = db_schema::ComponentMemoizationInfo {
+                    processor_fp: existing.processor_fp,
+                    return_value: existing.return_value,
+                    logic_deps: existing.logic_deps,
+                    memo_states: memo_states_serialized,
+                    context_memo_states: context_memo_states_serialized,
+                };
+                rmp_serde::to_vec_named(&new_info)?
             };
-            let existing: db_schema::ComponentMemoizationInfo<'_> = from_msgpack_slice(data)?;
-            let memo_info = db_schema::ComponentMemoizationInfo {
-                processor_fp: existing.processor_fp,
-                return_value: existing.return_value,
-                logic_deps: existing.logic_deps,
-                memo_states: memo_states_serialized,
-                context_memo_states: context_memo_states_serialized,
-            };
-            let encoded = rmp_serde::to_vec_named(&memo_info)?;
-            db.put(wtxn, key.as_slice(), encoded.as_slice())?;
-            Ok(())
+            // Borrows from wtxn are released; we can take &mut wtxn for write.
+            ops::write_component_memo_raw(wtxn, &store, &path, &encoded)
         })
         .await?;
     Ok(())
 }
 
 fn write_fn_call_memo<Prof: EngineProfile>(
-    wtxn: &mut RwTxn<'_>,
-    db: &db_schema::Database,
+    wtxn: &mut WriteTxn<'_>,
+    store: &Store,
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
     memo: FnCallMemo<Prof>,
 ) -> Result<()> {
-    let key = db_schema::DbEntryKey::StablePath(
-        comp_ctx.stable_path().clone(),
-        db_schema::StablePathEntryKey::FunctionMemoization(memo_fp),
-    )
-    .encode()?;
     let ret_bytes = memo.ret.to_bytes()?;
     let memo_states_serialized = serialize_memo_values::<Prof>(&memo.memo_states)?;
     let context_memo_states_serialized =
@@ -225,28 +210,19 @@ fn write_fn_call_memo<Prof: EngineProfile>(
         memo_states: memo_states_serialized,
         context_memo_states: context_memo_states_serialized,
     };
-    let encoded = rmp_serde::to_vec_named(&fn_call_memo)?;
-    db.put(wtxn, key.as_slice(), encoded.as_slice())?;
-    Ok(())
+    ops::write_fn_memo(wtxn, store, comp_ctx.stable_path(), memo_fp, &fn_call_memo)
 }
 
-fn read_fn_call_memo_with_txn<Prof: EngineProfile>(
-    rtxn: &RoTxn,
-    db: &db_schema::Database,
+fn read_fn_call_memo_with_txn<Prof: EngineProfile, T: AnyTxn>(
+    rtxn: &T,
+    store: &Store,
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
 ) -> Result<Option<FnCallMemo<Prof>>> {
-    let key = db_schema::DbEntryKey::StablePath(
-        comp_ctx.stable_path().clone(),
-        db_schema::StablePathEntryKey::FunctionMemoization(memo_fp),
-    )
-    .encode()?;
-
-    let data = db.get(rtxn, key.as_slice())?;
-    let Some(data) = data else {
+    let Some(fn_call_memo) = ops::read_fn_memo(rtxn, store, comp_ctx.stable_path(), memo_fp)?
+    else {
         return Ok(None);
     };
-    let fn_call_memo: db_schema::FunctionMemoizationEntry<'_> = from_msgpack_slice(&data)?;
     if !logic_registry::all_contained_with_env(&fn_call_memo.logic_deps, comp_ctx.app_ctx().env()) {
         return Ok(None);
     }
@@ -282,7 +258,7 @@ pub(crate) async fn read_fn_call_memo<Prof: EngineProfile>(
         return Ok(None);
     }
     let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().db(), comp_ctx, memo_fp)
+    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().store(), comp_ctx, memo_fp)
 }
 
 pub fn declare_target_state<Prof: EngineProfile>(
@@ -378,7 +354,7 @@ struct ChildPathInfo {
 
 struct Committer<Prof: EngineProfile> {
     component_ctx: ComponentProcessorContext<Prof>,
-    db: db_schema::Database,
+    store: Store,
     target_states_providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
 
     component_path: StablePath,
@@ -405,7 +381,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
         let encoded_tombstone_key_prefix = tombstone_key_prefix.encode()?;
         Ok(Self {
             component_ctx: component_ctx.clone(),
-            db: component_ctx.app_ctx().db().clone(),
+            store: component_ctx.app_ctx().store().clone(),
             target_states_providers: target_states_providers.clone(),
             component_path,
             encoded_tombstone_key_prefix,
@@ -419,7 +395,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
     /// Returns `self` so the caller can use it for post-commit work (e.g. GC).
     fn commit_in_txn(
         mut self,
-        wtxn: &mut RwTxn<'_>,
+        wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
         encoded_target_state_info_key: &[u8],
         all_memo_fps: &HashSet<Fingerprint>,
@@ -428,14 +404,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
     ) -> Result<Self> {
         {
             if self.component_ctx.mode() == ComponentProcessingMode::Delete {
-                self.db
+                self.store
+                    .db()
                     .delete(&mut *wtxn, encoded_target_state_info_key.as_ref())?;
             } else {
                 let curr_version = curr_version
                     .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;
-                let mut tracking_info: db_schema::StablePathEntryTrackingInfo = self
-                    .db
-                    .get(&*wtxn, encoded_target_state_info_key.as_ref())?
+                let mut tracking_info: db_schema::StablePathEntryTrackingInfo = wtxn
+                    .db_get_bytes(self.store.db(), encoded_target_state_info_key.as_ref())?
                     .map(|data| from_msgpack_slice(data))
                     .transpose()?
                     .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
@@ -494,7 +470,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
                 let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
                 drop(tracking_info); // Release borrow before mutable operations.
-                self.db.put(
+                self.store.db().put(
                     &mut *wtxn,
                     encoded_target_state_info_key.as_ref(),
                     data_bytes.as_slice(),
@@ -502,37 +478,17 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
                 // Clean up inverted tracking for pruned entries.
                 for path in &pruned_paths {
-                    delete_target_state_owner(&mut *wtxn, &self.db, path)?;
+                    ops::delete_target_state_owner(wtxn, &self.store, path)?;
                 }
             }
 
             // Write memos.
             for (fp, memo) in memos_without_mounts_to_store {
-                write_fn_call_memo(&mut *wtxn, &self.db, &self.component_ctx, fp, memo)?;
+                write_fn_call_memo(wtxn, &self.store, &self.component_ctx, fp, memo)?;
             }
 
             // Delete all function memo entries that are not in the all_memo_fps.
-            {
-                let fn_memo_key_prefix = db_schema::DbEntryKey::StablePath(
-                    self.component_path.clone(),
-                    db_schema::StablePathEntryKey::FunctionMemoizationPrefix,
-                );
-                let encoded_fn_memo_key_prefix = fn_memo_key_prefix.encode()?;
-                let mut fn_memo_key_prefix_iter = self
-                    .db
-                    .prefix_iter_mut(&mut *wtxn, encoded_fn_memo_key_prefix.as_ref())?;
-                while let Some((key, _)) = fn_memo_key_prefix_iter.next().transpose()? {
-                    // Decode key
-                    let decoded_fp: Fingerprint =
-                        storekey::decode(key[encoded_fn_memo_key_prefix.len()..].as_ref())?;
-                    if all_memo_fps.contains(&decoded_fp) {
-                        continue;
-                    }
-                    unsafe {
-                        fn_memo_key_prefix_iter.del_current()?;
-                    }
-                }
-            }
+            ops::retain_fn_memos(wtxn, &self.store, &self.component_path, all_memo_fps)?;
 
             if !self.demote_component_only {
                 self.update_existence(&mut *wtxn, child_path_set)?;
@@ -574,7 +530,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
     fn update_existence(
         &mut self,
-        wtxn: &mut RwTxn<'_>,
+        wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
     ) -> Result<()> {
         self.existence_processing_queue.push_back(ChildrenPathInfo {
@@ -615,8 +571,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 );
                 let encoded_db_key_prefix = db_key_prefix.encode()?;
                 let mut db_prefix_iter = self
-                    .db
-                    .prefix_iter_mut(wtxn, encoded_db_key_prefix.as_ref())?;
+                    .store
+                    .db()
+                    .prefix_iter_mut(&mut **wtxn, encoded_db_key_prefix.as_ref())?;
                 let mut db_next = db_prefix_iter.next().transpose()?;
 
                 loop {
@@ -710,8 +667,8 @@ impl<Prof: EngineProfile> Committer<Prof> {
                         child_path_set: Some(child_path_set),
                     });
                 }
-                self.db.put(
-                    wtxn,
+                self.store.db().put(
+                    &mut **wtxn,
                     child_to_add.encoded_db_key.as_slice(),
                     child_to_add.encoded_db_value.as_slice(),
                 )?;
@@ -722,10 +679,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
         Ok(())
     }
 
-    fn launch_child_component_gc(&self, rtxn: &RoTxn<'_>) -> Result<()> {
-        let tombstone_key_prefix_iter = self
-            .db
-            .prefix_iter(rtxn, self.encoded_tombstone_key_prefix.as_ref())?;
+    fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &T) -> Result<()> {
+        let tombstone_key_prefix_iter =
+            rtxn.db_prefix_iter(self.store.db(), self.encoded_tombstone_key_prefix.as_ref())?;
         for tombstone_entry in tombstone_key_prefix_iter {
             let (ts_key, _) = tombstone_entry?;
             let relative_path: StablePath =
@@ -768,7 +724,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
         Ok(())
     }
 
-    fn flush_component_tombstones(&mut self, wtxn: &mut RwTxn<'_>) -> Result<()> {
+    fn flush_component_tombstones(&mut self, wtxn: &mut WriteTxn<'_>) -> Result<()> {
         if self.buffered_paths_for_tombstone.is_empty() {
             return Ok(());
         }
@@ -777,7 +733,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
         for stable_path in std::mem::take(&mut self.buffered_paths_for_tombstone) {
             encoded_tombstone_key.truncate(prefix_len);
             storekey::encode(&mut encoded_tombstone_key, &stable_path)?;
-            self.db.put(wtxn, encoded_tombstone_key.as_slice(), &[])?;
+            self.store
+                .db()
+                .put(&mut **wtxn, encoded_tombstone_key.as_slice(), &[])?;
         }
         Ok(())
     }
@@ -842,19 +800,12 @@ struct PreCommitOutput<Prof: EngineProfile> {
 
 // --- Inverted tracking (TargetStatePath → owning component) helpers ---
 
-fn read_target_state_owner(
-    wtxn: &heed::RwTxn<'_>,
-    db: &db_schema::Database,
-    target_state_path: &TargetStatePath,
-) -> Result<Option<db_schema::TargetStateOwnerInfo>> {
-    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
-    Ok(db
-        .get(wtxn, key.as_slice())?
-        .map(|data| from_msgpack_slice(data))
-        .transpose()?)
-}
-
 /// Encode an inverted tracking upsert as a deferred write (key, Some(value)).
+///
+/// Still uses raw key+value bytes because `deferred_writes` mixes
+/// `TrackingInfo` writes and `TargetStateOwner` upserts in the same
+/// `Vec<(Vec<u8>, Vec<u8>)>`. See `specs/core/state_store_refactor.md` §10
+/// for the deferred typed-enum refactor.
 fn encode_owner_upsert(
     target_state_path: &TargetStatePath,
     component_path: &StablePath,
@@ -866,20 +817,10 @@ fn encode_owner_upsert(
     Ok((key, value))
 }
 
-fn delete_target_state_owner(
-    wtxn: &mut heed::RwTxn<'_>,
-    db: &db_schema::Database,
-    target_state_path: &TargetStatePath,
-) -> Result<()> {
-    let key = db_schema::DbEntryKey::TargetState(target_state_path.clone()).encode()?;
-    db.delete(wtxn, key.as_slice())?;
-    Ok(())
-}
-
 #[allow(clippy::too_many_arguments)]
 fn pre_commit<Prof: EngineProfile>(
-    wtxn: &mut heed::RwTxn<'_>,
-    db: &db_schema::Database,
+    wtxn: &mut WriteTxn<'_>,
+    store: &Store,
     comp_mode: ComponentProcessingMode,
     stable_path: &StablePath,
     full_reprocess: bool,
@@ -895,14 +836,14 @@ fn pre_commit<Prof: EngineProfile>(
     let mut processor_name_for_del: Option<String> = None;
 
     if comp_mode == ComponentProcessingMode::Delete {
-        db.delete(wtxn, memo_del_key)?;
+        store.db().delete(&mut **wtxn, memo_del_key)?;
     }
 
     if let Some((parent_path, key)) = stable_path.as_ref().split_parent() {
         match comp_mode {
             ComponentProcessingMode::Build => {
                 ensure_path_node_type(
-                    db,
+                    store,
                     wtxn,
                     parent_path,
                     key,
@@ -910,7 +851,7 @@ fn pre_commit<Prof: EngineProfile>(
                 )?;
             }
             ComponentProcessingMode::Delete => {
-                let node_type = get_path_node_type(db, wtxn, parent_path, key)?;
+                let node_type = get_path_node_type(store, wtxn, parent_path, key)?;
                 match node_type {
                     Some(db_schema::StablePathNodeType::Component) => {
                         return Ok(None);
@@ -925,8 +866,8 @@ fn pre_commit<Prof: EngineProfile>(
     }
 
     let mut id_reservation = IdReservation::new(&TARGET_ID_KEY);
-    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> = db
-        .get(wtxn, encoded_target_state_info_key)?
+    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> = wtxn
+        .db_get_bytes(store.db(), encoded_target_state_info_key)?
         .map(|data| from_msgpack_slice(data))
         .transpose()?;
     // Deferred DB writes that will be flushed after tracking_info is dropped,
@@ -982,14 +923,16 @@ fn pre_commit<Prof: EngineProfile>(
                 Some(existing_item)
             } else {
                 // Insert path: check inverted tracking for ownership preempt.
-                match read_target_state_owner(wtxn, db, &target_state_path)? {
+                match ops::read_target_state_owner(wtxn, store, &target_state_path)? {
                     Some(owner_info) if owner_info.component_path != *stable_path => {
                         let old_owner_key = db_schema::DbEntryKey::StablePath(
                             owner_info.component_path.clone(),
                             db_schema::StablePathEntryKey::TrackingInfo,
                         )
                         .encode()?;
-                        if let Some(data) = db.get(wtxn, old_owner_key.as_slice())? {
+                        if let Some(data) =
+                            wtxn.db_get_bytes(store.db(), old_owner_key.as_slice())?
+                        {
                             let mut old_tracking: db_schema::StablePathEntryTrackingInfo =
                                 from_msgpack_slice(data)?;
                             let len_before = old_tracking.target_state_items.len();
@@ -1073,7 +1016,7 @@ fn pre_commit<Prof: EngineProfile>(
                     let existing_gen = provider_generation.clone().unwrap_or_default();
                     let new_gen = match recon_output.child_invalidation {
                         Some(ChildInvalidation::Destructive) => {
-                            let new_id = id_reservation.next_id(wtxn, db)?;
+                            let new_id = id_reservation.next_id(wtxn, store)?;
                             TargetStateProviderGeneration {
                                 provider_id: new_id,
                                 provider_schema_version: 0,
@@ -1233,7 +1176,11 @@ fn pre_commit<Prof: EngineProfile>(
 
         let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
         drop(tracking_info); // Release borrow before mutable operations.
-        db.put(wtxn, encoded_target_state_info_key, data_bytes.as_slice())?;
+        store.db().put(
+            &mut **wtxn,
+            encoded_target_state_info_key,
+            data_bytes.as_slice(),
+        )?;
         Some(curr_version)
     } else {
         None
@@ -1241,10 +1188,12 @@ fn pre_commit<Prof: EngineProfile>(
 
     // Flush deferred writes now that tracking_info is dropped.
     for (key, value) in &deferred_writes {
-        db.put(wtxn, key.as_slice(), value.as_slice())?;
+        store
+            .db()
+            .put(&mut **wtxn, key.as_slice(), value.as_slice())?;
     }
 
-    id_reservation.commit(wtxn, db)?;
+    id_reservation.commit(wtxn, store)?;
     Ok(Some(PreCommitOutput {
         curr_version,
         previously_exists,
@@ -1307,7 +1256,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         ),
     };
 
-    let db = comp_ctx.app_ctx().db().clone();
+    let store = comp_ctx.app_ctx().store().clone();
     let comp_mode = comp_ctx.mode();
     let stable_path = comp_ctx.stable_path().clone();
     let full_reprocess = comp_ctx.full_reprocess();
@@ -1337,7 +1286,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         .run(move |wtxn| {
             pre_commit(
                 wtxn,
-                &db,
+                &store,
                 comp_mode,
                 &stable_path,
                 full_reprocess,
@@ -1439,11 +1388,6 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
     };
 
     // Serialize outside the closure (no transaction needed for serialization).
-    let key = db_schema::DbEntryKey::StablePath(
-        comp_ctx.stable_path().clone(),
-        db_schema::StablePathEntryKey::ComponentMemoization,
-    )
-    .encode()?;
     let ret_bytes = ret.to_bytes()?;
     let memo_states_serialized = serialize_memo_values::<Prof>(&memo_states.positional)?;
     let context_memo_states_serialized =
@@ -1457,15 +1401,13 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
     };
     let encoded = rmp_serde::to_vec_named(&memo_info)?;
 
-    let db = comp_ctx.app_ctx().db().clone();
+    let store = comp_ctx.app_ctx().store().clone();
+    let path = comp_ctx.stable_path().clone();
     comp_ctx
         .app_ctx()
         .env()
         .txn_batcher()
-        .run(move |wtxn| {
-            db.put(wtxn, key.as_slice(), encoded.as_slice())?;
-            Ok(())
-        })
+        .run(move |wtxn| ops::write_component_memo_raw(wtxn, &store, &path, &encoded))
         .await
 }
 
@@ -1475,97 +1417,38 @@ pub(crate) async fn cleanup_tombstone<Prof: EngineProfile>(
     let Some(parent) = comp_ctx.component().parent() else {
         return Ok(());
     };
-    let owner_path = parent.stable_path();
-    let relative_path = comp_ctx
+    let owner_path: StablePath = parent.stable_path().clone();
+    let relative_path: StablePath = comp_ctx
         .stable_path()
         .as_ref()
-        .strip_parent(owner_path.as_ref())?;
-    let tombstone_key = db_schema::DbEntryKey::StablePath(
-        owner_path.clone(),
-        db_schema::StablePathEntryKey::ChildComponentTombstone(relative_path.into()),
-    );
-    let encoded_tombstone_key = tombstone_key.encode()?;
-
-    let db = comp_ctx.app_ctx().db().clone();
+        .strip_parent(owner_path.as_ref())?
+        .into();
+    let store = comp_ctx.app_ctx().store().clone();
     comp_ctx
         .app_ctx()
         .env()
         .txn_batcher()
-        .run(move |wtxn| {
-            db.delete(wtxn, encoded_tombstone_key.as_ref())?;
-            Ok(())
-        })
+        .run(move |wtxn| ops::delete_tombstone(wtxn, &store, &owner_path, &relative_path))
         .await
 }
 
 pub(crate) fn ensure_path_node_type(
-    db: &db_schema::Database,
-    wtxn: &mut RwTxn<'_>,
+    store: &Store,
+    wtxn: &mut WriteTxn<'_>,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
     target_node_type: db_schema::StablePathNodeType,
 ) -> Result<()> {
-    let db_key = db_schema::DbEntryKey::StablePath(
-        parent_path.into(),
-        db_schema::StablePathEntryKey::ChildExistence(key.clone()),
-    );
-    let encoded_db_key = db_key.encode()?;
-
-    let existing_node_type = get_path_node_type_with_raw_key(db, wtxn, encoded_db_key.as_slice())?;
-    match (existing_node_type, target_node_type) {
-        (None, _)
-        | (
-            Some(db_schema::StablePathNodeType::Directory),
-            db_schema::StablePathNodeType::Component,
-        ) => {
-            let encoded_db_value = rmp_serde::to_vec_named(&db_schema::ChildExistenceInfo {
-                node_type: target_node_type,
-            })?;
-            db.put(wtxn, encoded_db_key.as_slice(), encoded_db_value.as_slice())?;
-        }
-        _ => {
-            // No-op for all other cases
-        }
-    }
-    if existing_node_type.is_none()
-        && let Some((parent, key)) = parent_path.split_parent()
-    {
-        return ensure_path_node_type(
-            db,
-            wtxn,
-            parent,
-            key,
-            db_schema::StablePathNodeType::Directory,
-        );
-    }
-    Ok(())
+    ops::ensure_path_node_type(wtxn, store, parent_path, key, target_node_type)
 }
 
-fn get_path_node_type(
-    db: &db_schema::Database,
-    rtxn: &RoTxn<'_>,
+fn get_path_node_type<T: AnyTxn>(
+    store: &Store,
+    rtxn: &T,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
 ) -> Result<Option<db_schema::StablePathNodeType>> {
-    let encoded_db_key = db_schema::DbEntryKey::StablePath(
-        parent_path.into(),
-        db_schema::StablePathEntryKey::ChildExistence(key.clone()),
-    )
-    .encode()?;
-    get_path_node_type_with_raw_key(db, rtxn, encoded_db_key.as_slice())
-}
-
-fn get_path_node_type_with_raw_key(
-    db: &db_schema::Database,
-    rtxn: &RoTxn<'_>,
-    raw_key: &[u8],
-) -> Result<Option<db_schema::StablePathNodeType>> {
-    let db_value = db.get(rtxn, raw_key)?;
-    let Some(db_value) = db_value else {
-        return Ok(None);
-    };
-    let child_existence_info: db_schema::ChildExistenceInfo = from_msgpack_slice(db_value)?;
-    Ok(Some(child_existence_info.node_type))
+    ops::read_path_node_type(rtxn, store, parent_path, key)
 }
 
 #[derive(Default)]
@@ -1614,12 +1497,12 @@ async fn finalize_fn_call_memoization<Prof: EngineProfile>(
     // Use a single read transaction for all DB reads.
     if !deps_to_process.is_empty() {
         let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let db = comp_ctx.app_ctx().db();
+        let store = comp_ctx.app_ctx().store();
         while let Some(fp) = deps_to_process.pop_front() {
             if !result.all_memos_fps.insert(fp) {
                 continue;
             }
-            let Some(memo) = read_fn_call_memo_with_txn(&rtxn, db, comp_ctx, fp)? else {
+            let Some(memo) = read_fn_call_memo_with_txn(&rtxn, store, comp_ctx, fp)? else {
                 continue;
             };
             result

--- a/rust/core/src/engine/id_sequencer.rs
+++ b/rust/core/src/engine/id_sequencer.rs
@@ -5,14 +5,15 @@
 //! - IDs start from 1 (0 is reserved)
 //! - IDs are allocated in batches to minimize database transactions
 //! - Batch sizes grow exponentially (2, 4, 8, ..., 256) for better performance
+//!
+//! Storage I/O goes through `crate::state_store::ops`; this module is
+//! the in-memory caching half and never touches LMDB directly.
 
 use std::collections::HashMap;
 
-use crate::engine::txn_batcher::TxnBatcher;
 use crate::prelude::*;
-use crate::state::db_schema;
 use crate::state::stable_path::StableKey;
-use cocoindex_utils::deser::from_msgpack_slice;
+use crate::state_store::{Store, TxnBatcher, WriteTxn, ops};
 
 /// Initial batch size for ID allocation.
 const INITIAL_BATCH_SIZE: u64 = 2;
@@ -85,7 +86,7 @@ impl IdSequencerManager {
     pub async fn next_id(
         &self,
         txn_batcher: &TxnBatcher,
-        db: &db_schema::Database,
+        store: &Store,
         key: &StableKey,
     ) -> Result<u64> {
         // Get or create the per-key state (brief lock on main map)
@@ -102,50 +103,23 @@ impl IdSequencerManager {
 
         if state.needs_refill() {
             let batch_size = state.next_batch_size;
-            let db = db.clone();
+            let store = store.clone();
             let key = key.clone();
             let start_id = txn_batcher
-                .run(move |wtxn| Self::reserve_ids_in_txn(wtxn, &db, &key, batch_size))
+                .run(move |wtxn| ops::reserve_id_range(wtxn, &store, &key, batch_size))
                 .await?;
             state.refill(start_id, batch_size);
         }
 
         Ok(state.take_id())
     }
-
-    /// Reserve `count` consecutive IDs in the given transaction, returning the first ID.
-    fn reserve_ids_in_txn(
-        wtxn: &mut heed::RwTxn<'_>,
-        db: &db_schema::Database,
-        key: &StableKey,
-        count: u64,
-    ) -> Result<u64> {
-        let db_key = db_schema::DbEntryKey::IdSequencer(key.clone()).encode()?;
-
-        // Read current value (IDs start from 1, 0 is reserved)
-        let current_next_id = if let Some(data) = db.get(wtxn, db_key.as_slice())? {
-            let info: db_schema::IdSequencerInfo = from_msgpack_slice(&data)?;
-            info.next_id
-        } else {
-            1
-        };
-
-        // Write updated value
-        let info = db_schema::IdSequencerInfo {
-            next_id: current_next_id + count,
-        };
-        let encoded = rmp_serde::to_vec_named(&info)?;
-        db.put(wtxn, db_key.as_slice(), encoded.as_slice())?;
-
-        Ok(current_next_id)
-    }
 }
 
-/// Deferred ID allocation that reads via `RoTxn` and commits writes later.
+/// Deferred ID allocation that reads via `&WriteTxn` and commits writes later.
 ///
 /// This splits the read and write phases of ID allocation so that the read
-/// (via `&RoTxn`) doesn't conflict with other immutable borrows of the transaction.
-/// Writes are applied in [`commit()`](IdReservation::commit).
+/// doesn't require exclusive access; writes are applied in
+/// [`commit()`](IdReservation::commit).
 ///
 /// Each reservation is scoped to a single key. At most one reservation per key
 /// should be live at a time, which is naturally enforced by LMDB's single-writer
@@ -165,18 +139,11 @@ impl IdReservation {
     }
 
     /// Allocate the next ID. Reads from DB on first call, then tracks locally.
-    /// Only needs `&RoTxn` (no mutable borrow).
-    pub fn next_id(&mut self, rtxn: &heed::RoTxn<'_>, db: &db_schema::Database) -> Result<u64> {
+    pub fn next_id(&mut self, wtxn: &WriteTxn<'_>, store: &Store) -> Result<u64> {
         let next_id = match &mut self.next_id_state {
             Some(n) => n,
             slot @ None => {
-                let db_key = db_schema::DbEntryKey::IdSequencer(self.key.clone()).encode()?;
-                let current = if let Some(data) = db.get(rtxn, db_key.as_slice())? {
-                    let info: db_schema::IdSequencerInfo = from_msgpack_slice(&data)?;
-                    info.next_id
-                } else {
-                    1
-                };
+                let current = ops::peek_id_sequence(wtxn, store, self.key)?.unwrap_or(1);
                 slot.insert(current)
             }
         };
@@ -186,12 +153,9 @@ impl IdReservation {
     }
 
     /// Write the reserved ID range back to DB. Call once at end of transaction.
-    pub fn commit(self, wtxn: &mut heed::RwTxn<'_>, db: &db_schema::Database) -> Result<()> {
+    pub fn commit(self, wtxn: &mut WriteTxn<'_>, store: &Store) -> Result<()> {
         if let Some(next_id) = self.next_id_state {
-            let db_key = db_schema::DbEntryKey::IdSequencer(self.key.clone()).encode()?;
-            let info = db_schema::IdSequencerInfo { next_id };
-            let encoded = rmp_serde::to_vec_named(&info)?;
-            db.put(wtxn, db_key.as_slice(), encoded.as_slice())?;
+            ops::write_id_sequence(wtxn, store, self.key, next_id)?;
         }
         Ok(())
     }

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -9,9 +9,9 @@ use crate::engine::profile::EngineProfile;
 use crate::engine::stats::ProcessingStats;
 use crate::engine::target_state::TargetStateProvider;
 use crate::prelude::*;
-use crate::state::db_schema;
 use crate::state::stable_path::StablePath;
 use crate::state::target_state_path::TargetStatePath;
+use crate::state_store::ops;
 use cocoindex_utils::error::{SharedError, SharedResult};
 
 use tokio::sync::oneshot;
@@ -546,7 +546,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // Synchronously remove the existence entry and write a tombstone,
         // matching the prior implementation's contract.
         if let Some((parent_ref, child_key)) = subpath.as_ref().split_parent() {
-            let db = self.component.app_ctx().db().clone();
+            let store = self.component.app_ctx().store().clone();
             let parent_path: StablePath = parent_ref.into();
             let child_key = child_key.clone();
             let component_path = self.component.stable_path().clone();
@@ -557,20 +557,14 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .env()
                 .txn_batcher()
                 .run(move |wtxn| {
-                    let existence_key = db_schema::DbEntryKey::StablePath(
-                        parent_path,
-                        db_schema::StablePathEntryKey::ChildExistence(child_key),
+                    ops::remove_child_with_tombstone(
+                        wtxn,
+                        &store,
+                        &parent_path,
+                        &child_key,
+                        &component_path,
+                        &relative_child,
                     )
-                    .encode()?;
-                    db.delete(wtxn, &existence_key)?;
-
-                    let tombstone_key = db_schema::DbEntryKey::StablePath(
-                        component_path,
-                        db_schema::StablePathEntryKey::ChildComponentTombstone(relative_child),
-                    )
-                    .encode()?;
-                    db.put(wtxn, &tombstone_key, &[])?;
-                    Ok(())
                 })
                 .await?;
         }
@@ -800,7 +794,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // operator.update call. With this row, the install/tombstone
         // state machine is symmetric across both installer paths.
         if let Some((parent_path_ref, child_key)) = child_path.as_ref().split_parent() {
-            let db = self.component.app_ctx().db().clone();
+            let store = self.component.app_ctx().store().clone();
             let parent_path: StablePath = parent_path_ref.into();
             let child_key = child_key.clone();
             self.component
@@ -809,7 +803,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .txn_batcher()
                 .run(move |wtxn| {
                     crate::engine::execution::ensure_path_node_type(
-                        &db,
+                        &store,
                         wtxn,
                         parent_path.as_ref(),
                         &child_key,

--- a/rust/core/src/engine/mod.rs
+++ b/rust/core/src/engine/mod.rs
@@ -12,4 +12,3 @@ pub mod progress_display;
 pub mod runtime;
 pub mod stats;
 pub mod target_state;
-pub mod txn_batcher;

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -4,36 +4,16 @@ use crate::prelude::*;
 
 use crate::engine::environment::Environment;
 use crate::engine::{app::App, profile::EngineProfile};
-use crate::state::db_schema::{self, DbEntryKey};
-use crate::state::stable_path::{StablePath, StablePathPrefix, StablePathRef};
-use cocoindex_utils::deser::from_msgpack_slice;
-use futures::stream::Stream;
-use heed::types::{DecodeIgnore, Str};
+use crate::state::db_schema;
+use crate::state::stable_path::StablePath;
+use crate::state_store::ops;
+use futures::stream::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
 pub fn list_stable_paths<Prof: EngineProfile>(app: &App<Prof>) -> Result<Vec<StablePath>> {
-    let encoded_key_prefix =
-        DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-    let db = app.app_ctx().db();
-    let txn = app.app_ctx().env().db_env().read_txn()?;
-
-    let mut result = Vec::new();
-    let mut last_prefix: Option<Vec<u8>> = None;
-    for entry in db.prefix_iter(&txn, encoded_key_prefix.as_ref())? {
-        let (raw_key, _) = entry?;
-        if let Some(last_prefix) = &last_prefix
-            && raw_key.starts_with(last_prefix)
-        {
-            continue;
-        }
-        let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
-        let DbEntryKey::StablePath(path, _) = key else {
-            internal_bail!("Expected StablePath, got {key:?}");
-        };
-        last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
-        result.push(path);
-    }
-    Ok(result)
+    let store = app.app_ctx().store();
+    let rtxn = ops::open_read_txn_for_inspect(app.app_ctx().env().db_env())?;
+    ops::list_all_stable_paths(&rtxn, store)
 }
 
 /// Represents a stable path with metadata (e.g. node type); more properties may be added.
@@ -51,9 +31,10 @@ pub use db_schema::StablePathNodeType;
 pub fn iter_stable_paths<Prof: EngineProfile>(
     app: &App<Prof>,
 ) -> impl Stream<Item = Result<StablePathInfo>> + Send + 'static {
-    let db = *app.app_ctx().db();
+    let store = app.app_ctx().store().clone();
     let db_env = app.app_ctx().env().db_env().clone();
-    iter_stable_paths_impl(db, db_env)
+    let rx = ops::spawn_iter_stable_paths_with_node_type(store, db_env);
+    receiver_to_stable_path_info_stream(rx)
 }
 
 /// Like [`iter_stable_paths`], but takes an environment and an app name instead of a full `App`.
@@ -63,113 +44,19 @@ pub fn iter_stable_paths_by_name<Prof: EngineProfile>(
     app_name: &str,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<StablePathInfo>> + Send + 'static>>> {
     let db_env = env.db_env().clone();
-    let rtxn = db_env.read_txn()?;
-    let db =
-        db_env.open_database::<heed::types::Bytes, heed::types::Bytes>(&rtxn, Some(app_name))?;
-    drop(rtxn);
-    match db {
-        Some(db) => Ok(Box::pin(iter_stable_paths_impl(db, db_env))),
+    match ops::spawn_iter_stable_paths_with_node_type_for_app_name(db_env, app_name)? {
+        Some(rx) => Ok(Box::pin(receiver_to_stable_path_info_stream(rx))),
         None => Ok(Box::pin(futures::stream::empty())),
     }
 }
 
-fn iter_stable_paths_impl(
-    db: db_schema::Database,
-    db_env: heed::Env<heed::WithoutTls>,
+fn receiver_to_stable_path_info_stream(
+    rx: tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>>,
 ) -> impl Stream<Item = Result<StablePathInfo>> + Send + 'static {
-    let (tx, rx) = tokio::sync::mpsc::channel::<Result<StablePathInfo>>(128);
-
-    std::thread::spawn(move || {
-        let result: Result<()> = (|| {
-            let encoded_key_prefix =
-                DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-            let txn = db_env.read_txn()?;
-
-            let mut last_prefix: Option<Vec<u8>> = None;
-            for entry in db.prefix_iter(&txn, encoded_key_prefix.as_ref())? {
-                let (raw_key, _) = entry?;
-                if let Some(last_prefix) = &last_prefix
-                    && raw_key.starts_with(last_prefix)
-                {
-                    continue;
-                }
-                let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
-                let path = match key {
-                    DbEntryKey::StablePath(path, _) => path,
-                    other => return Err(internal_error!("Expected StablePath, got {other:?}")),
-                };
-                last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
-
-                let node_type = if path.as_ref().is_empty() {
-                    db_schema::StablePathNodeType::Component
-                } else {
-                    let path_ref: StablePathRef<'_> = path.as_ref();
-                    if let Some((parent_ref, key)) = path_ref.split_parent() {
-                        get_path_node_type(&db, &txn, parent_ref, key)?
-                            .unwrap_or(db_schema::StablePathNodeType::Directory)
-                    } else {
-                        db_schema::StablePathNodeType::Component
-                    }
-                };
-
-                let item = StablePathInfo { path, node_type };
-                if tx.blocking_send(Ok(item)).is_err() {
-                    break;
-                }
-            }
-
-            Ok(())
-        })();
-
-        if let Err(err) = result {
-            let _ = tx.blocking_send(Err(err));
-        }
-    });
-
     ReceiverStream::new(rx)
-}
-
-fn get_path_node_type(
-    db: &db_schema::Database,
-    rtxn: &heed::RoTxn<'_>,
-    parent_path: StablePathRef<'_>,
-    key: &crate::state::stable_path::StableKey,
-) -> Result<Option<db_schema::StablePathNodeType>> {
-    let encoded_db_key = db_schema::DbEntryKey::StablePath(
-        parent_path.into(),
-        db_schema::StablePathEntryKey::ChildExistence(key.clone()),
-    )
-    .encode()?;
-    let db_value = db.get(rtxn, encoded_db_key.as_slice())?;
-    let Some(db_value) = db_value else {
-        return Ok(None);
-    };
-    let child_existence_info: db_schema::ChildExistenceInfo = from_msgpack_slice(db_value)?;
-    Ok(Some(child_existence_info.node_type))
+        .map(|item| item.map(|(path, node_type)| StablePathInfo { path, node_type }))
 }
 
 pub fn list_app_names<Prof: EngineProfile>(env: &Environment<Prof>) -> Result<Vec<String>> {
-    let db_env = env.db_env();
-    let rtxn = db_env.read_txn()?;
-
-    let unnamed: heed::Database<Str, DecodeIgnore> = db_env
-        .open_database(&rtxn, None)?
-        .expect("the unnamed database always exists");
-
-    let mut names = Vec::new();
-    for result in unnamed.iter(&rtxn)? {
-        let (name, ()) = result?;
-
-        if let Ok(Some(db)) =
-            db_env.open_database::<heed::types::Bytes, heed::types::Bytes>(&rtxn, Some(name))
-        {
-            // Only include databases that have entries (non-empty).
-            // Cleared databases are treated as deleted.
-            if db.first(&rtxn)?.is_some() {
-                names.push(name.to_string());
-            }
-        }
-    }
-
-    Ok(names)
+    ops::list_app_names(env.db_env())
 }

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -3,4 +3,5 @@ mod prelude;
 pub mod engine;
 pub mod inspect;
 pub mod state;
+pub mod state_store;
 pub mod telemetry;

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -17,8 +17,6 @@ use crate::state::{
     target_state_path::TargetStatePath,
 };
 
-pub type Database = heed::Database<heed::types::Bytes, heed::types::Bytes>;
-
 #[derive(Debug)]
 pub enum StablePathEntryKey {
     /// Value type: ComponentMemoizationInfo

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -5,10 +5,6 @@
 //! engine. The engine code outside this module never touches `heed::*`,
 //! the key codec, or the msgpack serialization — only typed entity ops.
 //!
-//! The function signatures in this module are the spec for any alternative
-//! backend (e.g. Postgres in the enterprise edition): a backend swap is a
-//! replacement of this module's bodies, not its surface.
-//!
 //! See `specs/core/state_store_refactor.md` for the design rationale.
 
 pub mod ops;

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -1,0 +1,19 @@
+//! Storage layer for engine internal state.
+//!
+//! Everything LMDB-specific lives in this module: heed types, key encoding,
+//! transaction batching, and the thin per-entity I/O wrappers used by the
+//! engine. The engine code outside this module never touches `heed::*`,
+//! the key codec, or the msgpack serialization — only typed entity ops.
+//!
+//! The function signatures in this module are the spec for any alternative
+//! backend (e.g. Postgres in the enterprise edition): a backend swap is a
+//! replacement of this module's bodies, not its surface.
+//!
+//! See `specs/core/state_store_refactor.md` for the design rationale.
+
+pub mod ops;
+pub mod store;
+pub mod txn_batcher;
+
+pub use store::{AnyTxn, Database, ReadTxn, Store, WriteTxn};
+pub use txn_batcher::TxnBatcher;

--- a/rust/core/src/state_store/ops.rs
+++ b/rust/core/src/state_store/ops.rs
@@ -2,13 +2,11 @@
 //!
 //! Each function is a thin wrapper around `(key encode) + (msgpack serde) +
 //! (heed get/put/delete/iter)`. Signatures are heed-free so the engine never
-//! sees LMDB types. The same signatures are expected to exist verbatim in
-//! the enterprise (Postgres) repo with PG-specific bodies.
+//! sees LMDB types.
 //!
 //! Lifetime contract: read functions return schema types parameterized by
-//! the transaction lifetime, borrowing from LMDB mmap pages (or, in the PG
-//! backend, from Row buffers retained by the read transaction). See
-//! `specs/core/state_store_refactor.md` §3 "borrow-on-read".
+//! the transaction lifetime, borrowing from the LMDB mmap pages held by
+//! the read transaction.
 
 use std::collections::HashSet;
 
@@ -18,13 +16,18 @@ use cocoindex_utils::fingerprint::Fingerprint;
 use crate::prelude::*;
 use crate::state::db_schema::{
     ChildExistenceInfo, ComponentMemoizationInfo, DbEntryKey, FunctionMemoizationEntry,
-    IdSequencerInfo, StablePathEntryKey, StablePathNodeType, TargetStateOwnerInfo,
+    IdSequencerInfo, StablePathEntryKey, StablePathEntryTrackingInfo, StablePathNodeType,
+    TargetStateOwnerInfo,
 };
 use crate::state::stable_path::{StableKey, StablePath, StablePathPrefix, StablePathRef};
 use crate::state::target_state_path::TargetStatePath;
 use crate::state_store::store::{AnyTxn, Database, ReadTxn, Store, WriteTxn};
 
 // --- Key encoding helpers (internal) ---
+
+fn key_tracking_info(path: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(path.clone(), StablePathEntryKey::TrackingInfo).encode()
+}
 
 fn key_component_memo(path: &StablePath) -> Result<Vec<u8>> {
     DbEntryKey::StablePath(path.clone(), StablePathEntryKey::ComponentMemoization).encode()
@@ -46,10 +49,22 @@ fn key_child_existence(parent: &StablePath, child_key: &StableKey) -> Result<Vec
     .encode()
 }
 
+fn key_child_existence_prefix(parent: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(parent.clone(), StablePathEntryKey::ChildExistencePrefix).encode()
+}
+
 fn key_tombstone(parent: &StablePath, relative_path: &StablePath) -> Result<Vec<u8>> {
     DbEntryKey::StablePath(
         parent.clone(),
         StablePathEntryKey::ChildComponentTombstone(relative_path.clone()),
+    )
+    .encode()
+}
+
+fn key_tombstone_prefix(parent: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(
+        parent.clone(),
+        StablePathEntryKey::ChildComponentTombstonePrefix,
     )
     .encode()
 }
@@ -60,6 +75,39 @@ fn key_target_state_owner(path: &TargetStatePath) -> Result<Vec<u8>> {
 
 fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
     DbEntryKey::IdSequencer(key.clone()).encode()
+}
+
+// --- Tracking info ---
+
+pub fn read_tracking_info<'a, T: AnyTxn>(
+    txn: &'a T,
+    store: &Store,
+    path: &StablePath,
+) -> Result<Option<StablePathEntryTrackingInfo<'a>>> {
+    let key = key_tracking_info(path)?;
+    let data = txn.db_get_bytes(store.db(), &key)?;
+    data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+/// Write pre-serialized tracking info. Callers serialize externally so the
+/// txn can be re-borrowed mutably after the read-modify-write pattern used
+/// in `pre_commit` (where the deserialized `tracking_info` borrows from the
+/// write txn and must be released before writing back).
+pub fn write_tracking_info_raw(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &StablePath,
+    encoded: &[u8],
+) -> Result<()> {
+    let key = key_tracking_info(path)?;
+    store.db().put(&mut **txn, &key, encoded)?;
+    Ok(())
+}
+
+pub fn delete_tracking_info(txn: &mut WriteTxn, store: &Store, path: &StablePath) -> Result<()> {
+    let key = key_tracking_info(path)?;
+    store.db().delete(&mut **txn, &key)?;
+    Ok(())
 }
 
 // --- Component memoization ---
@@ -143,9 +191,9 @@ pub fn retain_fn_memos(
     Ok(())
 }
 
-// --- Child existence (internal — public ops compose these) ---
+// --- Child existence ---
 
-fn read_child_existence<T: AnyTxn>(
+pub fn read_child_existence<T: AnyTxn>(
     txn: &T,
     store: &Store,
     parent: &StablePath,
@@ -156,7 +204,7 @@ fn read_child_existence<T: AnyTxn>(
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
-fn write_child_existence(
+pub fn write_child_existence(
     txn: &mut WriteTxn,
     store: &Store,
     parent: &StablePath,
@@ -169,7 +217,7 @@ fn write_child_existence(
     Ok(())
 }
 
-fn delete_child_existence(
+pub fn delete_child_existence(
     txn: &mut WriteTxn,
     store: &Store,
     parent: &StablePath,
@@ -180,9 +228,30 @@ fn delete_child_existence(
     Ok(())
 }
 
+/// All child-existence entries for `parent`, in sorted-key order (which
+/// matches `BTreeMap<StableKey, _>` iteration order because the on-disk
+/// encoding via `storekey` is order-preserving). Used by
+/// `Committer::update_existence` for the sorted-merge against the in-memory
+/// declared children.
+pub fn list_child_existence<T: AnyTxn>(
+    txn: &T,
+    store: &Store,
+    parent: &StablePath,
+) -> Result<Vec<(StableKey, ChildExistenceInfo)>> {
+    let prefix = key_child_existence_prefix(parent)?;
+    let mut out = Vec::new();
+    for entry in txn.db_prefix_iter(store.db(), &prefix)? {
+        let (raw_key, raw_value) = entry?;
+        let stable_key: StableKey = storekey::decode(raw_key[prefix.len()..].as_ref())?;
+        let info: ChildExistenceInfo = from_msgpack_slice(raw_value)?;
+        out.push((stable_key, info));
+    }
+    Ok(out)
+}
+
 // --- Tombstones ---
 
-fn write_tombstone(
+pub fn write_tombstone(
     txn: &mut WriteTxn,
     store: &Store,
     parent: &StablePath,
@@ -202,6 +271,23 @@ pub fn delete_tombstone(
     let key = key_tombstone(parent, relative_path)?;
     store.db().delete(&mut **txn, &key)?;
     Ok(())
+}
+
+/// Relative paths of all tombstones for `parent`. Used by
+/// `Committer::launch_child_component_gc` to find which children need GC.
+pub fn list_tombstones<T: AnyTxn>(
+    txn: &T,
+    store: &Store,
+    parent: &StablePath,
+) -> Result<Vec<StablePath>> {
+    let prefix = key_tombstone_prefix(parent)?;
+    let mut out = Vec::new();
+    for entry in txn.db_prefix_iter(store.db(), &prefix)? {
+        let (raw_key, _) = entry?;
+        let relative: StablePath = storekey::decode(raw_key[prefix.len()..].as_ref())?;
+        out.push(relative);
+    }
+    Ok(out)
 }
 
 /// Atomic existence-removal + tombstone-write, matching the contract of
@@ -229,6 +315,20 @@ pub fn read_target_state_owner<T: AnyTxn>(
     let key = key_target_state_owner(path)?;
     let data = txn.db_get_bytes(store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+pub fn upsert_target_state_owner(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &TargetStatePath,
+    owner: &StablePath,
+) -> Result<()> {
+    let key = key_target_state_owner(path)?;
+    let value = rmp_serde::to_vec_named(&TargetStateOwnerInfo {
+        component_path: owner.clone(),
+    })?;
+    store.db().put(&mut **txn, &key, &value)?;
+    Ok(())
 }
 
 pub fn delete_target_state_owner(
@@ -347,9 +447,6 @@ pub fn ensure_path_node_type(
 // --- Inspection (cross-component scans) ---
 
 /// Scan all stable-path entries and return one path per component / directory.
-///
-/// On Postgres this becomes a partition-wise scan across all hash partitions
-/// — acceptable cost for an inspection tool, see `specs/core/internal_states.md`.
 pub fn list_all_stable_paths(txn: &ReadTxn, store: &Store) -> Result<Vec<StablePath>> {
     let encoded_key_prefix =
         DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;

--- a/rust/core/src/state_store/ops.rs
+++ b/rust/core/src/state_store/ops.rs
@@ -1,0 +1,495 @@
+//! Typed per-entity I/O operations.
+//!
+//! Each function is a thin wrapper around `(key encode) + (msgpack serde) +
+//! (heed get/put/delete/iter)`. Signatures are heed-free so the engine never
+//! sees LMDB types. The same signatures are expected to exist verbatim in
+//! the enterprise (Postgres) repo with PG-specific bodies.
+//!
+//! Lifetime contract: read functions return schema types parameterized by
+//! the transaction lifetime, borrowing from LMDB mmap pages (or, in the PG
+//! backend, from Row buffers retained by the read transaction). See
+//! `specs/core/state_store_refactor.md` §3 "borrow-on-read".
+
+use std::collections::HashSet;
+
+use cocoindex_utils::deser::from_msgpack_slice;
+use cocoindex_utils::fingerprint::Fingerprint;
+
+use crate::prelude::*;
+use crate::state::db_schema::{
+    ChildExistenceInfo, ComponentMemoizationInfo, DbEntryKey, FunctionMemoizationEntry,
+    IdSequencerInfo, StablePathEntryKey, StablePathNodeType, TargetStateOwnerInfo,
+};
+use crate::state::stable_path::{StableKey, StablePath, StablePathPrefix, StablePathRef};
+use crate::state::target_state_path::TargetStatePath;
+use crate::state_store::store::{AnyTxn, Database, ReadTxn, Store, WriteTxn};
+
+// --- Key encoding helpers (internal) ---
+
+fn key_component_memo(path: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(path.clone(), StablePathEntryKey::ComponentMemoization).encode()
+}
+
+fn key_fn_memo(path: &StablePath, fp: Fingerprint) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(path.clone(), StablePathEntryKey::FunctionMemoization(fp)).encode()
+}
+
+fn key_fn_memo_prefix(path: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(path.clone(), StablePathEntryKey::FunctionMemoizationPrefix).encode()
+}
+
+fn key_child_existence(parent: &StablePath, child_key: &StableKey) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(
+        parent.clone(),
+        StablePathEntryKey::ChildExistence(child_key.clone()),
+    )
+    .encode()
+}
+
+fn key_tombstone(parent: &StablePath, relative_path: &StablePath) -> Result<Vec<u8>> {
+    DbEntryKey::StablePath(
+        parent.clone(),
+        StablePathEntryKey::ChildComponentTombstone(relative_path.clone()),
+    )
+    .encode()
+}
+
+fn key_target_state_owner(path: &TargetStatePath) -> Result<Vec<u8>> {
+    DbEntryKey::TargetState(path.clone()).encode()
+}
+
+fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
+    DbEntryKey::IdSequencer(key.clone()).encode()
+}
+
+// --- Component memoization ---
+
+pub fn read_component_memo<'a, T: AnyTxn>(
+    txn: &'a T,
+    store: &Store,
+    path: &StablePath,
+) -> Result<Option<ComponentMemoizationInfo<'a>>> {
+    let key = key_component_memo(path)?;
+    let data = txn.db_get_bytes(store.db(), &key)?;
+    data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+/// Write a pre-serialized component memo. Callers serialize externally so
+/// the txn can be re-borrowed mutably after the read-modify-write pattern
+/// in [`update_component_memo_states`] (engine code, not in this module).
+pub fn write_component_memo_raw(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &StablePath,
+    encoded: &[u8],
+) -> Result<()> {
+    let key = key_component_memo(path)?;
+    store.db().put(&mut **txn, &key, encoded)?;
+    Ok(())
+}
+
+pub fn delete_component_memo(txn: &mut WriteTxn, store: &Store, path: &StablePath) -> Result<()> {
+    let key = key_component_memo(path)?;
+    store.db().delete(&mut **txn, &key)?;
+    Ok(())
+}
+
+// --- Function memoization ---
+
+pub fn read_fn_memo<'a, T: AnyTxn>(
+    txn: &'a T,
+    store: &Store,
+    path: &StablePath,
+    fp: Fingerprint,
+) -> Result<Option<FunctionMemoizationEntry<'a>>> {
+    let key = key_fn_memo(path, fp)?;
+    let data = txn.db_get_bytes(store.db(), &key)?;
+    data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+pub fn write_fn_memo(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &StablePath,
+    fp: Fingerprint,
+    entry: &FunctionMemoizationEntry<'_>,
+) -> Result<()> {
+    let key = key_fn_memo(path, fp)?;
+    let value = rmp_serde::to_vec_named(entry)?;
+    store.db().put(&mut **txn, &key, &value)?;
+    Ok(())
+}
+
+/// GC: delete all function memos for `path` whose fingerprint is NOT in `keep`.
+pub fn retain_fn_memos(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &StablePath,
+    keep: &HashSet<Fingerprint>,
+) -> Result<()> {
+    let prefix = key_fn_memo_prefix(path)?;
+    let db = store.db();
+    let mut iter = db.prefix_iter_mut(&mut **txn, &prefix)?;
+    while let Some((raw_key, _)) = iter.next().transpose()? {
+        let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
+        if keep.contains(&fp) {
+            continue;
+        }
+        // Safety: we drop the borrowed key before the next `next()` call.
+        unsafe {
+            iter.del_current()?;
+        }
+    }
+    Ok(())
+}
+
+// --- Child existence (internal — public ops compose these) ---
+
+fn read_child_existence<T: AnyTxn>(
+    txn: &T,
+    store: &Store,
+    parent: &StablePath,
+    child_key: &StableKey,
+) -> Result<Option<ChildExistenceInfo>> {
+    let key = key_child_existence(parent, child_key)?;
+    let data = txn.db_get_bytes(store.db(), &key)?;
+    data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+fn write_child_existence(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent: &StablePath,
+    child_key: &StableKey,
+    info: &ChildExistenceInfo,
+) -> Result<()> {
+    let key = key_child_existence(parent, child_key)?;
+    let value = rmp_serde::to_vec_named(info)?;
+    store.db().put(&mut **txn, &key, &value)?;
+    Ok(())
+}
+
+fn delete_child_existence(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent: &StablePath,
+    child_key: &StableKey,
+) -> Result<()> {
+    let key = key_child_existence(parent, child_key)?;
+    store.db().delete(&mut **txn, &key)?;
+    Ok(())
+}
+
+// --- Tombstones ---
+
+fn write_tombstone(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent: &StablePath,
+    relative_path: &StablePath,
+) -> Result<()> {
+    let key = key_tombstone(parent, relative_path)?;
+    store.db().put(&mut **txn, &key, &[])?;
+    Ok(())
+}
+
+pub fn delete_tombstone(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent: &StablePath,
+    relative_path: &StablePath,
+) -> Result<()> {
+    let key = key_tombstone(parent, relative_path)?;
+    store.db().delete(&mut **txn, &key)?;
+    Ok(())
+}
+
+/// Atomic existence-removal + tombstone-write, matching the contract of
+/// `LiveComponentController::delete`'s synchronous step.
+pub fn remove_child_with_tombstone(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent: &StablePath,
+    child_key: &StableKey,
+    owner_path: &StablePath,
+    relative_child: &StablePath,
+) -> Result<()> {
+    delete_child_existence(txn, store, parent, child_key)?;
+    write_tombstone(txn, store, owner_path, relative_child)?;
+    Ok(())
+}
+
+// --- Inverted target-state owner index ---
+
+pub fn read_target_state_owner<T: AnyTxn>(
+    txn: &T,
+    store: &Store,
+    path: &TargetStatePath,
+) -> Result<Option<TargetStateOwnerInfo>> {
+    let key = key_target_state_owner(path)?;
+    let data = txn.db_get_bytes(store.db(), &key)?;
+    data.map(from_msgpack_slice).transpose().map_err(Into::into)
+}
+
+pub fn delete_target_state_owner(
+    txn: &mut WriteTxn,
+    store: &Store,
+    path: &TargetStatePath,
+) -> Result<()> {
+    let key = key_target_state_owner(path)?;
+    store.db().delete(&mut **txn, &key)?;
+    Ok(())
+}
+
+// --- ID sequencer ---
+
+pub fn peek_id_sequence<T: AnyTxn>(txn: &T, store: &Store, key: &StableKey) -> Result<Option<u64>> {
+    let db_key = key_id_sequencer(key)?;
+    let data = txn.db_get_bytes(store.db(), &db_key)?;
+    match data {
+        None => Ok(None),
+        Some(bytes) => {
+            let info: IdSequencerInfo = from_msgpack_slice(bytes)?;
+            Ok(Some(info.next_id))
+        }
+    }
+}
+
+pub fn write_id_sequence(
+    txn: &mut WriteTxn,
+    store: &Store,
+    key: &StableKey,
+    next_id: u64,
+) -> Result<()> {
+    let db_key = key_id_sequencer(key)?;
+    let info = IdSequencerInfo { next_id };
+    let value = rmp_serde::to_vec_named(&info)?;
+    store.db().put(&mut **txn, &db_key, &value)?;
+    Ok(())
+}
+
+/// Atomically reserve `count` consecutive IDs starting from the next
+/// available ID. Returns the first reserved ID. IDs start at 1 (0 is reserved).
+pub fn reserve_id_range(
+    txn: &mut WriteTxn,
+    store: &Store,
+    key: &StableKey,
+    count: u64,
+) -> Result<u64> {
+    let current_next_id = peek_id_sequence(txn, store, key)?.unwrap_or(1);
+    write_id_sequence(txn, store, key, current_next_id + count)?;
+    Ok(current_next_id)
+}
+
+// --- App-level ---
+
+pub fn clear_all(txn: &mut WriteTxn, store: &Store) -> Result<()> {
+    store.db().clear(&mut **txn)?;
+    Ok(())
+}
+
+// --- Path node type helpers (LMDB-encoded via ChildExistence on parent) ---
+
+/// Looks up the node type of `parent_path/key` by reading the parent's
+/// child-existence entry. Used by `pre_commit` path-existence checks.
+pub fn read_path_node_type<T: AnyTxn>(
+    txn: &T,
+    store: &Store,
+    parent_path: StablePathRef<'_>,
+    key: &StableKey,
+) -> Result<Option<StablePathNodeType>> {
+    let parent_owned: StablePath = parent_path.into();
+    let info = read_child_existence(txn, store, &parent_owned, key)?;
+    Ok(info.map(|i| i.node_type))
+}
+
+/// Ensures `parent_path/key` is recorded with `target_node_type`. Recurses
+/// up the ancestor chain creating directory entries as needed.
+///
+/// Promotion rule (matching the legacy `ensure_path_node_type` behavior):
+/// - missing → write `target_node_type`
+/// - Directory + target=Component → upgrade to Component
+/// - anything else → no-op
+pub fn ensure_path_node_type(
+    txn: &mut WriteTxn,
+    store: &Store,
+    parent_path: StablePathRef<'_>,
+    key: &StableKey,
+    target_node_type: StablePathNodeType,
+) -> Result<()> {
+    let parent_owned: StablePath = parent_path.into();
+    let existing = read_child_existence(txn, store, &parent_owned, key)?;
+    let existing_node_type = existing.as_ref().map(|i| i.node_type);
+    match (existing_node_type, target_node_type) {
+        (None, _) | (Some(StablePathNodeType::Directory), StablePathNodeType::Component) => {
+            write_child_existence(
+                txn,
+                store,
+                &parent_owned,
+                key,
+                &ChildExistenceInfo {
+                    node_type: target_node_type,
+                },
+            )?;
+        }
+        _ => {
+            // No-op for all other cases
+        }
+    }
+    if existing_node_type.is_none()
+        && let Some((parent, key)) = parent_path.split_parent()
+    {
+        return ensure_path_node_type(txn, store, parent, key, StablePathNodeType::Directory);
+    }
+    Ok(())
+}
+
+// --- Inspection (cross-component scans) ---
+
+/// Scan all stable-path entries and return one path per component / directory.
+///
+/// On Postgres this becomes a partition-wise scan across all hash partitions
+/// — acceptable cost for an inspection tool, see `specs/core/internal_states.md`.
+pub fn list_all_stable_paths(txn: &ReadTxn, store: &Store) -> Result<Vec<StablePath>> {
+    let encoded_key_prefix =
+        DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
+    let db = store.db();
+    let mut result = Vec::new();
+    let mut last_prefix: Option<Vec<u8>> = None;
+    for entry in db.prefix_iter(&**txn, &encoded_key_prefix)? {
+        let (raw_key, _) = entry?;
+        if let Some(last_prefix) = &last_prefix
+            && raw_key.starts_with(last_prefix)
+        {
+            continue;
+        }
+        let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
+        let DbEntryKey::StablePath(path, _) = key else {
+            internal_bail!("Expected StablePath, got {key:?}");
+        };
+        last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
+        result.push(path);
+    }
+    Ok(result)
+}
+
+/// Open a `ReadTxn` for inspection ops that don't go through the engine's
+/// retry-on-`MDB_READERS_FULL` path. Inspection tools are best-effort and
+/// callers can retry at a higher level if a read txn fails to open.
+pub fn open_read_txn_for_inspect(db_env: &heed::Env<heed::WithoutTls>) -> Result<ReadTxn<'_>> {
+    let rtxn = db_env.read_txn()?;
+    Ok(ReadTxn::new(rtxn))
+}
+
+/// Resolves the store by app name then spawns the stable-path iteration
+/// thread. Returns `None` if the app's database doesn't exist.
+pub fn spawn_iter_stable_paths_with_node_type_for_app_name(
+    db_env: heed::Env<heed::WithoutTls>,
+    app_name: &str,
+) -> Result<Option<tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>>>> {
+    let rtxn = db_env.read_txn()?;
+    let store = open_app_store_by_name(&db_env, &rtxn, app_name)?;
+    drop(rtxn);
+    Ok(store.map(|store| spawn_iter_stable_paths_with_node_type(store, db_env)))
+}
+
+/// Spawn a thread to stream every `(StablePath, node_type)` entry from the
+/// store via a channel. Used by `inspect::iter_stable_paths`; the thread
+/// model is needed because LMDB read transactions/cursors are `!Send`.
+pub fn spawn_iter_stable_paths_with_node_type(
+    store: Store,
+    db_env: heed::Env<heed::WithoutTls>,
+) -> tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>> {
+    let (tx, rx) = tokio::sync::mpsc::channel(128);
+
+    std::thread::spawn(move || {
+        let result: Result<()> = (|| {
+            let encoded_key_prefix =
+                DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
+            let txn = db_env.read_txn()?;
+            let db = store.db();
+
+            let mut last_prefix: Option<Vec<u8>> = None;
+            for entry in db.prefix_iter(&txn, &encoded_key_prefix)? {
+                let (raw_key, _) = entry?;
+                if let Some(last_prefix) = &last_prefix
+                    && raw_key.starts_with(last_prefix)
+                {
+                    continue;
+                }
+                let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
+                let path = match key {
+                    DbEntryKey::StablePath(path, _) => path,
+                    other => return Err(internal_error!("Expected StablePath, got {other:?}")),
+                };
+                last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
+
+                let node_type = if path.as_ref().is_empty() {
+                    StablePathNodeType::Component
+                } else {
+                    let path_ref: StablePathRef<'_> = path.as_ref();
+                    if let Some((parent_ref, key)) = path_ref.split_parent() {
+                        let parent_owned: StablePath = parent_ref.into();
+                        let info = {
+                            let key_encoded = DbEntryKey::StablePath(
+                                parent_owned,
+                                StablePathEntryKey::ChildExistence(key.clone()),
+                            )
+                            .encode()?;
+                            db.get(&txn, &key_encoded)?
+                                .map(from_msgpack_slice::<ChildExistenceInfo>)
+                                .transpose()?
+                        };
+                        info.map(|i| i.node_type)
+                            .unwrap_or(StablePathNodeType::Directory)
+                    } else {
+                        StablePathNodeType::Component
+                    }
+                };
+
+                if tx.blocking_send(Ok((path, node_type))).is_err() {
+                    break;
+                }
+            }
+            Ok(())
+        })();
+        if let Err(err) = result {
+            let _ = tx.blocking_send(Err(err));
+        }
+    });
+
+    rx
+}
+
+/// Open a logical app sub-database within the LMDB environment by name,
+/// returning `None` if it doesn't exist. Used by
+/// `spawn_iter_stable_paths_with_node_type_for_app_name`.
+fn open_app_store_by_name(
+    db_env: &heed::Env<heed::WithoutTls>,
+    rtxn: &heed::RoTxn<'_, heed::WithoutTls>,
+    app_name: &str,
+) -> Result<Option<Store>> {
+    let db: Option<Database> = db_env.open_database(rtxn, Some(app_name))?;
+    Ok(db.map(Store::new))
+}
+
+/// List every non-empty named app database in the environment. LMDB-specific
+/// — the unnamed database is its catalog of named sub-databases.
+pub fn list_app_names(db_env: &heed::Env<heed::WithoutTls>) -> Result<Vec<String>> {
+    let rtxn = db_env.read_txn()?;
+    let unnamed: heed::Database<heed::types::Str, heed::types::DecodeIgnore> = db_env
+        .open_database(&rtxn, None)?
+        .expect("the unnamed database always exists");
+
+    let mut names = Vec::new();
+    for result in unnamed.iter(&rtxn)? {
+        let (name, ()) = result?;
+        if let Ok(Some(db)) =
+            db_env.open_database::<heed::types::Bytes, heed::types::Bytes>(&rtxn, Some(name))
+            && db.first(&rtxn)?.is_some()
+        {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
+}

--- a/rust/core/src/state_store/store.rs
+++ b/rust/core/src/state_store/store.rs
@@ -1,0 +1,140 @@
+//! Opaque storage handle and transaction wrappers.
+//!
+//! These wrap the underlying LMDB types so engine code outside `state_store/`
+//! can pass them through as tokens without ever naming `heed::*`. During the
+//! refactor migration the wrappers implement `Deref` to the inner heed types
+//! so existing call sites continue to compile; once all engine call sites go
+//! through `state_store::ops::*` the deref impls can be tightened or removed.
+//!
+//! See `specs/core/state_store_refactor.md`.
+
+use std::ops::{Deref, DerefMut};
+
+/// LMDB database handle. Keys and values are opaque bytes; logical
+/// key/value schemas live in [`crate::state::db_schema`].
+pub type Database = heed::Database<heed::types::Bytes, heed::types::Bytes>;
+
+/// Per-app storage handle. Holds the LMDB database handle; transactions are
+/// opened from the parent `Environment`.
+#[derive(Clone)]
+pub struct Store {
+    pub(crate) db: Database,
+}
+
+impl Store {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Internal accessor for `state_store::ops`. Engine code outside this
+    /// module never reaches the raw `Database`.
+    pub(crate) fn db(&self) -> Database {
+        self.db
+    }
+}
+
+/// Write transaction wrapper. Threaded through `TxnBatcher::run` closures.
+pub struct WriteTxn<'env>(pub(crate) heed::RwTxn<'env>);
+
+impl<'env> WriteTxn<'env> {
+    pub(crate) fn new(inner: heed::RwTxn<'env>) -> Self {
+        Self(inner)
+    }
+
+    pub(crate) fn into_inner(self) -> heed::RwTxn<'env> {
+        self.0
+    }
+}
+
+impl<'env> Deref for WriteTxn<'env> {
+    type Target = heed::RwTxn<'env>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'env> DerefMut for WriteTxn<'env> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Read transaction wrapper. Opened from `Environment::read_txn()`.
+pub struct ReadTxn<'env>(pub(crate) heed::RoTxn<'env, heed::WithoutTls>);
+
+impl<'env> ReadTxn<'env> {
+    pub(crate) fn new(inner: heed::RoTxn<'env, heed::WithoutTls>) -> Self {
+        Self(inner)
+    }
+}
+
+impl<'env> Deref for ReadTxn<'env> {
+    type Target = heed::RoTxn<'env, heed::WithoutTls>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Marker trait for operations that only need read access. Implemented by
+/// both `ReadTxn` and `WriteTxn` so `state_store::ops` read functions can
+/// be called from either context without separate variants.
+///
+/// The trait is sealed — only the two wrapper types implement it. The hidden
+/// methods are accessed by the `ops` module via `pub(crate)` visibility.
+pub trait AnyTxn: sealed::Sealed {
+    #[doc(hidden)]
+    fn db_get_bytes<'a>(
+        &'a self,
+        db: Database,
+        key: &[u8],
+    ) -> crate::prelude::Result<Option<&'a [u8]>>;
+
+    #[doc(hidden)]
+    fn db_prefix_iter<'a>(
+        &'a self,
+        db: Database,
+        prefix: &[u8],
+    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>>;
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::ReadTxn<'_> {}
+    impl Sealed for super::WriteTxn<'_> {}
+}
+
+impl<'env> AnyTxn for ReadTxn<'env> {
+    fn db_get_bytes<'a>(
+        &'a self,
+        db: Database,
+        key: &[u8],
+    ) -> crate::prelude::Result<Option<&'a [u8]>> {
+        Ok(db.get(&self.0, key)?)
+    }
+
+    fn db_prefix_iter<'a>(
+        &'a self,
+        db: Database,
+        prefix: &[u8],
+    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {
+        Ok(db.prefix_iter(&self.0, prefix)?)
+    }
+}
+
+impl<'env> AnyTxn for WriteTxn<'env> {
+    fn db_get_bytes<'a>(
+        &'a self,
+        db: Database,
+        key: &[u8],
+    ) -> crate::prelude::Result<Option<&'a [u8]>> {
+        Ok(db.get(&self.0, key)?)
+    }
+
+    fn db_prefix_iter<'a>(
+        &'a self,
+        db: Database,
+        prefix: &[u8],
+    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {
+        Ok(db.prefix_iter(&self.0, prefix)?)
+    }
+}

--- a/rust/core/src/state_store/txn_batcher.rs
+++ b/rust/core/src/state_store/txn_batcher.rs
@@ -1,14 +1,20 @@
+//! Batched LMDB write transactions.
+//!
+//! Moved from `engine/txn_batcher.rs` as part of the storage refactor. The
+//! public surface now operates on `state_store::WriteTxn` rather than raw
+//! `heed::RwTxn` so engine code doesn't see heed types.
+
 use std::any::Any;
 use std::sync::Arc;
 
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 
 use crate::prelude::*;
+use crate::state_store::store::WriteTxn;
 
 /// Type-erased body for a write transaction.
-/// Runs inside a shared `RwTxn`, returns a boxed output value.
-type TxnBody =
-    Box<dyn for<'txn> FnOnce(&mut heed::RwTxn<'txn>) -> Result<Box<dyn Any + Send>> + Send>;
+/// Runs inside a shared `WriteTxn`, returns a boxed output value.
+type TxnBody = Box<dyn for<'txn> FnOnce(&mut WriteTxn<'txn>) -> Result<Box<dyn Any + Send>> + Send>;
 
 struct TxnRunner {
     db_env: heed::Env<heed::WithoutTls>,
@@ -24,11 +30,11 @@ impl Runner for TxnRunner {
         inputs: Vec<TxnBody>,
     ) -> Result<impl ExactSizeIterator<Item = Box<dyn Any + Send>>> {
         let mut outputs = Vec::with_capacity(inputs.len());
-        let mut wtxn = self.db_env.write_txn()?;
+        let mut wtxn = WriteTxn::new(self.db_env.write_txn()?);
         for body in inputs {
             outputs.push(body(&mut wtxn)?);
         }
-        wtxn.commit()?;
+        wtxn.into_inner().commit()?;
         Ok(outputs.into_iter())
     }
 }
@@ -41,8 +47,8 @@ impl Runner for TxnRunner {
 /// together once the current batch commits.
 ///
 /// If any closure in a batch returns `Err`, the whole batch is rolled back
-/// (the `RwTxn` is dropped without committing), and every caller in the batch
-/// receives an error.
+/// (the `WriteTxn` is dropped without committing), and every caller in the
+/// batch receives an error.
 pub struct TxnBatcher {
     inner: Batcher<TxnRunner>,
 }
@@ -57,12 +63,13 @@ impl TxnBatcher {
 
     /// Run `body` inside a batched write transaction.
     ///
-    /// The body receives an exclusive `&mut RwTxn` shared with other concurrent
-    /// callers. If the body returns `Ok(value)`, `value` is returned once the
-    /// transaction commits. If it returns `Err`, the transaction is aborted.
+    /// The body receives an exclusive `&mut WriteTxn` shared with other
+    /// concurrent callers. If the body returns `Ok(value)`, `value` is
+    /// returned once the transaction commits. If it returns `Err`, the
+    /// transaction is aborted.
     pub async fn run<T: Send + 'static>(
         &self,
-        body: impl for<'txn> FnOnce(&mut heed::RwTxn<'txn>) -> Result<T> + Send + 'static,
+        body: impl for<'txn> FnOnce(&mut WriteTxn<'txn>) -> Result<T> + Send + 'static,
     ) -> Result<T> {
         let output = self
             .inner


### PR DESCRIPTION
## Summary
- Isolate all LMDB-specific code under a new `state_store/` module: `Store`, `WriteTxn`, `ReadTxn`, `AnyTxn`, `TxnBatcher`, and typed per-entity `ops::*` wrappers around `(key encode) + (msgpack serde) + (heed get/put/delete/iter)`.
- Migrate every direct `heed::*` / `db.get/put/delete` / `prefix_iter_mut` call site in `engine/` to go through `state_store::ops`. `AppContext` now exposes `&Store` rather than `&Database`; `Environment::read_txn()` returns the wrapper `ReadTxn`; `TxnBatcher::run` hands closures `&mut WriteTxn` instead of `&mut heed::RwTxn`.
- Rework `Committer::update_existence`'s cursor-based sorted merge into an in-memory merge against the `Vec` returned by `ops::list_child_existence`. Type the previously-raw `deferred_writes` byte queue as a `DeferredWrite` enum.
- Net result: outside `engine/environment.rs` (the legitimate owner of `heed::Env`), the rest of `engine/` has no `heed::*`, no `DbEntryKey` / `StablePathEntryKey`, and no raw `db.get`/`put`/`delete` calls.

## Test plan
- [x] `cargo test -p cocoindex_core --lib` — 30 passed
- [x] `uv run maturin develop && uv run pytest python/tests/core/` — 346 passed
- [ ] CI
