### PR TITLE
docs(topbar): tap-to-open Examples/Documentation dropdowns on touch

### DIFF
--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -133,6 +133,41 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
       .catch(() => { /* offline / rate-limited — leave the em-dash. */ });
   })();
 
+  // On touch / no-hover devices the `:hover` rule that reveals .nav-dd-menu
+  // never fires, so the first tap on the trigger anchor navigates away
+  // before the user can pick v1 vs v0. Intercept that first tap to open
+  // the menu; the second tap (or selecting an item) navigates as normal.
+  (() => {
+    if (!window.matchMedia('(hover: none)').matches) return;
+    const dds = Array.from(document.querySelectorAll<HTMLElement>('.nav-dd'));
+    if (!dds.length) return;
+
+    const closeAll = (except?: HTMLElement) => {
+      for (const dd of dds) if (dd !== except) dd.classList.remove('open');
+    };
+
+    for (const dd of dds) {
+      const trigger = dd.querySelector<HTMLAnchorElement>('.nav-dd-trigger');
+      if (!trigger) continue;
+      trigger.addEventListener('click', (ev) => {
+        if (!dd.classList.contains('open')) {
+          ev.preventDefault();
+          closeAll(dd);
+          dd.classList.add('open');
+        }
+      });
+    }
+
+    document.addEventListener('click', (ev) => {
+      const target = ev.target as Node | null;
+      if (target && dds.some((dd) => dd.contains(target))) return;
+      closeAll();
+    });
+    document.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Escape') closeAll();
+    });
+  })();
+
   // Copy-to-clipboard for every .code-figure .copy button — one delegated
   // listener per document. Emitted markup lives in scripts/remark-code-titles.mjs.
   (() => {

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -148,7 +148,8 @@ nav.top {
   transition: transform .15s ease;
 }
 .nav-dd:hover .nav-dd-trigger svg,
-.nav-dd:focus-within .nav-dd-trigger svg {
+.nav-dd:focus-within .nav-dd-trigger svg,
+.nav-dd.open .nav-dd-trigger svg {
   color: var(--coral);
   transform: rotate(180deg);
 }
@@ -169,7 +170,8 @@ nav.top {
   z-index: 60;
 }
 .nav-dd:hover .nav-dd-menu,
-.nav-dd:focus-within .nav-dd-menu {
+.nav-dd:focus-within .nav-dd-menu,
+.nav-dd.open .nav-dd-menu {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);


### PR DESCRIPTION
## Pain point

When I was on my phone tapping around the docs / examples site, the **Examples** and **Documentation** items in the topbar each have a dropdown (v1 / v0). On desktop it shows up on hover, which is great — but on touch the hover never fires, so my first tap just navigated me straight to v1. I never even got the chance to pick v0.
<img width="1236" height="445" alt="ScreenShot_2026-05-18_151217_646" src="https://github.com/user-attachments/assets/8949bb98-a75c-47e6-a56f-15c8b623bd71" />


## Fix

Made the first tap on those dropdown triggers open the menu instead of navigating, but only on touch / no-hover devices (`matchMedia('(hover: none)')`). The second tap (or tapping a menu item) navigates as normal. Outside-tap and Escape close it. Desktop hover is untouched.

Two tiny changes:
- `globals.css` — added `.nav-dd.open` to the existing `:hover` / `:focus-within` rules so a JS-toggled class can reveal the menu.
- `Topbar.astro` — small script inside the existing `<script>` block that wires up the tap intercept on `(hover: none)` devices.

## How I verified

Ran the dev server locally and drove it with Playwright in two contexts:

- **Touch context** (`hasTouch: true`, viewport 1280×800 so desktop nav is rendered): first tap opens the dropdown without navigating, `.open` class is applied, menu becomes visible; outside tap closes; tapping the v0 entry navigates correctly. Same flow checked for the Documentation dropdown. 9/9 assertions pass.
- **Desktop context** (mouse, no touch): hover still reveals the menu without clicking, and clicking the trigger still navigates straight to `/docs/examples` — no regression.