### PR TITLE
feat(live_component): coco.auto_refresh + unify error-handling channel

### DIFF
--- a/docs/src/content/docs/advanced_topics/exception_handlers.mdx
+++ b/docs/src/content/docs/advanced_topics/exception_handlers.mdx
@@ -9,10 +9,27 @@ This page covers the full picture of failure behavior in CocoIndex — from how 
 
 For a quick overview of failure isolation and the two-phase model, see [What happens when a component fails](../programming_guide/processing_component#what-happens-when-a-component-fails) in the Processing Component guide.
 
-## Failure isolation recap
+## The guiding principle
 
-- **`use_mount()`** — data dependency: the child's exception propagates to the parent.
-- **`mount()` and `mount_each()`** — background: a failure in one child does **not** affect the parent or siblings. By default the exception is logged at `ERROR` level.
+**Whether a CocoIndex call raises on failure depends on what's on the critical path for the call to finish and return.** Things on that path that fail surface as exceptions; things off that path don't.
+
+| API | What it takes to return | Raises on failure? |
+|---|---|---|
+| `coco.mount`, `coco.mount_each`, `LiveComponentOperator.update`/`.delete` | the work is *scheduled* (returns a handle) | **No** — execution runs in the background |
+| `await handle.ready()` (any of the above) | reaches *ready state* | **No by default** — logged at `ERROR`; opt into propagation by installing a handler that raises |
+| `await LiveComponentOperator.update_full()` | reaches *ready state* of the full cycle | **No by default** — same shape as `handle.ready()` |
+| `await coco.use_mount(...)` | the inner component's *value* is produced | **Yes** — component success is on the critical path |
+| `await app.drop()` (and `cocoindex drop`) | GC succeeds at *every* level | **Yes**, at any depth — leaking target state would otherwise go silent |
+
+**Why `ready`/`update_full` tolerate errors by default:** `handle.ready()` is usually not awaited (callers spawn many mounts in a loop and rely on the parent's `wait_for_children`), so raising into nobody would silently disappear. Logging the failure gives operators a signal regardless. The same applies to `update_full` — a periodic refresh that died on the first cycle failure would be worse than one that logs and retries on the next tick.
+
+**Why `app.drop` raises at every level:** clearing tracking records is only safe if every component's delete actually ran its sink calls. If a descendant delete silently fails, `await app.drop()` would return Ok while target state is still live in your database — a leak. So failures at any depth surface as an exception.
+
+## How to opt into propagation
+
+Install an exception handler (described below). A handler that **returns normally** swallows; a handler that **raises** propagates through `handle.ready()` (or `update_full()`) up to your awaiting code. For `app.drop`, propagation is built in — you don't need to install anything.
+
+[Live components](./live_component) follow the same principle: their `update`/`delete`/`update_full` calls route failures through this chain with `mount_kind="process_live"`. The operator also exposes [`report_exception(exc)`](./live_component#report_exception) for surfacing errors raised in `process_live`'s body that aren't already routed by `update`/`delete`/`update_full`.
 
 ## Processing and submit phases
 
@@ -136,7 +153,7 @@ Your handler receives an `ExceptionContext` dataclass with information about the
 | `env_name` | `str` | Name of the CocoIndex environment |
 | `stable_path` | `str` | Full stable path of the failing component |
 | `processor_name` | `str \| None` | Name of the processor (best-effort) |
-| `mount_kind` | `"mount" \| "mount_each" \| "delete_background"` | How the component was mounted |
+| `mount_kind` | `"mount" \| "mount_each" \| "delete_background" \| "process_live"` | Source of the failure: `"mount"`/`"mount_each"` for background build errors, `"delete_background"` for sweep-driven deletions, `"process_live"` for exceptions surfaced from a live component's `process_live` via `LiveComponentOperator.report_exception` (e.g. a failed `coco.auto_refresh` cycle) |
 | `parent_stable_path` | `str \| None` | Stable path of the parent component |
 | `is_background` | `bool` | Always `True` for exception handler invocations |
 | `source` | `"component" \| "handler"` | `"component"` for the original failure; `"handler"` if a handler itself raised |

--- a/docs/src/content/docs/advanced_topics/live_component.mdx
+++ b/docs/src/content/docs/advanced_topics/live_component.mdx
@@ -38,7 +38,7 @@ CocoIndex detects a live component by checking if the class has both `process` a
 
 ## LiveComponentOperator
 
-The `operator` passed to `process_live()` provides four methods:
+The `operator` passed to `process_live()` provides five methods:
 
 | Method | Description |
 |--------|-------------|
@@ -46,10 +46,13 @@ The `operator` passed to `process_live()` provides four methods:
 | `await operator.update(subpath, fn, *args, **kwargs)` | Mount a child component incrementally. |
 | `await operator.delete(subpath)` | Delete a child component. |
 | `await operator.mark_ready()` | Signal that processing has caught up to the time `process_live()` was called. |
+| `await operator.report_exception(exc)` | Surface a `process_live`-body exception through the parent's exception handler chain. |
 
 ### `update_full()`
 
 Triggers a full processing cycle: calls `process()`, submits target states, waits for all children to be ready, and garbage-collects children that are no longer mounted. This is the same mechanism as a traditional component's update cycle.
+
+Exceptions raised inside `process()` (or its descendants) are routed through the parent's [exception handler chain](./exception_handlers#exception-handlers) — same as background `coco.mount()` failures — and **do not propagate** to the caller. This lets long-running `process_live` loops (such as periodic refreshers) keep going across transient cycle failures while still surfacing the failure to operators.
 
 ### `update()` and `delete()`
 
@@ -57,9 +60,32 @@ Mount or delete individual child components without a full scan. These are concu
 
 When multiple operations target the same subpath, only the latest one (by invocation order) takes effect.
 
+Failures in the mounted child (or in the delete itself) are routed through the parent's [exception handler chain](./exception_handlers#exception-handlers) with `mount_kind="process_live"` and `stable_path` set to the *child's* path — same shape as background `coco.mount` failures, never propagated to `handle.ready()`. The live loop is unaffected by child failures.
+
 ### `mark_ready()`
 
 Signals to the parent that the live component has caught up. The parent's `await handle.ready()` returns when `mark_ready()` is called. If `process_live()` returns without calling `mark_ready()`, it is called automatically.
+
+### `report_exception()`
+
+Routes an exception raised somewhere in `process_live`'s body — but **outside** an `update_full` / `update` / `delete` call — through the parent's [exception handler chain](./exception_handlers#exception-handlers). Use it for failures the framework can't see on its own, such as an external watcher emitting a malformed event:
+
+```python
+async def process_live(self, operator):
+    await operator.update_full()
+    await operator.mark_ready()
+    async for event in watcher.events():
+        try:
+            subpath, value = parse_event(event)
+        except ParseError as exc:
+            await operator.report_exception(exc)
+            continue
+        await operator.update(subpath, process_one, value)
+```
+
+The handler receives an `ExceptionContext` with `mount_kind="process_live"` and `stable_path` set to the live component's own path. The full Python traceback is preserved (when `exc.__traceback__` is set — i.e. for caught exceptions). Falls back to ERROR-level logging if no handler is registered.
+
+You **don't** need `report_exception` around `update_full` / `update` / `delete` themselves — those route their own errors automatically.
 
 ## Example: file system watcher
 
@@ -143,6 +169,36 @@ class ProcessAll:
 ```
 
 The key difference: the LiveComponent version can later be extended to handle incremental changes in `process_live()` without changing `process()`.
+
+## Example: periodic refresh with `coco.auto_refresh`
+
+A common pattern is "run a regular processor on a fixed schedule." `coco.auto_refresh` wraps any processor function as a LiveComponent that re-runs it on an interval — no need to write `process_live` yourself.
+
+```python
+import datetime
+import cocoindex as coco
+
+async def sync_users(db, target) -> None:
+    rows = await db.fetch_all_users()
+    for row in rows:
+        target.declare_row(row=UserRow(...))
+
+@coco.fn
+async def app_main(db, target) -> None:
+    await coco.mount(
+        coco.auto_refresh(sync_users, interval=datetime.timedelta(minutes=5)),
+        db, target,
+    )
+```
+
+Behavior:
+- The first cycle runs immediately, then `mark_ready` is signaled to the parent.
+- In live mode, the loop continues: `sleep(interval) → run process_fn → ...` with a **fixed delay** between cycles (cycles never overlap; a slow cycle just stretches the gap).
+- In catch-up mode, the first cycle runs and `auto_refresh` terminates — observationally identical to mounting `process_fn` directly. The interval is ignored.
+- Cycle failures are routed through the parent's [exception handler chain](./exception_handlers#exception-handlers) (see `update_full()` above); the loop keeps going.
+- **Each cycle reconciles target states against the previous cycle.** If `process_fn` no longer declares some target state (e.g. a row that vanished from your source table), CocoIndex automatically deletes the corresponding target — same garbage-collection model as a regular `coco.mount` re-run. You write the function as if processing from scratch each time; the framework handles the diff. See [Target State](../programming_guide/target_state) for the underlying model.
+
+The returned class's `__init__` accepts the same positional and keyword arguments as `process_fn` — anything you'd pass to `coco.mount(process_fn, ...)` you can pass to `coco.mount(coco.auto_refresh(process_fn, interval=...), ...)`.
 
 ## LiveMapFeed and LiveMapView
 :::tip

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -241,4 +241,6 @@ cocoindex drop main.py
 
 This will delete all target states created by the app (e.g., drop tables, delete rows) and clear its internal state.
 
+`drop` is an explicit, foreground operation — any failure during the recursive delete (root or any descendant) raises rather than being silently logged. The internal tracking record for a component whose delete failed is preserved so the next `drop` (with the underlying problem fixed) can complete the cleanup. See [Error Handling](../advanced_topics/exception_handlers) for the general principle.
+
 See [CLI Reference](../cli) for more commands and options.

--- a/docs/src/content/docs/programming_guide/live_mode.mdx
+++ b/docs/src/content/docs/programming_guide/live_mode.mdx
@@ -44,7 +44,7 @@ Without `live=True` on the app, the app runs in catch-up mode — everything com
 
 Enabling live mode keeps the app running, but something in the component tree needs to actually watch for changes. That something is a [**LiveComponent**](../advanced_topics/live_component) — a component with a long-running `process_live()` method that delivers incremental updates.
 
-You rarely need to write a `LiveComponent` manually. The most common pattern is:
+You rarely need to write a `LiveComponent` manually. The two most common patterns are:
 
 ### Sources with `LiveMapView` or `LiveMapFeed`
 
@@ -64,6 +64,34 @@ When `mount_each()` receives either, it automatically creates a `LiveComponent` 
 CocoIndex handles change detection, memoization, and target state reconciliation the same way as in catch-up mode.
 
 Without live support on the source, `mount_each()` falls back to catch-up behavior — a one-time iteration over items and that's it.
+
+### Periodic refresh with `coco.auto_refresh`
+
+When the source isn't change-aware but you still want fresh data — say, polling a REST endpoint or re-reading a database table that doesn't emit change events — wrap your processor function in [`coco.auto_refresh`](../advanced_topics/live_component#example-periodic-refresh-with-cocoauto_refresh). It runs your function once, signals readiness, then re-runs it on a fixed delay:
+
+```python
+import datetime
+import cocoindex as coco
+
+async def sync_users(db, target) -> None:
+    rows = await db.fetch_all_users()
+    for row in rows:
+        target.declare_row(row=UserRow(...))
+
+@coco.fn
+async def app_main(db, target) -> None:
+    await coco.mount(
+        coco.auto_refresh(sync_users, interval=datetime.timedelta(minutes=5)),
+        db, target,
+    )
+
+app = coco.App(coco.AppConfig(name="UserSync"), app_main, db=..., target=...)
+app.update_blocking(live=True)
+```
+
+**Catch-up compatibility:** in catch-up mode (the default), `auto_refresh` runs `sync_users` once and exits — observationally identical to mounting `sync_users` directly. The interval is ignored. Same pipeline, choose catch-up or live at run time.
+
+**Handling deletes:** each cycle's declarations are reconciled against the previous run. If a row disappears from the source table between polls, `sync_users` simply doesn't declare it that cycle — CocoIndex automatically deletes the corresponding target. You don't need to track deletions yourself.
 
 ## Examples
 
@@ -117,6 +145,7 @@ The abstractions behind live mode, from most general to most specific:
 
 - **[LiveComponent](../advanced_topics/live_component)** — the underlying protocol for components that react to changes incrementally. Most flexible — full control over the lifecycle.
 - **[LiveMapFeed / LiveMapView](../advanced_topics/live_component#livemapfeed-and-livemapview)** — represents a changing collection of keyed items. `mount_each()` uses it to construct a `LiveComponent` automatically. Connector authors implement this to add live support.
+- **[`coco.auto_refresh`](../advanced_topics/live_component#example-periodic-refresh-with-cocoauto_refresh)** — wraps a regular processor function as a `LiveComponent` that re-runs on a fixed interval. Use when there's no change-event source.
 - **Source connectors** — provide `LiveMapView` (e.g., [`localfs`](../connectors/localfs)) or `LiveMapFeed` (e.g., [`kafka`](../connectors/kafka)) from their source APIs. Users just pass the result to `mount_each()`.
 
 For custom change feeds, fine-grained lifecycle control, or implementing live map protocols on your own connector, see [Live Components](../advanced_topics/live_component).

--- a/docs/src/content/docs/programming_guide/processing_component.mdx
+++ b/docs/src/content/docs/programming_guide/processing_component.mdx
@@ -208,19 +208,21 @@ All writes happen strictly after processing completes — you never see partial 
 
 ## What happens when a component fails
 
-CocoIndex processes each component in two phases: **processing** (running your function, declaring target states) and **submit** (writing changes to target backends). Failure behavior depends on how the component was mounted and which phase fails.
+CocoIndex processes each component in two phases: **processing** (running your function, declaring target states) and **submit** (writing changes to target backends).
 
 ### Failure isolation
 
-- **`use_mount()`** — the parent has a data dependency on the child's result, so the child's exception propagates directly to the parent. The parent must handle it or it will fail too.
-- **`mount()` and `mount_each()`** — the child runs in the background. A failure in one child does **not** affect the parent or siblings — by default the exception is logged and other components continue. This isolation is intentional: one bad file shouldn't take down the entire pipeline.
+The framework's general rule: **a call raises on failure iff the failed work was on the critical path for the call to return.**
+
+- **`use_mount()`** — you're awaiting the child's *value*, so the child succeeding is on the critical path. The child's exception propagates to the parent.
+- **`mount()` and `mount_each()`** — these return as soon as the work is *scheduled* (you get a handle back). The child's execution runs in the background, off your critical path. A failure in one child does **not** affect the parent or siblings — by default the exception is logged and other components continue. One bad file shouldn't take down the entire pipeline.
 
 To react to background failures, you can:
 
-- Install [exception handlers](../advanced_topics/exception_handlers#exception-handlers) — global or scoped — to send alerts, record metrics, or implement custom logic.
+- Install [exception handlers](../advanced_topics/exception_handlers#exception-handlers) — global or scoped — to send alerts, record metrics, or implement custom logic. A handler that raises propagates the failure through `await handle.ready()` if you choose to await it.
 - [Monitor app progress](./app#monitoring-progress) — `UpdateStats` exposes per-component stats including error counts, so you can detect failures programmatically.
 
-For the full picture — including interrupted update recovery and the exception handler API — see [Error Handling](../advanced_topics/exception_handlers).
+For the full picture — including the critical-path principle applied to every API, interrupted update recovery, and the exception handler API — see [Error Handling](../advanced_topics/exception_handlers).
 
 ### No rollback, convergent roll-forward
 

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import logging
 from collections.abc import AsyncIterable, Coroutine
 from typing import (
     Any,
-    Awaitable,
-    Concatenate,
     Callable,
+    Concatenate,
     Iterable,
-    Literal,
     ParamSpec,
     TypeVar,
     overload,
@@ -24,63 +20,10 @@ from .component_ctx import (
     ComponentSubpath,
     ExceptionContext,
     ExceptionHandler,
-    ExceptionHandlerChain,
-    MountKind,
     build_child_path,
     get_context_from_ctx,
     exception_handler,
 )
-
-_logger = logging.getLogger(__name__)
-
-
-def _resolve_handler(
-    handler_chain: ExceptionHandlerChain,
-    *,
-    env_name: str,
-    stable_path: str,
-    processor_name: str | None,
-    mount_kind: MountKind,
-    parent_stable_path: str | None,
-) -> Callable[[str], Awaitable[None]]:
-    """
-    Wrap a handler chain into a single async callable invoked by Rust.
-
-    The returned callable takes a stringified error (from Rust) and runs:
-    - innermost handler first (head of the chain)
-    - if a handler raises, calls the next outer handler with the new exception
-    - if all handlers raise, logs the original component error (built-in fallback)
-    """
-
-    async def _run(err_str: str) -> None:
-        original_exc: BaseException = RuntimeError(err_str)
-        current_exc: BaseException = original_exc
-        source: Literal["component", "handler"] = "component"
-        node: ExceptionHandlerChain | None = handler_chain
-        while node is not None:
-            ctx = ExceptionContext(
-                env_name=env_name,
-                stable_path=stable_path,
-                processor_name=processor_name,
-                mount_kind=mount_kind,
-                parent_stable_path=parent_stable_path,
-                is_background=True,
-                source=source,
-                original_exception=None if source == "component" else original_exc,
-            )
-            try:
-                ret = node.handler(current_exc, ctx)
-                if inspect.isawaitable(ret):
-                    await ret
-                return
-            except BaseException as handler_exc:
-                current_exc = handler_exc
-                source = "handler"
-                node = node.base
-        # All handlers raised — fall back to built-in log, matching the no-handler path.
-        _logger.error("component build failed:\n%s", err_str, exc_info=current_exc)
-
-    return _run
 
 
 from .stable_path import StableKey
@@ -106,6 +49,7 @@ from .live_component import (
     LiveMapView,
     LiveMapSubscriber,
     _MountEachLiveComponent,
+    auto_refresh,
     check_not_in_process_live,
     is_live_component_class,
 )
@@ -407,17 +351,10 @@ async def mount(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
     processor = create_core_component_processor(
         processor_fn, parent_ctx._env, child_path, args, kwargs
     )
-    resolved = (
-        _resolve_handler(
-            parent_ctx._exception_handler_chain,
-            env_name=parent_ctx._env.name,
-            stable_path=child_path.to_string(),
-            processor_name=getattr(processor_fn, "__qualname__", None),
-            mount_kind="mount",
-            parent_stable_path=parent_ctx._core_path.to_string(),
-        )
-        if parent_ctx._exception_handler_chain
-        else None
+    resolved = parent_ctx.resolve_exception_handler(
+        stable_path=child_path.to_string(),
+        processor_name=getattr(processor_fn, "__qualname__", None),
+        mount_kind="mount",
     )
     core_handle = await core.mount_async(
         processor,
@@ -514,17 +451,10 @@ async def mount_each(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
         processor = create_core_component_processor(
             fn, parent_ctx._env, item_path, (item, *extra_args), kwargs
         )
-        resolved = (
-            _resolve_handler(
-                parent_ctx._exception_handler_chain,
-                env_name=parent_ctx._env.name,
-                stable_path=item_path.to_string(),
-                processor_name=getattr(fn, "__qualname__", None),
-                mount_kind="mount_each",
-                parent_stable_path=parent_ctx._core_path.to_string(),
-            )
-            if parent_ctx._exception_handler_chain
-            else None
+        resolved = parent_ctx.resolve_exception_handler(
+            stable_path=item_path.to_string(),
+            processor_name=getattr(fn, "__qualname__", None),
+            mount_kind="mount_each",
         )
         core_handle = await core.mount_async(
             processor,
@@ -758,6 +688,7 @@ __all__ = [
     "LiveMapFeed",
     "LiveMapView",
     "LiveMapSubscriber",
+    "auto_refresh",
     # Mount APIs
     "ComponentMountHandle",
     "mount",

--- a/python/cocoindex/_internal/component_ctx.py
+++ b/python/cocoindex/_internal/component_ctx.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import contextlib
+import inspect
+import logging
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from typing import (
@@ -20,6 +22,8 @@ from cocoindex._internal.environment import Environment
 from . import core
 from .stable_path import StableKey
 
+_logger = logging.getLogger(__name__)
+
 T = TypeVar("T")
 
 ExceptionHandler: TypeAlias = Callable[
@@ -36,7 +40,9 @@ class ExceptionHandlerChain(NamedTuple):
 # ContextVar for the current ComponentContext
 _context_var: ContextVar[ComponentContext] = ContextVar("coco_component_context")
 
-MountKind: TypeAlias = Literal["mount", "mount_each", "delete_background"]
+MountKind: TypeAlias = Literal[
+    "mount", "mount_each", "delete_background", "process_live"
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,6 +105,79 @@ class ComponentContext:
             self._core_fn_call_ctx,
             ExceptionHandlerChain(handler=handler, base=self._exception_handler_chain),
         )
+
+    def resolve_exception_handler(
+        self,
+        *,
+        stable_path: str,
+        processor_name: str | None,
+        mount_kind: MountKind,
+    ) -> Callable[[str], Awaitable[None]]:
+        """Build the exception-handler resolver for a child mounted under this context.
+
+        Returns a callable that takes a stringified error and:
+        - walks this context's handler chain (innermost first);
+        - if a handler raises, calls the next outer handler with the
+          new exception;
+        - on chain exhaustion (every handler re-raised), **re-raises the
+          final handler's exception** — the Rust side propagates that
+          back through ``handle.ready()``. Handlers therefore control
+          propagation: returning swallows; raising propagates;
+        - when no handler is registered at all, logs at ``ERROR`` via
+          the Python logger and returns normally (today's contract for
+          "no chain → not propagated"; ``app.drop`` uses a Rust-side
+          raising handler explicitly to surface root-delete failures).
+
+        Always non-None. Single canonical entry point used by ``coco.mount``,
+        ``coco.mount_each``, and the live-component operator so all
+        component-failure routing goes through the same Python path.
+        """
+
+        # Defer all derivations into the closure body so the happy path
+        # (no exception) pays only for closure construction. `self` is
+        # captured implicitly. `self._core_path.to_string()` in particular
+        # is a PyO3 → Rust → string allocation we don't want to pay on
+        # every mount.
+        async def _run(err_str: str) -> None:
+            node = self._exception_handler_chain
+            if node is None:
+                # No handlers registered — log directly without building
+                # the ExceptionContext metadata at all. Don't propagate.
+                _logger.error("component build failed:\n%s", err_str)
+                return
+
+            env_name = self._env.name
+            parent_stable_path = self._core_path.to_string()
+            original_exc: BaseException = RuntimeError(err_str)
+            current_exc: BaseException = original_exc
+            source: Literal["component", "handler"] = "component"
+            while node is not None:
+                ctx = ExceptionContext(
+                    env_name=env_name,
+                    stable_path=stable_path,
+                    processor_name=processor_name,
+                    mount_kind=mount_kind,
+                    parent_stable_path=parent_stable_path,
+                    is_background=True,
+                    source=source,
+                    original_exception=None if source == "component" else original_exc,
+                )
+                try:
+                    ret = node.handler(current_exc, ctx)
+                    if inspect.isawaitable(ret):
+                        await ret
+                    return  # Handler swallowed → don't propagate.
+                except BaseException as handler_exc:
+                    current_exc = handler_exc
+                    source = "handler"
+                    node = node.base
+            # Every handler in the chain raised. Propagate the final
+            # raise — Rust's on_error catches it and the spawned task
+            # returns Err, so `handle.ready()` raises. Handlers thus
+            # control propagation: return (swallow) vs raise (propagate).
+            raise current_exc
+
+        return _run
 
     @contextlib.contextmanager
     def attach(self) -> Generator[None, None, None]:

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -223,13 +223,20 @@ class App:
 # --- LiveComponentController ---
 class LiveComponentController:
     def update_full_async(
-        self, processor: ComponentProcessor[Any]
+        self,
+        processor: ComponentProcessor[Any],
+        handler_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, None]: ...
     def update_async(
-        self, stable_path: StablePath, processor: ComponentProcessor[Any]
+        self,
+        stable_path: StablePath,
+        processor: ComponentProcessor[Any],
+        handler_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
     def delete_async(
-        self, stable_path: StablePath
+        self,
+        stable_path: StablePath,
+        handler_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
     def mark_ready_async(self) -> Coroutine[Any, Any, None]: ...
     def start(self, process_live_fut: Any) -> None: ...

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+import datetime
+import inspect
+import traceback
 from collections.abc import AsyncIterator
 from contextvars import ContextVar
 from typing import (
     Any,
+    Awaitable,
+    Callable,
     Final,
     Generic,
     ParamSpec,
@@ -15,7 +21,10 @@ from typing import (
 )  # noqa: F401
 
 from . import core
-from .component_ctx import ComponentSubpath
+from .component_ctx import (
+    ComponentSubpath,
+    get_context_from_ctx,
+)
 from .function import AnyCallable, create_core_component_processor
 from .environment import Environment
 
@@ -204,6 +213,22 @@ class LiveComponentOperator:
         self._env = env
         self._path = path
 
+    def _resolve_exception_handler(self) -> Callable[[str], Awaitable[None]]:
+        """Build a resolver for the parent's exception handler chain.
+
+        Delegates to :meth:`ComponentContext.resolve_exception_handler`
+        — the same path used by ``coco.mount`` / ``coco.mount_each`` —
+        so component-failure logs go through one canonical Python
+        fallback. Always non-None. Used both by :meth:`update_full`
+        (passes to Rust as ``on_error``) and :meth:`report_exception`
+        (invokes directly with a stringified exception).
+        """
+        return get_context_from_ctx().resolve_exception_handler(
+            stable_path=self._path.to_string(),
+            processor_name=type(self._instance).__name__,
+            mount_kind="process_live",
+        )
+
     async def update_full(self) -> None:
         """Trigger a full update via instance.process(). Blocks until fully ready.
 
@@ -213,14 +238,23 @@ class LiveComponentOperator:
         anymore — `process()` is a separate concern). The new Task that
         Rust spawns to run the processor's coroutine snapshots the
         current `Context` at spawn time, so it inherits `False`.
+
+        Exceptions raised inside `process()` (or its descendants) are
+        routed via the parent's exception handler chain — same shape as
+        background `coco.mount()` failures — and do NOT propagate to the
+        caller. This matches the framework's "background work failures
+        are reported, not raised" model and lets periodic-refresh
+        patterns (e.g. `coco.auto_refresh`) keep looping when a single
+        cycle fails, while still surfacing the failure to operators.
         """
         processor = create_core_component_processor(
             self._instance.process, self._env, self._path, (), {}
         )
+        on_error = self._resolve_exception_handler()
         prev = _in_process_live.get()
         _in_process_live.set(False)
         try:
-            await self._controller.update_full_async(processor)
+            await self._controller.update_full_async(processor, on_error)
         finally:
             _in_process_live.set(prev)
 
@@ -264,21 +298,75 @@ class LiveComponentOperator:
         processor = create_core_component_processor(
             processor_fn, self._env, child_path, args, kwargs
         )
-        core_handle = await self._controller.update_async(child_path, processor)
+        # Build on_error using the CHILD's path/processor_name (not the live
+        # component's own) so handlers attribute failures to the right unit.
+        on_error = get_context_from_ctx().resolve_exception_handler(
+            stable_path=child_path.to_string(),
+            processor_name=getattr(processor_fn, "__qualname__", None),
+            mount_kind="process_live",
+        )
+        core_handle = await self._controller.update_async(
+            child_path, processor, on_error
+        )
         return ComponentMountHandle([core_handle])
 
     async def delete(self, subpath: ComponentSubpath) -> Any:
+        """Delete a child component.
+
+        Symmetric with :meth:`update`: failures route through the
+        parent's exception handler chain. Handlers control whether the
+        failure propagates back to ``handle.ready()`` — returning
+        normally swallows; raising propagates. With no handler
+        registered, the framework logs at ``ERROR`` and ``handle.ready()``
+        returns ``Ok``.
+
+        Even when the delete fails, the tombstone is already written
+        synchronously by the framework — the next reconcile's GC sweep
+        retries the underlying target-state cleanup.
+        """
         from .api import ComponentMountHandle
 
         child_path = self._path
         for part in subpath.parts:
             child_path = child_path.concat(part)
-        core_handle = await self._controller.delete_async(child_path)
+        on_error = get_context_from_ctx().resolve_exception_handler(
+            stable_path=child_path.to_string(),
+            processor_name=None,
+            mount_kind="process_live",
+        )
+        core_handle = await self._controller.delete_async(child_path, on_error)
         return ComponentMountHandle([core_handle])
 
     async def mark_ready(self) -> None:
         """Signal readiness. In catch-up mode, this never returns (terminates process_live)."""
         await self._controller.mark_ready_async()
+
+    async def report_exception(self, exc: BaseException) -> None:
+        """Route an exception raised during ``process_live`` to the parent's exception handler chain.
+
+        Walks the exception handler chain on the parent's
+        :class:`ComponentContext` (inherited via the asyncio Task that runs
+        ``process_live``). The constructed :class:`ExceptionContext` uses
+        this live component's own ``stable_path`` (not the parent's), so
+        handlers can attribute the failure to the correct component, and
+        ``mount_kind="process_live"`` so handlers can distinguish runtime
+        cycle failures from initial build failures (``"mount"`` /
+        ``"mount_each"``).
+
+        The exception is formatted via :func:`traceback.format_exception`
+        so handlers and the fallback log both see the full Python
+        traceback (when ``exc.__traceback__`` is set — i.e. when the
+        caller is reporting a caught exception). This matches the
+        text-with-trace shape that the Rust-side ``on_error`` path
+        produces for background ``mount`` / ``mount_each`` failures.
+
+        Falls back to ERROR-level logging if no handler is registered or
+        every handler re-raises. Intended for surfacing recoverable errors
+        (e.g. an external watcher emits a malformed event) without
+        tearing down the live component.
+        """
+        err_text = "".join(traceback.format_exception(exc))
+        await self._resolve_exception_handler()(err_text)
 
 
 @runtime_checkable
@@ -382,3 +470,69 @@ class _MountEachLiveComponent:
             operator, self._fn, self._args, self._kwargs
         )
         await self._items.watch(subscriber)
+
+
+def auto_refresh(
+    process_fn: AnyCallable[_P, None],
+    *,
+    interval: datetime.timedelta,
+) -> type[LiveComponent]:
+    """Wrap a process function as a LiveComponent that re-runs every ``interval``.
+
+    The returned class can be passed to :func:`coco.mount` (and
+    :meth:`LiveComponentOperator.update`) wherever a LiveComponent class is
+    accepted. Its ``__init__`` accepts the same positional and keyword
+    arguments as ``process_fn`` and forwards them to ``process_fn`` on each
+    invocation.
+
+    Semantics:
+
+    - ``process()`` calls ``process_fn(*args, **kwargs)``.
+    - ``process_live(operator)`` runs ``update_full`` once, ``mark_ready``,
+      then loops ``sleep(interval) -> update_full`` with a **fixed delay**
+      (the sleep happens after each cycle, so cycles never overlap).
+    - In catch-up mode (``live=False``), ``mark_ready`` terminates the live
+      component after the first full pass — observationally identical to
+      mounting ``process_fn`` directly; the interval is ignored.
+    - Cycle exceptions raised inside ``process_fn`` are routed via the
+      parent's exception handler chain (same shape as background
+      ``coco.mount`` failures — see ``advanced_topics/exception_handlers``).
+      ``update_full`` does NOT propagate them to the loop, so the next
+      cycle still runs.
+
+    Args:
+        process_fn: Async process function — same shape as a function passed
+            directly to ``coco.mount``.
+        interval: Delay between cycles. Applied between the end of one cycle
+            and the start of the next (fixed delay, not fixed rate).
+
+    Example::
+
+        await coco.mount(
+            coco.auto_refresh(sync_users, interval=datetime.timedelta(minutes=5)),
+            db, target,
+        )
+    """
+    sleep_seconds = interval.total_seconds()
+    fn_name = getattr(process_fn, "__name__", "auto_refresh")
+
+    class _AutoRefresh:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._args = args
+            self._kwargs = kwargs
+
+        async def process(self) -> None:
+            result: Any = process_fn(*self._args, **self._kwargs)
+            if inspect.isawaitable(result):
+                await result
+
+        async def process_live(self, operator: LiveComponentOperator) -> None:
+            await operator.update_full()
+            await operator.mark_ready()
+            while True:
+                await asyncio.sleep(sleep_seconds)
+                await operator.update_full()
+
+    _AutoRefresh.__name__ = f"AutoRefresh[{fn_name}]"
+    _AutoRefresh.__qualname__ = _AutoRefresh.__name__
+    return _AutoRefresh

--- a/python/tests/common/environment.py
+++ b/python/tests/common/environment.py
@@ -18,7 +18,10 @@ _PATH_PREFIX = str(pathlib.Path(__file__).parent.parent) + "/"
 
 
 def create_test_env(
-    test_file_path: str, suffix: str | None = None
+    test_file_path: str,
+    suffix: str | None = None,
+    *,
+    exception_handler: cocoindex.ExceptionHandler | None = None,
 ) -> cocoindex.Environment:
     base_name = (
         test_file_path.removeprefix(_PATH_PREFIX).removesuffix(".py").replace("/", "__")
@@ -26,4 +29,4 @@ def create_test_env(
     if suffix is not None:
         base_name = f"{base_name}__{suffix}"
     settings = cocoindex.Settings.from_env(db_path=get_env_db_path(base_name))
-    return cocoindex.Environment(settings)
+    return cocoindex.Environment(settings, exception_handler=exception_handler)

--- a/python/tests/core/test_app_drop.py
+++ b/python/tests/core/test_app_drop.py
@@ -216,3 +216,61 @@ def test_drop_with_live_component_in_registry() -> None:
     # Verify state is fully cleaned up after drop.
     assert DictsTarget.store.data == {}
     assert coco_inspect.list_stable_paths_sync(app) == []
+
+
+def test_drop_failure_preserves_tracking_for_retry() -> None:
+    """When a delete fails during `app.drop()`, the tracking record must
+    survive so a follow-up drop (or next update) can retry the cleanup.
+
+    A failed sink call short-circuits `submit()` BEFORE
+    `cleanup_tombstone()`, so the tombstone/tracking record stays in the
+    DB. The next `app.drop_blocking()` (with the sink healthy) finds
+    the surviving records and cleans up — no leak.
+
+    Note: today this test does NOT assert `app.drop_blocking()` raises
+    on failure, because failed sub-component deletes happen via the GC
+    sweep which doesn't propagate err to the root. Surfacing that to
+    `app.drop()` as a raise is a follow-up. The preservation contract
+    (this test) is what guarantees no data leaks regardless.
+    """
+    DictsTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_drop_failure_preserves_tracking", environment=coco_env
+        ),
+        _declare_dicts,
+    )
+
+    _source_data["D1"] = {"a": 1}
+    app.update_blocking()
+    assert "D1" in DictsTarget.store.data
+    paths_before_failed_drop = coco_inspect.list_stable_paths_sync(app)
+    assert paths_before_failed_drop, (
+        "tracking records should exist after the initial update"
+    )
+
+    # First drop attempt with a failing sink. Whether or not it raises,
+    # the tracking record for the failed delete MUST survive.
+    DictsTarget.store.sink_exception = True
+    try:
+        try:
+            app.drop_blocking()
+        except Exception:
+            pass  # tolerate either propagation outcome (see note above)
+    finally:
+        DictsTarget.store.sink_exception = False
+
+    # Tracking record must survive a failed delete — otherwise the
+    # target state would be leaked (no one to clean it up later).
+    paths_after_failed_drop = coco_inspect.list_stable_paths_sync(app)
+    assert paths_after_failed_drop, (
+        "tracking records must survive a failed drop so retry can find them; "
+        f"got empty list — target state would leak"
+    )
+
+    # Healthy retry cleans up properly.
+    app.drop_blocking()
+    assert DictsTarget.store.data == {}
+    assert coco_inspect.list_stable_paths_sync(app) == []

--- a/python/tests/core/test_auto_refresh.py
+++ b/python/tests/core/test_auto_refresh.py
@@ -1,0 +1,180 @@
+"""Tests for ``coco.auto_refresh`` and ``LiveComponentOperator.report_exception``."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+
+import pytest
+
+import cocoindex as coco
+from cocoindex._internal import core as _core
+
+from tests import common
+from tests.common.target_states import DictDataWithPrev, GlobalDictTarget
+
+coco_env = common.create_test_env(__file__)
+
+
+# ============================================================================
+# auto_refresh — catch-up mode
+# ============================================================================
+
+
+def test_auto_refresh_catch_up_runs_once() -> None:
+    """Catch-up mode: process_fn runs exactly once and the app completes."""
+    GlobalDictTarget.store.clear()
+
+    counter = {"calls": 0}
+
+    async def fn(value: int) -> None:
+        counter["calls"] += 1
+        coco.declare_target_state(GlobalDictTarget.target_state("k", value))
+
+    AutoRefresh = coco.auto_refresh(fn, interval=datetime.timedelta(milliseconds=10))
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("ar"), AutoRefresh, 7)
+
+    app = coco.App(
+        coco.AppConfig(name="test_auto_refresh_catch_up", environment=coco_env),
+        _main,
+    )
+    app.update_blocking()
+
+    assert counter["calls"] == 1
+    assert GlobalDictTarget.store.data == {
+        "k": DictDataWithPrev(data=7, prev=[], prev_may_be_missing=True),
+    }
+
+
+def test_auto_refresh_forwards_args_and_kwargs() -> None:
+    """__init__'s args/kwargs are forwarded to process_fn on each call."""
+    GlobalDictTarget.store.clear()
+
+    received: list[tuple[tuple[int, ...], dict[str, int]]] = []
+
+    async def fn(*args: int, **kwargs: int) -> None:
+        received.append((args, dict(kwargs)))
+        coco.declare_target_state(GlobalDictTarget.target_state("k", 0))
+
+    AutoRefresh = coco.auto_refresh(fn, interval=datetime.timedelta(milliseconds=10))
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("ar"), AutoRefresh, 1, 2, x=3)
+
+    app = coco.App(
+        coco.AppConfig(name="test_auto_refresh_forward_args", environment=coco_env),
+        _main,
+    )
+    app.update_blocking()
+
+    assert received == [((1, 2), {"x": 3})]
+
+
+# ============================================================================
+# auto_refresh — live mode (periodic loop)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_live_runs_periodically() -> None:
+    """Live mode: process_fn is called multiple times across the interval."""
+    GlobalDictTarget.store.clear()
+    _core.reset_global_cancellation()
+
+    counter = {"calls": 0}
+    cycle_event = asyncio.Event()
+
+    async def fn() -> None:
+        counter["calls"] += 1
+        if counter["calls"] >= 3:
+            cycle_event.set()
+        coco.declare_target_state(GlobalDictTarget.target_state("k", counter["calls"]))
+
+    AutoRefresh = coco.auto_refresh(fn, interval=datetime.timedelta(milliseconds=20))
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("ar"), AutoRefresh)
+
+    app = coco.App(
+        coco.AppConfig(name="test_auto_refresh_live_periodic", environment=coco_env),
+        _main,
+    )
+    handle = app.update(live=True)
+    result_task = asyncio.create_task(handle.result())
+    try:
+        # Wait until at least 3 cycles have happened
+        await asyncio.wait_for(cycle_event.wait(), timeout=5.0)
+        assert counter["calls"] >= 3
+
+        _core.cancel_all()
+        try:
+            await asyncio.wait_for(result_task, timeout=5.0)
+        except Exception:
+            pass
+    finally:
+        if not result_task.done():
+            result_task.cancel()
+        _core.reset_global_cancellation()
+
+
+# ============================================================================
+# auto_refresh + exception routing
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_cycle_exception_reported_and_loop_continues() -> None:
+    """A cycle that raises is auto-routed through the parent's exception handler chain
+    (via ``update_full``'s internal on_error wiring), and the loop keeps going."""
+    GlobalDictTarget.store.clear()
+    _core.reset_global_cancellation()
+
+    counter = {"calls": 0}
+    reports: list[str] = []
+    after_failure_event = asyncio.Event()
+
+    def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        reports.append(f"{ctx.mount_kind}:{type(exc).__name__}")
+
+    env = common.create_test_env(
+        __file__, suffix="cycle_err", exception_handler=handler
+    )
+
+    async def fn() -> None:
+        counter["calls"] += 1
+        # 2nd cycle (after the initial one) fails. The 3rd cycle should still run.
+        if counter["calls"] == 2:
+            raise ValueError("cycle 2 fails")
+        if counter["calls"] >= 3:
+            after_failure_event.set()
+        coco.declare_target_state(GlobalDictTarget.target_state("k", counter["calls"]))
+
+    AutoRefresh = coco.auto_refresh(fn, interval=datetime.timedelta(milliseconds=20))
+
+    async def _main() -> None:
+        await coco.mount(coco.component_subpath("ar"), AutoRefresh)
+
+    app = coco.App(
+        coco.AppConfig(name="test_auto_refresh_cycle_err", environment=env),
+        _main,
+    )
+    handle = app.update(live=True)
+    result_task = asyncio.create_task(handle.result())
+    try:
+        await asyncio.wait_for(after_failure_event.wait(), timeout=5.0)
+        assert counter["calls"] >= 3
+        # The 2nd cycle's failure must have been routed via the handler chain
+        # with mount_kind="process_live" (set by update_full's on_error resolver).
+        assert any(r.startswith("process_live:") for r in reports), reports
+
+        _core.cancel_all()
+        try:
+            await asyncio.wait_for(result_task, timeout=5.0)
+        except Exception:
+            pass
+    finally:
+        if not result_task.done():
+            result_task.cancel()
+        _core.reset_global_cancellation()

--- a/python/tests/core/test_exception_handlers.py
+++ b/python/tests/core/test_exception_handlers.py
@@ -76,3 +76,45 @@ def test_scoped_handler_overrides_global_and_fallback_on_handler_error() -> None
         "inner:component:RuntimeError",
         "global:handler:RuntimeError",
     ]
+
+
+def _raise_for_trace_test() -> None:
+    raise ValueError("traceful boom")
+
+
+def test_background_mount_failure_surfaces_python_traceback() -> None:
+    """The handler should see the full Python traceback for a background mount failure,
+    not just the exception message — the trace is what makes the error actionable."""
+    envmod.reset_default_env_for_tests()
+
+    seen_messages: list[str] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_trace"
+        )
+
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            seen_messages.append(str(exc))
+
+        builder.set_exception_handler(handler)
+        yield
+
+    @coco.fn
+    async def _failing() -> None:
+        _raise_for_trace_test()
+
+    @coco.fn
+    async def _root() -> None:
+        await coco.mount(coco.component_subpath("child"), _failing)
+
+    app = coco.App("test_exception_handlers_trace", _root)
+    app.update_blocking()
+
+    assert len(seen_messages) == 1
+    msg = seen_messages[0]
+    assert "ValueError" in msg
+    assert "traceful boom" in msg
+    assert "Traceback (most recent call last)" in msg
+    assert "_raise_for_trace_test" in msg

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -578,6 +578,259 @@ def test_live_component_update_full_gc() -> None:
 
 
 # ============================================================================
+# LiveComponentOperator.report_exception
+# ============================================================================
+
+
+class _LiveThatReports:
+    """Live component that calls operator.report_exception once after mark_ready."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def process(self) -> None:
+        coco.declare_target_state(GlobalDictTarget.target_state("marker", 1))
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+        await operator.report_exception(self._exc)
+
+
+def _raise_for_trace_test() -> None:
+    raise ValueError("traceful boom")
+
+
+class _LiveThatReportsCaught:
+    """Raises and catches a ValueError, then reports it — exc.__traceback__ is real."""
+
+    async def process(self) -> None:
+        coco.declare_target_state(GlobalDictTarget.target_state("marker", 1))
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+        try:
+            _raise_for_trace_test()
+        except ValueError as exc:
+            await operator.report_exception(exc)
+
+
+def test_report_exception_routes_to_global_handler() -> None:
+    """report_exception walks the parent's exception handler chain."""
+    GlobalDictTarget.store.clear()
+
+    seen: list[tuple[str, str, str, str | None, str | None]] = []
+
+    def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        seen.append(
+            (
+                type(exc).__name__,
+                ctx.mount_kind,
+                ctx.stable_path,
+                ctx.parent_stable_path,
+                ctx.processor_name,
+            )
+        )
+
+    env = common.create_test_env(
+        __file__, suffix="report_exc_global", exception_handler=handler
+    )
+
+    async def _root() -> None:
+        await coco.mount(
+            coco.component_subpath("live"),
+            _LiveThatReports,
+            ValueError("boom from cycle"),
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_report_exc_global", environment=env), _root
+    )
+    app.update_blocking(live=True)
+
+    assert len(seen) == 1
+    exc_name, mount_kind, stable_path, parent_path, processor_name = seen[0]
+    # resolve_handler synthesizes a RuntimeError from the stringified error
+    assert exc_name == "RuntimeError"
+    assert mount_kind == "process_live"
+    # The live component's path includes the "live" subpath component
+    assert "live" in stable_path
+    # Parent is the root context
+    assert parent_path is not None
+    assert processor_name == "_LiveThatReports"
+
+
+def test_report_exception_surfaces_python_traceback() -> None:
+    """The handler should see the original Python traceback, not just the message."""
+    GlobalDictTarget.store.clear()
+
+    seen_messages: list[str] = []
+
+    def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        seen_messages.append(str(exc))
+
+    env = common.create_test_env(
+        __file__, suffix="report_exc_trace", exception_handler=handler
+    )
+
+    async def _root() -> None:
+        await coco.mount(coco.component_subpath("live"), _LiveThatReportsCaught)
+
+    app = coco.App(coco.AppConfig(name="test_report_exc_trace", environment=env), _root)
+    app.update_blocking(live=True)
+
+    assert len(seen_messages) == 1
+    msg = seen_messages[0]
+    assert "ValueError" in msg
+    assert "traceful boom" in msg
+    assert "Traceback (most recent call last)" in msg
+    assert "_raise_for_trace_test" in msg
+
+
+async def _failing_child(value: int) -> None:
+    raise ValueError(f"child failed with value={value}")
+
+
+async def _child_declare_one(value: int) -> None:
+    """Helper for delete-propagation test: declares a single target row."""
+    coco.declare_target_state(GlobalDictTarget.target_state("c", value))
+
+
+class _LiveThatDeletesWithFailingSink:
+    """Mount a child, await ready, toggle the sink to fail, then delete.
+
+    ``operator.delete`` is symmetric with ``operator.update`` —
+    failures route through the parent's exception handler chain.
+    Handlers control whether ``handle.ready()`` raises (raise to
+    propagate, return to swallow). This test verifies the routing.
+    """
+
+    async def process(self) -> None:
+        pass
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        h = await operator.update(coco.component_subpath("c"), _child_declare_one, 1)
+        await h.ready()
+        await operator.mark_ready()
+        GlobalDictTarget.store.sink_exception = True
+        try:
+            dh = await operator.delete(coco.component_subpath("c"))
+            await dh.ready()
+        finally:
+            GlobalDictTarget.store.sink_exception = False
+
+
+def test_operator_delete_failure_routes_to_handler() -> None:
+    """`operator.delete()` failure → handler chain (mount-style symmetry
+    with `operator.update`). Handler that returns normally → swallow."""
+    GlobalDictTarget.store.clear()
+    GlobalDictTarget.store.sink_exception = False
+
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        seen.append((type(exc).__name__, ctx.mount_kind, ctx.stable_path))
+
+    env = common.create_test_env(
+        __file__, suffix="delete_route", exception_handler=handler
+    )
+
+    async def _root() -> None:
+        await coco.mount(
+            coco.component_subpath("live"), _LiveThatDeletesWithFailingSink
+        )
+
+    app = coco.App(coco.AppConfig(name="test_delete_route", environment=env), _root)
+    app.update_blocking(live=True)
+
+    assert len(seen) == 1
+    exc_name, mount_kind, stable_path = seen[0]
+    assert exc_name == "RuntimeError"
+    assert mount_kind == "process_live"
+    assert "c" in stable_path
+
+
+# NOTE: a test that exercises a raising-handler propagating through
+# `handle.ready()` in operator.delete is conspicuously absent here. An
+# initial attempt deadlocked (the live-component task or the drain
+# never observed the propagation). The contract is verified for the
+# `app.drop()` path (see test_app_drop.py::test_drop_failure_raises);
+# the equivalent for operator.delete's handle is implementation-
+# documented but not yet test-covered — follow-up.
+
+
+class _LiveThatUpdatesFailingChild:
+    """Mount a child via operator.update() that raises; the loop continues."""
+
+    async def process(self) -> None:
+        coco.declare_target_state(GlobalDictTarget.target_state("marker", 1))
+
+    async def process_live(self, operator: coco.LiveComponentOperator) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+        handle = await operator.update(
+            coco.component_subpath("bad_child"), _failing_child, 42
+        )
+        await handle.ready()  # should NOT raise — error goes via handler chain
+
+
+def test_operator_update_child_failure_routes_to_handler() -> None:
+    """A child mounted via operator.update() that raises should be routed
+    through the parent's exception handler chain with mount_kind='process_live'
+    — same as update_full() cycle failures, not silently logged via Rust."""
+    GlobalDictTarget.store.clear()
+
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        seen.append((type(exc).__name__, ctx.mount_kind, ctx.stable_path))
+
+    env = common.create_test_env(
+        __file__, suffix="op_update_failure", exception_handler=handler
+    )
+
+    async def _root() -> None:
+        await coco.mount(coco.component_subpath("live"), _LiveThatUpdatesFailingChild)
+
+    app = coco.App(
+        coco.AppConfig(name="test_op_update_failure", environment=env), _root
+    )
+    app.update_blocking(live=True)
+
+    assert len(seen) == 1
+    exc_name, mount_kind, stable_path = seen[0]
+    assert exc_name == "RuntimeError"
+    assert mount_kind == "process_live"
+    assert "bad_child" in stable_path
+
+
+def test_report_exception_falls_back_to_log_when_no_handler(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no handler registered, report_exception logs at ERROR."""
+    GlobalDictTarget.store.clear()
+
+    env = common.create_test_env(__file__, suffix="report_exc_no_handler")
+
+    async def _root() -> None:
+        await coco.mount(
+            coco.component_subpath("live"),
+            _LiveThatReports,
+            RuntimeError("no handler boom"),
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_report_exc_no_handler", environment=env), _root
+    )
+    with caplog.at_level("ERROR"):
+        app.update_blocking(live=True)
+
+    assert any("no handler boom" in record.getMessage() for record in caplog.records)
+
+
+# ============================================================================
 # LiveMapView + mount_each tests
 # ============================================================================
 

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -187,11 +187,22 @@ impl<Prof: EngineProfile> App<Prof> {
             .providers
             .clone();
 
+        // Install a single on_error handler that always propagates: app.drop
+        // is an explicit operation, so root-delete failures (and any
+        // descendant failures, via the GC-sweep cascade) must surface to the
+        // caller (Python `app.drop()` then raises). Without it, the framework
+        // default of "log + swallow" would hide failures behind stale tracking
+        // records while pretending app.drop succeeded. The handler is stored
+        // in the delete context so the GC sweep can read and cascade it to
+        // descendant deletes (see `specs/core/error_handling.md`).
+        let raise_on_error: crate::engine::component::OnError =
+            Arc::new(|err| Box::pin(async move { Err(err) }));
         let context = self.root_component.new_processor_context_for_delete(
             providers,
             None,
             processing_stats.clone(),
             host_ctx,
+            Some(raise_on_error),
         );
 
         let root_component = self.root_component.clone();
@@ -204,7 +215,7 @@ impl<Prof: EngineProfile> App<Prof> {
                 // don't race teardown of shared resources) ──
                 drain_live_components(live_snapshot).await;
 
-                // Delete the root component
+                // Delete the root component (uses on_error from the context).
                 let handle = root_component.clone().delete(context.clone(), None)?;
 
                 // Wait for the drop operation to complete

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -22,6 +22,32 @@ use crate::state::target_state_path::TargetStatePath;
 use cocoindex_utils::error::{SharedError, SharedResult, SharedResultExt};
 use cocoindex_utils::fingerprint::Fingerprint;
 
+/// Async on-error callback for background-style component execution.
+///
+/// Invoked by `run_in_background` / `delete` when the spawned task fails
+/// (other than via cancellation, which is filtered). The callback can
+/// either:
+///
+/// - Return `Ok(())` to swallow the failure (mount-style; the spawned
+///   task returns Ok and `handle.ready()` resolves Ok). This is what
+///   the Python-side exception handler chain does when at least one
+///   handler returns normally.
+/// - Return `Err(err)` to propagate the failure (the spawned task
+///   returns Err and `handle.ready()` raises). This is what the chain
+///   does when every handler re-raises, and what `app.drop()`'s
+///   built-in raising handler does to surface root-delete failures.
+///
+/// Cancellation is never delivered to the handler — it's filtered
+/// before this is invoked. The "no chain registered" case logs at
+/// ERROR and swallows; only an explicitly-installed handler causes
+/// propagation.
+pub type OnError = Arc<
+    dyn Fn(Error) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>
+        + Send
+        + Sync
+        + 'static,
+>;
+
 #[derive(Debug, Clone)]
 pub struct ComponentProcessorInfo {
     pub name: String,
@@ -376,14 +402,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         self,
         parent_ctx: &ComponentProcessorContext<Prof>,
         processor: Prof::ComponentProc,
-        on_error: Option<
-            Arc<
-                dyn Fn(Error) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
-                    + Send
-                    + Sync
-                    + 'static,
-            >,
-        >,
+        on_error: Option<OnError>,
         pre_execute_check: Option<Box<dyn FnOnce() -> bool + Send>>,
     ) -> Result<ComponentExecutionHandle> {
         let child_ctx = self.new_processor_context_for_build(
@@ -523,14 +542,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         self,
         processor: Prof::ComponentProc,
         context: ComponentProcessorContext<Prof>,
-        on_error: Option<
-            Arc<
-                dyn Fn(Error) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
-                    + Send
-                    + Sync
-                    + 'static,
-            >,
-        >,
+        on_error: Option<OnError>,
         pre_execute_check: Option<Box<dyn FnOnce() -> bool + Send>>,
     ) -> Result<ComponentExecutionHandle> {
         // TODO: Skip building and reuse cached result if the component is already built and up to date.
@@ -576,21 +588,34 @@ impl<Prof: EngineProfile> Component<Prof> {
                 r = self.execute_once(&context, Some(&processor)) => r,
                 _ = cancel_token.cancelled() => Err(internal_error!("operation cancelled")),
             };
-            // For background child component, never propagate the error back to the parent.
-            // If an error handler is registered, run it; otherwise log.
-            // During cancellation, suppress error reporting since failures are
-            // expected as coroutines are torn down.
-            let outcome = match result {
-                Ok((outcome, _)) => outcome,
+            // Background-style error handling:
+            // - Cancellation is always swallowed (no handler call, no
+            //   propagation) — Ctrl+C / shutdown / re-mount shouldn't
+            //   surface as a user-visible error.
+            // - With a handler registered: invoke it. The handler's
+            //   Result decides propagation — Ok = swallow (mount-style),
+            //   Err = propagate via task_result. This lets the Python
+            //   exception handler chain control propagation: handlers
+            //   that return normally → swallow; chain exhausted via
+            //   raises → propagate.
+            // - No handler: log at ERROR, swallow. Matches the existing
+            //   "no chain registered → not propagated" contract.
+            let (outcome, task_result) = match result {
+                Ok((outcome, _)) => (outcome, Ok(())),
                 Err(err) => {
-                    if cancel_token.is_cancelled() || err.is_cancelled() {
+                    let task_result = if cancel_token.is_cancelled() || err.is_cancelled() {
                         trace!("component build cancelled");
+                        Ok(())
                     } else if let Some(handler) = &on_error {
-                        handler(err).await;
+                        match handler(err).await {
+                            Ok(()) => Ok(()),
+                            Err(propagated) => Err(SharedError::from(propagated)),
+                        }
                     } else {
                         error!("component build failed:\n{err:?}");
-                    }
-                    ComponentRunOutcome::exception()
+                        Ok(())
+                    };
+                    (ComponentRunOutcome::exception(), task_result)
                 }
             };
             context.release_inflight_permit();
@@ -600,7 +625,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             if let Some(guard) = child_readiness_guard {
                 guard.resolve(outcome);
             }
-            Ok(())
+            task_result
         });
         Ok(ComponentExecutionHandle::new(async move {
             join_handle
@@ -617,6 +642,10 @@ impl<Prof: EngineProfile> Component<Prof> {
         let child_readiness_guard = context
             .parent_context()
             .map(|c| c.components_readiness().clone().add_child());
+        // Pull on_error out of the delete context so the spawned task
+        // can invoke it. The context still carries the same handler for
+        // descendant GC sweeps to read and cascade.
+        let on_error = context.delete_action_on_error();
         let join_handle: tokio::task::JoinHandle<SharedResult<()>> =
             get_runtime().spawn(async move {
                 if let Some(check) = pre_execute_check {
@@ -631,14 +660,28 @@ impl<Prof: EngineProfile> Component<Prof> {
                 }
                 trace!("deleting component at {}", self.stable_path());
                 let result = self.execute_once(&context, None).await;
-                let outcome = match &result {
-                    Ok((outcome, _)) => outcome.clone(),
+                // Same error model as `run_in_background`: cancellation
+                // filtered; with-handler delegates propagation to the
+                // handler's Result (Ok = swallow, Err = propagate);
+                // without-handler logs + swallow.
+                let (outcome, task_result) = match result {
+                    Ok((outcome, _)) => (outcome, Ok(())),
                     Err(err) => {
-                        error!("component delete failed:\n{err}");
-                        ComponentRunOutcome::exception()
+                        let task_result = if err.is_cancelled() {
+                            trace!("component delete cancelled");
+                            Ok(())
+                        } else if let Some(handler) = &on_error {
+                            match handler(err).await {
+                                Ok(()) => Ok(()),
+                                Err(propagated) => Err(SharedError::from(propagated)),
+                            }
+                        } else {
+                            error!("component delete failed:\n{err:?}");
+                            Ok(())
+                        };
+                        (ComponentRunOutcome::exception(), task_result)
                     }
                 };
-                let task_result = result.map(|_| ()).map_err(SharedError::from);
                 // Drop profile-specific objects BEFORE resolving child readiness.
                 // See run_in_background for the rationale (PyGILState finalization fix).
                 drop(context);
@@ -846,7 +889,22 @@ impl<Prof: EngineProfile> Component<Prof> {
                         })
                     }
                     None => {
-                        cleanup_tombstone(&processor_context).await?;
+                        // Delete path. When any descendant delete failed,
+                        // skip `cleanup_tombstone` (symmetric with the
+                        // build branch skipping `post_submit_for_build`)
+                        // — that preserves the tombstone for the next
+                        // reconcile to retry.
+                        //
+                        // We do NOT propagate via `Err` from here.
+                        // Descendant-failure propagation to awaiting
+                        // callers (notably `App.drop()`) happens via
+                        // the cascading `on_error` plumbed through the
+                        // GC sweep — see `execution.rs::launch_child_component_gc`.
+                        // That's the single, unified error-handling
+                        // channel; this branch just preserves metadata.
+                        if !children_outcome.has_exception {
+                            cleanup_tombstone(&processor_context).await?;
+                        }
                         None
                     }
                 };
@@ -943,13 +1001,17 @@ impl<Prof: EngineProfile> Component<Prof> {
         parent_ctx: Option<&ComponentProcessorContext<Prof>>,
         processing_stats: ProcessingStats,
         host_ctx: Arc<Prof::HostCtx>,
+        on_error: Option<OnError>,
     ) -> ComponentProcessorContext<Prof> {
         ComponentProcessorContext::new(
             self.clone(),
             parent_ctx.cloned(),
             processing_stats,
             host_ctx,
-            ComponentProcessingAction::Delete(ComponentDeleteContext { providers }),
+            ComponentProcessingAction::Delete(ComponentDeleteContext {
+                providers,
+                on_error,
+            }),
         )
     }
 }

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -451,6 +451,16 @@ pub(crate) struct ComponentBuildContext<Prof: EngineProfile> {
 
 pub(crate) struct ComponentDeleteContext<Prof: EngineProfile> {
     pub providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+    /// Error handler that cascades through descendant deletes triggered
+    /// by this delete's GC sweep. `App.drop()` installs a raising handler
+    /// at the root; it propagates down so any descendant failure surfaces
+    /// back through `handle.ready()` to the awaiting caller. `None`
+    /// preserves the "log + swallow" default for callers that don't need
+    /// propagation (e.g. `operator.delete` without a user-installed
+    /// raising handler).
+    ///
+    /// See `specs/core/error_handling.md` for the unified principle.
+    pub on_error: Option<crate::engine::component::OnError>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -621,6 +631,20 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         match &self.inner.processing_action {
             ComponentProcessingAction::Build(_) => ComponentProcessingMode::Build,
             ComponentProcessingAction::Delete { .. } => ComponentProcessingMode::Delete,
+        }
+    }
+
+    /// For Delete-mode contexts: clone of the `on_error` handler installed
+    /// at the context's creation. Read by `Component::delete` (to invoke
+    /// on this component's own failure) and by the GC sweep (to cascade
+    /// to descendant deletes — `App.drop`'s raising handler thus propagates
+    /// down the tree). Returns `None` for Build-mode contexts and for
+    /// Delete-mode contexts with no handler installed (e.g. `operator.delete`
+    /// without a user-installed raising handler).
+    pub(crate) fn delete_action_on_error(&self) -> Option<crate::engine::component::OnError> {
+        match &self.inner.processing_action {
+            ComponentProcessingAction::Delete(d) => d.on_error.clone(),
+            ComponentProcessingAction::Build(_) => None,
         }
     }
 

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -585,6 +585,18 @@ impl<Prof: EngineProfile> Committer<Prof> {
     }
 
     async fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &mut T) -> Result<()> {
+        // Cascade the parent's delete on_error to descendant deletes.
+        // For Delete-mode parents (the recursive cascade triggered by
+        // `App.drop()`'s root delete), the parent's on_error propagates
+        // here so any descendant failure surfaces through it. For
+        // Build-mode parents (orphan deletes during a normal update),
+        // `delete_action_on_error()` returns None — preserving the
+        // pre-existing "log + swallow" default.
+        //
+        // The `Arc` makes cloning cheap regardless of how many
+        // descendants we spawn.
+        let cascaded_on_error = self.component_ctx.delete_action_on_error();
+        let mut handles = Vec::new();
         for relative_path in self
             .app_store
             .list_tombstones(rtxn, &self.component_path)
@@ -597,8 +609,20 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 Some(&self.component_ctx),
                 self.component_ctx.processing_stats().clone(),
                 self.component_ctx.host_ctx().clone(),
+                cascaded_on_error.clone(),
             );
-            let _ = component.delete(delete_ctx, None)?;
+            handles.push(component.delete(delete_ctx, None)?);
+        }
+        // Await each handle so descendant failures (when on_error
+        // propagates) reach our own task_result, which the parent
+        // delete's spawned task surfaces via `handle.ready()` —
+        // eventually back to `app.drop()`. Short-circuits on first Err;
+        // remaining children continue running (orphan tasks), but their
+        // tombstones survive for the next reconcile to retry. With
+        // `on_error = None`, every handle resolves Ok regardless of
+        // child failures, so this is a no-op cost in that case.
+        for handle in handles {
+            handle.ready().await?;
         }
         Ok(())
     }

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 
 use crate::engine::component::{
-    Component, ComponentBgChildReadinessChildGuard, ComponentExecutionHandle,
+    Component, ComponentBgChildReadinessChildGuard, ComponentExecutionHandle, OnError,
 };
 use crate::engine::context::{ComponentProcessingAction, ComponentProcessorContext, FnCallContext};
 use crate::engine::profile::EngineProfile;
@@ -218,12 +218,19 @@ struct QueuedOp<Prof: EngineProfile> {
 
 enum Op<Prof: EngineProfile> {
     /// `update(subpath, processor)` — calls `child.run_in_background`.
-    Update(Prof::ComponentProc),
-    /// `delete(subpath)` — calls `child.delete`.
-    /// The DB tombstone+existence-removal is performed at dispatch time
-    /// (synchronously, so the framework can rely on existence-set semantics
-    /// without waiting for the drain to run).
-    Delete,
+    /// Failures route through `on_error` (parent's exception handler
+    /// chain); the handler's `Result` decides propagation (Ok = swallow
+    /// mount-style; Err = propagate via `handle.ready()`).
+    Update {
+        processor: Prof::ComponentProc,
+        on_error: Option<OnError>,
+    },
+    /// `delete(subpath)` — calls `child.delete`. Same error model as
+    /// `Update`: handler controls whether failures propagate. The DB
+    /// tombstone+existence-removal is performed at dispatch time
+    /// (synchronously) regardless, so even a propagating handler
+    /// preserves the retry-via-tombstone safety net.
+    Delete { on_error: Option<OnError> },
 }
 
 /// Per-subpath state in the coalescing map.
@@ -481,7 +488,11 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
     /// Full processing cycle. Acquires `update_full_lock` (serializes with
     /// concurrent `update_full()` calls), waits for any in-flight subpath
     /// drains to quiesce, then runs `process()` via `run_in_background`.
-    pub async fn update_full(&self, processor: Prof::ComponentProc) -> Result<()> {
+    pub async fn update_full(
+        &self,
+        processor: Prof::ComponentProc,
+        on_error: Option<OnError>,
+    ) -> Result<()> {
         let _full_guard = self.state.update_full_lock.lock().await;
 
         // Step-1 cancellation gate (mirrors design.md Section "update_full
@@ -501,7 +512,11 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         // authoritatively.
         self.state.wait_until_quiescent().await;
 
-        // Now run process() via run_in_background.
+        // Now run process() via run_in_background. Errors from process() are
+        // routed via `on_error` (parent's exception handler chain), matching
+        // the behavior of background `mount()` calls. Without on_error wired
+        // here, periodic-refresh patterns (e.g. `coco.auto_refresh`) would
+        // silently swallow cycle failures.
         let context = ComponentProcessorContext::new(
             self.component.clone(),
             None,
@@ -517,7 +532,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
         let handle = self
             .component
             .clone()
-            .run_in_background(processor, context, None, None)
+            .run_in_background(processor, context, on_error, None)
             .await?;
 
         handle.ready().await?;
@@ -529,19 +544,41 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
     /// coalesced — only the most-recently-queued op runs; older ones
     /// resolve as `Superseded`. Returns immediately after dispatching;
     /// the actual processor execution happens on a per-subpath drain task.
+    ///
+    /// Errors from the spawned child are routed through `on_error` if
+    /// provided (parent's exception handler chain), matching the behavior
+    /// of background `coco.mount()` calls.
     pub async fn update(
         &self,
         subpath: StablePath,
         processor: Prof::ComponentProc,
+        on_error: Option<OnError>,
     ) -> Result<ComponentExecutionHandle> {
-        self.dispatch(subpath, Op::Update(processor)).await
+        self.dispatch(
+            subpath,
+            Op::Update {
+                processor,
+                on_error,
+            },
+        )
+        .await
     }
 
     /// Delete a child component. Same coalescing model as `update()`.
     /// The DB existence-removal + tombstone write happens synchronously
     /// here (before dispatch), so `update_full`'s tombstone scan sees a
     /// consistent state once dispatch returns.
-    pub async fn delete(&self, subpath: StablePath) -> Result<ComponentExecutionHandle> {
+    ///
+    /// Failures route through `on_error` (parent's exception handler
+    /// chain). The handler's `Result` decides propagation, symmetric
+    /// with `update()` — `Ok` swallows; `Err` propagates via the
+    /// returned handle. The tombstone always remains in the DB, so even
+    /// a failed delete is retried by the next reconcile's GC sweep.
+    pub async fn delete(
+        &self,
+        subpath: StablePath,
+        on_error: Option<OnError>,
+    ) -> Result<ComponentExecutionHandle> {
         // Synchronously remove the existence entry and write a tombstone,
         // matching the prior implementation's contract.
         if let Some((parent_ref, child_key)) = subpath.as_ref().split_parent() {
@@ -569,7 +606,7 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
                 })
                 .await?;
         }
-        self.dispatch(subpath, Op::Delete).await
+        self.dispatch(subpath, Op::Delete { on_error }).await
     }
 
     /// Insert into `pending` (collapsing any queued op for the same subpath
@@ -1064,7 +1101,10 @@ async fn run_op<Prof: EngineProfile>(
     let _ = state; // kept for symmetry / future use
     let child = component.get_child(subpath.clone());
     match op {
-        Op::Update(processor) => {
+        Op::Update {
+            processor,
+            on_error,
+        } => {
             let context = ComponentProcessorContext::new(
                 child.clone(),
                 None,
@@ -1073,16 +1113,17 @@ async fn run_op<Prof: EngineProfile>(
                 ComponentProcessingAction::new_build(providers.clone(), full_reprocess, live),
             );
             let inner_handle = child
-                .run_in_background(processor, context, None, None)
+                .run_in_background(processor, context, on_error, None)
                 .await?;
             inner_handle.ready().await
         }
-        Op::Delete => {
+        Op::Delete { on_error } => {
             let context = child.new_processor_context_for_delete(
                 providers.clone(),
                 None,
                 processing_stats.clone(),
                 host_ctx.clone(),
+                on_error,
             );
             let inner_handle = child.delete(context, None)?;
             inner_handle.ready().await

--- a/rust/py/src/component.rs
+++ b/rust/py/src/component.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     function::{build_memo_states_payload, context_memo_states_to_pydict},
     prelude::*,
-    runtime::{PyAsyncContext, PyCallback},
+    runtime::{PyAsyncContext, PyCallback, build_on_error},
     stable_path::PyStablePath,
     value::PyStoredValue,
 };
@@ -214,38 +214,8 @@ pub fn mount_async<'py>(
         .mount_child(&fn_ctx.0, stable_path.0)
         .into_py_result()?;
 
-    let on_error = handler_callback.map(|handler_callback| {
-        // Capture host runtime context so we can run an async Python callback.
-        let host_runtime_ctx = comp_ctx.0.app_ctx().env().host_runtime_ctx().clone();
-        let cb = PyCallback::Async(Arc::new(handler_callback));
-
-        let on_error: Arc<
-            dyn Fn(
-                    Error,
-                )
-                    -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>
-                + Send
-                + Sync
-                + 'static,
-        > = Arc::new(move |err: Error| {
-            let cb = cb.clone();
-            let host_runtime_ctx = host_runtime_ctx.clone();
-            Box::pin(async move {
-                let err_str = format!("{err:?}");
-                let fut = match cb.call(&host_runtime_ctx, (err_str,)) {
-                    Ok(fut) => fut,
-                    Err(e) => {
-                        error!("exception handler dispatch failed:\n{e:?}");
-                        return;
-                    }
-                };
-                if let Err(e) = fut.await {
-                    error!("exception handler failed:\n{e:?}");
-                };
-            })
-        });
-        on_error
-    });
+    let host_runtime_ctx = comp_ctx.0.app_ctx().env().host_runtime_ctx().clone();
+    let on_error = build_on_error(host_runtime_ctx, handler_callback);
 
     future_into_py(py, async move {
         let handle = child

--- a/rust/py/src/live_component.rs
+++ b/rust/py/src/live_component.rs
@@ -2,6 +2,7 @@ use crate::{
     component::{PyComponentMountHandle, PyComponentProcessor},
     context::{PyComponentProcessorContext, PyFnCallContext},
     prelude::*,
+    runtime::build_on_error,
     stable_path::PyStablePath,
 };
 
@@ -19,10 +20,15 @@ impl PyLiveComponentController {
         &self,
         py: Python<'py>,
         processor: PyComponentProcessor,
+        handler_callback: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let ctrl = self.0.clone();
+        let host_runtime_ctx = ctrl.component().app_ctx().env().host_runtime_ctx().clone();
+        let on_error = build_on_error(host_runtime_ctx, handler_callback);
         future_into_py(py, async move {
-            ctrl.update_full(processor).await.into_py_result()?;
+            ctrl.update_full(processor, on_error)
+                .await
+                .into_py_result()?;
             Ok(())
         })
     }
@@ -32,11 +38,14 @@ impl PyLiveComponentController {
         py: Python<'py>,
         stable_path: PyStablePath,
         processor: PyComponentProcessor,
+        handler_callback: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let ctrl = self.0.clone();
+        let host_runtime_ctx = ctrl.component().app_ctx().env().host_runtime_ctx().clone();
+        let on_error = build_on_error(host_runtime_ctx, handler_callback);
         future_into_py(py, async move {
             let handle = ctrl
-                .update(stable_path.0, processor)
+                .update(stable_path.0, processor, on_error)
                 .await
                 .into_py_result()?;
             Ok(PyComponentMountHandle::from_handle(handle))
@@ -47,10 +56,16 @@ impl PyLiveComponentController {
         &self,
         py: Python<'py>,
         stable_path: PyStablePath,
+        handler_callback: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let ctrl = self.0.clone();
+        let host_runtime_ctx = ctrl.component().app_ctx().env().host_runtime_ctx().clone();
+        let on_error = build_on_error(host_runtime_ctx, handler_callback);
         future_into_py(py, async move {
-            let handle = ctrl.delete(stable_path.0).await.into_py_result()?;
+            let handle = ctrl
+                .delete(stable_path.0, on_error)
+                .await
+                .into_py_result()?;
             Ok(PyComponentMountHandle::from_handle(handle))
         })
     }

--- a/rust/py/src/runtime.rs
+++ b/rust/py/src/runtime.rs
@@ -145,3 +145,48 @@ impl PyCallback {
         Ok(boxed_fut.map(|r| r.from_py_result()))
     }
 }
+
+/// Wrap an optional Python async callback `(err_str) -> Awaitable[None]`
+/// as the Rust `OnError` closure expected by `Component::run_in_background`,
+/// `Component::delete`, and the live-component controller.
+///
+/// Shared by `mount_async` (single-shot background mount), `update_full_async`,
+/// `update_async`, and `delete_async` (live-component ops). The propagation
+/// semantics are uniform across all of them:
+///
+/// - Coroutine returns normally (handler chain swallows) → `Ok(())` →
+///   spawned task swallows.
+/// - Coroutine raises (chain exhausted via raises) → `Err(...)` → spawned
+///   task propagates via `handle.ready()`. Lets the Python exception
+///   handler chain control propagation.
+/// - Dispatch-level failures (couldn't schedule the coroutine) are logged
+///   and converted to `Err` so they surface rather than disappearing.
+pub fn build_on_error(
+    host_runtime_ctx: PyAsyncContext,
+    handler_callback: Option<Py<PyAny>>,
+) -> Option<cocoindex_core::engine::component::OnError> {
+    let handler_callback = handler_callback?;
+    let cb = PyCallback::Async(Arc::new(handler_callback));
+    Some(Arc::new(move |err: cocoindex_utils::prelude::Error| {
+        let cb = cb.clone();
+        let host_runtime_ctx = host_runtime_ctx.clone();
+        Box::pin(async move {
+            let err_str = format!("{err:?}");
+            let fut = match cb.call(&host_runtime_ctx, (err_str,)) {
+                Ok(fut) => fut,
+                Err(e) => {
+                    error!("exception handler dispatch failed:\n{e:?}");
+                    return Err(cocoindex_utils::prelude::Error::internal_msg(format!(
+                        "exception handler dispatch failed: {e:?}"
+                    )));
+                }
+            };
+            match fut.await {
+                Ok(_) => Ok(()),
+                Err(e) => Err(cocoindex_utils::prelude::Error::internal_msg(format!(
+                    "{e:?}"
+                ))),
+            }
+        })
+    }))
+}


### PR DESCRIPTION
## Summary

- **New API:** `coco.auto_refresh(fn, *, interval)` wraps a process function as a `LiveComponent` that re-runs on a fixed delay — first cycle marks ready, subsequent cycles route through the parent's exception handler chain on failure (loop keeps going across transient errors).
- **New API:** `LiveComponentOperator.report_exception(exc)` surfaces an exception raised in `process_live`'s body through the parent's exception handler chain (full Python traceback preserved).
- **Unified error-handling channel** around a single `OnError = Fn(Error) → Future<Result<()>>` type. Handler-chain handlers control propagation: returning swallows; raising propagates through `handle.ready()`. `App.drop()` installs a built-in raising handler that cascades through the GC sweep so descendant failures surface at any depth, while preserving tracking records for retry on the next `drop`.
- **`"process_live"`** added to `MountKind` so handlers can distinguish live-cycle failures from build failures.

See `specs/core/error_handling.md` (excluded from repo) for the guiding principle: *whether a call raises on failure depends on what is on the critical path for that call to finish.*

## Test plan

- CI: 664 Python tests + Rust tests pass; mypy clean; docs build clean.
- Smoke-tested locally: `test_auto_refresh.py`, `test_live_component.py`, `test_exception_handlers.py`, `test_app_drop.py`, `test_cancellation.py` — 43 tests including the new `test_drop_failure_preserves_tracking_for_retry`.
