### PR TITLE
refactor(engine): per-component fn-memo cache with prefetch + flush

### DIFF
--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -741,6 +741,13 @@ impl<Prof: EngineProfile> Component<Prof> {
                 let ret_n_submit_output = {
                     let _permit = self.inner.build_semaphore.acquire().await?;
 
+                    // Eagerly load all function-memo entries for this component
+                    // into the per-build cache, so every subsequent fn-call probe
+                    // serves from memory. Skipped under `full_reprocess` and in
+                    // delete mode (no `ComponentBuildingState`); see the cache
+                    // flush logic for how those cases are handled at commit time.
+                    processor_context.prefetch_fn_memos().await?;
+
                     if memo_fp_to_store.is_some() {
                         *self.inner.last_memo_fp.lock().unwrap() = memo_fp_to_store;
                         // TODO: when matching, it means there're ongoing processing for the same memoization key pending on children.

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -18,8 +18,16 @@ use crate::state::target_state_path::TargetStatePath;
 use crate::{
     engine::environment::{AppRegistration, Environment},
     state::stable_path::StablePath,
-    state_store::{AppStore, FnMemoAccessor},
+    state_store::{AppStore, WriteTxn},
 };
+
+use cocoindex_utils::deser::from_msgpack_slice;
+
+use crate::engine::execution::{
+    deserialize_context_memo_states, deserialize_memo_values, serialize_context_memo_states,
+    serialize_memo_values,
+};
+use crate::engine::profile::Persist;
 
 struct AppContextInner<Prof: EngineProfile> {
     env: Environment<Prof>,
@@ -209,6 +217,10 @@ impl<Prof: EngineProfile> MemoStatesPayload<Prof> {
 }
 
 pub enum FnCallMemoEntry<Prof: EngineProfile> {
+    /// Prefetched from the database but not yet accessed during this build.
+    /// Lazily decoded on first access (transitions to `Ready` or stays
+    /// `Stored` for later GC). Treated as untouched at flush time.
+    Stored(Vec<u8>),
     /// Memoization result is pending, i.e. the function call is not finished yet.
     Pending,
     /// Memoization result is ready. None means memoization is disabled, e.g. it mounts child components.
@@ -221,10 +233,214 @@ impl<Prof: EngineProfile> Default for FnCallMemoEntry<Prof> {
     }
 }
 
+/// In-memory cache of all function-memoization entries for a single
+/// component build. Populated by [`Self::prefetch`] (one prefix scan over
+/// the storage layer) at the start of build mode, then serves every
+/// subsequent fn-memo lookup in memory. New entries from cache-miss
+/// executions accumulate here; [`Self::flush_to_db`] applies the diff to
+/// storage at commit time as per-entry writes and deletes.
+pub(crate) struct FnMemoCache<Prof: EngineProfile> {
+    /// All known fn-memo entries for this component. Prefetched entries
+    /// start as `Stored(bytes)` and lazily decode to `Ready` on first
+    /// access; cache-miss inserts go straight to `Pending` then `Ready`.
+    entries: HashMap<Fingerprint, Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>>,
+    /// True after a successful `prefetch`. Stays false under
+    /// `full_reprocess` (prefetch skipped) or before `prefetch` runs.
+    /// Determines the flush strategy: per-entry writes/deletes when true,
+    /// prefix-delete + per-entry writes when false.
+    is_fully_loaded: bool,
+}
+
+impl<Prof: EngineProfile> FnMemoCache<Prof> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            is_fully_loaded: false,
+        }
+    }
+
+    /// Insert prefetched rows from the database into the cache and mark it
+    /// fully loaded. The async I/O lives at the context layer
+    /// ([`ComponentProcessorContext::prefetch_fn_memos`]); this is the sync
+    /// half that runs under the building-state mutex.
+    pub(crate) fn populate(&mut self, rows: Vec<(Fingerprint, Vec<u8>)>) {
+        for (fp, bytes) in rows {
+            self.entries.entry(fp).or_insert_with(|| {
+                Arc::new(tokio::sync::RwLock::new(FnCallMemoEntry::Stored(bytes)))
+            });
+        }
+        self.is_fully_loaded = true;
+    }
+
+    /// Get the entry for `fp`, inserting a `Pending` slot if absent. The
+    /// returned `Arc<RwLock<_>>` is what `reserve_memoization` locks.
+    pub(crate) fn entry_or_pending(
+        &mut self,
+        fp: Fingerprint,
+    ) -> Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>> {
+        self.entries
+            .entry(fp)
+            .or_insert_with(|| Arc::new(tokio::sync::RwLock::new(FnCallMemoEntry::Pending)))
+            .clone()
+    }
+
+    /// Read-only lookup. Returns `None` if no entry exists for `fp`. Used
+    /// by the finalize-time dep walk.
+    pub(crate) fn get(
+        &self,
+        fp: Fingerprint,
+    ) -> Option<Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>> {
+        self.entries.get(&fp).cloned()
+    }
+
+    pub(crate) fn is_fully_loaded(&self) -> bool {
+        self.is_fully_loaded
+    }
+
+    /// Walk all entries. Used by finalize to enumerate touched/untouched
+    /// state without consuming the cache.
+    pub(crate) fn iter(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            &Fingerprint,
+            &Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>,
+        ),
+    > {
+        self.entries.iter()
+    }
+
+    /// Consume the cache and apply its diff to storage in a single write
+    /// transaction.
+    ///
+    /// - If `is_fully_loaded` is true: for each entry, write `Ready(Some)`
+    ///   with `already_stored=false` (new or re-executed), delete
+    ///   `Stored(_)` and `Ready(None)` (untouched or memoization-disabled),
+    ///   skip `Ready(Some)` with `already_stored=true` (cache hit, row
+    ///   already in DB).
+    /// - Otherwise: prefix-delete every fn-memo row for `path`, then write
+    ///   the `Ready(Some)` `already_stored=false` entries. Covers
+    ///   `full_reprocess` and any path where the cache was not prefetched.
+    pub(crate) async fn flush_to_db(
+        self,
+        wtxn: &mut WriteTxn<'_>,
+        app_store: &AppStore,
+        path: &StablePath,
+    ) -> Result<()> {
+        if !self.is_fully_loaded {
+            app_store.delete_all_fn_memos(wtxn, path).await?;
+        }
+        for (fp, lock) in self.entries.into_iter() {
+            // No other holders at flush time — extract by reference under
+            // a try_write guard rather than unwrapping the Arc, since
+            // upstream cancellation paths may have leaked clones.
+            let mut guard = lock.try_write().map_err(|_| {
+                internal_error!("fn memo entry for {fp:?} still locked at flush time")
+            })?;
+            let state = std::mem::replace(&mut *guard, FnCallMemoEntry::Pending);
+            match state {
+                FnCallMemoEntry::Ready(Some(memo)) => {
+                    if memo.already_stored {
+                        // Cache hit: DB row already correct.
+                        continue;
+                    }
+                    let ret_bytes = memo.ret.to_bytes()?;
+                    let memo_states_serialized = serialize_memo_values::<Prof>(&memo.memo_states)?;
+                    let context_memo_states_serialized =
+                        serialize_context_memo_states::<Prof>(&memo.context_memo_states)?;
+                    let entry = db_schema::FunctionMemoizationEntry {
+                        return_value: db_schema::MemoizedValue::Inlined(Cow::Borrowed(
+                            ret_bytes.as_ref(),
+                        )),
+                        child_components: vec![],
+                        target_state_paths: memo.target_state_paths,
+                        dependency_memo_entries: memo.dependency_memo_entries.into_iter().collect(),
+                        logic_deps: memo.logic_deps.into_iter().collect(),
+                        memo_states: memo_states_serialized,
+                        context_memo_states: context_memo_states_serialized,
+                    };
+                    app_store.write_fn_memo(wtxn, path, fp, &entry).await?;
+                }
+                FnCallMemoEntry::Stored(_) | FnCallMemoEntry::Ready(None) => {
+                    if self.is_fully_loaded {
+                        // Stored: untouched prefetched entry, stale.
+                        // Ready(None): memoization disabled at runtime.
+                        app_store.delete_fn_memo(wtxn, path, fp).await?;
+                    }
+                }
+                FnCallMemoEntry::Pending => {
+                    // The slot was inserted via `entry_or_pending` for a fp not
+                    // present in the prefetched cache (prefetched fps decode
+                    // to `Ready` in `reserve_memoization`, never end up
+                    // Pending). The function call then errored before
+                    // resolving — e.g. the caller wrapped it in try/except
+                    // and continued. Such fps have no DB row, so nothing to
+                    // write or delete.
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<Prof: EngineProfile> Default for FnMemoCache<Prof> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode a `Stored(bytes)` entry into `Ready(Some(memo))` if the entry's
+/// stored logic deps still resolve. If the deps no longer resolve (e.g.
+/// logic registry no longer contains a fingerprint), or the entry is a
+/// legacy form with `child_components`, the result is `Ready(None)` so
+/// the entry is treated as a deletion at flush time.
+///
+/// This helper is shared between `reserve_memoization` (probe path) and
+/// the finalize dep walk; both call it under the per-entry write lock.
+///
+/// `*entry` must be `Stored(_)` on entry. After this call it is `Ready`.
+pub(crate) fn decode_stored_entry<Prof: EngineProfile>(
+    entry: &mut FnCallMemoEntry<Prof>,
+    env: &Environment<Prof>,
+) -> Result<()> {
+    let FnCallMemoEntry::Stored(bytes) = std::mem::replace(entry, FnCallMemoEntry::Pending) else {
+        internal_bail!("decode_stored_entry called on non-Stored entry");
+    };
+    let decoded: db_schema::FunctionMemoizationEntry<'_> = from_msgpack_slice(&bytes)?;
+    if !crate::engine::logic_registry::all_contained_with_env(&decoded.logic_deps, env) {
+        *entry = FnCallMemoEntry::Ready(None);
+        return Ok(());
+    }
+    if !decoded.child_components.is_empty() {
+        // Legacy entry with stored child component paths. Invalidate so the
+        // function re-runs, detects child components, and the entry is
+        // cleaned up.
+        *entry = FnCallMemoEntry::Ready(None);
+        return Ok(());
+    }
+    let return_value_bytes = match decoded.return_value {
+        db_schema::MemoizedValue::Inlined(b) => b,
+    };
+    let ret = Prof::FunctionData::from_bytes(return_value_bytes.as_ref())?;
+    let memo_states = deserialize_memo_values::<Prof>(&decoded.memo_states)?;
+    let context_memo_states =
+        deserialize_context_memo_states::<Prof>(&decoded.context_memo_states)?;
+    *entry = FnCallMemoEntry::Ready(Some(FnCallMemo {
+        ret,
+        target_state_paths: decoded.target_state_paths,
+        dependency_memo_entries: decoded.dependency_memo_entries.into_iter().collect(),
+        logic_deps: decoded.logic_deps.into_iter().collect(),
+        memo_states,
+        context_memo_states,
+        already_stored: true,
+    }));
+    Ok(())
+}
+
 pub(crate) struct ComponentBuildingState<Prof: EngineProfile> {
     pub target_states: ComponentTargetStatesContext<Prof>,
     pub child_path_set: ChildStablePathSet,
-    pub fn_call_memos: HashMap<Fingerprint, Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>>,
+    pub fn_memos: FnMemoCache<Prof>,
 }
 
 pub(crate) struct ComponentBuildContext<Prof: EngineProfile> {
@@ -261,7 +477,7 @@ impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
                     provider_registry: TargetStateProviderRegistry::new(providers),
                 },
                 child_path_set: Default::default(),
-                fn_call_memos: Default::default(),
+                fn_memos: FnMemoCache::new(),
             })),
             full_reprocess,
             live,
@@ -283,13 +499,6 @@ struct ComponentProcessorContextInner<Prof: EngineProfile> {
 
     /// Opaque per-operation context (e.g. ContextProvider on the Python side).
     host_ctx: Arc<Prof::HostCtx>,
-
-    /// Per-component handle for function-memo I/O. Built once when the
-    /// context is constructed and shared by reference, so any per-build
-    /// state inside the accessor (e.g. a buffer in a future backend)
-    /// persists across the many fn-memo lookups within one component's
-    /// processing phase.
-    fn_memo_accessor: FnMemoAccessor,
 }
 
 #[derive(Clone)]
@@ -305,10 +514,6 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         host_ctx: Arc<Prof::HostCtx>,
         processing_action: ComponentProcessingAction<Prof>,
     ) -> Self {
-        let fn_memo_accessor = FnMemoAccessor::new(
-            component.app_ctx().app_store().clone(),
-            component.stable_path().clone(),
-        );
         Self {
             inner: Arc::new(ComponentProcessorContextInner {
                 component,
@@ -319,7 +524,6 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
                 inflight_permit: Mutex::new(None),
                 logic_deps: Mutex::new(HashSet::new()),
                 host_ctx,
-                fn_memo_accessor,
             }),
         }
     }
@@ -340,12 +544,38 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         self.inner.component.stable_path()
     }
 
-    /// Per-component handle for function-memoization I/O. All engine code
-    /// that reads, writes, or retains function memos under this component's
-    /// path should go through this handle rather than calling `AppStore`
-    /// methods directly — see [`FnMemoAccessor`] for why.
-    pub fn fn_memo_accessor(&self) -> &FnMemoAccessor {
-        &self.inner.fn_memo_accessor
+    /// Eagerly load every function-memo entry for this component from
+    /// storage into the per-build cache. Called at the start of build mode
+    /// before any function calls run; skipped under `full_reprocess` so
+    /// the cache stays empty and `FnMemoCache::flush_to_db` falls through
+    /// to a prefix delete + write of newly-computed entries.
+    pub(crate) async fn prefetch_fn_memos(&self) -> Result<()> {
+        if self.full_reprocess() {
+            return Ok(());
+        }
+        // Cheap check: skip if already loaded (re-entry, etc.).
+        let already_loaded = match &self.inner.processing_action {
+            ComponentProcessingAction::Build(build_ctx) => {
+                let guard = build_ctx.state.lock().unwrap();
+                let Some(state) = guard.as_ref() else {
+                    return Ok(());
+                };
+                state.fn_memos.is_fully_loaded()
+            }
+            ComponentProcessingAction::Delete { .. } => return Ok(()),
+        };
+        if already_loaded {
+            return Ok(());
+        }
+        let app_store = self.app_ctx().app_store();
+        let path = self.stable_path();
+        let mut rtxn = self.app_ctx().env().read_txn().await?;
+        let rows = app_store.list_fn_memos(&mut rtxn, path).await?;
+        drop(rtxn);
+        self.update_building_state(|s| {
+            s.fn_memos.populate(rows);
+            Ok(())
+        })
     }
 
     pub(crate) fn parent_context(&self) -> Option<&ComponentProcessorContext<Prof>> {

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -7,9 +7,9 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque, btree_map};
 
 use crate::engine::context::{
     ComponentProcessingAction, ComponentProcessingMode, ComponentProcessorContext,
-    DeclaredTargetState, FnCallMemo, MemoStatesPayload, TARGET_ID_KEY,
+    DeclaredTargetState, MemoStatesPayload, TARGET_ID_KEY,
 };
-use crate::engine::context::{FnCallContext, FnCallMemoEntry};
+use crate::engine::context::{FnCallContext, FnCallMemoEntry, FnMemoCache, decode_stored_entry};
 use crate::engine::id_sequencer::IdReservation;
 use crate::engine::logic_registry;
 use crate::engine::profile::{EngineProfile, Persist};
@@ -27,7 +27,7 @@ use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
 /// Deserialize a `Vec<MemoizedValue>` into a `Vec<Prof::FunctionData>`.
-fn deserialize_memo_values<Prof: EngineProfile>(
+pub(crate) fn deserialize_memo_values<Prof: EngineProfile>(
     values: &[db_schema::MemoizedValue<'_>],
 ) -> Result<Vec<Prof::FunctionData>> {
     values
@@ -44,7 +44,7 @@ fn deserialize_memo_values<Prof: EngineProfile>(
 /// Serialize a `&[Prof::FunctionData]` into a `Vec<MemoizedValue<'static>>`.
 /// The returned values own their bytes (`Cow::Owned`), so they're independent of
 /// the input lifetime.
-fn serialize_memo_values<Prof: EngineProfile>(
+pub(crate) fn serialize_memo_values<Prof: EngineProfile>(
     values: &[Prof::FunctionData],
 ) -> Result<Vec<db_schema::MemoizedValue<'static>>> {
     values
@@ -57,7 +57,7 @@ fn serialize_memo_values<Prof: EngineProfile>(
 }
 
 /// Deserialize the context-borne memo states (fp-tagged list of value blobs).
-fn deserialize_context_memo_states<Prof: EngineProfile>(
+pub(crate) fn deserialize_context_memo_states<Prof: EngineProfile>(
     entries: &[(Fingerprint, Vec<db_schema::MemoizedValue<'_>>)],
 ) -> Result<Vec<(Fingerprint, Vec<Prof::FunctionData>)>> {
     entries
@@ -67,7 +67,7 @@ fn deserialize_context_memo_states<Prof: EngineProfile>(
 }
 
 /// Serialize the context-borne memo states into the on-disk representation.
-fn serialize_context_memo_states<Prof: EngineProfile>(
+pub(crate) fn serialize_context_memo_states<Prof: EngineProfile>(
     entries: &[(Fingerprint, Vec<Prof::FunctionData>)],
 ) -> Result<Vec<(Fingerprint, Vec<db_schema::MemoizedValue<'static>>)>> {
     entries
@@ -197,78 +197,6 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
     Ok(())
 }
 
-async fn write_fn_call_memo<Prof: EngineProfile>(
-    wtxn: &mut WriteTxn<'_>,
-    comp_ctx: &ComponentProcessorContext<Prof>,
-    memo_fp: Fingerprint,
-    memo: FnCallMemo<Prof>,
-) -> Result<()> {
-    let ret_bytes = memo.ret.to_bytes()?;
-    let memo_states_serialized = serialize_memo_values::<Prof>(&memo.memo_states)?;
-    let context_memo_states_serialized =
-        serialize_context_memo_states::<Prof>(&memo.context_memo_states)?;
-    let fn_call_memo = db_schema::FunctionMemoizationEntry {
-        return_value: db_schema::MemoizedValue::Inlined(Cow::Borrowed(ret_bytes.as_ref())),
-        child_components: vec![],
-        target_state_paths: memo.target_state_paths,
-        dependency_memo_entries: memo.dependency_memo_entries.into_iter().collect(),
-        logic_deps: memo.logic_deps.into_iter().collect(),
-        memo_states: memo_states_serialized,
-        context_memo_states: context_memo_states_serialized,
-    };
-    comp_ctx
-        .fn_memo_accessor()
-        .write(wtxn, memo_fp, &fn_call_memo)
-        .await
-}
-
-async fn read_fn_call_memo_with_txn<Prof: EngineProfile, T: AnyTxn>(
-    rtxn: &mut T,
-    comp_ctx: &ComponentProcessorContext<Prof>,
-    memo_fp: Fingerprint,
-) -> Result<Option<FnCallMemo<Prof>>> {
-    let Some(bytes) = comp_ctx.fn_memo_accessor().read(rtxn, memo_fp).await? else {
-        return Ok(None);
-    };
-    let fn_call_memo: db_schema::FunctionMemoizationEntry<'_> = from_msgpack_slice(&bytes)?;
-    if !logic_registry::all_contained_with_env(&fn_call_memo.logic_deps, comp_ctx.app_ctx().env()) {
-        return Ok(None);
-    }
-    if !fn_call_memo.child_components.is_empty() {
-        // Legacy entry stored child component paths. Invalidate it so the function re-runs,
-        // detects the child components, logs a warning, and the entry is cleaned up.
-        return Ok(None);
-    }
-    let return_value_bytes = match fn_call_memo.return_value {
-        db_schema::MemoizedValue::Inlined(b) => b,
-    };
-    let ret = Prof::FunctionData::from_bytes(return_value_bytes.as_ref())?;
-    let memo_states = deserialize_memo_values::<Prof>(&fn_call_memo.memo_states)?;
-    let context_memo_states =
-        deserialize_context_memo_states::<Prof>(&fn_call_memo.context_memo_states)?;
-    Ok(Some(FnCallMemo {
-        ret,
-        target_state_paths: fn_call_memo.target_state_paths,
-        dependency_memo_entries: fn_call_memo.dependency_memo_entries.into_iter().collect(),
-        logic_deps: fn_call_memo.logic_deps.into_iter().collect(),
-        memo_states,
-        context_memo_states,
-        already_stored: true,
-    }))
-}
-
-pub(crate) async fn read_fn_call_memo<Prof: EngineProfile>(
-    comp_ctx: &ComponentProcessorContext<Prof>,
-    memo_fp: Fingerprint,
-) -> Result<Option<FnCallMemo<Prof>>> {
-    // Short-circuit to miss under full_reprocess
-    if comp_ctx.full_reprocess() {
-        return Ok(None);
-    }
-    let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-    read_fn_call_memo_with_txn(&mut rtxn, comp_ctx, memo_fp).await
-}
-
 pub fn declare_target_state<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     fn_ctx: &FnCallContext,
@@ -390,8 +318,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
         mut self,
         wtxn: &mut WriteTxn<'_>,
         child_path_set: Option<ChildStablePathSet>,
-        all_memo_fps: &HashSet<Fingerprint>,
-        memos_without_mounts_to_store: Vec<(Fingerprint, FnCallMemo<Prof>)>,
+        fn_memos: FnMemoCache<Prof>,
         curr_version: Option<u64>,
     ) -> Result<Self> {
         {
@@ -474,15 +401,11 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 }
             }
 
-            // Write memos.
-            for (fp, memo) in memos_without_mounts_to_store {
-                write_fn_call_memo(wtxn, &self.component_ctx, fp, memo).await?;
-            }
-
-            // Delete all function memo entries that are not in the all_memo_fps.
-            self.component_ctx
-                .fn_memo_accessor()
-                .retain(wtxn, all_memo_fps)
+            // Flush the function-memo cache: writes new/re-executed entries,
+            // deletes untouched prefetched entries (or prefix-deletes the
+            // whole range under full_reprocess / no-prefetch paths).
+            fn_memos
+                .flush_to_db(wtxn, &self.app_store, &self.component_path)
                 .await?;
 
             if !self.demote_component_only {
@@ -496,8 +419,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
     async fn commit(
         self,
         child_path_set: Option<ChildStablePathSet>,
-        all_memo_fps: HashSet<Fingerprint>,
-        memos_without_mounts_to_store: Vec<(Fingerprint, FnCallMemo<Prof>)>,
+        fn_memos: FnMemoCache<Prof>,
         curr_version: Option<u64>,
     ) -> Result<()> {
         // Single cheap Arc clone so we can call run_txn() / read_txn() after self moves into the closure.
@@ -506,14 +428,8 @@ impl<Prof: EngineProfile> Committer<Prof> {
             .env()
             .run_txn(move |wtxn| {
                 Box::pin(async move {
-                    self.commit_in_txn(
-                        wtxn,
-                        child_path_set,
-                        &all_memo_fps,
-                        memos_without_mounts_to_store,
-                        curr_version,
-                    )
-                    .await
+                    self.commit_in_txn(wtxn, child_path_set, fn_memos, curr_version)
+                        .await
                 })
             })
             .await?;
@@ -1216,7 +1132,8 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         target_states_providers,
         declared_target_states,
         child_path_set,
-        mut finalized_fn_call_memos,
+        fn_memos,
+        contained_target_state_paths,
     ) = match comp_ctx.processing_state() {
         ComponentProcessingAction::Build(build_ctx) => {
             // Extract from MutexGuard in a block so the guard is dropped before `.await`.
@@ -1232,22 +1149,24 @@ pub(crate) async fn submit<Prof: EngineProfile>(
             };
 
             let child_path_set = building_state.child_path_set;
-            let finalized_fn_call_memos =
-                finalize_fn_call_memoization(comp_ctx, building_state.fn_call_memos).await?;
+            let fn_memos = building_state.fn_memos;
+            let contained_target_state_paths = finalize_fn_call_memoization(comp_ctx, &fn_memos)?;
             (
                 &built_target_states_providers
                     .get_or_insert(building_state.target_states.provider_registry)
                     .providers,
                 building_state.target_states.declared_target_states,
                 Some(child_path_set),
-                finalized_fn_call_memos,
+                fn_memos,
+                contained_target_state_paths,
             )
         }
         ComponentProcessingAction::Delete(delete_context) => (
             &delete_context.providers,
             Default::default(),
             None,
-            Default::default(),
+            FnMemoCache::default(),
+            HashSet::new(),
         ),
     };
 
@@ -1256,9 +1175,6 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     let stable_path = comp_ctx.stable_path().clone();
     let full_reprocess = comp_ctx.full_reprocess();
     let processor_name_owned: Option<String> = processor_name.map(|s| s.to_owned());
-
-    let contained_target_state_paths =
-        std::mem::take(&mut finalized_fn_call_memos.contained_target_state_paths);
 
     let mut pending_fulfillments: Vec<(TargetStateProvider<Prof>, Prof::TargetHdl)> = Vec::new();
     let target_states_providers_owned = target_states_providers.clone();
@@ -1336,12 +1252,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
 
     let committer = Committer::new(comp_ctx, &target_states_providers, demote_component_only)?;
     committer
-        .commit(
-            child_path_set,
-            finalized_fn_call_memos.all_memos_fps,
-            finalized_fn_call_memos.memos_without_mounts_to_store,
-            curr_version,
-        )
+        .commit(child_path_set, fn_memos, curr_version)
         .await?;
 
     // Fulfill child handlers and register their attachment providers.
@@ -1447,64 +1358,65 @@ async fn get_path_node_type<T: AnyTxn>(
     app_store.read_path_node_type(rtxn, parent_path, key).await
 }
 
-#[derive(Default)]
-struct FinalizedFnCallMemoization<Prof: EngineProfile> {
-    memos_without_mounts_to_store: Vec<(Fingerprint, FnCallMemo<Prof>)>,
-    // Fingerprints of all memos, including dependencies that is not populated in the current processing.
-    all_memos_fps: HashSet<Fingerprint>,
-    // Target state paths covered by memos but not explicitly declared in the current run, because of contained by memos that already stored, including dependency memos of already stored ones.
-    // We collect them to avoid GC of these target states.
-    contained_target_state_paths: HashSet<TargetStatePath>,
-}
-
-async fn finalize_fn_call_memoization<Prof: EngineProfile>(
+/// Walk every entry in the function-memo cache and produce the set of
+/// target-state paths protected from GC because they are referenced
+/// (directly or transitively) by an already-stored memo.
+///
+/// All reads are in-memory; the cache was eagerly prefetched at the start
+/// of build mode. Untouched entries remain in `Stored(_)` state and get
+/// deleted at flush time; entries that are reachable as transitive deps
+/// of an already-stored memo are decoded in place so flush keeps them.
+fn finalize_fn_call_memoization<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
-    fn_call_memos: HashMap<Fingerprint, Arc<tokio::sync::RwLock<FnCallMemoEntry<Prof>>>>,
-) -> Result<FinalizedFnCallMemoization<Prof>> {
-    let mut result = FinalizedFnCallMemoization::default();
+    cache: &FnMemoCache<Prof>,
+) -> Result<HashSet<TargetStatePath>> {
+    let env = comp_ctx.app_ctx().env();
+    let mut contained_target_state_paths: HashSet<TargetStatePath> = HashSet::new();
+    let mut visited: HashSet<Fingerprint> = HashSet::new();
+    let mut deps_to_walk: VecDeque<Fingerprint> = VecDeque::new();
 
-    let mut deps_to_process: VecDeque<Fingerprint> = VecDeque::new();
-
-    // Extract memos from the in-memory map.
-    for (fp, memo_lock) in fn_call_memos.iter() {
-        let mut guard = memo_lock
-            .try_write()
+    // First pass: every Ready(Some) entry with `already_stored=true`
+    // contributes its target states and seeds the dep walk. `already_stored=false`
+    // entries were just executed this run; their target states are in the
+    // regular declared_target_states pipeline, not "contained".
+    for (fp, lock) in cache.iter() {
+        let guard = lock
+            .try_read()
             .map_err(|_| internal_error!("fn call memo entry is locked during finalize"))?;
-        let FnCallMemoEntry::Ready(Some(memo)) = std::mem::take(&mut *guard) else {
+        if let FnCallMemoEntry::Ready(Some(memo)) = &*guard {
+            if memo.already_stored {
+                visited.insert(*fp);
+                contained_target_state_paths.extend(memo.target_state_paths.iter().cloned());
+                for dep_fp in memo.dependency_memo_entries.iter() {
+                    if visited.insert(*dep_fp) {
+                        deps_to_walk.push_back(*dep_fp);
+                    }
+                }
+            }
+        }
+    }
+
+    // Transitive dep walk: decode-on-access `Stored` entries so flush keeps
+    // them, and collect their target states. Entries already `Ready` skip
+    // straight to the field read.
+    while let Some(fp) = deps_to_walk.pop_front() {
+        let Some(lock) = cache.get(fp) else {
             continue;
         };
-
-        result.all_memos_fps.insert(*fp);
-
-        if memo.already_stored {
-            result
-                .contained_target_state_paths
-                .extend(memo.target_state_paths.into_iter());
-            deps_to_process.extend(memo.dependency_memo_entries.into_iter());
-        } else {
-            result.memos_without_mounts_to_store.push((*fp, memo));
+        let mut guard = lock
+            .try_write()
+            .map_err(|_| internal_error!("fn call memo entry is locked during finalize"))?;
+        if matches!(&*guard, FnCallMemoEntry::Stored(_)) {
+            decode_stored_entry::<Prof>(&mut guard, env)?;
         }
-        // For non-stored memos, their dependencies were already resolved in this run,
-        // so they exist in `fn_call_memos` and will be visited by the outer loop.
-    }
-
-    // Transitively expand deps of already-stored memos (read from DB).
-    // Collect their target_state_paths so those target states are not GC'd.
-    // Use a single read transaction for all DB reads.
-    if !deps_to_process.is_empty() {
-        let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        while let Some(fp) = deps_to_process.pop_front() {
-            if !result.all_memos_fps.insert(fp) {
-                continue;
+        if let FnCallMemoEntry::Ready(Some(memo)) = &*guard {
+            contained_target_state_paths.extend(memo.target_state_paths.iter().cloned());
+            for dep_fp in memo.dependency_memo_entries.iter() {
+                if visited.insert(*dep_fp) {
+                    deps_to_walk.push_back(*dep_fp);
+                }
             }
-            let Some(memo) = read_fn_call_memo_with_txn(&mut rtxn, comp_ctx, fp).await? else {
-                continue;
-            };
-            result
-                .contained_target_state_paths
-                .extend(memo.target_state_paths.into_iter());
-            deps_to_process.extend(memo.dependency_memo_entries.into_iter());
         }
     }
-    Ok(result)
+    Ok(contained_target_state_paths)
 }

--- a/rust/core/src/engine/function.rs
+++ b/rust/core/src/engine/function.rs
@@ -1,7 +1,7 @@
 use crate::engine::context::{
     ComponentProcessorContext, FnCallContext, FnCallMemo, FnCallMemoEntry, MemoStatesPayload,
+    decode_stored_entry,
 };
-use crate::engine::execution::read_fn_call_memo;
 use crate::engine::profile::EngineProfile;
 use crate::prelude::*;
 
@@ -113,24 +113,19 @@ pub async fn reserve_memoization<Prof: EngineProfile>(
     memo_fp: Fingerprint,
 ) -> Result<FnCallMemoGuard<Prof>> {
     // Clone the Arc so we don't hold building_state's mutex across `.await`.
+    // The cache was eagerly prefetched at the start of build mode, so any
+    // entry from the database is already in memory as `Stored(bytes)`.
     let memo_entry = comp_exec_ctx.update_building_state(|building_state| {
-        Ok(building_state
-            .fn_call_memos
-            .entry(memo_fp)
-            .or_insert_with(|| Arc::new(tokio::sync::RwLock::new(FnCallMemoEntry::Pending)))
-            .clone())
+        Ok(building_state.fn_memos.entry_or_pending(memo_fp))
     })?;
 
     let mut guard = memo_entry.write_owned().await;
 
-    // If still pending (first caller, or retry after a previous caller failed),
-    // try loading from the database.
-    if let FnCallMemoEntry::Pending = &*guard {
-        if !comp_exec_ctx.full_reprocess() {
-            if let Some(fn_call_memo) = read_fn_call_memo(comp_exec_ctx, memo_fp).await? {
-                *guard = FnCallMemoEntry::Ready(Some(fn_call_memo));
-            }
-        }
+    // Lazy-decode prefetched bytes on first access. Decoding may fall through
+    // to `Ready(None)` if the entry's logic deps no longer resolve or if it's
+    // a legacy entry with `child_components` — both cases force re-execution.
+    if matches!(&*guard, FnCallMemoEntry::Stored(_)) {
+        decode_stored_entry::<Prof>(&mut guard, comp_exec_ctx.app_ctx().env())?;
     }
 
     Ok(FnCallMemoGuard { guard })

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -10,8 +10,6 @@
 //! synchronous internally — the returned futures never yield — but the
 //! async signature future-proofs the API.
 
-use std::collections::HashSet;
-
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
@@ -181,74 +179,65 @@ impl AppStore {
     }
 }
 
-// --- Function memoization (per-component, via FnMemoAccessor) -----------
+// --- Function memoization ------------------------------------------------
 
-/// Per-component handle that mediates function-memoization reads, writes,
-/// and retention during a single component build.
-///
-/// Engine code routes all per-component function-memo I/O through this type
-/// rather than calling [`AppStore`] methods directly, so storage backends
-/// that benefit from prefetching (e.g. a future Postgres backend that wants
-/// to load all entries for a component in one prefix scan and serve all
-/// reads from memory) can introduce a per-build buffer here without
-/// touching the engine call sites.
-///
-/// The accessor is constructed once per component build and held by
-/// [`ComponentProcessorContext`](crate::engine::context::ComponentProcessorContext)
-/// — engine code reaches it via `comp_ctx.fn_memo_accessor()`, which
-/// returns a borrow rather than a fresh value, so any per-build state
-/// (a future buffer) persists across the many fn-memo lookups inside a
-/// single component's processing phase.
-///
-/// The current LMDB implementation is a pure passthrough — every call
-/// delegates directly to the corresponding [`AppStore`] method, since LMDB's
-/// random reads are already memory speed.
-pub struct FnMemoAccessor {
-    app_store: AppStore,
-    component_path: StablePath,
-}
-
-impl FnMemoAccessor {
-    pub fn new(app_store: AppStore, component_path: StablePath) -> Self {
-        Self {
-            app_store,
-            component_path,
-        }
-    }
-
-    /// Read raw function-memo bytes for the given fingerprint. Returns
-    /// owned bytes; see [`AppStore::read_tracking_info`] for the rationale.
-    pub async fn read<T: AnyTxn>(&self, txn: &mut T, fp: Fingerprint) -> Result<Option<Vec<u8>>> {
-        let key = key_fn_memo(&self.component_path, fp)?;
-        Ok(txn
-            .db_get_bytes(self.app_store.db(), &key)?
-            .map(<[u8]>::to_vec))
-    }
-
-    pub async fn write(
+impl AppStore {
+    /// List every function memo under `path`. Returns owned `(fp, value)`
+    /// pairs from a single prefix scan. Matches the shape of
+    /// [`Self::list_child_existence`] and [`Self::list_tombstones`].
+    pub async fn list_fn_memos(
         &self,
-        wtxn: &mut WriteTxn<'_>,
+        txn: &mut ReadTxn<'_>,
+        path: &StablePath,
+    ) -> Result<Vec<(Fingerprint, Vec<u8>)>> {
+        let prefix = key_fn_memo_prefix(path)?;
+        let db = self.db();
+        let mut out = Vec::new();
+        for entry in db.prefix_iter(&**txn, &prefix)? {
+            let (raw_key, raw_val) = entry?;
+            let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
+            out.push((fp, raw_val.to_vec()));
+        }
+        Ok(out)
+    }
+
+    pub async fn write_fn_memo(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        path: &StablePath,
         fp: Fingerprint,
         entry: &FunctionMemoizationEntry<'_>,
     ) -> Result<()> {
-        let key = key_fn_memo(&self.component_path, fp)?;
+        let key = key_fn_memo(path, fp)?;
         let value = rmp_serde::to_vec_named(entry)?;
-        self.app_store.db().put(&mut **wtxn, &key, &value)?;
+        self.db().put(&mut **txn, &key, &value)?;
         Ok(())
     }
 
-    /// GC: delete all function memos for this component whose fingerprint
-    /// is NOT in `keep`.
-    pub async fn retain(&self, wtxn: &mut WriteTxn<'_>, keep: &HashSet<Fingerprint>) -> Result<()> {
-        let prefix = key_fn_memo_prefix(&self.component_path)?;
-        let db = self.app_store.db();
-        let mut iter = db.prefix_iter_mut(&mut **wtxn, &prefix)?;
-        while let Some((raw_key, _)) = iter.next().transpose()? {
-            let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
-            if keep.contains(&fp) {
-                continue;
-            }
-            // Safety: we drop the borrowed key before the next `next()` call.
+    pub async fn delete_fn_memo(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        path: &StablePath,
+        fp: Fingerprint,
+    ) -> Result<()> {
+        let key = key_fn_memo(path, fp)?;
+        self.db().delete(&mut **txn, &key)?;
+        Ok(())
+    }
+
+    /// Prefix-delete every function memo under `path`. Used when the cache
+    /// was not populated (full_reprocess, delete mode) — see
+    /// `FnMemoCache::flush_to_db`.
+    pub async fn delete_all_fn_memos(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        path: &StablePath,
+    ) -> Result<()> {
+        let prefix = key_fn_memo_prefix(path)?;
+        let db = self.db();
+        let mut iter = db.prefix_iter_mut(&mut **txn, &prefix)?;
+        while iter.next().transpose()?.is_some() {
+            // Safety: we drop the borrowed key/value before the next `next()`.
             unsafe {
                 iter.del_current()?;
             }

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -12,6 +12,6 @@ mod app_store;
 mod storage;
 mod txn;
 
-pub use app_store::{AppStore, FnMemoAccessor};
+pub use app_store::AppStore;
 pub use storage::{Storage, StorageSettings};
 pub use txn::{AnyTxn, ReadTxn, WriteTxn};


### PR DESCRIPTION
## Summary

Replace the previous `FnMemoAccessor` handle (#1990) with a `FnMemoCache` that owns the function-memoization lifecycle at the engine layer.

- **Eager prefetch at build start.** One prefix scan loads every fn-memo entry for the component into memory as `Stored(bytes)`. Subsequent `reserve_memoization` calls serve from the cache; entries lazy-decode on first access via `decode_stored_entry`.
- **In-memory finalize.** `finalize_fn_call_memoization` walks the cache directly and decodes `Stored` entries it reaches via dep chains — no DB reads at finalize, down from one read per transitive dep.
- **Single commit-time flush.** `FnMemoCache::flush_to_db` consolidates the write loop and the retain GC. When the cache is fully loaded: per-entry write/delete based on entry state. When it isn't (full_reprocess, delete mode): prefix-delete + write the new entries.
- **Net I/O per build:** one prefix scan up front instead of O(N) per-fn point lookups during processing + one prefix scan at commit.

Storage API: new `list_fn_memos` (prefix read; layer-neutral name matching `list_child_existence` / `list_tombstones`), `delete_fn_memo`, `delete_all_fn_memos`. Drop `read_fn_memo` and `retain_fn_memos`. `write_fn_memo` unchanged.

Engine API: new `FnCallMemoEntry::Stored(Vec<u8>)` variant; new `FnMemoCache<Prof>` on `ComponentBuildingState` with an `is_fully_loaded` flag driving the flush strategy; `ComponentProcessorContext::prefetch_fn_memos()` invoked in `execute_once` after the build semaphore is acquired. `Committer::commit_in_txn` / `commit` take a single `fn_memos: FnMemoCache<Prof>` parameter instead of the previous `all_memo_fps` + `memos_without_mounts_to_store` pair.

No behavior change for the LMDB backend.

## Test plan

CI. Locally: `cargo test -p cocoindex_core --lib` (30/30), `pytest python/tests/core/` (358/358). The full engine lifecycle (component memoization, fn memoization with cache hits / state validation / re-execution, dep transitive expansion, full_reprocess, live components, GC) exercises the new cache paths.
