### PR TITLE
refactor(state_store): async I/O for state_store pub methods

### DIFF
--- a/benchmarks/file_summarization/rust/src/main.rs
+++ b/benchmarks/file_summarization/rust/src/main.rs
@@ -241,7 +241,8 @@ async fn main() -> cocoindex::Result<()> {
     .db_path(&args.state)
     .provide(metrics.clone())
     .provide(profile.clone())
-    .build()?;
+    .build()
+    .await?;
 
     let dataset = args.dataset.clone();
     let output = args.output.clone();

--- a/examples/rust/files-transform/src/main.rs
+++ b/examples/rust/files-transform/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     let (source_dir, output_dir) = parse_args();
     ensure_dir(&output_dir)?;
 
-    let app = cocoindex::App::open("files_transform", ".cocoindex_db")?;
+    let app = cocoindex::App::open("files_transform", ".cocoindex_db").await?;
     let stats = app
         .run(move |ctx| {
             let source_dir = source_dir.clone();

--- a/examples/rust/multi-codebase-summarization/src/main.rs
+++ b/examples/rust/multi-codebase-summarization/src/main.rs
@@ -354,7 +354,7 @@ async fn main() -> Result<()> {
     );
     let output_dir = PathBuf::from(args.get(2).map(|s| s.as_str()).unwrap_or("./output"));
 
-    let app = cocoindex::App::open("multi_codebase_summarization", ".cocoindex_db")?;
+    let app = cocoindex::App::open("multi_codebase_summarization", ".cocoindex_db").await?;
 
     let stats = app
         .run(move |ctx| async move {

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -64,7 +64,7 @@ pub struct App<Prof: EngineProfile> {
 }
 
 impl<Prof: EngineProfile> App<Prof> {
-    pub fn new(
+    pub async fn new(
         name: &str,
         env: Environment<Prof>,
         max_inflight_components: Option<usize>,
@@ -72,7 +72,7 @@ impl<Prof: EngineProfile> App<Prof> {
         let app_reg = AppRegistration::new(name, &env)?;
 
         // TODO: This database initialization logic should happen lazily on first call to `update()`.
-        let app_store = env.create_app_store(name)?;
+        let app_store = env.create_app_store(name).await?;
 
         let app_ctx = AppContext::new(env, app_store, app_reg, max_inflight_components);
         let root_component = Component::new(app_ctx, StablePath::root(), None);
@@ -215,7 +215,7 @@ impl<Prof: EngineProfile> App<Prof> {
                 root_component
                     .app_ctx()
                     .env()
-                    .run_txn(move |wtxn| app_store.clear_all(wtxn))
+                    .run_txn(move |wtxn| Box::pin(async move { app_store.clear_all(wtxn).await }))
                     .await?;
 
                 info!("App dropped successfully");

--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use cocoindex_utils::fingerprint::Fingerprint;
+use futures::future::BoxFuture;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::RwLock;
 
@@ -33,12 +34,12 @@ pub struct Environment<Prof: EngineProfile> {
 }
 
 impl<Prof: EngineProfile> Environment<Prof> {
-    pub fn new(
+    pub async fn new(
         settings: EnvironmentSettings,
         target_states_providers: Arc<Mutex<TargetStateProviderRegistry<Prof>>>,
         host_runtime_ctx: Prof::HostRuntimeCtx,
     ) -> Result<Self> {
-        let storage = Storage::new(&settings)?;
+        let storage = Storage::new(&settings).await?;
         let state = Arc::new(EnvironmentInner {
             storage,
             app_names: Mutex::new(BTreeSet::new()),
@@ -64,14 +65,16 @@ impl<Prof: EngineProfile> Environment<Prof> {
     pub async fn run_txn<T, F>(&self, body: F) -> Result<T>
     where
         T: Send + 'static,
-        F: for<'txn> FnOnce(&mut WriteTxn<'txn>) -> Result<T> + Send + 'static,
+        F: for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<T>>
+            + Send
+            + 'static,
     {
         self.inner.storage.run_txn(body).await
     }
 
     /// Create the per-app sub-store. Delegates to [`Storage::create_app_store`].
-    pub fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
-        self.inner.storage.create_app_store(app_name)
+    pub async fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
+        self.inner.storage.create_app_store(app_name).await
     }
 
     pub fn target_states_providers(&self) -> &Arc<Mutex<TargetStateProviderRegistry<Prof>>> {

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -23,6 +23,7 @@ use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
 use crate::state_store::{AnyTxn, AppStore, WriteTxn};
+use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
 /// Deserialize a `Vec<MemoizedValue>` into a `Vec<Prof::FunctionData>`.
@@ -87,10 +88,11 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
     let app_store = comp_ctx.app_ctx().app_store();
     let path = comp_ctx.stable_path();
     {
-        let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let Some(memo_info) = app_store.read_component_memo(&rtxn, path)? else {
+        let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
+        let Some(memo_bytes) = app_store.read_component_memo(&mut rtxn, path).await? else {
             return Ok(None);
         };
+        let memo_info: db_schema::ComponentMemoizationInfo<'_> = from_msgpack_slice(&memo_bytes)?;
         if let Some(processor_fp) = processor_fp {
             if memo_info.processor_fp == processor_fp
                 && logic_registry::all_contained_with_env(
@@ -134,7 +136,9 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
         comp_ctx
             .app_ctx()
             .env()
-            .run_txn(move |wtxn| app_store.delete_component_memo(wtxn, &path))
+            .run_txn(move |wtxn| {
+                Box::pin(async move { app_store.delete_component_memo(wtxn, &path).await })
+            })
             .await?;
     }
 
@@ -167,27 +171,33 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
         .app_ctx()
         .env()
         .run_txn(move |wtxn| {
-            let encoded = {
-                let Some(existing) = app_store.read_component_memo(&*wtxn, &path)? else {
-                    return Ok(());
+            Box::pin(async move {
+                let encoded = {
+                    let Some(existing_bytes) = app_store.read_component_memo(wtxn, &path).await?
+                    else {
+                        return Ok(());
+                    };
+                    let existing: db_schema::ComponentMemoizationInfo<'_> =
+                        from_msgpack_slice(&existing_bytes)?;
+                    let new_info = db_schema::ComponentMemoizationInfo {
+                        processor_fp: existing.processor_fp,
+                        return_value: existing.return_value,
+                        logic_deps: existing.logic_deps,
+                        memo_states: memo_states_serialized,
+                        context_memo_states: context_memo_states_serialized,
+                    };
+                    rmp_serde::to_vec_named(&new_info)?
                 };
-                let new_info = db_schema::ComponentMemoizationInfo {
-                    processor_fp: existing.processor_fp,
-                    return_value: existing.return_value,
-                    logic_deps: existing.logic_deps,
-                    memo_states: memo_states_serialized,
-                    context_memo_states: context_memo_states_serialized,
-                };
-                rmp_serde::to_vec_named(&new_info)?
-            };
-            // Borrows from wtxn are released; we can take &mut wtxn for write.
-            app_store.write_component_memo_raw(wtxn, &path, &encoded)
+                app_store
+                    .write_component_memo_raw(wtxn, &path, &encoded)
+                    .await
+            })
         })
         .await?;
     Ok(())
 }
 
-fn write_fn_call_memo<Prof: EngineProfile>(
+async fn write_fn_call_memo<Prof: EngineProfile>(
     wtxn: &mut WriteTxn<'_>,
     app_store: &AppStore,
     comp_ctx: &ComponentProcessorContext<Prof>,
@@ -207,18 +217,24 @@ fn write_fn_call_memo<Prof: EngineProfile>(
         memo_states: memo_states_serialized,
         context_memo_states: context_memo_states_serialized,
     };
-    app_store.write_fn_memo(wtxn, comp_ctx.stable_path(), memo_fp, &fn_call_memo)
+    app_store
+        .write_fn_memo(wtxn, comp_ctx.stable_path(), memo_fp, &fn_call_memo)
+        .await
 }
 
-fn read_fn_call_memo_with_txn<Prof: EngineProfile, T: AnyTxn>(
-    rtxn: &T,
+async fn read_fn_call_memo_with_txn<Prof: EngineProfile, T: AnyTxn>(
+    rtxn: &mut T,
     app_store: &AppStore,
     comp_ctx: &ComponentProcessorContext<Prof>,
     memo_fp: Fingerprint,
 ) -> Result<Option<FnCallMemo<Prof>>> {
-    let Some(fn_call_memo) = app_store.read_fn_memo(rtxn, comp_ctx.stable_path(), memo_fp)? else {
+    let Some(bytes) = app_store
+        .read_fn_memo(rtxn, comp_ctx.stable_path(), memo_fp)
+        .await?
+    else {
         return Ok(None);
     };
+    let fn_call_memo: db_schema::FunctionMemoizationEntry<'_> = from_msgpack_slice(&bytes)?;
     if !logic_registry::all_contained_with_env(&fn_call_memo.logic_deps, comp_ctx.app_ctx().env()) {
         return Ok(None);
     }
@@ -253,8 +269,8 @@ pub(crate) async fn read_fn_call_memo<Prof: EngineProfile>(
     if comp_ctx.full_reprocess() {
         return Ok(None);
     }
-    let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-    read_fn_call_memo_with_txn(&rtxn, comp_ctx.app_ctx().app_store(), comp_ctx, memo_fp)
+    let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
+    read_fn_call_memo_with_txn(&mut rtxn, comp_ctx.app_ctx().app_store(), comp_ctx, memo_fp).await
 }
 
 pub fn declare_target_state<Prof: EngineProfile>(
@@ -374,7 +390,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
     /// Run all DB write operations inside a provided write transaction.
     /// Returns `self` so the caller can use it for post-commit work (e.g. GC).
-    fn commit_in_txn(
+    async fn commit_in_txn(
         mut self,
         wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
@@ -385,14 +401,18 @@ impl<Prof: EngineProfile> Committer<Prof> {
         {
             if self.component_ctx.mode() == ComponentProcessingMode::Delete {
                 self.app_store
-                    .delete_tracking_info(wtxn, &self.component_path)?;
+                    .delete_tracking_info(wtxn, &self.component_path)
+                    .await?;
             } else {
                 let curr_version = curr_version
                     .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;
-                let mut tracking_info: db_schema::StablePathEntryTrackingInfo = self
+                let tracking_info_bytes = self
                     .app_store
-                    .read_tracking_info(&*wtxn, &self.component_path)?
+                    .read_tracking_info(&mut *wtxn, &self.component_path)
+                    .await?
                     .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
+                let mut tracking_info: db_schema::StablePathEntryTrackingInfo<'_> =
+                    from_msgpack_slice(&tracking_info_bytes)?;
 
                 for item in tracking_info.target_state_items.values_mut() {
                     item.states.retain(|(version, state)| {
@@ -449,25 +469,27 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
                 drop(tracking_info); // Release borrow before mutable operations.
                 self.app_store
-                    .write_tracking_info_raw(wtxn, &self.component_path, &data_bytes)?;
+                    .write_tracking_info_raw(wtxn, &self.component_path, &data_bytes)
+                    .await?;
 
                 // Clean up inverted tracking for pruned entries.
                 for path in &pruned_paths {
-                    self.app_store.delete_target_state_owner(wtxn, path)?;
+                    self.app_store.delete_target_state_owner(wtxn, path).await?;
                 }
             }
 
             // Write memos.
             for (fp, memo) in memos_without_mounts_to_store {
-                write_fn_call_memo(wtxn, &self.app_store, &self.component_ctx, fp, memo)?;
+                write_fn_call_memo(wtxn, &self.app_store, &self.component_ctx, fp, memo).await?;
             }
 
             // Delete all function memo entries that are not in the all_memo_fps.
             self.app_store
-                .retain_fn_memos(wtxn, &self.component_path, all_memo_fps)?;
+                .retain_fn_memos(wtxn, &self.component_path, all_memo_fps)
+                .await?;
 
             if !self.demote_component_only {
-                self.update_existence(&mut *wtxn, child_path_set)?;
+                self.update_existence(&mut *wtxn, child_path_set).await?;
             }
         }
 
@@ -486,21 +508,24 @@ impl<Prof: EngineProfile> Committer<Prof> {
         let committer = app_ctx
             .env()
             .run_txn(move |wtxn| {
-                self.commit_in_txn(
-                    wtxn,
-                    child_path_set,
-                    &all_memo_fps,
-                    memos_without_mounts_to_store,
-                    curr_version,
-                )
+                Box::pin(async move {
+                    self.commit_in_txn(
+                        wtxn,
+                        child_path_set,
+                        &all_memo_fps,
+                        memos_without_mounts_to_store,
+                        curr_version,
+                    )
+                    .await
+                })
             })
             .await?;
         // Transaction committed — open a read txn so GC sees the committed tombstones.
-        let rtxn = app_ctx.env().read_txn().await?;
-        committer.launch_child_component_gc(&rtxn)
+        let mut rtxn = app_ctx.env().read_txn().await?;
+        committer.launch_child_component_gc(&mut rtxn).await
     }
 
-    fn update_existence(
+    async fn update_existence(
         &mut self,
         wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
@@ -517,7 +542,10 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 .child_path_set
                 .into_iter()
                 .flat_map(|set| set.children.into_iter());
-            let existing_children = self.app_store.list_child_existence(wtxn, &path_info.path)?;
+            let existing_children = self
+                .app_store
+                .list_child_existence(&mut *wtxn, &path_info.path)
+                .await?;
             let mut existing_iter = existing_children.into_iter();
 
             let mut curr_next = curr_iter.next();
@@ -539,12 +567,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
                         // All remaining existing children should be deleted.
                         if let Some((key, info)) = existing_next.take() {
                             self.app_store
-                                .delete_child_existence(wtxn, &path_info.path, &key)?;
+                                .delete_child_existence(wtxn, &path_info.path, &key)
+                                .await?;
                             self.del_child(&key, &info, &path_info.path)?;
                         }
                         for (key, info) in existing_iter.by_ref() {
                             self.app_store
-                                .delete_child_existence(wtxn, &path_info.path, &key)?;
+                                .delete_child_existence(wtxn, &path_info.path, &key)
+                                .await?;
                             self.del_child(&key, &info, &path_info.path)?;
                         }
                         break;
@@ -561,11 +591,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
                                 // Existing child no longer declared — delete.
                                 let (key, info) =
                                     existing_next.take().ok_or_else(invariance_violation)?;
-                                self.app_store.delete_child_existence(
-                                    wtxn,
-                                    &path_info.path,
-                                    &key,
-                                )?;
+                                self.app_store
+                                    .delete_child_existence(wtxn, &path_info.path, &key)
+                                    .await?;
                                 self.del_child(&key, &info, &path_info.path)?;
                                 existing_next = existing_iter.next();
                             }
@@ -578,14 +606,16 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
                                 // Update the child existence info if the node type changed.
                                 if existing_info.node_type != new_node_type {
-                                    self.app_store.write_child_existence(
-                                        wtxn,
-                                        &path_info.path,
-                                        &curr_key,
-                                        &db_schema::ChildExistenceInfo {
-                                            node_type: new_node_type,
-                                        },
-                                    )?;
+                                    self.app_store
+                                        .write_child_existence(
+                                            wtxn,
+                                            &path_info.path,
+                                            &curr_key,
+                                            &db_schema::ChildExistenceInfo {
+                                                node_type: new_node_type,
+                                            },
+                                        )
+                                        .await?;
                                 }
 
                                 if let StablePathSet::Directory(curr_dir_set) = curr_path_set {
@@ -616,12 +646,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
             for (stable_key, path_set) in children_to_add {
                 let node_type = node_type_for(&path_set);
-                self.app_store.write_child_existence(
-                    wtxn,
-                    &path_info.path,
-                    &stable_key,
-                    &db_schema::ChildExistenceInfo { node_type },
-                )?;
+                self.app_store
+                    .write_child_existence(
+                        wtxn,
+                        &path_info.path,
+                        &stable_key,
+                        &db_schema::ChildExistenceInfo { node_type },
+                    )
+                    .await?;
                 if let StablePathSet::Directory(child_path_set) = path_set {
                     self.existence_processing_queue.push_back(ChildrenPathInfo {
                         path: path_info.path.concat_part(stable_key),
@@ -630,13 +662,17 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 }
             }
 
-            self.flush_component_tombstones(wtxn)?;
+            self.flush_component_tombstones(wtxn).await?;
         }
         Ok(())
     }
 
-    fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &T) -> Result<()> {
-        for relative_path in self.app_store.list_tombstones(rtxn, &self.component_path)? {
+    async fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &mut T) -> Result<()> {
+        for relative_path in self
+            .app_store
+            .list_tombstones(rtxn, &self.component_path)
+            .await?
+        {
             let stable_path = self.component_path.concat(relative_path.as_ref());
             let component = self.component_ctx.component().get_child(stable_path);
             let delete_ctx = component.new_processor_context_for_delete(
@@ -673,10 +709,11 @@ impl<Prof: EngineProfile> Committer<Prof> {
         Ok(())
     }
 
-    fn flush_component_tombstones(&mut self, wtxn: &mut WriteTxn<'_>) -> Result<()> {
+    async fn flush_component_tombstones(&mut self, wtxn: &mut WriteTxn<'_>) -> Result<()> {
         for relative_path in std::mem::take(&mut self.buffered_paths_for_tombstone) {
             self.app_store
-                .write_tombstone(wtxn, &self.component_path, &relative_path)?;
+                .write_tombstone(wtxn, &self.component_path, &relative_path)
+                .await?;
         }
         Ok(())
     }
@@ -755,21 +792,27 @@ enum DeferredWrite {
 }
 
 impl DeferredWrite {
-    fn flush(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
+    async fn flush(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
         match self {
             DeferredWrite::TrackingInfoRaw { path, encoded } => {
-                app_store.write_tracking_info_raw(wtxn, &path, &encoded)
+                app_store
+                    .write_tracking_info_raw(wtxn, &path, &encoded)
+                    .await
             }
             DeferredWrite::OwnerUpsert {
                 target_state_path,
                 component_path,
-            } => app_store.upsert_target_state_owner(wtxn, &target_state_path, &component_path),
+            } => {
+                app_store
+                    .upsert_target_state_owner(wtxn, &target_state_path, &component_path)
+                    .await
+            }
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn pre_commit<Prof: EngineProfile>(
+async fn pre_commit<Prof: EngineProfile>(
     wtxn: &mut WriteTxn<'_>,
     app_store: &AppStore,
     comp_mode: ComponentProcessingMode,
@@ -785,7 +828,7 @@ fn pre_commit<Prof: EngineProfile>(
     let mut processor_name_for_del: Option<String> = None;
 
     if comp_mode == ComponentProcessingMode::Delete {
-        app_store.delete_component_memo(wtxn, stable_path)?;
+        app_store.delete_component_memo(wtxn, stable_path).await?;
     }
 
     if let Some((parent_path, key)) = stable_path.as_ref().split_parent() {
@@ -797,10 +840,11 @@ fn pre_commit<Prof: EngineProfile>(
                     parent_path,
                     key,
                     db_schema::StablePathNodeType::Component,
-                )?;
+                )
+                .await?;
             }
             ComponentProcessingMode::Delete => {
-                let node_type = get_path_node_type(app_store, wtxn, parent_path, key)?;
+                let node_type = get_path_node_type(app_store, wtxn, parent_path, key).await?;
                 match node_type {
                     Some(db_schema::StablePathNodeType::Component) => {
                         return Ok(None);
@@ -815,8 +859,11 @@ fn pre_commit<Prof: EngineProfile>(
     }
 
     let mut id_reservation = IdReservation::new(&TARGET_ID_KEY);
-    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo> =
-        app_store.read_tracking_info(wtxn, stable_path)?;
+    let tracking_info_bytes = app_store.read_tracking_info(wtxn, stable_path).await?;
+    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'_>> = tracking_info_bytes
+        .as_deref()
+        .map(from_msgpack_slice)
+        .transpose()?;
     // Deferred DB writes that will be flushed after tracking_info is dropped,
     // since tracking_info borrows from wtxn and prevents mutable DB operations.
     let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
@@ -869,18 +916,26 @@ fn pre_commit<Prof: EngineProfile>(
                 Some(existing_item)
             } else {
                 // Insert path: check inverted tracking for ownership preempt.
-                match app_store.read_target_state_owner(wtxn, &target_state_path)? {
+                match app_store
+                    .read_target_state_owner(wtxn, &target_state_path)
+                    .await?
+                {
                     Some(owner_info) if owner_info.component_path != *stable_path => {
                         let old_owner_path = owner_info.component_path.clone();
-                        if let Some(mut old_tracking) =
-                            app_store.read_tracking_info(wtxn, &old_owner_path)?
+                        if let Some(old_tracking_bytes) =
+                            app_store.read_tracking_info(wtxn, &old_owner_path).await?
                         {
+                            let mut old_tracking: db_schema::StablePathEntryTrackingInfo<'_> =
+                                from_msgpack_slice(&old_tracking_bytes)?;
                             let len_before = old_tracking.target_state_items.len();
                             // Look up the entry matching current provider_id.
+                            // `into_owned()` releases the borrow on `old_tracking_bytes` so
+                            // `prev_item` can outlive this `if let` block.
                             let prev_item = old_tracking
                                 .target_state_items
                                 .remove(&lookup_key)
-                                .map(|mut item| {
+                                .map(|item| {
+                                    let mut item = item.into_owned();
                                     // Reset version numbers so the new component's commit
                                     // retention prunes them. The old owner's versions are from
                                     // a different version space and may collide with
@@ -960,7 +1015,7 @@ fn pre_commit<Prof: EngineProfile>(
                     let existing_gen = provider_generation.clone().unwrap_or_default();
                     let new_gen = match recon_output.child_invalidation {
                         Some(ChildInvalidation::Destructive) => {
-                            let new_id = id_reservation.next_id(wtxn, app_store)?;
+                            let new_id = id_reservation.next_id(wtxn, app_store).await?;
                             TargetStateProviderGeneration {
                                 provider_id: new_id,
                                 provider_schema_version: 0,
@@ -1123,7 +1178,9 @@ fn pre_commit<Prof: EngineProfile>(
 
         let data_bytes = rmp_serde::to_vec_named(&tracking_info)?;
         drop(tracking_info); // Release borrow before mutable operations.
-        app_store.write_tracking_info_raw(wtxn, stable_path, &data_bytes)?;
+        app_store
+            .write_tracking_info_raw(wtxn, stable_path, &data_bytes)
+            .await?;
         Some(curr_version)
     } else {
         None
@@ -1131,10 +1188,10 @@ fn pre_commit<Prof: EngineProfile>(
 
     // Flush deferred writes now that tracking_info is dropped.
     for dw in deferred_writes {
-        dw.flush(wtxn, app_store)?;
+        dw.flush(wtxn, app_store).await?;
     }
 
-    id_reservation.commit(wtxn, app_store)?;
+    id_reservation.commit(wtxn, app_store).await?;
     Ok(Some(PreCommitOutput {
         curr_version,
         previously_exists,
@@ -1214,17 +1271,20 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         .app_ctx()
         .env()
         .run_txn(move |wtxn| {
-            pre_commit(
-                wtxn,
-                &app_store,
-                comp_mode,
-                &stable_path,
-                full_reprocess,
-                processor_name_owned.as_deref(),
-                &contained_target_state_paths,
-                &target_states_providers_owned,
-                declared_target_states,
-            )
+            Box::pin(async move {
+                pre_commit(
+                    wtxn,
+                    &app_store,
+                    comp_mode,
+                    &stable_path,
+                    full_reprocess,
+                    processor_name_owned.as_deref(),
+                    &contained_target_state_paths,
+                    &target_states_providers_owned,
+                    declared_target_states,
+                )
+                .await
+            })
         })
         .await?;
 
@@ -1333,7 +1393,13 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
     comp_ctx
         .app_ctx()
         .env()
-        .run_txn(move |wtxn| app_store.write_component_memo_raw(wtxn, &path, &encoded))
+        .run_txn(move |wtxn| {
+            Box::pin(async move {
+                app_store
+                    .write_component_memo_raw(wtxn, &path, &encoded)
+                    .await
+            })
+        })
         .await
 }
 
@@ -1353,27 +1419,35 @@ pub(crate) async fn cleanup_tombstone<Prof: EngineProfile>(
     comp_ctx
         .app_ctx()
         .env()
-        .run_txn(move |wtxn| app_store.delete_tombstone(wtxn, &owner_path, &relative_path))
+        .run_txn(move |wtxn| {
+            Box::pin(async move {
+                app_store
+                    .delete_tombstone(wtxn, &owner_path, &relative_path)
+                    .await
+            })
+        })
         .await
 }
 
-pub(crate) fn ensure_path_node_type(
+pub(crate) async fn ensure_path_node_type(
     app_store: &AppStore,
     wtxn: &mut WriteTxn<'_>,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
     target_node_type: db_schema::StablePathNodeType,
 ) -> Result<()> {
-    app_store.ensure_path_node_type(wtxn, parent_path, key, target_node_type)
+    app_store
+        .ensure_path_node_type(wtxn, parent_path, key, target_node_type)
+        .await
 }
 
-fn get_path_node_type<T: AnyTxn>(
+async fn get_path_node_type<T: AnyTxn>(
     app_store: &AppStore,
-    rtxn: &T,
+    rtxn: &mut T,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
 ) -> Result<Option<db_schema::StablePathNodeType>> {
-    app_store.read_path_node_type(rtxn, parent_path, key)
+    app_store.read_path_node_type(rtxn, parent_path, key).await
 }
 
 #[derive(Default)]
@@ -1421,13 +1495,14 @@ async fn finalize_fn_call_memoization<Prof: EngineProfile>(
     // Collect their target_state_paths so those target states are not GC'd.
     // Use a single read transaction for all DB reads.
     if !deps_to_process.is_empty() {
-        let rtxn = comp_ctx.app_ctx().env().read_txn().await?;
+        let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
         let app_store = comp_ctx.app_ctx().app_store();
         while let Some(fp) = deps_to_process.pop_front() {
             if !result.all_memos_fps.insert(fp) {
                 continue;
             }
-            let Some(memo) = read_fn_call_memo_with_txn(&rtxn, app_store, comp_ctx, fp)? else {
+            let Some(memo) = read_fn_call_memo_with_txn(&mut rtxn, app_store, comp_ctx, fp).await?
+            else {
                 continue;
             };
             result

--- a/rust/core/src/engine/id_sequencer.rs
+++ b/rust/core/src/engine/id_sequencer.rs
@@ -107,7 +107,11 @@ impl IdSequencerManager {
             let app_store = app_store.clone();
             let key = key.clone();
             let start_id = storage
-                .run_txn(move |wtxn| app_store.reserve_id_range(wtxn, &key, batch_size))
+                .run_txn(move |wtxn| {
+                    Box::pin(
+                        async move { app_store.reserve_id_range(wtxn, &key, batch_size).await },
+                    )
+                })
                 .await?;
             state.refill(start_id, batch_size);
         }
@@ -140,11 +144,14 @@ impl IdReservation {
     }
 
     /// Allocate the next ID. Reads from DB on first call, then tracks locally.
-    pub fn next_id(&mut self, wtxn: &WriteTxn<'_>, app_store: &AppStore) -> Result<u64> {
+    pub async fn next_id(&mut self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<u64> {
         let next_id = match &mut self.next_id_state {
             Some(n) => n,
             slot @ None => {
-                let current = app_store.peek_id_sequence(wtxn, self.key)?.unwrap_or(1);
+                let current = app_store
+                    .peek_id_sequence(wtxn, self.key)
+                    .await?
+                    .unwrap_or(1);
                 slot.insert(current)
             }
         };
@@ -154,9 +161,9 @@ impl IdReservation {
     }
 
     /// Write the reserved ID range back to DB. Call once at end of transaction.
-    pub fn commit(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
+    pub async fn commit(self, wtxn: &mut WriteTxn<'_>, app_store: &AppStore) -> Result<()> {
         if let Some(next_id) = self.next_id_state {
-            app_store.write_id_sequence(wtxn, self.key, next_id)?;
+            app_store.write_id_sequence(wtxn, self.key, next_id).await?;
         }
         Ok(())
     }

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -555,13 +555,17 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .app_ctx()
                 .env()
                 .run_txn(move |wtxn| {
-                    app_store.remove_child_with_tombstone(
-                        wtxn,
-                        &parent_path,
-                        &child_key,
-                        &component_path,
-                        &relative_child,
-                    )
+                    Box::pin(async move {
+                        app_store
+                            .remove_child_with_tombstone(
+                                wtxn,
+                                &parent_path,
+                                &child_key,
+                                &component_path,
+                                &relative_child,
+                            )
+                            .await
+                    })
                 })
                 .await?;
         }
@@ -798,13 +802,16 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 .app_ctx()
                 .env()
                 .run_txn(move |wtxn| {
-                    crate::engine::execution::ensure_path_node_type(
-                        &app_store,
-                        wtxn,
-                        parent_path.as_ref(),
-                        &child_key,
-                        crate::state::db_schema::StablePathNodeType::Component,
-                    )
+                    Box::pin(async move {
+                        crate::engine::execution::ensure_path_node_type(
+                            &app_store,
+                            wtxn,
+                            parent_path.as_ref(),
+                            &child_key,
+                            crate::state::db_schema::StablePathNodeType::Component,
+                        )
+                        .await
+                    })
                 })
                 .await?;
         }

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -9,10 +9,10 @@ use crate::state::stable_path::StablePath;
 use futures::stream::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
-pub fn list_stable_paths<Prof: EngineProfile>(app: &App<Prof>) -> Result<Vec<StablePath>> {
+pub async fn list_stable_paths<Prof: EngineProfile>(app: &App<Prof>) -> Result<Vec<StablePath>> {
     let app_store = app.app_ctx().app_store();
-    let rtxn = app.app_ctx().env().storage().read_txn_for_inspect()?;
-    app_store.list_all_stable_paths(&rtxn)
+    let mut rtxn = app.app_ctx().env().storage().read_txn_for_inspect().await?;
+    app_store.list_all_stable_paths(&mut rtxn).await
 }
 
 /// Represents a stable path with metadata (e.g. node type); more properties may be added.
@@ -27,23 +27,28 @@ pub use db_schema::StablePathNodeType;
 
 /// Returns a stream of stable paths with their metadata (e.g. node type).
 /// Iteration runs on a dedicated thread (read txns/cursors are !Send); items are sent over a channel.
-pub fn iter_stable_paths<Prof: EngineProfile>(
+pub async fn iter_stable_paths<Prof: EngineProfile>(
     app: &App<Prof>,
-) -> impl Stream<Item = Result<StablePathInfo>> + Send + 'static {
+) -> impl Stream<Item = Result<StablePathInfo>> + Send + 'static + use<Prof> {
     let app_store = app.app_ctx().app_store().clone();
     let storage = app.app_ctx().env().storage().clone();
-    let rx = storage.spawn_iter_stable_paths_with_node_type(app_store);
+    let rx = storage
+        .spawn_iter_stable_paths_with_node_type(app_store)
+        .await;
     receiver_to_stable_path_info_stream(rx)
 }
 
 /// Like [`iter_stable_paths`], but takes an environment and an app name instead of a full `App`.
 /// Opens the app's database read-only; returns an empty stream if the database doesn't exist.
-pub fn iter_stable_paths_by_name<Prof: EngineProfile>(
+pub async fn iter_stable_paths_by_name<Prof: EngineProfile>(
     env: &Environment<Prof>,
     app_name: &str,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<StablePathInfo>> + Send + 'static>>> {
     let storage = env.storage();
-    match storage.spawn_iter_stable_paths_with_node_type_for_app_name(app_name)? {
+    match storage
+        .spawn_iter_stable_paths_with_node_type_for_app_name(app_name)
+        .await?
+    {
         Some(rx) => Ok(Box::pin(receiver_to_stable_path_info_stream(rx))),
         None => Ok(Box::pin(futures::stream::empty())),
     }
@@ -56,6 +61,6 @@ fn receiver_to_stable_path_info_stream(
         .map(|item| item.map(|(path, node_type)| StablePathInfo { path, node_type }))
 }
 
-pub fn list_app_names<Prof: EngineProfile>(env: &Environment<Prof>) -> Result<Vec<String>> {
-    env.storage().list_app_names()
+pub async fn list_app_names<Prof: EngineProfile>(env: &Environment<Prof>) -> Result<Vec<String>> {
+    env.storage().list_app_names().await
 }

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -238,6 +238,15 @@ impl<'a> TargetStateInfoItemState<'a> {
             TargetStateInfoItemState::Existing(s) => Some(s.as_ref()),
         }
     }
+
+    pub fn into_owned(self) -> TargetStateInfoItemState<'static> {
+        match self {
+            TargetStateInfoItemState::Deleted => TargetStateInfoItemState::Deleted,
+            TargetStateInfoItemState::Existing(s) => {
+                TargetStateInfoItemState::Existing(Cow::Owned(s.into_owned()))
+            }
+        }
+    }
 }
 
 fn u64_is_zero(v: &u64) -> bool {
@@ -262,6 +271,21 @@ pub struct TargetStateInfoItem<'a> {
     /// It decides the generation of the provider.
     #[serde(rename = "G", default, skip_serializing_if = "Option::is_none")]
     pub provider_generation: Option<TargetStateProviderGeneration>,
+}
+
+impl<'a> TargetStateInfoItem<'a> {
+    pub fn into_owned(self) -> TargetStateInfoItem<'static> {
+        TargetStateInfoItem {
+            key: Cow::Owned(self.key.into_owned()),
+            states: self
+                .states
+                .into_iter()
+                .map(|(v, s)| (v, s.into_owned()))
+                .collect(),
+            provider_schema_version: self.provider_schema_version,
+            provider_generation: self.provider_generation,
+        }
+    }
 }
 
 /// Inverted tracking: maps a `TargetStatePath` to the component that owns it.

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -5,6 +5,10 @@
 //! [`WriteTxn`](super::WriteTxn) or [`ReadTxn`](super::ReadTxn) (or
 //! anything implementing [`AnyTxn`](super::AnyTxn) for the read-only ops),
 //! and the txn parameter always comes first.
+//!
+//! All I/O methods are `async fn`. The current LMDB implementation is
+//! synchronous internally — the returned futures never yield — but the
+//! async signature future-proofs the API.
 
 use std::collections::HashSet;
 
@@ -13,9 +17,8 @@ use cocoindex_utils::fingerprint::Fingerprint;
 
 use crate::prelude::*;
 use crate::state::db_schema::{
-    ChildExistenceInfo, ComponentMemoizationInfo, DbEntryKey, FunctionMemoizationEntry,
-    IdSequencerInfo, StablePathEntryKey, StablePathEntryTrackingInfo, StablePathNodeType,
-    TargetStateOwnerInfo,
+    ChildExistenceInfo, DbEntryKey, FunctionMemoizationEntry, IdSequencerInfo, StablePathEntryKey,
+    StablePathNodeType, TargetStateOwnerInfo,
 };
 use crate::state::stable_path::{StableKey, StablePath, StablePathPrefix, StablePathRef};
 use crate::state::target_state_path::TargetStatePath;
@@ -100,23 +103,26 @@ fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
 // --- Tracking info -------------------------------------------------------
 
 impl AppStore {
-    pub fn read_tracking_info<'a, T: AnyTxn>(
+    /// Read raw tracking-info bytes. Returns owned bytes (`Vec<u8>`) so the
+    /// caller can deserialize from a local buffer and avoid keeping the txn
+    /// borrowed for the deserialized struct's lifetime. Callers typically
+    /// then do `from_msgpack_slice::<StablePathEntryTrackingInfo>(&bytes)`.
+    pub async fn read_tracking_info<T: AnyTxn>(
         &self,
-        txn: &'a T,
+        txn: &mut T,
         path: &StablePath,
-    ) -> Result<Option<StablePathEntryTrackingInfo<'a>>> {
+    ) -> Result<Option<Vec<u8>>> {
         let key = key_tracking_info(path)?;
-        let data = txn.db_get_bytes(self.db(), &key)?;
-        data.map(from_msgpack_slice).transpose().map_err(Into::into)
+        Ok(txn.db_get_bytes(self.db(), &key)?.map(<[u8]>::to_vec))
     }
 
     /// Write pre-serialized tracking info. Callers serialize externally so
     /// the txn can be re-borrowed mutably after the read-modify-write
     /// pattern used in `pre_commit` (the deserialized `tracking_info`
     /// borrows from the write txn and must be released before writing back).
-    pub fn write_tracking_info_raw(
+    pub async fn write_tracking_info_raw(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
         encoded: &[u8],
     ) -> Result<()> {
@@ -125,7 +131,11 @@ impl AppStore {
         Ok(())
     }
 
-    pub fn delete_tracking_info(&self, txn: &mut WriteTxn, path: &StablePath) -> Result<()> {
+    pub async fn delete_tracking_info(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        path: &StablePath,
+    ) -> Result<()> {
         let key = key_tracking_info(path)?;
         self.db().delete(&mut **txn, &key)?;
         Ok(())
@@ -135,22 +145,23 @@ impl AppStore {
 // --- Component memoization -----------------------------------------------
 
 impl AppStore {
-    pub fn read_component_memo<'a, T: AnyTxn>(
+    /// Read raw component-memo bytes. See [`Self::read_tracking_info`] for
+    /// the owned-bytes return rationale.
+    pub async fn read_component_memo<T: AnyTxn>(
         &self,
-        txn: &'a T,
+        txn: &mut T,
         path: &StablePath,
-    ) -> Result<Option<ComponentMemoizationInfo<'a>>> {
+    ) -> Result<Option<Vec<u8>>> {
         let key = key_component_memo(path)?;
-        let data = txn.db_get_bytes(self.db(), &key)?;
-        data.map(from_msgpack_slice).transpose().map_err(Into::into)
+        Ok(txn.db_get_bytes(self.db(), &key)?.map(<[u8]>::to_vec))
     }
 
     /// Write a pre-serialized component memo. Callers serialize externally
     /// for the read-modify-write pattern (see `update_component_memo_states`
     /// in engine code).
-    pub fn write_component_memo_raw(
+    pub async fn write_component_memo_raw(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
         encoded: &[u8],
     ) -> Result<()> {
@@ -159,7 +170,11 @@ impl AppStore {
         Ok(())
     }
 
-    pub fn delete_component_memo(&self, txn: &mut WriteTxn, path: &StablePath) -> Result<()> {
+    pub async fn delete_component_memo(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        path: &StablePath,
+    ) -> Result<()> {
         let key = key_component_memo(path)?;
         self.db().delete(&mut **txn, &key)?;
         Ok(())
@@ -169,20 +184,21 @@ impl AppStore {
 // --- Function memoization ------------------------------------------------
 
 impl AppStore {
-    pub fn read_fn_memo<'a, T: AnyTxn>(
+    /// Read raw function-memo bytes. See [`Self::read_tracking_info`] for
+    /// the owned-bytes return rationale.
+    pub async fn read_fn_memo<T: AnyTxn>(
         &self,
-        txn: &'a T,
+        txn: &mut T,
         path: &StablePath,
         fp: Fingerprint,
-    ) -> Result<Option<FunctionMemoizationEntry<'a>>> {
+    ) -> Result<Option<Vec<u8>>> {
         let key = key_fn_memo(path, fp)?;
-        let data = txn.db_get_bytes(self.db(), &key)?;
-        data.map(from_msgpack_slice).transpose().map_err(Into::into)
+        Ok(txn.db_get_bytes(self.db(), &key)?.map(<[u8]>::to_vec))
     }
 
-    pub fn write_fn_memo(
+    pub async fn write_fn_memo(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
         fp: Fingerprint,
         entry: &FunctionMemoizationEntry<'_>,
@@ -194,9 +210,9 @@ impl AppStore {
     }
 
     /// GC: delete all function memos for `path` whose fingerprint is NOT in `keep`.
-    pub fn retain_fn_memos(
+    pub async fn retain_fn_memos(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
         keep: &HashSet<Fingerprint>,
     ) -> Result<()> {
@@ -220,9 +236,9 @@ impl AppStore {
 // --- Child existence -----------------------------------------------------
 
 impl AppStore {
-    pub fn read_child_existence<T: AnyTxn>(
+    pub async fn read_child_existence<T: AnyTxn>(
         &self,
-        txn: &T,
+        txn: &mut T,
         parent: &StablePath,
         child_key: &StableKey,
     ) -> Result<Option<ChildExistenceInfo>> {
@@ -231,9 +247,9 @@ impl AppStore {
         data.map(from_msgpack_slice).transpose().map_err(Into::into)
     }
 
-    pub fn write_child_existence(
+    pub async fn write_child_existence(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         child_key: &StableKey,
         info: &ChildExistenceInfo,
@@ -244,9 +260,9 @@ impl AppStore {
         Ok(())
     }
 
-    pub fn delete_child_existence(
+    pub async fn delete_child_existence(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         child_key: &StableKey,
     ) -> Result<()> {
@@ -260,9 +276,9 @@ impl AppStore {
     /// encoding via `storekey` is order-preserving). Used by
     /// `Committer::update_existence` for the sorted-merge against the
     /// in-memory declared children.
-    pub fn list_child_existence<T: AnyTxn>(
+    pub async fn list_child_existence<T: AnyTxn>(
         &self,
-        txn: &T,
+        txn: &mut T,
         parent: &StablePath,
     ) -> Result<Vec<(StableKey, ChildExistenceInfo)>> {
         let prefix = key_child_existence_prefix(parent)?;
@@ -280,9 +296,9 @@ impl AppStore {
 // --- Tombstones ----------------------------------------------------------
 
 impl AppStore {
-    pub fn write_tombstone(
+    pub async fn write_tombstone(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         relative_path: &StablePath,
     ) -> Result<()> {
@@ -291,9 +307,9 @@ impl AppStore {
         Ok(())
     }
 
-    pub fn delete_tombstone(
+    pub async fn delete_tombstone(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         relative_path: &StablePath,
     ) -> Result<()> {
@@ -304,9 +320,9 @@ impl AppStore {
 
     /// Relative paths of all tombstones for `parent`. Used by
     /// `Committer::launch_child_component_gc` to find which children need GC.
-    pub fn list_tombstones<T: AnyTxn>(
+    pub async fn list_tombstones<T: AnyTxn>(
         &self,
-        txn: &T,
+        txn: &mut T,
         parent: &StablePath,
     ) -> Result<Vec<StablePath>> {
         let prefix = key_tombstone_prefix(parent)?;
@@ -321,16 +337,17 @@ impl AppStore {
 
     /// Atomic existence-removal + tombstone-write, matching the contract of
     /// `LiveComponentController::delete`'s synchronous step.
-    pub fn remove_child_with_tombstone(
+    pub async fn remove_child_with_tombstone(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         child_key: &StableKey,
         owner_path: &StablePath,
         relative_child: &StablePath,
     ) -> Result<()> {
-        self.delete_child_existence(txn, parent, child_key)?;
-        self.write_tombstone(txn, owner_path, relative_child)?;
+        self.delete_child_existence(txn, parent, child_key).await?;
+        self.write_tombstone(txn, owner_path, relative_child)
+            .await?;
         Ok(())
     }
 }
@@ -338,9 +355,9 @@ impl AppStore {
 // --- Inverted target-state owner index -----------------------------------
 
 impl AppStore {
-    pub fn read_target_state_owner<T: AnyTxn>(
+    pub async fn read_target_state_owner<T: AnyTxn>(
         &self,
-        txn: &T,
+        txn: &mut T,
         path: &TargetStatePath,
     ) -> Result<Option<TargetStateOwnerInfo>> {
         let key = key_target_state_owner(path)?;
@@ -348,9 +365,9 @@ impl AppStore {
         data.map(from_msgpack_slice).transpose().map_err(Into::into)
     }
 
-    pub fn upsert_target_state_owner(
+    pub async fn upsert_target_state_owner(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &TargetStatePath,
         owner: &StablePath,
     ) -> Result<()> {
@@ -362,9 +379,9 @@ impl AppStore {
         Ok(())
     }
 
-    pub fn delete_target_state_owner(
+    pub async fn delete_target_state_owner(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         path: &TargetStatePath,
     ) -> Result<()> {
         let key = key_target_state_owner(path)?;
@@ -376,7 +393,11 @@ impl AppStore {
 // --- ID sequencer --------------------------------------------------------
 
 impl AppStore {
-    pub fn peek_id_sequence<T: AnyTxn>(&self, txn: &T, key: &StableKey) -> Result<Option<u64>> {
+    pub async fn peek_id_sequence<T: AnyTxn>(
+        &self,
+        txn: &mut T,
+        key: &StableKey,
+    ) -> Result<Option<u64>> {
         let db_key = key_id_sequencer(key)?;
         let data = txn.db_get_bytes(self.db(), &db_key)?;
         match data {
@@ -388,9 +409,9 @@ impl AppStore {
         }
     }
 
-    pub fn write_id_sequence(
+    pub async fn write_id_sequence(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         key: &StableKey,
         next_id: u64,
     ) -> Result<()> {
@@ -404,9 +425,15 @@ impl AppStore {
     /// Atomically reserve `count` consecutive IDs starting from the next
     /// available ID. Returns the first reserved ID. IDs start at 1
     /// (0 is reserved).
-    pub fn reserve_id_range(&self, txn: &mut WriteTxn, key: &StableKey, count: u64) -> Result<u64> {
-        let current_next_id = self.peek_id_sequence(txn, key)?.unwrap_or(1);
-        self.write_id_sequence(txn, key, current_next_id + count)?;
+    pub async fn reserve_id_range(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        key: &StableKey,
+        count: u64,
+    ) -> Result<u64> {
+        let current_next_id = self.peek_id_sequence(&mut *txn, key).await?.unwrap_or(1);
+        self.write_id_sequence(txn, key, current_next_id + count)
+            .await?;
         Ok(current_next_id)
     }
 }
@@ -414,7 +441,7 @@ impl AppStore {
 // --- App-level -----------------------------------------------------------
 
 impl AppStore {
-    pub fn clear_all(&self, txn: &mut WriteTxn) -> Result<()> {
+    pub async fn clear_all(&self, txn: &mut WriteTxn<'_>) -> Result<()> {
         self.db().clear(&mut **txn)?;
         Ok(())
     }
@@ -425,14 +452,14 @@ impl AppStore {
 impl AppStore {
     /// Looks up the node type of `parent_path/key` by reading the parent's
     /// child-existence entry. Used by `pre_commit` path-existence checks.
-    pub fn read_path_node_type<T: AnyTxn>(
+    pub async fn read_path_node_type<T: AnyTxn>(
         &self,
-        txn: &T,
+        txn: &mut T,
         parent_path: StablePathRef<'_>,
         key: &StableKey,
     ) -> Result<Option<StablePathNodeType>> {
         let parent_owned: StablePath = parent_path.into();
-        let info = self.read_child_existence(txn, &parent_owned, key)?;
+        let info = self.read_child_existence(txn, &parent_owned, key).await?;
         Ok(info.map(|i| i.node_type))
     }
 
@@ -443,15 +470,15 @@ impl AppStore {
     /// - missing → write `target_node_type`
     /// - `Directory` + target=`Component` → upgrade to Component
     /// - anything else → no-op
-    pub fn ensure_path_node_type(
+    pub async fn ensure_path_node_type(
         &self,
-        txn: &mut WriteTxn,
+        txn: &mut WriteTxn<'_>,
         parent_path: StablePathRef<'_>,
         key: &StableKey,
         target_node_type: StablePathNodeType,
     ) -> Result<()> {
         let parent_owned: StablePath = parent_path.into();
-        let existing = self.read_child_existence(txn, &parent_owned, key)?;
+        let existing = self.read_child_existence(txn, &parent_owned, key).await?;
         let existing_node_type = existing.as_ref().map(|i| i.node_type);
         match (existing_node_type, target_node_type) {
             (None, _) | (Some(StablePathNodeType::Directory), StablePathNodeType::Component) => {
@@ -462,7 +489,8 @@ impl AppStore {
                     &ChildExistenceInfo {
                         node_type: target_node_type,
                     },
-                )?;
+                )
+                .await?;
             }
             _ => {
                 // No-op for all other cases
@@ -471,7 +499,13 @@ impl AppStore {
         if existing_node_type.is_none()
             && let Some((parent, key)) = parent_path.split_parent()
         {
-            return self.ensure_path_node_type(txn, parent, key, StablePathNodeType::Directory);
+            return Box::pin(self.ensure_path_node_type(
+                txn,
+                parent,
+                key,
+                StablePathNodeType::Directory,
+            ))
+            .await;
         }
         Ok(())
     }
@@ -482,7 +516,7 @@ impl AppStore {
 impl AppStore {
     /// Scan all stable-path entries in this app and return one path per
     /// component / directory.
-    pub fn list_all_stable_paths(&self, txn: &ReadTxn) -> Result<Vec<StablePath>> {
+    pub async fn list_all_stable_paths(&self, txn: &mut ReadTxn<'_>) -> Result<Vec<StablePath>> {
         let encoded_key_prefix =
             DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
         let db = self.db();

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -16,6 +16,7 @@ use crate::state_store::txn::{ReadTxn, WriteTxn};
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::retryable;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::path::{Path, PathBuf};
@@ -70,12 +71,16 @@ struct StorageInner {
     batcher: Batcher<TxnRunner>,
 }
 
-/// Type-erased body for a batched write transaction. Runs inside a shared
-/// `WriteTxn`, returns a boxed output value.
-type TxnBody = Box<dyn for<'txn> FnOnce(&mut WriteTxn<'txn>) -> Result<Box<dyn Any + Send>> + Send>;
+/// Type-erased body for a batched write transaction. Each body returns a
+/// future that runs against the shared `WriteTxn` and resolves to a boxed
+/// output. The future is bound to the borrow of the txn (`'a`).
+type TxnBody = Box<
+    dyn for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<Box<dyn Any + Send>>>
+        + Send,
+>;
 
 /// `Runner` implementation that opens a single write txn, runs each batched
-/// closure against it, then commits.
+/// body against it (awaiting in turn), then commits.
 struct TxnRunner {
     db_env: heed::Env<heed::WithoutTls>,
 }
@@ -92,7 +97,7 @@ impl Runner for TxnRunner {
         let mut outputs = Vec::with_capacity(inputs.len());
         let mut wtxn = WriteTxn::new(self.db_env.write_txn()?);
         for body in inputs {
-            outputs.push(body(&mut wtxn)?);
+            outputs.push(body(&mut wtxn).await?);
         }
         wtxn.into_inner().commit()?;
         Ok(outputs.into_iter())
@@ -100,7 +105,7 @@ impl Runner for TxnRunner {
 }
 
 impl Storage {
-    pub fn new(settings: &StorageSettings) -> Result<Self> {
+    pub async fn new(settings: &StorageSettings) -> Result<Self> {
         let db_path = settings.db_path.join("mdb");
         std::fs::create_dir_all(&db_path)?;
         // Backward compatibility: migrate files from old layout into mdb/.
@@ -159,24 +164,33 @@ impl Storage {
 
     /// Run `body` inside a batched write transaction.
     ///
-    /// Multiple concurrent callers' closures are coalesced into a single
-    /// underlying write txn for throughput. FIFO: the first caller executes
-    /// inline; concurrent callers queue up and are flushed together once
-    /// the current batch commits. If any closure in a batch returns `Err`,
-    /// the whole batch is rolled back (the `WriteTxn` is dropped without
-    /// committing) and every caller in the batch receives an error.
+    /// `body` receives `&mut WriteTxn` and returns a `Send` future (typically
+    /// `Box::pin(async move { … })`). Multiple concurrent callers' bodies are
+    /// coalesced into a single underlying write txn for throughput. FIFO:
+    /// the first caller executes inline; concurrent callers queue up and are
+    /// flushed together once the current batch commits. Bodies within a
+    /// batch are awaited sequentially against the same txn. If any body
+    /// resolves to `Err`, the whole batch is rolled back (the `WriteTxn` is
+    /// dropped without committing) and every caller in the batch receives
+    /// an error.
+    ///
+    /// The future must be boxed (`BoxFuture<'a, _>` = `Pin<Box<dyn Future +
+    /// Send + 'a>>`) because stable Rust can't yet express a `Send` bound on
+    /// the future returned by an `AsyncFnOnce` borrowing from the txn.
     pub async fn run_txn<T, F>(&self, body: F) -> Result<T>
     where
         T: Send + 'static,
-        F: for<'txn> FnOnce(&mut WriteTxn<'txn>) -> Result<T> + Send + 'static,
+        F: for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<T>>
+            + Send
+            + 'static,
     {
-        let output = self
-            .inner
-            .batcher
-            .run(Box::new(move |wtxn| {
-                Ok(Box::new(body(wtxn)?) as Box<dyn Any + Send>)
-            }))
-            .await?;
+        let erased: TxnBody = Box::new(move |wtxn| {
+            Box::pin(async move {
+                let value = body(wtxn).await?;
+                Ok(Box::new(value) as Box<dyn Any + Send>)
+            })
+        });
+        let output = self.inner.batcher.run(erased).await?;
         output
             .downcast::<T>()
             .map(|b| *b)
@@ -184,7 +198,7 @@ impl Storage {
     }
 
     /// Create the per-app sub-database and wrap it in an `AppStore`.
-    pub fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
+    pub async fn create_app_store(&self, app_name: &str) -> Result<AppStore> {
         let mut wtxn = self.inner.db_env.write_txn()?;
         let db = self
             .inner
@@ -196,7 +210,7 @@ impl Storage {
 
     /// Open the per-app sub-database by name, or `None` if it doesn't exist.
     /// Opens an internal read transaction for the lookup.
-    pub fn open_app_store_by_name(&self, app_name: &str) -> Result<Option<AppStore>> {
+    pub async fn open_app_store_by_name(&self, app_name: &str) -> Result<Option<AppStore>> {
         let rtxn = self.inner.db_env.read_txn()?;
         let db: Option<Database> = self.inner.db_env.open_database(&rtxn, Some(app_name))?;
         Ok(db.map(AppStore::new))
@@ -241,17 +255,17 @@ impl Storage {
             .map_err(Into::into)
     }
 
-    /// Synchronous, non-retrying read txn for inspection use. Callers tolerate
+    /// Non-retrying read txn for inspection use. Callers tolerate
     /// `MDB_READERS_FULL` at a higher level rather than going through the
     /// engine's two-phase retry path.
-    pub fn read_txn_for_inspect(&self) -> Result<ReadTxn<'_>> {
+    pub async fn read_txn_for_inspect(&self) -> Result<ReadTxn<'_>> {
         Ok(ReadTxn::new(self.inner.db_env.read_txn()?))
     }
 
     /// Spawn a thread that streams every `(StablePath, node_type)` entry
     /// from `app_store` via a channel. A dedicated thread is needed because
     /// LMDB read transactions and cursors are `!Send`.
-    pub fn spawn_iter_stable_paths_with_node_type(
+    pub async fn spawn_iter_stable_paths_with_node_type(
         &self,
         app_store: AppStore,
     ) -> tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>> {
@@ -321,17 +335,20 @@ impl Storage {
 
     /// Resolves the app store by name, then spawns the stable-path iteration
     /// thread. Returns `None` if the app's database doesn't exist.
-    pub fn spawn_iter_stable_paths_with_node_type_for_app_name(
+    pub async fn spawn_iter_stable_paths_with_node_type_for_app_name(
         &self,
         app_name: &str,
     ) -> Result<Option<tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>>>> {
-        let app_store = self.open_app_store_by_name(app_name)?;
-        Ok(app_store.map(|store| self.spawn_iter_stable_paths_with_node_type(store)))
+        let app_store = self.open_app_store_by_name(app_name).await?;
+        Ok(match app_store {
+            Some(store) => Some(self.spawn_iter_stable_paths_with_node_type(store).await),
+            None => None,
+        })
     }
 
     /// List every non-empty named app sub-store in this storage environment.
     /// The "unnamed database" is LMDB's catalog of named sub-databases.
-    pub fn list_app_names(&self) -> Result<Vec<String>> {
+    pub async fn list_app_names(&self) -> Result<Vec<String>> {
         let db_env = &self.inner.db_env;
         let rtxn = db_env.read_txn()?;
         let unnamed: heed::Database<heed::types::Str, heed::types::DecodeIgnore> = db_env

--- a/rust/core/src/state_store/txn.rs
+++ b/rust/core/src/state_store/txn.rs
@@ -60,17 +60,24 @@ impl<'env> Deref for ReadTxn<'env> {
 ///
 /// The trait is sealed — only the two wrapper types implement it. The hidden
 /// methods are accessed within this module via `pub(crate)` visibility.
+///
+/// The methods take `&mut self`. They don't actually mutate the txn — but
+/// the LMDB-backed transactions wrap `!Sync` raw pointers, so a `&Self`
+/// borrow would make any async future capturing this txn `!Send`. Using
+/// `&mut self` keeps borrows `Send`, at the cost of forcing read methods to
+/// be called sequentially (which they are anyway — there's no parallelism
+/// to lose).
 pub trait AnyTxn: sealed::Sealed {
     #[doc(hidden)]
     fn db_get_bytes<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         key: &[u8],
     ) -> crate::prelude::Result<Option<&'a [u8]>>;
 
     #[doc(hidden)]
     fn db_prefix_iter<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         prefix: &[u8],
     ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>>;
@@ -84,7 +91,7 @@ mod sealed {
 
 impl<'env> AnyTxn for ReadTxn<'env> {
     fn db_get_bytes<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         key: &[u8],
     ) -> crate::prelude::Result<Option<&'a [u8]>> {
@@ -92,7 +99,7 @@ impl<'env> AnyTxn for ReadTxn<'env> {
     }
 
     fn db_prefix_iter<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         prefix: &[u8],
     ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {
@@ -102,7 +109,7 @@ impl<'env> AnyTxn for ReadTxn<'env> {
 
 impl<'env> AnyTxn for WriteTxn<'env> {
     fn db_get_bytes<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         key: &[u8],
     ) -> crate::prelude::Result<Option<&'a [u8]>> {
@@ -110,7 +117,7 @@ impl<'env> AnyTxn for WriteTxn<'env> {
     }
 
     fn db_prefix_iter<'a>(
-        &'a self,
+        &'a mut self,
         db: Database,
         prefix: &[u8],
     ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {

--- a/rust/py/src/app.rs
+++ b/rust/py/src/app.rs
@@ -166,11 +166,19 @@ impl PyApp {
     #[new]
     #[pyo3(signature = (name, env, max_inflight_components=None))]
     pub fn new(
+        py: Python<'_>,
         name: &str,
         env: &PyEnvironment,
         max_inflight_components: Option<usize>,
     ) -> PyResult<Self> {
-        let app = App::new(name, env.0.clone(), max_inflight_components)
+        let name_owned = name.to_string();
+        let env = env.0.clone();
+        let app = py
+            .detach(|| {
+                get_runtime().block_on(async move {
+                    App::new(&name_owned, env, max_inflight_components).await
+                })
+            })
             .context(format!("failed to initialize app '{name}'"))
             .into_py_result()?;
         Ok(Self(Arc::new(app)))

--- a/rust/py/src/environment.rs
+++ b/rust/py/src/environment.rs
@@ -4,6 +4,7 @@ use crate::{prelude::*, target_state::root_target_states_provider_registry};
 
 use crate::runtime::PyAsyncContext;
 use cocoindex_core::engine::environment::{Environment, EnvironmentSettings};
+use cocoindex_core::engine::runtime::get_runtime;
 use cocoindex_py_utils::Pythonized;
 
 #[pyclass(name = "Environment")]
@@ -13,16 +14,23 @@ pub struct PyEnvironment(pub Environment<PyEngineProfile>);
 impl PyEnvironment {
     #[new]
     pub fn new(
+        py: Python<'_>,
         settings: Pythonized<EnvironmentSettings>,
         async_context: PyAsyncContext,
     ) -> PyResult<Self> {
         let settings = settings.into_inner();
-        let environment = Environment::<PyEngineProfile>::new(
-            settings,
-            root_target_states_provider_registry().clone(),
-            async_context,
-        )
-        .into_py_result()?;
+        let environment = py
+            .detach(|| {
+                get_runtime().block_on(async move {
+                    Environment::<PyEngineProfile>::new(
+                        settings,
+                        root_target_states_provider_registry().clone(),
+                        async_context,
+                    )
+                    .await
+                })
+            })
+            .into_py_result()?;
         Ok(Self(environment))
     }
 

--- a/rust/py/src/inspect.rs
+++ b/rust/py/src/inspect.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::{app::PyApp, environment::PyEnvironment, prelude::*, stable_path::PyStablePath};
 
+use cocoindex_core::engine::runtime::get_runtime;
 use cocoindex_core::inspect::db_inspect;
 use cocoindex_core::inspect::db_inspect::StablePathNodeType;
 use futures::stream::Stream;
@@ -10,8 +11,11 @@ use pyo3::exceptions::PyStopAsyncIteration;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 #[pyfunction]
-pub fn list_stable_paths(app: &PyApp) -> PyResult<Vec<PyStablePath>> {
-    let stable_paths = db_inspect::list_stable_paths(&app.0).into_py_result()?;
+pub fn list_stable_paths(py: Python<'_>, app: &PyApp) -> PyResult<Vec<PyStablePath>> {
+    let app = app.0.clone();
+    let stable_paths = py
+        .detach(|| get_runtime().block_on(async move { db_inspect::list_stable_paths(&app).await }))
+        .into_py_result()?;
     let py_stable_paths = stable_paths
         .into_iter()
         .map(|path| PyStablePath(path))
@@ -106,7 +110,9 @@ impl PyStablePathInfoAsyncIterator {
 #[pyfunction]
 pub fn iter_stable_paths<'py>(app: &PyApp, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
     let app_clone = app.0.clone();
-    let stream = db_inspect::iter_stable_paths(&app_clone);
+    let stream = py.detach(|| {
+        get_runtime().block_on(async move { db_inspect::iter_stable_paths(&app_clone).await })
+    });
     wrap_stream_as_async_iterator(stream, py)
 }
 
@@ -116,7 +122,15 @@ pub fn iter_stable_paths_by_name<'py>(
     app_name: &str,
     py: Python<'py>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let stream = db_inspect::iter_stable_paths_by_name(&env.0, app_name).into_py_result()?;
+    let env_clone = env.0.clone();
+    let app_name = app_name.to_string();
+    let stream = py
+        .detach(|| {
+            get_runtime().block_on(async move {
+                db_inspect::iter_stable_paths_by_name(&env_clone, &app_name).await
+            })
+        })
+        .into_py_result()?;
     wrap_stream_as_async_iterator(stream, py)
 }
 
@@ -136,6 +150,10 @@ fn wrap_stream_as_async_iterator<'py>(
 }
 
 #[pyfunction]
-pub fn list_app_names(env: &PyEnvironment) -> PyResult<Vec<String>> {
-    db_inspect::list_app_names(&env.0).into_py_result()
+pub fn list_app_names(py: Python<'_>, env: &PyEnvironment) -> PyResult<Vec<String>> {
+    let env_clone = env.0.clone();
+    py.detach(|| {
+        get_runtime().block_on(async move { db_inspect::list_app_names(&env_clone).await })
+    })
+    .into_py_result()
 }

--- a/rust/sdk/cocoindex/src/app.rs
+++ b/rust/sdk/cocoindex/src/app.rs
@@ -55,7 +55,7 @@ impl AppBuilder {
     ///
     /// Returns an error if the LMDB database environment fails to initialize
     /// (e.g., due to permissions, disk space, or a corrupted state directory).
-    pub fn build(self) -> Result<App> {
+    pub async fn build(self) -> Result<App> {
         let db_path = self
             .db_path
             .unwrap_or_else(|| PathBuf::from(format!("./coco_state/{}/", self.name)));
@@ -69,8 +69,10 @@ impl AppBuilder {
             Default::default(),
         )));
         let env = Environment::<RustProfile>::new(settings, providers, ())
+            .await
             .map_err(|e| Error::engine(format!("failed to open LMDB: {e}")))?;
         let core_app = CoreApp::new(&self.name, env, None)
+            .await
             .map_err(|e| Error::engine(format!("failed to create app: {e}")))?;
 
         Ok(App {
@@ -80,6 +82,14 @@ impl AppBuilder {
                 state: self.state,
             }),
         })
+    }
+
+    /// Build the app (blocking). Convenience for sync callers — creates a
+    /// tokio runtime internally and awaits [`Self::build`].
+    pub fn build_blocking(self) -> Result<App> {
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| Error::engine(format!("failed to create tokio runtime: {e}")))?;
+        rt.block_on(self.build())
     }
 }
 
@@ -113,14 +123,14 @@ pub struct App {
 
 impl App {
     /// Convenience: open an app with a specific DB path. Equivalent to
-    /// `App::builder(name).db_path(db_path).build()`.
+    /// `App::builder(name).db_path(db_path).build().await`.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use cocoindex::app::App;
-    /// # fn main() -> cocoindex::error::Result<()> {
-    /// let app = App::open("my_app", "./data")?;
+    /// # async fn run() -> cocoindex::error::Result<()> {
+    /// let app = App::open("my_app", "./data").await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -128,8 +138,14 @@ impl App {
     /// # Errors
     ///
     /// Returns an error if the LMDB database environment fails to initialize.
-    pub fn open(name: &str, db_path: impl Into<PathBuf>) -> Result<App> {
-        App::builder(name).db_path(db_path).build()
+    pub async fn open(name: &str, db_path: impl Into<PathBuf>) -> Result<App> {
+        App::builder(name).db_path(db_path).build().await
+    }
+
+    /// Convenience: synchronously open an app with a specific DB path. Same
+    /// as [`Self::open`] but blocks on a tokio runtime internally.
+    pub fn open_blocking(name: &str, db_path: impl Into<PathBuf>) -> Result<App> {
+        App::builder(name).db_path(db_path).build_blocking()
     }
 
     /// Start building an app. Name determines the LMDB database namespace.
@@ -138,11 +154,12 @@ impl App {
     ///
     /// ```no_run
     /// # use cocoindex::app::App;
-    /// # fn main() -> cocoindex::error::Result<()> {
+    /// # async fn run() -> cocoindex::error::Result<()> {
     /// let app = App::builder("my_app")
     ///     .db_path("./data")
     ///     .provide(String::from("shared resource"))
-    ///     .build()?;
+    ///     .build()
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -162,7 +179,7 @@ impl App {
     /// ```no_run
     /// # use cocoindex::app::App;
     /// # async fn run() -> cocoindex::error::Result<()> {
-    /// let app = App::open("my_app", "./data")?;
+    /// let app = App::open("my_app", "./data").await?;
     /// let stats = app.run(|ctx| async move {
     ///     // ... pipeline logic ...
     ///     Ok(())
@@ -196,7 +213,7 @@ impl App {
     /// ```no_run
     /// # use cocoindex::app::App;
     /// # async fn doc() -> cocoindex::error::Result<()> {
-    /// let app = App::open("my_app", "./data")?;
+    /// let app = App::open("my_app", "./data").await?;
     /// app.update(|ctx| async move {
     ///     // ... update logic ...
     ///     Ok(())

--- a/rust/sdk/cocoindex/tests/memo_batch_regressions.rs
+++ b/rust/sdk/cocoindex/tests/memo_batch_regressions.rs
@@ -5,11 +5,12 @@ use cocoindex::App;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Focused regression tests for `memo::batch` edge cases.
-fn temp_app(name: &str) -> (App, tempfile::TempDir) {
+async fn temp_app(name: &str) -> (App, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let app = App::builder(name)
         .db_path(dir.path().join("lmdb"))
         .build()
+        .await
         .unwrap();
     (app, dir)
 }
@@ -45,7 +46,7 @@ async fn batch_serialization_error_releases_previous_pending_entries() {
         }
     }
 
-    let (app, _dir) = temp_app("batch_serialize_fail");
+    let (app, _dir) = temp_app("batch_serialize_fail").await;
     let first_calls = Arc::new(AtomicUsize::new(0));
     let first_calls_for_run = first_calls.clone();
     let result = app
@@ -153,7 +154,7 @@ async fn batch_fingerprint_error_releases_previous_pending_entries() {
         }
     }
 
-    let (app, _dir) = temp_app("batch_fingerprint_fail");
+    let (app, _dir) = temp_app("batch_fingerprint_fail").await;
     let first_calls = Arc::new(AtomicUsize::new(0));
     let first_calls_for_run = first_calls.clone();
     let result = app
@@ -211,7 +212,7 @@ async fn batch_fingerprint_error_releases_previous_pending_entries() {
 
 #[tokio::test]
 async fn batch_returns_error_when_mismatch_count() {
-    let (app, _dir) = temp_app("batch_result_mismatch");
+    let (app, _dir) = temp_app("batch_result_mismatch").await;
     let result = app
         .update(|ctx| async move {
             let items = vec![1, 2, 3];

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -3,12 +3,24 @@
 use cocoindex::App;
 use tokio::time::{Duration, sleep};
 
-/// Helper: create an App with a temp LMDB directory.
-fn temp_app(name: &str) -> (App, tempfile::TempDir) {
+/// Helper: create an App with a temp LMDB directory (async tests).
+async fn temp_app(name: &str) -> (App, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let app = App::builder(name)
         .db_path(dir.path().join("lmdb"))
         .build()
+        .await
+        .unwrap();
+    (app, dir)
+}
+
+/// Helper: create an App with a temp LMDB directory (sync tests). Uses
+/// the `_blocking` variant so it can be called from `#[test]` functions.
+fn temp_app_blocking(name: &str) -> (App, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let app = App::builder(name)
+        .db_path(dir.path().join("lmdb"))
+        .build_blocking()
         .unwrap();
     (app, dir)
 }
@@ -19,14 +31,14 @@ fn temp_app(name: &str) -> (App, tempfile::TempDir) {
 
 #[test]
 fn update_blocking_runs_closure() {
-    let (app, _dir) = temp_app("sync_basic");
+    let (app, _dir) = temp_app_blocking("sync_basic");
     let result = app.update_blocking(|_ctx| async move { Ok(()) });
     assert!(result.is_ok());
 }
 
 #[test]
 fn update_blocking_provides_pipeline_context() {
-    let (app, _dir) = temp_app("sync_ctx");
+    let (app, _dir) = temp_app_blocking("sync_ctx");
     app.update_blocking(|ctx| async move {
         assert!(ctx.has_pipeline_context());
         Ok(())
@@ -45,7 +57,7 @@ fn update_blocking_provide_and_get() {
     let app = App::builder("sync_provide")
         .db_path(dir.path().join("lmdb"))
         .provide(Config { value: 42 })
-        .build()
+        .build_blocking()
         .unwrap();
 
     app.update_blocking(|ctx| async move {
@@ -61,7 +73,7 @@ fn update_blocking_missing_context_returns_typed_error() {
     #[derive(Debug)]
     struct MissingConfig;
 
-    let (app, _dir) = temp_app("sync_missing_context");
+    let (app, _dir) = temp_app_blocking("sync_missing_context");
     app.update_blocking(|ctx| async move {
         let err = ctx.get_or_err::<MissingConfig>().unwrap_err();
         assert!(
@@ -79,13 +91,13 @@ fn update_blocking_missing_context_returns_typed_error() {
 
 #[tokio::test]
 async fn update_async_runs_closure() {
-    let (app, _dir) = temp_app("async_basic");
+    let (app, _dir) = temp_app("async_basic").await;
     app.update(|_ctx| async move { Ok(()) }).await.unwrap();
 }
 
 #[tokio::test]
 async fn update_async_provides_pipeline_context() {
-    let (app, _dir) = temp_app("async_ctx");
+    let (app, _dir) = temp_app("async_ctx").await;
     app.update(|ctx| async move {
         assert!(ctx.has_pipeline_context());
         Ok(())
@@ -103,7 +115,7 @@ async fn memo_cached_executes_on_first_call() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("memo_first");
+    let (app, _dir) = temp_app("memo_first").await;
     let call_count = Arc::new(AtomicUsize::new(0));
 
     let count = call_count.clone();
@@ -129,7 +141,7 @@ async fn memo_cached_returns_cached_on_second_run() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("memo_cache_hit");
+    let (app, _dir) = temp_app("memo_cache_hit").await;
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run: should execute the closure.
@@ -174,7 +186,7 @@ async fn memo_cached_reexecutes_on_key_change() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("memo_cache_miss");
+    let (app, _dir) = temp_app("memo_cache_miss").await;
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run with key "v1".
@@ -219,7 +231,7 @@ fn memo_cached_blocking() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("memo_blocking");
+    let (app, _dir) = temp_app_blocking("memo_blocking");
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run.
@@ -266,7 +278,7 @@ fn drop_state_blocking_clears_memoization() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("drop_state");
+    let (app, _dir) = temp_app_blocking("drop_state");
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run: populate cache.
@@ -312,7 +324,7 @@ fn drop_state_blocking_clears_memoization() {
 
 #[tokio::test]
 async fn memo_cached_propagates_closure_error() {
-    let (app, _dir) = temp_app("memo_error");
+    let (app, _dir) = temp_app("memo_error").await;
     let result = app
         .update(|ctx| async move {
             let _: i32 = cocoindex::memo::cached(&ctx, &"key", || async {
@@ -327,7 +339,7 @@ async fn memo_cached_propagates_closure_error() {
 
 #[test]
 fn update_blocking_propagates_closure_error() {
-    let (app, _dir) = temp_app("sync_error");
+    let (app, _dir) = temp_app_blocking("sync_error");
     let result = app.update_blocking(|_ctx| async move {
         Err::<(), _>(cocoindex::Error::engine("sync test error"))
     });
@@ -348,7 +360,7 @@ async fn memo_cached_complex_types() {
         line: usize,
     }
 
-    let (app, _dir) = temp_app("memo_complex");
+    let (app, _dir) = temp_app("memo_complex").await;
 
     // Run 1: store complex type.
     app.update(|ctx| async move {
@@ -394,7 +406,7 @@ async fn memo_cached_complex_types() {
 #[test]
 fn app_open_convenience() {
     let dir = tempfile::tempdir().unwrap();
-    let app = App::open("open_test", dir.path().join("lmdb")).unwrap();
+    let app = App::open_blocking("open_test", dir.path().join("lmdb")).unwrap();
     app.update_blocking(|ctx| async move {
         assert!(ctx.has_pipeline_context());
         Ok(())
@@ -409,7 +421,9 @@ fn app_open_convenience() {
 #[tokio::test]
 async fn app_run_returns_stats() {
     let dir = tempfile::tempdir().unwrap();
-    let app = App::open("run_stats", dir.path().join("lmdb")).unwrap();
+    let app = App::open("run_stats", dir.path().join("lmdb"))
+        .await
+        .unwrap();
     let stats = app.run(|_ctx| async move { Ok(()) }).await.unwrap();
     // Stats should have a non-zero elapsed time
     assert!(stats.elapsed.as_nanos() > 0);
@@ -427,7 +441,7 @@ async fn ctx_memo_method() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("ctx_memo");
+    let (app, _dir) = temp_app("ctx_memo").await;
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run
@@ -482,7 +496,7 @@ async fn ctx_scope_runs_child() {
         value: i32,
     }
 
-    let (app, _dir) = temp_app("ctx_scope");
+    let (app, _dir) = temp_app("ctx_scope").await;
     app.update(|ctx| async move {
         let result: Output = ctx
             .scope(
@@ -503,7 +517,7 @@ async fn ctx_scope_runs_child() {
 
 #[tokio::test]
 async fn ctx_write_file_creates_file() {
-    let (app, dir) = temp_app("ctx_write");
+    let (app, dir) = temp_app("ctx_write").await;
     let output_dir = dir.path().join("output");
 
     let out = output_dir.clone();
@@ -520,7 +534,7 @@ async fn ctx_write_file_creates_file() {
 
 #[tokio::test]
 async fn ctx_write_file_creates_nested_dirs_and_overwrites() {
-    let (app, dir) = temp_app("ctx_write_nested");
+    let (app, dir) = temp_app("ctx_write_nested").await;
     let output_dir = dir.path().join("output");
     let nested = output_dir.join("sub/hello.txt");
 
@@ -556,7 +570,7 @@ async fn function_macro_bare() {
     assert_ne!(hash, 0);
 
     // The function itself should still work normally.
-    let (app, _dir) = temp_app("fn_bare");
+    let (app, _dir) = temp_app("fn_bare").await;
     app.update(|ctx| async move {
         let result = bare_fn(&ctx, "hello").await?;
         assert_eq!(result, 1);
@@ -590,7 +604,7 @@ mod memo_test_basic {
         assert_ne!(hash, 0);
 
         CALLS.store(0, Ordering::SeqCst);
-        let (app, _dir) = temp_app("fn_memo");
+        let (app, _dir) = temp_app("fn_memo").await;
 
         app.update(|ctx| async move {
             let result = the_fn(&ctx, &"k1".to_string()).await?;
@@ -620,7 +634,7 @@ mod memo_test_cache_hit {
     #[tokio::test]
     async fn function_macro_memo_cache_hit() {
         CALLS.store(0, Ordering::SeqCst);
-        let (app, _dir) = temp_app("fn_memo_hit");
+        let (app, _dir) = temp_app("fn_memo_hit").await;
 
         // First run — executes.
         app.update(|ctx| async move {
@@ -675,7 +689,7 @@ async fn ctx_mount_each() {
         value: i32,
     }
 
-    let (app, _dir) = temp_app("mount_each");
+    let (app, _dir) = temp_app("mount_each").await;
     app.update(|ctx| async move {
         let items = vec![("alpha", 1), ("beta", 2), ("gamma", 3)];
         let results: Vec<Output> = ctx
@@ -709,7 +723,7 @@ async fn ctx_mount_each_independent_memo() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("mount_each_memo");
+    let (app, _dir) = temp_app("mount_each_memo").await;
     let call_count = Arc::new(AtomicUsize::new(0));
 
     // First run: two children, each memos.
@@ -777,7 +791,7 @@ async fn ctx_mount_each_independent_memo() {
 
 #[tokio::test]
 async fn ctx_mount_each_preserves_input_order_under_concurrency() {
-    let (app, _dir) = temp_app("mount_each_order");
+    let (app, _dir) = temp_app("mount_each_order").await;
     app.update(|ctx| async move {
         let items = vec![("slow", 30_u64), ("fast", 0_u64), ("mid", 10_u64)];
         let results: Vec<String> = ctx
@@ -804,7 +818,7 @@ async fn ctx_mount_each_preserves_input_order_under_concurrency() {
 
 #[tokio::test]
 async fn ctx_map() {
-    let (app, _dir) = temp_app("ctx_map");
+    let (app, _dir) = temp_app("ctx_map").await;
     app.update(|ctx| async move {
         let items = vec![1, 2, 3, 4, 5];
         let results: Vec<i32> = ctx.map(items, |x| async move { Ok(x * x) }).await?;
@@ -817,7 +831,7 @@ async fn ctx_map() {
 
 #[tokio::test]
 async fn ctx_map_error_propagation() {
-    let (app, _dir) = temp_app("ctx_map_err");
+    let (app, _dir) = temp_app("ctx_map_err").await;
     let result = app
         .update(|ctx| async move {
             let items = vec![1, 2, 3];
@@ -845,7 +859,7 @@ async fn ctx_batch_all_miss() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("batch_miss");
+    let (app, _dir) = temp_app("batch_miss").await;
     let batch_calls = Arc::new(AtomicUsize::new(0));
 
     let calls = batch_calls.clone();
@@ -876,7 +890,7 @@ async fn ctx_batch_cache_hit() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("batch_hit");
+    let (app, _dir) = temp_app("batch_hit").await;
     let batch_calls = Arc::new(AtomicUsize::new(0));
 
     // First run: all misses.
@@ -925,7 +939,7 @@ async fn ctx_batch_partial_hit() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let (app, _dir) = temp_app("batch_partial");
+    let (app, _dir) = temp_app("batch_partial").await;
     let batch_calls = Arc::new(AtomicUsize::new(0));
 
     // First run: cache "a" and "b".
@@ -975,7 +989,7 @@ async fn ctx_batch_partial_hit() {
 
 #[tokio::test]
 async fn ctx_batch_error_propagation() {
-    let (app, _dir) = temp_app("batch_err");
+    let (app, _dir) = temp_app("batch_err").await;
     let result = app
         .update(|ctx| async move {
             let items = vec![1, 2, 3];
@@ -1027,7 +1041,7 @@ async fn ctx_batch_serialization_error_clears_pending_memo() {
         }
     }
 
-    let (app, _dir) = temp_app("batch_serialize_fail");
+    let (app, _dir) = temp_app("batch_serialize_fail").await;
     let first_calls = Arc::new(AtomicUsize::new(0));
     let first_calls_for_run = first_calls.clone();
     let result = app
@@ -1139,7 +1153,7 @@ async fn ctx_batch_fingerprint_error_clears_pending_memo() {
         }
     }
 
-    let (app, _dir) = temp_app("batch_fingerprint_fail");
+    let (app, _dir) = temp_app("batch_fingerprint_fail").await;
     let first_calls = Arc::new(AtomicUsize::new(0));
     let first_calls_for_run = first_calls.clone();
     let result = app
@@ -1224,7 +1238,7 @@ mod batch_macro_miss {
         assert_ne!(hash, 0);
 
         let before = BATCH_CALLS.load(Ordering::SeqCst);
-        let (app, _dir) = temp_app("fn_batch_miss");
+        let (app, _dir) = temp_app("fn_batch_miss").await;
 
         app.update(|ctx| async move {
             let results = process_items(&ctx, vec![1, 2, 3]).await?;
@@ -1257,7 +1271,7 @@ mod batch_macro_hit {
 
     #[tokio::test]
     async fn function_macro_batch_cache_hit() {
-        let (app, _dir) = temp_app("fn_batch_hit");
+        let (app, _dir) = temp_app("fn_batch_hit").await;
 
         // First run — all misses.
         let before = BATCH_CALLS.load(Ordering::SeqCst);
@@ -1301,7 +1315,7 @@ mod batch_macro_partial {
 
     #[tokio::test]
     async fn function_macro_batch_partial_hit() {
-        let (app, _dir) = temp_app("fn_batch_partial");
+        let (app, _dir) = temp_app("fn_batch_partial").await;
 
         // First run: cache items 1 and 2.
         let before = BATCH_CALLS.load(Ordering::SeqCst);
@@ -1366,6 +1380,7 @@ mod batch_macro_ctx_access {
             .db_path(dir.path().join("lmdb"))
             .provide("hello".to_string())
             .build()
+            .await
             .unwrap();
 
         app.update(|ctx| async move {
@@ -1401,7 +1416,7 @@ mod batching_no_memo {
         let hash = __COCO_FN_HASH_PROCESS_ALL;
         assert_ne!(hash, 0);
 
-        let (app, _dir) = temp_app("batching_only");
+        let (app, _dir) = temp_app("batching_only").await;
 
         let before = CALLS.load(Ordering::SeqCst);
         app.update(|ctx| async move {
@@ -1430,7 +1445,7 @@ mod batching_no_memo_no_cache {
 
     #[tokio::test]
     async fn batching_only_no_cache_on_second_run() {
-        let (app, _dir) = temp_app("batching_no_cache");
+        let (app, _dir) = temp_app("batching_no_cache").await;
 
         // First run.
         let before = CALLS.load(Ordering::SeqCst);
@@ -1514,6 +1529,7 @@ mod mock_bare {
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
             .unwrap();
 
         // First run.
@@ -1569,6 +1585,7 @@ mod mock_memo {
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
             .unwrap();
 
         // First run — cache miss, API called.
@@ -1626,6 +1643,7 @@ mod mock_batching {
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
             .unwrap();
 
         // First run.
@@ -1677,6 +1695,7 @@ mod mock_memo_batching {
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
             .unwrap();
 
         // First run — all misses, API called once with all 3 items.
@@ -1744,7 +1763,7 @@ fn fs_walk_integration() {
 
 #[tokio::test]
 async fn ctx_mount_each_rejects_duplicate_keys() {
-    let (app, _dir) = temp_app("mount_each_dupes");
+    let (app, _dir) = temp_app("mount_each_dupes").await;
     let result = app
         .update(|ctx| async move {
             // "alpha" is duplicated
@@ -1771,7 +1790,7 @@ async fn ctx_mount_each_rejects_duplicate_keys() {
 
 #[tokio::test]
 async fn ctx_batch_rejects_duplicate_keys() {
-    let (app, _dir) = temp_app("batch_each_dupes");
+    let (app, _dir) = temp_app("batch_each_dupes").await;
     let result = app
         .update(|ctx| async move {
             // "gamma" is duplicated


### PR DESCRIPTION
## Summary
- Make every public method in `state_store` that does I/O — and the `run_txn` body closure — `async fn`. The current LMDB implementation is synchronous internally; the returned futures resolve without yielding. This is an API-shape change to future-proof call sites.
- Cascade `.await` through the engine (`pre_commit`, `Committer`, `IdReservation`, etc.), the inspection helpers, the Rust SDK (`App::open`, `AppBuilder::build`), and the Python bindings.
- `AppStore` read methods take `&mut T: AnyTxn` so the returned futures are `Send`-compatible (heed's txn types are `Send` but `!Sync`, so `&WriteTxn` would make any future capturing it `!Send` and break the batcher's `tokio::spawn`). Three read methods that previously returned `Cow`-borrowed structs (`read_tracking_info`, `read_component_memo`, `read_fn_memo`) now return owned `Vec<u8>` so the caller can hold the deserialized struct across subsequent txn ops.
- Add `AppBuilder::build_blocking` / `App::open_blocking` sync wrappers in the SDK for `#[test]` and other sync entry points. Python bindings bridge via `py.detach(|| get_runtime().block_on(...))`.

## Test plan
CI (`cargo test`, `cargo build --all-targets`, `uv run mypy`, `uv run pytest python/`).
