### PR TITLE
fix(iggy): cast topic.messages_count to int for mypy --no-any-return

### DIFF
--- a/python/cocoindex/connectors/iggy/_source.py
+++ b/python/cocoindex/connectors/iggy/_source.py
@@ -299,7 +299,7 @@ class TopicStream:
                 "Pass initial_high_watermark for multi-partition topics, or consume "
                 "a single-partition topic."
             )
-        return topic.messages_count
+        return int(topic.messages_count)
 
     async def _create_consumer(self) -> IggyConsumer:
         """Create an Iggy consumer group configured for manual offset storage."""


### PR DESCRIPTION
## Summary
- Cast `topic.messages_count` to `int` in `_resolve_initial_high_watermark`.
- The iggy SDK is untyped, so the attribute returns `Any`, which violated mypy's `--no-any-return` after #1969 landed (e2e-type-check failed on `main`).

## Test plan
- CI (full `uv run mypy` passes locally on 223 source files).
