### PR TITLE
fix(py): add context to Rust→Python error messages for App operations

### DIFF
--- a/rust/py/src/app.rs
+++ b/rust/py/src/app.rs
@@ -170,7 +170,9 @@ impl PyApp {
         env: &PyEnvironment,
         max_inflight_components: Option<usize>,
     ) -> PyResult<Self> {
-        let app = App::new(name, env.0.clone(), max_inflight_components).into_py_result()?;
+        let app = App::new(name, env.0.clone(), max_inflight_components)
+            .context(format!("failed to initialize app '{name}'"))
+            .into_py_result()?;
         Ok(Self(Arc::new(app)))
     }
 
@@ -190,6 +192,7 @@ impl PyApp {
         let host_ctx = Arc::new(host_ctx);
         let handle = app
             .update(root_processor, options, host_ctx)
+            .context("failed to start app update")
             .into_py_result()?;
         Ok(PyUpdateHandle::new(handle))
     }
@@ -214,6 +217,7 @@ impl PyApp {
             get_runtime().block_on(async move {
                 let handle = app
                     .update(root_processor, options, host_ctx)
+                    .context("failed to start app update")
                     .into_py_result()?;
                 if report_to_stdout {
                     rust_show_progress(handle, ProgressDisplayOptions::default())
@@ -229,7 +233,10 @@ impl PyApp {
     pub fn drop_async(&self, host_ctx: Py<PyAny>) -> PyResult<PyDropHandle> {
         let app = self.0.clone();
         let host_ctx = Arc::new(host_ctx);
-        let handle = app.drop_app(host_ctx).into_py_result()?;
+        let handle = app
+            .drop_app(host_ctx)
+            .context("failed to start app drop")
+            .into_py_result()?;
         Ok(PyDropHandle::new(handle))
     }
 
@@ -244,7 +251,10 @@ impl PyApp {
         let host_ctx = Arc::new(host_ctx);
         py.detach(|| {
             get_runtime().block_on(async move {
-                let handle = app.drop_app(host_ctx).into_py_result()?;
+                let handle = app
+                    .drop_app(host_ctx)
+                    .context("failed to start app drop")
+                    .into_py_result()?;
                 if report_to_stdout {
                     rust_show_progress(handle, ProgressDisplayOptions::default())
                         .await


### PR DESCRIPTION
## Summary

Wraps `App::new()`, `app.update()`, and `app.drop_app()` calls at the PyO3 boundary with `.context()` messages so terse internal Rust errors include the name of the operation that triggered them.

**Before:**
```
Exception: version 1213486160 is not supported
```

**After:**
```
Exception:
Context:
  1: failed to initialize app 'my_app'
version 1213486160 is not supported
```

Uses the existing `ContextExt::context()` infrastructure already in place in `cocoindex_utils::error`. No new dependencies, no API surface changes.

Part of #1060.

## Test plan

- `cargo test -p cocoindex_core -p cocoindex_utils -p cocoindex_ops_text` — all pass
- `uv run maturin develop --uv` — builds cleanly
- `uv run pytest python/tests/ -q` — 625 passed, 138 skipped