### PR TITLE
refactor(state_store): isolate Storage, rename Store→AppStore

### DIFF
--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -72,9 +72,9 @@ impl<Prof: EngineProfile> App<Prof> {
         let app_reg = AppRegistration::new(name, &env)?;
 
         // TODO: This database initialization logic should happen lazily on first call to `update()`.
-        let store = env.create_app_store(name)?;
+        let app_store = env.create_app_store(name)?;
 
-        let app_ctx = AppContext::new(env, store, app_reg, max_inflight_components);
+        let app_ctx = AppContext::new(env, app_store, app_reg, max_inflight_components);
         let root_component = Component::new(app_ctx, StablePath::root(), None);
         crate::telemetry::track("app_create");
         Ok(Self { root_component })
@@ -211,12 +211,12 @@ impl<Prof: EngineProfile> App<Prof> {
                 handle.ready().await?;
 
                 // Clear the database
-                let store = root_component.app_ctx().store().clone();
+                let app_store = root_component.app_ctx().app_store().clone();
                 root_component
                     .app_ctx()
                     .env()
                     .txn_batcher()
-                    .run(move |wtxn| crate::state_store::ops::clear_all(wtxn, &store))
+                    .run(move |wtxn| crate::state_store::ops::clear_all(wtxn, &app_store))
                     .await?;
 
                 info!("App dropped successfully");

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -18,12 +18,12 @@ use crate::state::target_state_path::TargetStatePath;
 use crate::{
     engine::environment::{AppRegistration, Environment},
     state::stable_path::StablePath,
-    state_store::Store,
+    state_store::AppStore,
 };
 
 struct AppContextInner<Prof: EngineProfile> {
     env: Environment<Prof>,
-    store: Store,
+    app_store: AppStore,
     app_reg: AppRegistration<Prof>,
     id_sequencer_manager: IdSequencerManager,
     inflight_semaphore: Option<Arc<tokio::sync::Semaphore>>,
@@ -54,7 +54,7 @@ pub struct AppContext<Prof: EngineProfile> {
 impl<Prof: EngineProfile> AppContext<Prof> {
     pub fn new(
         env: Environment<Prof>,
-        store: Store,
+        app_store: AppStore,
         app_reg: AppRegistration<Prof>,
         max_inflight_components: Option<usize>,
     ) -> Self {
@@ -63,7 +63,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         Self {
             inner: Arc::new(AppContextInner {
                 env,
-                store,
+                app_store,
                 app_reg,
                 id_sequencer_manager: IdSequencerManager::new(),
                 inflight_semaphore,
@@ -114,8 +114,8 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         &self.inner.env
     }
 
-    pub fn store(&self) -> &Store {
-        &self.inner.store
+    pub fn app_store(&self) -> &AppStore {
+        &self.inner.app_store
     }
 
     pub fn app_reg(&self) -> &AppRegistration<Prof> {
@@ -153,7 +153,7 @@ impl<Prof: EngineProfile> AppContext<Prof> {
         let key = key.unwrap_or(&default_key);
         self.inner
             .id_sequencer_manager
-            .next_id(self.inner.env.txn_batcher(), &self.inner.store, key)
+            .next_id(self.inner.env.txn_batcher(), &self.inner.app_store, key)
             .await
     }
 }

--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -2,53 +2,19 @@ use crate::{
     engine::profile::EngineProfile,
     engine::target_state::TargetStateProviderRegistry,
     prelude::*,
-    state_store::{ReadTxn, TxnBatcher},
+    state_store::{AppStore, ReadTxn, Storage, StorageSettings, TxnBatcher},
 };
 
 use cocoindex_utils::fingerprint::Fingerprint;
-use cocoindex_utils::retryable;
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::path::PathBuf;
 use std::sync::RwLock;
-use std::time::Duration;
 
-const DEFAULT_MAX_DBS: u32 = 1024;
-const DEFAULT_LMDB_MAP_SIZE: usize = 0x1_0000_0000; // 4GiB
-
-/// Phase 1: short timeout to handle transient concurrency.
-static LMDB_READ_TXN_RETRY_PHASE1: retryable::RetryOptions = retryable::RetryOptions {
-    retry_timeout: Some(Duration::from_secs(3)),
-    initial_backoff: Duration::from_millis(10),
-    max_backoff: Duration::from_secs(1),
-};
-
-/// Phase 2: after clearing stale readers, retry indefinitely.
-static LMDB_READ_TXN_RETRY_PHASE2: retryable::RetryOptions = retryable::RetryOptions {
-    retry_timeout: None,
-    initial_backoff: Duration::from_millis(10),
-    max_backoff: Duration::from_secs(1),
-};
-
-fn default_max_dbs() -> u32 {
-    DEFAULT_MAX_DBS
-}
-fn default_lmdb_map_size() -> usize {
-    DEFAULT_LMDB_MAP_SIZE
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct EnvironmentSettings {
-    pub db_path: PathBuf,
-    #[serde(default = "default_max_dbs")]
-    pub lmdb_max_dbs: u32,
-    #[serde(default = "default_lmdb_map_size")]
-    pub lmdb_map_size: usize,
-}
+/// User-facing environment settings. Currently just storage configuration;
+/// re-exported as a type alias so existing call sites continue to work.
+pub type EnvironmentSettings = StorageSettings;
 
 struct EnvironmentInner<Prof: EngineProfile> {
-    db_env: heed::Env<heed::WithoutTls>,
-    txn_batcher: TxnBatcher,
+    storage: Storage,
     app_names: Mutex<BTreeSet<String>>,
     target_states_providers: Arc<Mutex<TargetStateProviderRegistry<Prof>>>,
     host_runtime_ctx: Prof::HostRuntimeCtx,
@@ -72,33 +38,9 @@ impl<Prof: EngineProfile> Environment<Prof> {
         target_states_providers: Arc<Mutex<TargetStateProviderRegistry<Prof>>>,
         host_runtime_ctx: Prof::HostRuntimeCtx,
     ) -> Result<Self> {
-        let db_path = settings.db_path.join("mdb");
-        // Create the directory if not exists.
-        std::fs::create_dir_all(&db_path)?;
-        // Backward compatibility: migrate LMDB files from old layout into mdb/.
-        Self::migrate_legacy_db_files(&settings.db_path, &db_path)?;
-        if settings.lmdb_max_dbs < 1 {
-            client_bail!("lmdb_max_dbs must be >= 1, got {}", settings.lmdb_max_dbs);
-        }
-        if settings.lmdb_map_size == 0 {
-            client_bail!("lmdb_map_size must be > 0, got {}", settings.lmdb_map_size);
-        }
-        let db_env = unsafe {
-            heed::EnvOpenOptions::new()
-                .read_txn_without_tls()
-                .max_dbs(settings.lmdb_max_dbs)
-                .map_size(settings.lmdb_map_size)
-                .open(db_path)
-        }?;
-        let cleared_count = db_env.clear_stale_readers()?;
-        if cleared_count > 0 {
-            info!("Cleared {cleared_count} stale readers");
-        }
-
-        let txn_batcher = TxnBatcher::new(db_env.clone());
+        let storage = Storage::new(&settings)?;
         let state = Arc::new(EnvironmentInner {
-            db_env,
-            txn_batcher,
+            storage,
             app_names: Mutex::new(BTreeSet::new()),
             target_states_providers,
             host_runtime_ctx,
@@ -108,87 +50,23 @@ impl<Prof: EngineProfile> Environment<Prof> {
         Ok(Self { inner: state })
     }
 
-    /// Migrate legacy LMDB files from the old layout (directly in `base_path`)
-    /// into the new `db_path` subdirectory.
-    fn migrate_legacy_db_files(base_path: &PathBuf, db_path: &PathBuf) -> Result<()> {
-        let legacy_files: Vec<PathBuf> = ["data.mdb", "lock.mdb"]
-            .iter()
-            .map(|name| base_path.join(name))
-            .filter(|path| path.exists())
-            .collect();
-        if legacy_files.is_empty() {
-            return Ok(());
-        }
-        info!(
-            "Migrating legacy LMDB files from {} to {}",
-            base_path.display(),
-            db_path.display()
-        );
-        for src in legacy_files {
-            let dst = db_path.join(src.file_name().unwrap());
-            std::fs::rename(&src, &dst)?;
-        }
-        Ok(())
+    pub fn storage(&self) -> &Storage {
+        &self.inner.storage
     }
 
-    pub fn db_env(&self) -> &heed::Env<heed::WithoutTls> {
-        &self.inner.db_env
-    }
-
-    /// Create the per-app sub-database for this environment and wrap it in a
-    /// `Store`. Hides the underlying LMDB sub-database creation from
-    /// `App::new`.
-    pub fn create_app_store(&self, app_name: &str) -> Result<crate::state_store::Store> {
-        let mut wtxn = self.inner.db_env.write_txn()?;
-        let db = self
-            .inner
-            .db_env
-            .create_database(&mut wtxn, Some(app_name))?;
-        wtxn.commit()?;
-        Ok(crate::state_store::Store::new(db))
-    }
-
-    /// Open an LMDB read transaction with automatic retry on `MDB_READERS_FULL`.
-    ///
-    /// Two-phase strategy:
-    /// 1. Retry with a short timeout — handles transient reader slot contention.
-    /// 2. If phase 1 times out, call `clear_stale_readers()` to reclaim slots
-    ///    from dead processes, then retry indefinitely.
+    /// Open a read transaction. Delegates to [`Storage::read_txn`] which
+    /// handles transient and stale-reader retry.
     pub async fn read_txn(&self) -> Result<ReadTxn<'_>> {
-        let db_env = self.db_env();
-        let try_read_txn = || async {
-            match db_env.read_txn() {
-                Ok(txn) => retryable::Ok(txn),
-                Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
-                    warn!("LMDB readers full, retrying");
-                    Err(retryable::Error::retryable(internal_error!(
-                        "LMDB readers full"
-                    )))
-                }
-                Err(e) => Err(retryable::Error::not_retryable(e)),
-            }
-        };
-
-        // Phase 1: short timeout for transient concurrency.
-        match retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE1).await {
-            Ok(txn) => return Ok(ReadTxn::new(txn)),
-            Err(e) if !e.is_retryable => return Err(e.into()),
-            Err(_) => {}
-        }
-
-        // Phase 2: clear stale readers, then retry indefinitely.
-        let cleared = db_env.clear_stale_readers()?;
-        if cleared > 0 {
-            warn!("Cleared {cleared} stale LMDB readers");
-        }
-        retryable::run(&try_read_txn, &LMDB_READ_TXN_RETRY_PHASE2)
-            .await
-            .map(ReadTxn::new)
-            .map_err(Into::into)
+        self.inner.storage.read_txn().await
     }
 
     pub fn txn_batcher(&self) -> &TxnBatcher {
-        &self.inner.txn_batcher
+        self.inner.storage.txn_batcher()
+    }
+
+    /// Create the per-app sub-app_store. Delegates to [`Storage::create_app_store`].
+    pub fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
+        self.inner.storage.create_app_store(app_name)
     }
 
     pub fn target_states_providers(&self) -> &Arc<Mutex<TargetStateProviderRegistry<Prof>>> {

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -22,7 +22,7 @@ use crate::state::stable_path_set::{ChildStablePathSet, StablePathSet};
 use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
-use crate::state_store::{AnyTxn, Store, WriteTxn, ops};
+use crate::state_store::{AnyTxn, AppStore, WriteTxn, ops};
 use cocoindex_utils::fingerprint::Fingerprint;
 
 /// Deserialize a `Vec<MemoizedValue>` into a `Vec<Prof::FunctionData>`.
@@ -84,11 +84,11 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
         return Ok(None);
     }
 
-    let store = comp_ctx.app_ctx().store();
+    let app_store = comp_ctx.app_ctx().app_store();
     let path = comp_ctx.stable_path();
     {
         let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let Some(memo_info) = ops::read_component_memo(&rtxn, store, path)? else {
+        let Some(memo_info) = ops::read_component_memo(&rtxn, app_store, path)? else {
             return Ok(None);
         };
         if let Some(processor_fp) = processor_fp {
@@ -129,13 +129,13 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
 
     // Invalidate the memoization.
     {
-        let store = comp_ctx.app_ctx().store().clone();
+        let app_store = comp_ctx.app_ctx().app_store().clone();
         let path = path.clone();
         comp_ctx
             .app_ctx()
             .env()
             .txn_batcher()
-            .run(move |wtxn| ops::delete_component_memo(wtxn, &store, &path))
+            .run(move |wtxn| ops::delete_component_memo(wtxn, &app_store, &path))
             .await?;
     }
 
@@ -152,7 +152,7 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     new_states: &MemoStatesPayload<Prof>,
 ) -> Result<()> {
-    let store = comp_ctx.app_ctx().store().clone();
+    let app_store = comp_ctx.app_ctx().app_store().clone();
     let path = comp_ctx.stable_path().clone();
 
     // Serialize new states
@@ -170,7 +170,7 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
         .txn_batcher()
         .run(move |wtxn| {
             let encoded = {
-                let Some(existing) = ops::read_component_memo(&*wtxn, &store, &path)? else {
+                let Some(existing) = ops::read_component_memo(&*wtxn, &app_store, &path)? else {
                     return Ok(());
                 };
                 let new_info = db_schema::ComponentMemoizationInfo {
@@ -183,7 +183,7 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
                 rmp_serde::to_vec_named(&new_info)?
             };
             // Borrows from wtxn are released; we can take &mut wtxn for write.
-            ops::write_component_memo_raw(wtxn, &store, &path, &encoded)
+            ops::write_component_memo_raw(wtxn, &app_store, &path, &encoded)
         })
         .await?;
     Ok(())
@@ -191,7 +191,7 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
 
 fn write_fn_call_memo<Prof: EngineProfile>(
     wtxn: &mut WriteTxn<'_>,
-    store: &Store,
+    app_store: &AppStore,
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
     memo: FnCallMemo<Prof>,
@@ -209,16 +209,22 @@ fn write_fn_call_memo<Prof: EngineProfile>(
         memo_states: memo_states_serialized,
         context_memo_states: context_memo_states_serialized,
     };
-    ops::write_fn_memo(wtxn, store, comp_ctx.stable_path(), memo_fp, &fn_call_memo)
+    ops::write_fn_memo(
+        wtxn,
+        app_store,
+        comp_ctx.stable_path(),
+        memo_fp,
+        &fn_call_memo,
+    )
 }
 
 fn read_fn_call_memo_with_txn<Prof: EngineProfile, T: AnyTxn>(
     rtxn: &T,
-    store: &Store,
+    app_store: &AppStore,
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
 ) -> Result<Option<FnCallMemo<Prof>>> {
-    let Some(fn_call_memo) = ops::read_fn_memo(rtxn, store, comp_ctx.stable_path(), memo_fp)?
+    let Some(fn_call_memo) = ops::read_fn_memo(rtxn, app_store, comp_ctx.stable_path(), memo_fp)?
     else {
         return Ok(None);
     };
@@ -257,7 +263,7 @@ pub(crate) async fn read_fn_call_memo<Prof: EngineProfile>(
         return Ok(None);
     }
     let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().store(), comp_ctx, memo_fp)
+    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().app_store(), comp_ctx, memo_fp)
 }
 
 pub fn declare_target_state<Prof: EngineProfile>(
@@ -346,7 +352,7 @@ struct ChildrenPathInfo {
 
 struct Committer<Prof: EngineProfile> {
     component_ctx: ComponentProcessorContext<Prof>,
-    store: Store,
+    app_store: AppStore,
     target_states_providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
 
     component_path: StablePath,
@@ -366,7 +372,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
         let component_path = component_ctx.stable_path().clone();
         Ok(Self {
             component_ctx: component_ctx.clone(),
-            store: component_ctx.app_ctx().store().clone(),
+            app_store: component_ctx.app_ctx().app_store().clone(),
             target_states_providers: target_states_providers.clone(),
             component_path,
             existence_processing_queue: VecDeque::new(),
@@ -387,12 +393,12 @@ impl<Prof: EngineProfile> Committer<Prof> {
     ) -> Result<Self> {
         {
             if self.component_ctx.mode() == ComponentProcessingMode::Delete {
-                ops::delete_tracking_info(wtxn, &self.store, &self.component_path)?;
+                ops::delete_tracking_info(wtxn, &self.app_store, &self.component_path)?;
             } else {
                 let curr_version = curr_version
                     .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;
                 let mut tracking_info: db_schema::StablePathEntryTrackingInfo =
-                    ops::read_tracking_info(&*wtxn, &self.store, &self.component_path)?
+                    ops::read_tracking_info(&*wtxn, &self.app_store, &self.component_path)?
                         .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
 
                 for item in tracking_info.target_state_items.values_mut() {
@@ -449,21 +455,26 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
                 let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
                 drop(tracking_info); // Release borrow before mutable operations.
-                ops::write_tracking_info_raw(wtxn, &self.store, &self.component_path, &data_bytes)?;
+                ops::write_tracking_info_raw(
+                    wtxn,
+                    &self.app_store,
+                    &self.component_path,
+                    &data_bytes,
+                )?;
 
                 // Clean up inverted tracking for pruned entries.
                 for path in &pruned_paths {
-                    ops::delete_target_state_owner(wtxn, &self.store, path)?;
+                    ops::delete_target_state_owner(wtxn, &self.app_store, path)?;
                 }
             }
 
             // Write memos.
             for (fp, memo) in memos_without_mounts_to_store {
-                write_fn_call_memo(wtxn, &self.store, &self.component_ctx, fp, memo)?;
+                write_fn_call_memo(wtxn, &self.app_store, &self.component_ctx, fp, memo)?;
             }
 
             // Delete all function memo entries that are not in the all_memo_fps.
-            ops::retain_fn_memos(wtxn, &self.store, &self.component_path, all_memo_fps)?;
+            ops::retain_fn_memos(wtxn, &self.app_store, &self.component_path, all_memo_fps)?;
 
             if !self.demote_component_only {
                 self.update_existence(&mut *wtxn, child_path_set)?;
@@ -517,7 +528,8 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 .child_path_set
                 .into_iter()
                 .flat_map(|set| set.children.into_iter());
-            let existing_children = ops::list_child_existence(wtxn, &self.store, &path_info.path)?;
+            let existing_children =
+                ops::list_child_existence(wtxn, &self.app_store, &path_info.path)?;
             let mut existing_iter = existing_children.into_iter();
 
             let mut curr_next = curr_iter.next();
@@ -538,11 +550,21 @@ impl<Prof: EngineProfile> Committer<Prof> {
                     (None, Some(_)) => {
                         // All remaining existing children should be deleted.
                         if let Some((key, info)) = existing_next.take() {
-                            ops::delete_child_existence(wtxn, &self.store, &path_info.path, &key)?;
+                            ops::delete_child_existence(
+                                wtxn,
+                                &self.app_store,
+                                &path_info.path,
+                                &key,
+                            )?;
                             self.del_child(&key, &info, &path_info.path)?;
                         }
                         for (key, info) in existing_iter.by_ref() {
-                            ops::delete_child_existence(wtxn, &self.store, &path_info.path, &key)?;
+                            ops::delete_child_existence(
+                                wtxn,
+                                &self.app_store,
+                                &path_info.path,
+                                &key,
+                            )?;
                             self.del_child(&key, &info, &path_info.path)?;
                         }
                         break;
@@ -561,7 +583,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                                     existing_next.take().ok_or_else(invariance_violation)?;
                                 ops::delete_child_existence(
                                     wtxn,
-                                    &self.store,
+                                    &self.app_store,
                                     &path_info.path,
                                     &key,
                                 )?;
@@ -579,7 +601,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                                 if existing_info.node_type != new_node_type {
                                     ops::write_child_existence(
                                         wtxn,
-                                        &self.store,
+                                        &self.app_store,
                                         &path_info.path,
                                         &curr_key,
                                         &db_schema::ChildExistenceInfo {
@@ -618,7 +640,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 let node_type = node_type_for(&path_set);
                 ops::write_child_existence(
                     wtxn,
-                    &self.store,
+                    &self.app_store,
                     &path_info.path,
                     &stable_key,
                     &db_schema::ChildExistenceInfo { node_type },
@@ -637,7 +659,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
     }
 
     fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &T) -> Result<()> {
-        for relative_path in ops::list_tombstones(rtxn, &self.store, &self.component_path)? {
+        for relative_path in ops::list_tombstones(rtxn, &self.app_store, &self.component_path)? {
             let stable_path = self.component_path.concat(relative_path.as_ref());
             let component = self.component_ctx.component().get_child(stable_path);
             let delete_ctx = component.new_processor_context_for_delete(
@@ -676,7 +698,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
     fn flush_component_tombstones(&mut self, wtxn: &mut WriteTxn<'_>) -> Result<()> {
         for relative_path in std::mem::take(&mut self.buffered_paths_for_tombstone) {
-            ops::write_tombstone(wtxn, &self.store, &self.component_path, &relative_path)?;
+            ops::write_tombstone(wtxn, &self.app_store, &self.component_path, &relative_path)?;
         }
         Ok(())
     }
@@ -755,15 +777,17 @@ enum DeferredWrite {
 }
 
 impl DeferredWrite {
-    fn flush(self, wtxn: &mut WriteTxn<'_>, store: &Store) -> Result<()> {
+    fn flush(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
         match self {
             DeferredWrite::TrackingInfoRaw { path, encoded } => {
-                ops::write_tracking_info_raw(wtxn, store, &path, &encoded)
+                ops::write_tracking_info_raw(wtxn, app_store, &path, &encoded)
             }
             DeferredWrite::OwnerUpsert {
                 target_state_path,
                 component_path,
-            } => ops::upsert_target_state_owner(wtxn, store, &target_state_path, &component_path),
+            } => {
+                ops::upsert_target_state_owner(wtxn, app_store, &target_state_path, &component_path)
+            }
         }
     }
 }
@@ -771,7 +795,7 @@ impl DeferredWrite {
 #[allow(clippy::too_many_arguments)]
 fn pre_commit<Prof: EngineProfile>(
     wtxn: &mut WriteTxn<'_>,
-    store: &Store,
+    app_store: &AppStore,
     comp_mode: ComponentProcessingMode,
     stable_path: &StablePath,
     full_reprocess: bool,
@@ -785,14 +809,14 @@ fn pre_commit<Prof: EngineProfile>(
     let mut processor_name_for_del: Option<String> = None;
 
     if comp_mode == ComponentProcessingMode::Delete {
-        ops::delete_component_memo(wtxn, store, stable_path)?;
+        ops::delete_component_memo(wtxn, app_store, stable_path)?;
     }
 
     if let Some((parent_path, key)) = stable_path.as_ref().split_parent() {
         match comp_mode {
             ComponentProcessingMode::Build => {
                 ensure_path_node_type(
-                    store,
+                    app_store,
                     wtxn,
                     parent_path,
                     key,
@@ -800,7 +824,7 @@ fn pre_commit<Prof: EngineProfile>(
                 )?;
             }
             ComponentProcessingMode::Delete => {
-                let node_type = get_path_node_type(store, wtxn, parent_path, key)?;
+                let node_type = get_path_node_type(app_store, wtxn, parent_path, key)?;
                 match node_type {
                     Some(db_schema::StablePathNodeType::Component) => {
                         return Ok(None);
@@ -816,7 +840,7 @@ fn pre_commit<Prof: EngineProfile>(
 
     let mut id_reservation = IdReservation::new(&TARGET_ID_KEY);
     let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> =
-        ops::read_tracking_info(wtxn, store, stable_path)?;
+        ops::read_tracking_info(wtxn, app_store, stable_path)?;
     // Deferred DB writes that will be flushed after tracking_info is dropped,
     // since tracking_info borrows from wtxn and prevents mutable DB operations.
     let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
@@ -869,11 +893,11 @@ fn pre_commit<Prof: EngineProfile>(
                 Some(existing_item)
             } else {
                 // Insert path: check inverted tracking for ownership preempt.
-                match ops::read_target_state_owner(wtxn, store, &target_state_path)? {
+                match ops::read_target_state_owner(wtxn, app_store, &target_state_path)? {
                     Some(owner_info) if owner_info.component_path != *stable_path => {
                         let old_owner_path = owner_info.component_path.clone();
                         if let Some(mut old_tracking) =
-                            ops::read_tracking_info(wtxn, store, &old_owner_path)?
+                            ops::read_tracking_info(wtxn, app_store, &old_owner_path)?
                         {
                             let len_before = old_tracking.target_state_items.len();
                             // Look up the entry matching current provider_id.
@@ -960,7 +984,7 @@ fn pre_commit<Prof: EngineProfile>(
                     let existing_gen = provider_generation.clone().unwrap_or_default();
                     let new_gen = match recon_output.child_invalidation {
                         Some(ChildInvalidation::Destructive) => {
-                            let new_id = id_reservation.next_id(wtxn, store)?;
+                            let new_id = id_reservation.next_id(wtxn, app_store)?;
                             TargetStateProviderGeneration {
                                 provider_id: new_id,
                                 provider_schema_version: 0,
@@ -1123,7 +1147,7 @@ fn pre_commit<Prof: EngineProfile>(
 
         let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
         drop(tracking_info); // Release borrow before mutable operations.
-        ops::write_tracking_info_raw(wtxn, store, stable_path, &data_bytes)?;
+        ops::write_tracking_info_raw(wtxn, app_store, stable_path, &data_bytes)?;
         Some(curr_version)
     } else {
         None
@@ -1131,10 +1155,10 @@ fn pre_commit<Prof: EngineProfile>(
 
     // Flush deferred writes now that tracking_info is dropped.
     for dw in deferred_writes {
-        dw.flush(wtxn, store)?;
+        dw.flush(wtxn, app_store)?;
     }
 
-    id_reservation.commit(wtxn, store)?;
+    id_reservation.commit(wtxn, app_store)?;
     Ok(Some(PreCommitOutput {
         curr_version,
         previously_exists,
@@ -1197,7 +1221,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         ),
     };
 
-    let store = comp_ctx.app_ctx().store().clone();
+    let app_store = comp_ctx.app_ctx().app_store().clone();
     let comp_mode = comp_ctx.mode();
     let stable_path = comp_ctx.stable_path().clone();
     let full_reprocess = comp_ctx.full_reprocess();
@@ -1217,7 +1241,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         .run(move |wtxn| {
             pre_commit(
                 wtxn,
-                &store,
+                &app_store,
                 comp_mode,
                 &stable_path,
                 full_reprocess,
@@ -1329,13 +1353,13 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
     };
     let encoded = rmp_serde::to_vec_named(&memo_info)?;
 
-    let store = comp_ctx.app_ctx().store().clone();
+    let app_store = comp_ctx.app_ctx().app_store().clone();
     let path = comp_ctx.stable_path().clone();
     comp_ctx
         .app_ctx()
         .env()
         .txn_batcher()
-        .run(move |wtxn| ops::write_component_memo_raw(wtxn, &store, &path, &encoded))
+        .run(move |wtxn| ops::write_component_memo_raw(wtxn, &app_store, &path, &encoded))
         .await
 }
 
@@ -1351,32 +1375,32 @@ pub(crate) async fn cleanup_tombstone<Prof: EngineProfile>(
         .as_ref()
         .strip_parent(owner_path.as_ref())?
         .into();
-    let store = comp_ctx.app_ctx().store().clone();
+    let app_store = comp_ctx.app_ctx().app_store().clone();
     comp_ctx
         .app_ctx()
         .env()
         .txn_batcher()
-        .run(move |wtxn| ops::delete_tombstone(wtxn, &store, &owner_path, &relative_path))
+        .run(move |wtxn| ops::delete_tombstone(wtxn, &app_store, &owner_path, &relative_path))
         .await
 }
 
 pub(crate) fn ensure_path_node_type(
-    store: &Store,
+    app_store: &AppStore,
     wtxn: &mut WriteTxn<'_>,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
     target_node_type: db_schema::StablePathNodeType,
 ) -> Result<()> {
-    ops::ensure_path_node_type(wtxn, store, parent_path, key, target_node_type)
+    ops::ensure_path_node_type(wtxn, app_store, parent_path, key, target_node_type)
 }
 
 fn get_path_node_type<T: AnyTxn>(
-    store: &Store,
+    app_store: &AppStore,
     rtxn: &T,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
 ) -> Result<Option<db_schema::StablePathNodeType>> {
-    ops::read_path_node_type(rtxn, store, parent_path, key)
+    ops::read_path_node_type(rtxn, app_store, parent_path, key)
 }
 
 #[derive(Default)]
@@ -1425,12 +1449,12 @@ async fn finalize_fn_call_memoization<Prof: EngineProfile>(
     // Use a single read transaction for all DB reads.
     if !deps_to_process.is_empty() {
         let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let store = comp_ctx.app_ctx().store();
+        let app_store = comp_ctx.app_ctx().app_store();
         while let Some(fp) = deps_to_process.pop_front() {
             if !result.all_memos_fps.insert(fp) {
                 continue;
             }
-            let Some(memo) = read_fn_call_memo_with_txn(&rtxn, store, comp_ctx, fp)? else {
+            let Some(memo) = read_fn_call_memo_with_txn(&rtxn, app_store, comp_ctx, fp)? else {
                 continue;
             };
             result

--- a/rust/core/src/engine/id_sequencer.rs
+++ b/rust/core/src/engine/id_sequencer.rs
@@ -7,13 +7,13 @@
 //! - Batch sizes grow exponentially (2, 4, 8, ..., 256) for better performance
 //!
 //! Storage I/O goes through `crate::state_store::ops`; this module is
-//! the in-memory caching half and never touches LMDB directly.
+//! the in-memory caching half and never touches the storage backend directly.
 
 use std::collections::HashMap;
 
 use crate::prelude::*;
 use crate::state::stable_path::StableKey;
-use crate::state_store::{Store, TxnBatcher, WriteTxn, ops};
+use crate::state_store::{AppStore, TxnBatcher, WriteTxn, ops};
 
 /// Initial batch size for ID allocation.
 const INITIAL_BATCH_SIZE: u64 = 2;
@@ -86,7 +86,7 @@ impl IdSequencerManager {
     pub async fn next_id(
         &self,
         txn_batcher: &TxnBatcher,
-        store: &Store,
+        app_store: &AppStore,
         key: &StableKey,
     ) -> Result<u64> {
         // Get or create the per-key state (brief lock on main map)
@@ -103,10 +103,10 @@ impl IdSequencerManager {
 
         if state.needs_refill() {
             let batch_size = state.next_batch_size;
-            let store = store.clone();
+            let app_store = app_store.clone();
             let key = key.clone();
             let start_id = txn_batcher
-                .run(move |wtxn| ops::reserve_id_range(wtxn, &store, &key, batch_size))
+                .run(move |wtxn| ops::reserve_id_range(wtxn, &app_store, &key, batch_size))
                 .await?;
             state.refill(start_id, batch_size);
         }
@@ -122,8 +122,8 @@ impl IdSequencerManager {
 /// [`commit()`](IdReservation::commit).
 ///
 /// Each reservation is scoped to a single key. At most one reservation per key
-/// should be live at a time, which is naturally enforced by LMDB's single-writer
-/// constraint.
+/// should be live at a time, which is naturally enforced by the storage
+/// backend's single-writer transaction.
 pub struct IdReservation {
     key: &'static StableKey,
     /// Next ID to hand out (initialized from DB on first `next_id` call).
@@ -139,11 +139,11 @@ impl IdReservation {
     }
 
     /// Allocate the next ID. Reads from DB on first call, then tracks locally.
-    pub fn next_id(&mut self, wtxn: &WriteTxn<'_>, store: &Store) -> Result<u64> {
+    pub fn next_id(&mut self, wtxn: &WriteTxn<'_>, app_store: &AppStore) -> Result<u64> {
         let next_id = match &mut self.next_id_state {
             Some(n) => n,
             slot @ None => {
-                let current = ops::peek_id_sequence(wtxn, store, self.key)?.unwrap_or(1);
+                let current = ops::peek_id_sequence(wtxn, app_store, self.key)?.unwrap_or(1);
                 slot.insert(current)
             }
         };
@@ -153,9 +153,9 @@ impl IdReservation {
     }
 
     /// Write the reserved ID range back to DB. Call once at end of transaction.
-    pub fn commit(self, wtxn: &mut WriteTxn<'_>, store: &Store) -> Result<()> {
+    pub fn commit(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
         if let Some(next_id) = self.next_id_state {
-            ops::write_id_sequence(wtxn, store, self.key, next_id)?;
+            ops::write_id_sequence(wtxn, app_store, self.key, next_id)?;
         }
         Ok(())
     }

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -133,7 +133,7 @@ impl<Prof: EngineProfile> MountLivePending<Prof> {
         ));
 
         // 6. Install ordering (matters for drop_app race coverage):
-        //    (i)   store the new state in `child.live_state` (strong-ref anchor)
+        //    (i)   app_store the new state in `child.live_state` (strong-ref anchor)
         //    (ii)  register Weak in `app_ctx.live_components` (compaction-on-push)
         //
         // The DB `ChildExistence` row is written separately:
@@ -546,7 +546,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // Synchronously remove the existence entry and write a tombstone,
         // matching the prior implementation's contract.
         if let Some((parent_ref, child_key)) = subpath.as_ref().split_parent() {
-            let store = self.component.app_ctx().store().clone();
+            let app_store = self.component.app_ctx().app_store().clone();
             let parent_path: StablePath = parent_ref.into();
             let child_key = child_key.clone();
             let component_path = self.component.stable_path().clone();
@@ -559,7 +559,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .run(move |wtxn| {
                     ops::remove_child_with_tombstone(
                         wtxn,
-                        &store,
+                        &app_store,
                         &parent_path,
                         &child_key,
                         &component_path,
@@ -794,7 +794,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // operator.update call. With this row, the install/tombstone
         // state machine is symmetric across both installer paths.
         if let Some((parent_path_ref, child_key)) = child_path.as_ref().split_parent() {
-            let store = self.component.app_ctx().store().clone();
+            let app_store = self.component.app_ctx().app_store().clone();
             let parent_path: StablePath = parent_path_ref.into();
             let child_key = child_key.clone();
             self.component
@@ -803,7 +803,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .txn_batcher()
                 .run(move |wtxn| {
                     crate::engine::execution::ensure_path_node_type(
-                        &store,
+                        &app_store,
                         wtxn,
                         parent_path.as_ref(),
                         &child_key,

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -11,9 +11,9 @@ use futures::stream::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
 pub fn list_stable_paths<Prof: EngineProfile>(app: &App<Prof>) -> Result<Vec<StablePath>> {
-    let store = app.app_ctx().store();
-    let rtxn = ops::open_read_txn_for_inspect(app.app_ctx().env().db_env())?;
-    ops::list_all_stable_paths(&rtxn, store)
+    let app_store = app.app_ctx().app_store();
+    let rtxn = app.app_ctx().env().storage().read_txn_for_inspect()?;
+    ops::list_all_stable_paths(&rtxn, app_store)
 }
 
 /// Represents a stable path with metadata (e.g. node type); more properties may be added.
@@ -27,13 +27,13 @@ pub struct StablePathInfo {
 pub use db_schema::StablePathNodeType;
 
 /// Returns a stream of stable paths with their metadata (e.g. node type).
-/// LMDB iteration runs on a dedicated thread (RoTxn/cursors are !Send); items are sent over a channel.
+/// Iteration runs on a dedicated thread (read txns/cursors are !Send); items are sent over a channel.
 pub fn iter_stable_paths<Prof: EngineProfile>(
     app: &App<Prof>,
 ) -> impl Stream<Item = Result<StablePathInfo>> + Send + 'static {
-    let store = app.app_ctx().store().clone();
-    let db_env = app.app_ctx().env().db_env().clone();
-    let rx = ops::spawn_iter_stable_paths_with_node_type(store, db_env);
+    let app_store = app.app_ctx().app_store().clone();
+    let storage = app.app_ctx().env().storage().clone();
+    let rx = ops::spawn_iter_stable_paths_with_node_type(app_store, storage);
     receiver_to_stable_path_info_stream(rx)
 }
 
@@ -43,8 +43,8 @@ pub fn iter_stable_paths_by_name<Prof: EngineProfile>(
     env: &Environment<Prof>,
     app_name: &str,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<StablePathInfo>> + Send + 'static>>> {
-    let db_env = env.db_env().clone();
-    match ops::spawn_iter_stable_paths_with_node_type_for_app_name(db_env, app_name)? {
+    let storage = env.storage().clone();
+    match ops::spawn_iter_stable_paths_with_node_type_for_app_name(storage, app_name)? {
         Some(rx) => Ok(Box::pin(receiver_to_stable_path_info_stream(rx))),
         None => Ok(Box::pin(futures::stream::empty())),
     }
@@ -58,5 +58,5 @@ fn receiver_to_stable_path_info_stream(
 }
 
 pub fn list_app_names<Prof: EngineProfile>(env: &Environment<Prof>) -> Result<Vec<String>> {
-    ops::list_app_names(env.db_env())
+    ops::list_app_names(env.storage())
 }

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -1,0 +1,28 @@
+//! Per-app handle within a [`Storage`](super::Storage).
+//!
+//! An `AppStore` is a cheap-clone token (the underlying database handle is
+//! `Copy`) that identifies which app's entries a `state_store::ops::*` call
+//! reads or writes. Operations always pair an `AppStore` with a `WriteTxn`
+//! or `ReadTxn` (from [`crate::state_store::txn`]).
+
+/// LMDB database handle. Keys and values are opaque bytes; logical
+/// key/value schemas live in [`crate::state::db_schema`].
+pub type Database = heed::Database<heed::types::Bytes, heed::types::Bytes>;
+
+/// Per-app handle within a `Storage`.
+#[derive(Clone)]
+pub struct AppStore {
+    pub(crate) db: Database,
+}
+
+impl AppStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Internal accessor for `state_store::ops`. Engine code outside this
+    /// module never reaches the raw `Database`.
+    pub(crate) fn db(&self) -> Database {
+        self.db
+    }
+}

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -7,9 +7,13 @@
 //!
 //! See `specs/core/state_store_refactor.md` for the design rationale.
 
+pub mod app_store;
 pub mod ops;
-pub mod store;
+pub mod storage;
+pub mod txn;
 pub mod txn_batcher;
 
-pub use store::{AnyTxn, Database, ReadTxn, Store, WriteTxn};
+pub use app_store::{AppStore, Database};
+pub use storage::{Storage, StorageSettings};
+pub use txn::{AnyTxn, ReadTxn, WriteTxn};
 pub use txn_batcher::TxnBatcher;

--- a/rust/core/src/state_store/ops.rs
+++ b/rust/core/src/state_store/ops.rs
@@ -21,7 +21,9 @@ use crate::state::db_schema::{
 };
 use crate::state::stable_path::{StableKey, StablePath, StablePathPrefix, StablePathRef};
 use crate::state::target_state_path::TargetStatePath;
-use crate::state_store::store::{AnyTxn, Database, ReadTxn, Store, WriteTxn};
+use crate::state_store::app_store::AppStore;
+use crate::state_store::storage::Storage;
+use crate::state_store::txn::{AnyTxn, ReadTxn, WriteTxn};
 
 // --- Key encoding helpers (internal) ---
 
@@ -81,11 +83,11 @@ fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
 
 pub fn read_tracking_info<'a, T: AnyTxn>(
     txn: &'a T,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
 ) -> Result<Option<StablePathEntryTrackingInfo<'a>>> {
     let key = key_tracking_info(path)?;
-    let data = txn.db_get_bytes(store.db(), &key)?;
+    let data = txn.db_get_bytes(app_store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
@@ -95,18 +97,22 @@ pub fn read_tracking_info<'a, T: AnyTxn>(
 /// write txn and must be released before writing back).
 pub fn write_tracking_info_raw(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
     encoded: &[u8],
 ) -> Result<()> {
     let key = key_tracking_info(path)?;
-    store.db().put(&mut **txn, &key, encoded)?;
+    app_store.db().put(&mut **txn, &key, encoded)?;
     Ok(())
 }
 
-pub fn delete_tracking_info(txn: &mut WriteTxn, store: &Store, path: &StablePath) -> Result<()> {
+pub fn delete_tracking_info(
+    txn: &mut WriteTxn,
+    app_store: &AppStore,
+    path: &StablePath,
+) -> Result<()> {
     let key = key_tracking_info(path)?;
-    store.db().delete(&mut **txn, &key)?;
+    app_store.db().delete(&mut **txn, &key)?;
     Ok(())
 }
 
@@ -114,11 +120,11 @@ pub fn delete_tracking_info(txn: &mut WriteTxn, store: &Store, path: &StablePath
 
 pub fn read_component_memo<'a, T: AnyTxn>(
     txn: &'a T,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
 ) -> Result<Option<ComponentMemoizationInfo<'a>>> {
     let key = key_component_memo(path)?;
-    let data = txn.db_get_bytes(store.db(), &key)?;
+    let data = txn.db_get_bytes(app_store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
@@ -127,18 +133,22 @@ pub fn read_component_memo<'a, T: AnyTxn>(
 /// in [`update_component_memo_states`] (engine code, not in this module).
 pub fn write_component_memo_raw(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
     encoded: &[u8],
 ) -> Result<()> {
     let key = key_component_memo(path)?;
-    store.db().put(&mut **txn, &key, encoded)?;
+    app_store.db().put(&mut **txn, &key, encoded)?;
     Ok(())
 }
 
-pub fn delete_component_memo(txn: &mut WriteTxn, store: &Store, path: &StablePath) -> Result<()> {
+pub fn delete_component_memo(
+    txn: &mut WriteTxn,
+    app_store: &AppStore,
+    path: &StablePath,
+) -> Result<()> {
     let key = key_component_memo(path)?;
-    store.db().delete(&mut **txn, &key)?;
+    app_store.db().delete(&mut **txn, &key)?;
     Ok(())
 }
 
@@ -146,37 +156,37 @@ pub fn delete_component_memo(txn: &mut WriteTxn, store: &Store, path: &StablePat
 
 pub fn read_fn_memo<'a, T: AnyTxn>(
     txn: &'a T,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
     fp: Fingerprint,
 ) -> Result<Option<FunctionMemoizationEntry<'a>>> {
     let key = key_fn_memo(path, fp)?;
-    let data = txn.db_get_bytes(store.db(), &key)?;
+    let data = txn.db_get_bytes(app_store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
 pub fn write_fn_memo(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
     fp: Fingerprint,
     entry: &FunctionMemoizationEntry<'_>,
 ) -> Result<()> {
     let key = key_fn_memo(path, fp)?;
     let value = rmp_serde::to_vec_named(entry)?;
-    store.db().put(&mut **txn, &key, &value)?;
+    app_store.db().put(&mut **txn, &key, &value)?;
     Ok(())
 }
 
 /// GC: delete all function memos for `path` whose fingerprint is NOT in `keep`.
 pub fn retain_fn_memos(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &StablePath,
     keep: &HashSet<Fingerprint>,
 ) -> Result<()> {
     let prefix = key_fn_memo_prefix(path)?;
-    let db = store.db();
+    let db = app_store.db();
     let mut iter = db.prefix_iter_mut(&mut **txn, &prefix)?;
     while let Some((raw_key, _)) = iter.next().transpose()? {
         let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
@@ -195,36 +205,36 @@ pub fn retain_fn_memos(
 
 pub fn read_child_existence<T: AnyTxn>(
     txn: &T,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     child_key: &StableKey,
 ) -> Result<Option<ChildExistenceInfo>> {
     let key = key_child_existence(parent, child_key)?;
-    let data = txn.db_get_bytes(store.db(), &key)?;
+    let data = txn.db_get_bytes(app_store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
 pub fn write_child_existence(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     child_key: &StableKey,
     info: &ChildExistenceInfo,
 ) -> Result<()> {
     let key = key_child_existence(parent, child_key)?;
     let value = rmp_serde::to_vec_named(info)?;
-    store.db().put(&mut **txn, &key, &value)?;
+    app_store.db().put(&mut **txn, &key, &value)?;
     Ok(())
 }
 
 pub fn delete_child_existence(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     child_key: &StableKey,
 ) -> Result<()> {
     let key = key_child_existence(parent, child_key)?;
-    store.db().delete(&mut **txn, &key)?;
+    app_store.db().delete(&mut **txn, &key)?;
     Ok(())
 }
 
@@ -235,12 +245,12 @@ pub fn delete_child_existence(
 /// declared children.
 pub fn list_child_existence<T: AnyTxn>(
     txn: &T,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
 ) -> Result<Vec<(StableKey, ChildExistenceInfo)>> {
     let prefix = key_child_existence_prefix(parent)?;
     let mut out = Vec::new();
-    for entry in txn.db_prefix_iter(store.db(), &prefix)? {
+    for entry in txn.db_prefix_iter(app_store.db(), &prefix)? {
         let (raw_key, raw_value) = entry?;
         let stable_key: StableKey = storekey::decode(raw_key[prefix.len()..].as_ref())?;
         let info: ChildExistenceInfo = from_msgpack_slice(raw_value)?;
@@ -253,23 +263,23 @@ pub fn list_child_existence<T: AnyTxn>(
 
 pub fn write_tombstone(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     relative_path: &StablePath,
 ) -> Result<()> {
     let key = key_tombstone(parent, relative_path)?;
-    store.db().put(&mut **txn, &key, &[])?;
+    app_store.db().put(&mut **txn, &key, &[])?;
     Ok(())
 }
 
 pub fn delete_tombstone(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     relative_path: &StablePath,
 ) -> Result<()> {
     let key = key_tombstone(parent, relative_path)?;
-    store.db().delete(&mut **txn, &key)?;
+    app_store.db().delete(&mut **txn, &key)?;
     Ok(())
 }
 
@@ -277,12 +287,12 @@ pub fn delete_tombstone(
 /// `Committer::launch_child_component_gc` to find which children need GC.
 pub fn list_tombstones<T: AnyTxn>(
     txn: &T,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
 ) -> Result<Vec<StablePath>> {
     let prefix = key_tombstone_prefix(parent)?;
     let mut out = Vec::new();
-    for entry in txn.db_prefix_iter(store.db(), &prefix)? {
+    for entry in txn.db_prefix_iter(app_store.db(), &prefix)? {
         let (raw_key, _) = entry?;
         let relative: StablePath = storekey::decode(raw_key[prefix.len()..].as_ref())?;
         out.push(relative);
@@ -294,14 +304,14 @@ pub fn list_tombstones<T: AnyTxn>(
 /// `LiveComponentController::delete`'s synchronous step.
 pub fn remove_child_with_tombstone(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent: &StablePath,
     child_key: &StableKey,
     owner_path: &StablePath,
     relative_child: &StablePath,
 ) -> Result<()> {
-    delete_child_existence(txn, store, parent, child_key)?;
-    write_tombstone(txn, store, owner_path, relative_child)?;
+    delete_child_existence(txn, app_store, parent, child_key)?;
+    write_tombstone(txn, app_store, owner_path, relative_child)?;
     Ok(())
 }
 
@@ -309,17 +319,17 @@ pub fn remove_child_with_tombstone(
 
 pub fn read_target_state_owner<T: AnyTxn>(
     txn: &T,
-    store: &Store,
+    app_store: &AppStore,
     path: &TargetStatePath,
 ) -> Result<Option<TargetStateOwnerInfo>> {
     let key = key_target_state_owner(path)?;
-    let data = txn.db_get_bytes(store.db(), &key)?;
+    let data = txn.db_get_bytes(app_store.db(), &key)?;
     data.map(from_msgpack_slice).transpose().map_err(Into::into)
 }
 
 pub fn upsert_target_state_owner(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &TargetStatePath,
     owner: &StablePath,
 ) -> Result<()> {
@@ -327,25 +337,29 @@ pub fn upsert_target_state_owner(
     let value = rmp_serde::to_vec_named(&TargetStateOwnerInfo {
         component_path: owner.clone(),
     })?;
-    store.db().put(&mut **txn, &key, &value)?;
+    app_store.db().put(&mut **txn, &key, &value)?;
     Ok(())
 }
 
 pub fn delete_target_state_owner(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     path: &TargetStatePath,
 ) -> Result<()> {
     let key = key_target_state_owner(path)?;
-    store.db().delete(&mut **txn, &key)?;
+    app_store.db().delete(&mut **txn, &key)?;
     Ok(())
 }
 
 // --- ID sequencer ---
 
-pub fn peek_id_sequence<T: AnyTxn>(txn: &T, store: &Store, key: &StableKey) -> Result<Option<u64>> {
+pub fn peek_id_sequence<T: AnyTxn>(
+    txn: &T,
+    app_store: &AppStore,
+    key: &StableKey,
+) -> Result<Option<u64>> {
     let db_key = key_id_sequencer(key)?;
-    let data = txn.db_get_bytes(store.db(), &db_key)?;
+    let data = txn.db_get_bytes(app_store.db(), &db_key)?;
     match data {
         None => Ok(None),
         Some(bytes) => {
@@ -357,14 +371,14 @@ pub fn peek_id_sequence<T: AnyTxn>(txn: &T, store: &Store, key: &StableKey) -> R
 
 pub fn write_id_sequence(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     key: &StableKey,
     next_id: u64,
 ) -> Result<()> {
     let db_key = key_id_sequencer(key)?;
     let info = IdSequencerInfo { next_id };
     let value = rmp_serde::to_vec_named(&info)?;
-    store.db().put(&mut **txn, &db_key, &value)?;
+    app_store.db().put(&mut **txn, &db_key, &value)?;
     Ok(())
 }
 
@@ -372,19 +386,19 @@ pub fn write_id_sequence(
 /// available ID. Returns the first reserved ID. IDs start at 1 (0 is reserved).
 pub fn reserve_id_range(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     key: &StableKey,
     count: u64,
 ) -> Result<u64> {
-    let current_next_id = peek_id_sequence(txn, store, key)?.unwrap_or(1);
-    write_id_sequence(txn, store, key, current_next_id + count)?;
+    let current_next_id = peek_id_sequence(txn, app_store, key)?.unwrap_or(1);
+    write_id_sequence(txn, app_store, key, current_next_id + count)?;
     Ok(current_next_id)
 }
 
 // --- App-level ---
 
-pub fn clear_all(txn: &mut WriteTxn, store: &Store) -> Result<()> {
-    store.db().clear(&mut **txn)?;
+pub fn clear_all(txn: &mut WriteTxn, app_store: &AppStore) -> Result<()> {
+    app_store.db().clear(&mut **txn)?;
     Ok(())
 }
 
@@ -394,12 +408,12 @@ pub fn clear_all(txn: &mut WriteTxn, store: &Store) -> Result<()> {
 /// child-existence entry. Used by `pre_commit` path-existence checks.
 pub fn read_path_node_type<T: AnyTxn>(
     txn: &T,
-    store: &Store,
+    app_store: &AppStore,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
 ) -> Result<Option<StablePathNodeType>> {
     let parent_owned: StablePath = parent_path.into();
-    let info = read_child_existence(txn, store, &parent_owned, key)?;
+    let info = read_child_existence(txn, app_store, &parent_owned, key)?;
     Ok(info.map(|i| i.node_type))
 }
 
@@ -412,19 +426,19 @@ pub fn read_path_node_type<T: AnyTxn>(
 /// - anything else → no-op
 pub fn ensure_path_node_type(
     txn: &mut WriteTxn,
-    store: &Store,
+    app_store: &AppStore,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
     target_node_type: StablePathNodeType,
 ) -> Result<()> {
     let parent_owned: StablePath = parent_path.into();
-    let existing = read_child_existence(txn, store, &parent_owned, key)?;
+    let existing = read_child_existence(txn, app_store, &parent_owned, key)?;
     let existing_node_type = existing.as_ref().map(|i| i.node_type);
     match (existing_node_type, target_node_type) {
         (None, _) | (Some(StablePathNodeType::Directory), StablePathNodeType::Component) => {
             write_child_existence(
                 txn,
-                store,
+                app_store,
                 &parent_owned,
                 key,
                 &ChildExistenceInfo {
@@ -439,7 +453,7 @@ pub fn ensure_path_node_type(
     if existing_node_type.is_none()
         && let Some((parent, key)) = parent_path.split_parent()
     {
-        return ensure_path_node_type(txn, store, parent, key, StablePathNodeType::Directory);
+        return ensure_path_node_type(txn, app_store, parent, key, StablePathNodeType::Directory);
     }
     Ok(())
 }
@@ -447,10 +461,10 @@ pub fn ensure_path_node_type(
 // --- Inspection (cross-component scans) ---
 
 /// Scan all stable-path entries and return one path per component / directory.
-pub fn list_all_stable_paths(txn: &ReadTxn, store: &Store) -> Result<Vec<StablePath>> {
+pub fn list_all_stable_paths(txn: &ReadTxn, app_store: &AppStore) -> Result<Vec<StablePath>> {
     let encoded_key_prefix =
         DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-    let db = store.db();
+    let db = app_store.db();
     let mut result = Vec::new();
     let mut last_prefix: Option<Vec<u8>> = None;
     for entry in db.prefix_iter(&**txn, &encoded_key_prefix)? {
@@ -470,32 +484,22 @@ pub fn list_all_stable_paths(txn: &ReadTxn, store: &Store) -> Result<Vec<StableP
     Ok(result)
 }
 
-/// Open a `ReadTxn` for inspection ops that don't go through the engine's
-/// retry-on-`MDB_READERS_FULL` path. Inspection tools are best-effort and
-/// callers can retry at a higher level if a read txn fails to open.
-pub fn open_read_txn_for_inspect(db_env: &heed::Env<heed::WithoutTls>) -> Result<ReadTxn<'_>> {
-    let rtxn = db_env.read_txn()?;
-    Ok(ReadTxn::new(rtxn))
-}
-
-/// Resolves the store by app name then spawns the stable-path iteration
+/// Resolves the app_store by app name then spawns the stable-path iteration
 /// thread. Returns `None` if the app's database doesn't exist.
 pub fn spawn_iter_stable_paths_with_node_type_for_app_name(
-    db_env: heed::Env<heed::WithoutTls>,
+    storage: Storage,
     app_name: &str,
 ) -> Result<Option<tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>>>> {
-    let rtxn = db_env.read_txn()?;
-    let store = open_app_store_by_name(&db_env, &rtxn, app_name)?;
-    drop(rtxn);
-    Ok(store.map(|store| spawn_iter_stable_paths_with_node_type(store, db_env)))
+    let app_store = storage.open_app_store_by_name(app_name)?;
+    Ok(app_store.map(|app_store| spawn_iter_stable_paths_with_node_type(app_store, storage)))
 }
 
 /// Spawn a thread to stream every `(StablePath, node_type)` entry from the
-/// store via a channel. Used by `inspect::iter_stable_paths`; the thread
+/// app_store via a channel. Used by `inspect::iter_stable_paths`; the thread
 /// model is needed because LMDB read transactions/cursors are `!Send`.
 pub fn spawn_iter_stable_paths_with_node_type(
-    store: Store,
-    db_env: heed::Env<heed::WithoutTls>,
+    app_store: AppStore,
+    storage: Storage,
 ) -> tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>> {
     let (tx, rx) = tokio::sync::mpsc::channel(128);
 
@@ -503,8 +507,8 @@ pub fn spawn_iter_stable_paths_with_node_type(
         let result: Result<()> = (|| {
             let encoded_key_prefix =
                 DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-            let txn = db_env.read_txn()?;
-            let db = store.db();
+            let txn = storage.heed_env().read_txn()?;
+            let db = app_store.db();
 
             let mut last_prefix: Option<Vec<u8>> = None;
             for entry in db.prefix_iter(&txn, &encoded_key_prefix)? {
@@ -558,21 +562,10 @@ pub fn spawn_iter_stable_paths_with_node_type(
     rx
 }
 
-/// Open a logical app sub-database within the LMDB environment by name,
-/// returning `None` if it doesn't exist. Used by
-/// `spawn_iter_stable_paths_with_node_type_for_app_name`.
-fn open_app_store_by_name(
-    db_env: &heed::Env<heed::WithoutTls>,
-    rtxn: &heed::RoTxn<'_, heed::WithoutTls>,
-    app_name: &str,
-) -> Result<Option<Store>> {
-    let db: Option<Database> = db_env.open_database(rtxn, Some(app_name))?;
-    Ok(db.map(Store::new))
-}
-
-/// List every non-empty named app database in the environment. LMDB-specific
-/// — the unnamed database is its catalog of named sub-databases.
-pub fn list_app_names(db_env: &heed::Env<heed::WithoutTls>) -> Result<Vec<String>> {
+/// List every non-empty named app sub-app_store in the storage environment.
+/// The "unnamed database" is LMDB's catalog of named sub-databases.
+pub fn list_app_names(storage: &Storage) -> Result<Vec<String>> {
+    let db_env = storage.heed_env();
     let rtxn = db_env.read_txn()?;
     let unnamed: heed::Database<heed::types::Str, heed::types::DecodeIgnore> = db_env
         .open_database(&rtxn, None)?

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -1,0 +1,197 @@
+//! Per-environment storage handle: opens the underlying LMDB env, hosts
+//! the [`TxnBatcher`], and exposes per-app [`AppStore`] creation.
+//!
+//! `Storage` is the env-level analog of the per-app [`AppStore`]. Both are
+//! cheaply clonable (internally `Arc`-backed) so callers can move them
+//! into spawned threads for inspection-style streaming reads.
+
+use crate::prelude::*;
+use crate::state_store::app_store::{AppStore, Database};
+use crate::state_store::txn::ReadTxn;
+use crate::state_store::txn_batcher::TxnBatcher;
+
+use cocoindex_utils::retryable;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEFAULT_MAX_DBS: u32 = 1024;
+const DEFAULT_MAP_SIZE: usize = 0x1_0000_0000; // 4GiB
+
+/// Phase 1: short timeout to handle transient concurrency.
+static READ_TXN_RETRY_PHASE1: retryable::RetryOptions = retryable::RetryOptions {
+    retry_timeout: Some(Duration::from_secs(3)),
+    initial_backoff: Duration::from_millis(10),
+    max_backoff: Duration::from_secs(1),
+};
+
+/// Phase 2: after clearing stale readers, retry indefinitely.
+static READ_TXN_RETRY_PHASE2: retryable::RetryOptions = retryable::RetryOptions {
+    retry_timeout: None,
+    initial_backoff: Duration::from_millis(10),
+    max_backoff: Duration::from_secs(1),
+};
+
+fn default_max_dbs() -> u32 {
+    DEFAULT_MAX_DBS
+}
+
+fn default_map_size() -> usize {
+    DEFAULT_MAP_SIZE
+}
+
+/// Configuration for opening the storage environment.
+///
+/// The on-disk schema (field names, defaults) is the public configuration
+/// surface deserialized from user settings.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct StorageSettings {
+    pub db_path: PathBuf,
+    #[serde(default = "default_max_dbs")]
+    pub lmdb_max_dbs: u32,
+    #[serde(default = "default_map_size")]
+    pub lmdb_map_size: usize,
+}
+
+#[derive(Clone)]
+pub struct Storage {
+    inner: Arc<StorageInner>,
+}
+
+struct StorageInner {
+    db_env: heed::Env<heed::WithoutTls>,
+    txn_batcher: TxnBatcher,
+}
+
+impl Storage {
+    pub fn new(settings: &StorageSettings) -> Result<Self> {
+        let db_path = settings.db_path.join("mdb");
+        std::fs::create_dir_all(&db_path)?;
+        // Backward compatibility: migrate files from old layout into mdb/.
+        Self::migrate_legacy_db_files(&settings.db_path, &db_path)?;
+        if settings.lmdb_max_dbs < 1 {
+            client_bail!("lmdb_max_dbs must be >= 1, got {}", settings.lmdb_max_dbs);
+        }
+        if settings.lmdb_map_size == 0 {
+            client_bail!("lmdb_map_size must be > 0, got {}", settings.lmdb_map_size);
+        }
+        let db_env = unsafe {
+            heed::EnvOpenOptions::new()
+                .read_txn_without_tls()
+                .max_dbs(settings.lmdb_max_dbs)
+                .map_size(settings.lmdb_map_size)
+                .open(db_path)
+        }?;
+        let cleared_count = db_env.clear_stale_readers()?;
+        if cleared_count > 0 {
+            info!("Cleared {cleared_count} stale readers");
+        }
+        let txn_batcher = TxnBatcher::new(db_env.clone());
+        Ok(Self {
+            inner: Arc::new(StorageInner {
+                db_env,
+                txn_batcher,
+            }),
+        })
+    }
+
+    /// Migrate legacy files from the old layout (directly in `base_path`)
+    /// into the new `db_path` subdirectory.
+    fn migrate_legacy_db_files(base_path: &Path, db_path: &Path) -> Result<()> {
+        let legacy_files: Vec<PathBuf> = ["data.mdb", "lock.mdb"]
+            .iter()
+            .map(|name| base_path.join(name))
+            .filter(|path| path.exists())
+            .collect();
+        if legacy_files.is_empty() {
+            return Ok(());
+        }
+        info!(
+            "Migrating legacy storage files from {} to {}",
+            base_path.display(),
+            db_path.display()
+        );
+        for src in legacy_files {
+            let dst = db_path.join(src.file_name().unwrap());
+            std::fs::rename(&src, &dst)?;
+        }
+        Ok(())
+    }
+
+    pub fn txn_batcher(&self) -> &TxnBatcher {
+        &self.inner.txn_batcher
+    }
+
+    /// Create the per-app sub-database and wrap it in an `AppStore`.
+    pub fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
+        let mut wtxn = self.inner.db_env.write_txn()?;
+        let db = self
+            .inner
+            .db_env
+            .create_database(&mut wtxn, Some(app_name))?;
+        wtxn.commit()?;
+        Ok(AppStore::new(db))
+    }
+
+    /// Open the per-app sub-database by name, or `None` if it doesn't exist.
+    /// Opens an internal read transaction for the lookup.
+    pub fn open_app_store_by_name(&self, app_name: &str) -> Result<Option<AppStore>> {
+        let rtxn = self.inner.db_env.read_txn()?;
+        let db: Option<Database> = self.inner.db_env.open_database(&rtxn, Some(app_name))?;
+        Ok(db.map(AppStore::new))
+    }
+
+    /// Open a read transaction with automatic retry on `MDB_READERS_FULL`.
+    ///
+    /// Two-phase strategy:
+    /// 1. Retry with a short timeout — handles transient reader slot contention.
+    /// 2. If phase 1 times out, call `clear_stale_readers()` to reclaim slots
+    ///    from dead processes, then retry indefinitely.
+    pub async fn read_txn(&self) -> Result<ReadTxn<'_>> {
+        let db_env = &self.inner.db_env;
+        let try_read_txn = || async {
+            match db_env.read_txn() {
+                Ok(txn) => retryable::Ok(txn),
+                Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
+                    warn!("Storage readers full, retrying");
+                    Err(retryable::Error::retryable(internal_error!(
+                        "Storage readers full"
+                    )))
+                }
+                Err(e) => Err(retryable::Error::not_retryable(e)),
+            }
+        };
+
+        // Phase 1: short timeout for transient concurrency.
+        match retryable::run(&try_read_txn, &READ_TXN_RETRY_PHASE1).await {
+            Ok(txn) => return Ok(ReadTxn::new(txn)),
+            Err(e) if !e.is_retryable => return Err(e.into()),
+            Err(_) => {}
+        }
+
+        // Phase 2: clear stale readers, then retry indefinitely.
+        let cleared = db_env.clear_stale_readers()?;
+        if cleared > 0 {
+            warn!("Cleared {cleared} stale storage readers");
+        }
+        retryable::run(&try_read_txn, &READ_TXN_RETRY_PHASE2)
+            .await
+            .map(ReadTxn::new)
+            .map_err(Into::into)
+    }
+
+    /// Synchronous, non-retrying read txn for inspection use. Callers tolerate
+    /// `MDB_READERS_FULL` at a higher level rather than going through the
+    /// engine's two-phase retry path.
+    pub fn read_txn_for_inspect(&self) -> Result<ReadTxn<'_>> {
+        Ok(ReadTxn::new(self.inner.db_env.read_txn()?))
+    }
+
+    /// Internal accessor for the spawn-iter pattern in `state_store::ops`,
+    /// which needs to move the env handle into a dedicated thread because
+    /// LMDB read transactions and cursors are `!Send`.
+    pub(crate) fn heed_env(&self) -> &heed::Env<heed::WithoutTls> {
+        &self.inner.db_env
+    }
+}

--- a/rust/core/src/state_store/txn.rs
+++ b/rust/core/src/state_store/txn.rs
@@ -1,37 +1,16 @@
-//! Opaque storage handle and transaction wrappers.
+//! Read and write transaction wrappers.
 //!
-//! These wrap the underlying LMDB types so engine code outside `state_store/`
-//! can pass them through as tokens without ever naming `heed::*`. During the
-//! refactor migration the wrappers implement `Deref` to the inner heed types
-//! so existing call sites continue to compile; once all engine call sites go
-//! through `state_store::ops::*` the deref impls can be tightened or removed.
+//! These wrap the underlying LMDB transaction types so engine code outside
+//! `state_store/` doesn't see `heed::*`. The wrappers `Deref` to the inner
+//! heed types so internal call sites (within `state_store::ops`) can still
+//! reach the heed API.
 //!
-//! See `specs/core/state_store_refactor.md`.
+//! The [`AnyTxn`] trait lets read-only `state_store::ops` functions be
+//! called from either a `ReadTxn` or `WriteTxn` context.
+
+use crate::state_store::app_store::Database;
 
 use std::ops::{Deref, DerefMut};
-
-/// LMDB database handle. Keys and values are opaque bytes; logical
-/// key/value schemas live in [`crate::state::db_schema`].
-pub type Database = heed::Database<heed::types::Bytes, heed::types::Bytes>;
-
-/// Per-app storage handle. Holds the LMDB database handle; transactions are
-/// opened from the parent `Environment`.
-#[derive(Clone)]
-pub struct Store {
-    pub(crate) db: Database,
-}
-
-impl Store {
-    pub fn new(db: Database) -> Self {
-        Self { db }
-    }
-
-    /// Internal accessor for `state_store::ops`. Engine code outside this
-    /// module never reaches the raw `Database`.
-    pub(crate) fn db(&self) -> Database {
-        self.db
-    }
-}
 
 /// Write transaction wrapper. Threaded through `TxnBatcher::run` closures.
 pub struct WriteTxn<'env>(pub(crate) heed::RwTxn<'env>);
@@ -59,7 +38,7 @@ impl<'env> DerefMut for WriteTxn<'env> {
     }
 }
 
-/// Read transaction wrapper. Opened from `Environment::read_txn()`.
+/// Read transaction wrapper. Opened from [`Storage::read_txn`](super::Storage::read_txn).
 pub struct ReadTxn<'env>(pub(crate) heed::RoTxn<'env, heed::WithoutTls>);
 
 impl<'env> ReadTxn<'env> {

--- a/rust/core/src/state_store/txn_batcher.rs
+++ b/rust/core/src/state_store/txn_batcher.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 
 use crate::prelude::*;
-use crate::state_store::store::WriteTxn;
+use crate::state_store::txn::WriteTxn;
 
 /// Type-erased body for a write transaction.
 /// Runs inside a shared `WriteTxn`, returns a boxed output value.


### PR DESCRIPTION
## Summary
- Pull the env-level LMDB handle out of `engine/environment.rs` into a new `state_store::Storage` type. `Storage` owns the `heed::Env`, the `TxnBatcher`, the `MDB_READERS_FULL` retry, the legacy `data.mdb`/`lock.mdb` file migration, and the `lmdb_max_dbs`/`lmdb_map_size` settings. `Environment` shrinks to engine-only state plus a `storage: Storage` field; `EnvironmentSettings` is now a `pub type` alias for `StorageSettings` so existing call sites compile unchanged.
- Rename `state_store::Store` → `state_store::AppStore` and split `state_store/store.rs` into three purpose-specific files: `app_store.rs` (per-app token + `Database` alias), `txn.rs` (`WriteTxn` / `ReadTxn` / `AnyTxn`), and `storage.rs` (env-level handle). `AppContext::store()` → `AppContext::app_store()`, with the field/variable name following.
- Net: outside `state_store/`, the engine has zero `heed::*` or `lmdb` references (the previous four in `engine/environment.rs` have moved to `state_store::storage`). The pair reads as "Storage / AppStore" instead of the previously-confusing "Storage / Store".

## Test plan
- [x] `cargo test -p cocoindex_core --lib` — 30 passed
- [x] `uv run maturin develop && uv run pytest python/tests/core/` — 346 passed
- [ ] CI
