### PR TITLE
fix(engine): cascade on_error through Build-mode GC sweep

### DIFF
--- a/python/tests/core/test_exception_handlers.py
+++ b/python/tests/core/test_exception_handlers.py
@@ -5,6 +5,7 @@ import cocoindex as coco
 from cocoindex._internal import environment as envmod
 
 from tests import common
+from tests.common.target_states import GlobalDictTarget, DictDataWithPrev
 
 
 def test_global_exception_handler_invoked_for_background_mount() -> None:
@@ -80,6 +81,81 @@ def test_scoped_handler_overrides_global_and_fallback_on_handler_error() -> None
 
 def _raise_for_trace_test() -> None:
     raise ValueError("traceful boom")
+
+
+_orphan_source: dict[str, int] = {}
+
+
+def test_orphan_delete_failure_routes_through_parent_handler() -> None:
+    """Build-mode cascade: when a parent's commit-phase GC sweep deletes a
+    child component that's no longer mounted (orphan) and the cleanup
+    sink fails, the parent's exception handler chain should see the
+    failure — not the framework's default `error!` log.
+
+    Without §4.2 (storing `on_error` on `ComponentBuildContext` and
+    reading it from `processing_action_on_error()` in
+    `launch_child_component_gc`), the orphan-delete failure would
+    silently log + swallow, and `seen` would stay empty.
+    """
+    envmod.reset_default_env_for_tests()
+    GlobalDictTarget.store.clear()
+    GlobalDictTarget.store.sink_exception = False
+
+    seen: list[tuple[str, str]] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_orphan_cascade"
+        )
+
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            seen.append((type(exc).__name__, ctx.mount_kind))
+
+        builder.set_exception_handler(handler)
+        yield
+
+    @coco.fn
+    async def _child(value: int) -> None:
+        coco.declare_target_state(GlobalDictTarget.target_state("k", value))
+
+    @coco.fn
+    async def _parent() -> None:
+        for name, value in _orphan_source.items():
+            await coco.mount(coco.component_subpath(name), _child, value)
+
+    @coco.fn
+    async def _root() -> None:
+        await coco.mount(coco.component_subpath("parent"), _parent)
+
+    app = coco.App("test_exception_handlers_orphan_cascade", _root)
+
+    # First update: mount child "A", child declares target state. Sink healthy.
+    _orphan_source.clear()
+    _orphan_source["A"] = 1
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "k": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert seen == []
+
+    # Second update: source empty, child "A" is now an orphan. The parent's
+    # commit-phase GC sweep deletes A; the cleanup sink fails. With §4.2,
+    # the cascaded on_error fires the parent's handler.
+    _orphan_source.clear()
+    GlobalDictTarget.store.sink_exception = True
+    try:
+        app.update_blocking()
+    finally:
+        GlobalDictTarget.store.sink_exception = False
+
+    # Exactly one failure surfaces — the orphan-delete of "A". The handler's
+    # mount_kind is "mount" because the on_error was wired through
+    # `coco.mount(..., parent_fn)` at the parent's mount time.
+    assert len(seen) == 1, f"expected one handler call; got {seen}"
+    exc_name, mount_kind = seen[0]
+    assert exc_name == "RuntimeError"
+    assert mount_kind == "mount"
 
 
 def test_background_mount_failure_surfaces_python_traceback() -> None:

--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -107,6 +107,12 @@ impl<Prof: EngineProfile> App<Prof> {
             options.full_reprocess,
             options.live,
             host_ctx,
+            // Root has no installed on_error in Build mode — orphan-delete
+            // failures from the root's GC sweep log + swallow. (Cascading
+            // a raising on_error from root would equate "any orphan delete
+            // failed" with "the whole update failed", which is too strict;
+            // tombstones survive for retry on the next reconcile.)
+            None,
         )?;
 
         let root_component = self.root_component.clone();

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -392,6 +392,11 @@ impl<Prof: EngineProfile> Component<Prof> {
             parent_ctx.full_reprocess(),
             parent_ctx.live(), // use_mount inherits live from parent
             parent_ctx.host_ctx().clone(),
+            // No build-mode on_error: use_mount is foreground; failures
+            // propagate as `Err` to the awaiting parent via `.result()`.
+            // Orphan-delete failures during this child's commit fall
+            // through to the framework's default `error!` log.
+            None,
         )?;
         self.run(processor, child_ctx).await
     }
@@ -405,12 +410,17 @@ impl<Prof: EngineProfile> Component<Prof> {
         on_error: Option<OnError>,
         pre_execute_check: Option<Box<dyn FnOnce() -> bool + Send>>,
     ) -> Result<ComponentExecutionHandle> {
+        // Store `on_error` on the child's build context too, so the
+        // commit-phase GC sweep can cascade it to orphan deletes. The
+        // same handler is also passed to `run_in_background` for the
+        // child's own task failure — one handler, two surfaces.
         let child_ctx = self.new_processor_context_for_build(
             Some(parent_ctx),
             parent_ctx.processing_stats().clone(),
             parent_ctx.full_reprocess(),
             parent_ctx.live(), // mount inherits live from parent
             parent_ctx.host_ctx().clone(),
+            on_error.clone(),
         )?;
         self.run_in_background(processor, child_ctx, on_error, pre_execute_check)
             .await
@@ -961,6 +971,7 @@ impl<Prof: EngineProfile> Component<Prof> {
         full_reprocess: bool,
         live: bool,
         host_ctx: Arc<Prof::HostCtx>,
+        on_error: Option<OnError>,
     ) -> Result<ComponentProcessorContext<Prof>> {
         let providers = if let Some(parent_ctx) = parent_ctx {
             let sub_path = self
@@ -991,7 +1002,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             parent_ctx.cloned(),
             processing_stats,
             host_ctx,
-            ComponentProcessingAction::new_build(providers, full_reprocess, live),
+            ComponentProcessingAction::new_build(providers, full_reprocess, live, on_error),
         ))
     }
 

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -447,6 +447,13 @@ pub(crate) struct ComponentBuildContext<Prof: EngineProfile> {
     pub state: Mutex<Option<ComponentBuildingState<Prof>>>,
     pub full_reprocess: bool,
     pub live: bool,
+    /// Error handler routed to orphan-delete failures from this build's
+    /// commit-phase GC sweep. Same shape and meaning as
+    /// `ComponentDeleteContext::on_error` — see that doc for the
+    /// unified principle. `None` preserves the "log + swallow"
+    /// default (e.g. root `App.update`, `use_mount`'s foreground path,
+    /// `mount_inner_live`'s self-built parent context).
+    pub on_error: Option<crate::engine::component::OnError>,
 }
 
 pub(crate) struct ComponentDeleteContext<Prof: EngineProfile> {
@@ -479,6 +486,7 @@ impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
         providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
         full_reprocess: bool,
         live: bool,
+        on_error: Option<crate::engine::component::OnError>,
     ) -> Self {
         Self::Build(ComponentBuildContext {
             state: Mutex::new(Some(ComponentBuildingState {
@@ -491,6 +499,7 @@ impl<Prof: EngineProfile> ComponentProcessingAction<Prof> {
             })),
             full_reprocess,
             live,
+            on_error,
         })
     }
 }
@@ -634,13 +643,39 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         }
     }
 
-    /// For Delete-mode contexts: clone of the `on_error` handler installed
-    /// at the context's creation. Read by `Component::delete` (to invoke
-    /// on this component's own failure) and by the GC sweep (to cascade
-    /// to descendant deletes — `App.drop`'s raising handler thus propagates
-    /// down the tree). Returns `None` for Build-mode contexts and for
-    /// Delete-mode contexts with no handler installed (e.g. `operator.delete`
-    /// without a user-installed raising handler).
+    /// Clone of the `on_error` handler installed at the context's creation,
+    /// available for both Build- and Delete-mode contexts.
+    ///
+    /// Read by:
+    /// - `Component::delete`'s spawned task (Delete only — invoke on this
+    ///   component's own failure).
+    /// - The commit-phase GC sweep (both modes — cascade to descendant
+    ///   deletes triggered by this component's submit/commit).
+    ///
+    /// For Delete-mode (`App.drop`'s root), the raising handler installed
+    /// at root cascades down through every recursive delete. For Build-mode
+    /// (a `coco.mount` child whose `process()` no longer declares a
+    /// previously-existing grandchild), the child's user-installed
+    /// exception handler chain — wired through `Component::mount`'s
+    /// `on_error` parameter — sees orphan-delete failures from the
+    /// commit-phase GC sweep.
+    ///
+    /// Returns `None` when no handler was installed (e.g. root `App.update`,
+    /// `use_mount`'s foreground path, `operator.delete` without a
+    /// user-installed raising handler).
+    pub(crate) fn processing_action_on_error(&self) -> Option<crate::engine::component::OnError> {
+        match &self.inner.processing_action {
+            ComponentProcessingAction::Build(b) => b.on_error.clone(),
+            ComponentProcessingAction::Delete(d) => d.on_error.clone(),
+        }
+    }
+
+    /// Delete-mode-only on_error accessor. Used by `Component::delete`'s
+    /// spawned task to invoke the handler on this component's own
+    /// execution failure (a *Build*-context's on_error is meant for
+    /// orphan-delete cascades, not for invoking on the build's own
+    /// failure — that flows through the `on_error` argument to
+    /// `run_in_background` directly).
     pub(crate) fn delete_action_on_error(&self) -> Option<crate::engine::component::OnError> {
         match &self.inner.processing_action {
             ComponentProcessingAction::Delete(d) => d.on_error.clone(),

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -586,17 +586,24 @@ impl<Prof: EngineProfile> Committer<Prof> {
     }
 
     async fn launch_child_component_gc<T: AnyTxn>(&self, rtxn: &mut T) -> Result<()> {
-        // Cascade the parent's delete on_error to descendant deletes.
-        // For Delete-mode parents (the recursive cascade triggered by
-        // `App.drop()`'s root delete), the parent's on_error propagates
-        // here so any descendant failure surfaces through it. For
-        // Build-mode parents (orphan deletes during a normal update),
-        // `delete_action_on_error()` returns None — preserving the
-        // pre-existing "log + swallow" default.
+        // Cascade the parent's on_error to descendant orphan deletes.
+        //
+        // - Delete-mode parent (recursive cascade from `App.drop()`'s
+        //   root delete): the raising on_error propagates so any
+        //   descendant failure surfaces back through `handle.ready()`.
+        // - Build-mode parent (orphan deletes during a normal update,
+        //   triggered by the parent's `process()` no longer declaring a
+        //   previously-existing child): the on_error installed on the
+        //   parent's build context — same handler `Component::mount`
+        //   wires for the child's own task failure — sees orphan-delete
+        //   failures too.
+        // - No installed handler (root `App.update`, `use_mount`,
+        //   `operator.delete` without a chain): `None` preserves the
+        //   "log + swallow" default.
         //
         // The `Arc` makes cloning cheap regardless of how many
         // descendants we spawn.
-        let cascaded_on_error = self.component_ctx.delete_action_on_error();
+        let cascaded_on_error = self.component_ctx.processing_action_on_error();
         let mut handles = Vec::new();
         for relative_path in self
             .app_store

--- a/rust/core/src/engine/live_component.rs
+++ b/rust/core/src/engine/live_component.rs
@@ -522,10 +522,14 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
             None,
             self.processing_stats.clone(),
             self.host_ctx.clone(),
+            // Mirror `Component::mount`: store the same on_error on the
+            // build context so the cycle's commit-phase GC sweep cascades
+            // it to orphan deletes too.
             ComponentProcessingAction::new_build(
                 self.providers.clone(),
                 self.full_reprocess,
                 self.live,
+                on_error.clone(),
             ),
         );
 
@@ -813,10 +817,14 @@ impl<Prof: EngineProfile> LiveComponentController<Prof> {
             None,
             self.processing_stats.clone(),
             self.host_ctx.clone(),
+            // No on_error on this synthetic parent context — it only
+            // exists to register the child in `child_path_set`; no
+            // commit/GC sweep runs through it.
             ComponentProcessingAction::new_build(
                 self.providers.clone(),
                 self.full_reprocess,
                 self.live,
+                None,
             ),
         );
         let fn_ctx = FnCallContext::default();
@@ -1110,7 +1118,15 @@ async fn run_op<Prof: EngineProfile>(
                 None,
                 processing_stats.clone(),
                 host_ctx.clone(),
-                ComponentProcessingAction::new_build(providers.clone(), full_reprocess, live),
+                // Mirror `Component::mount`: same on_error stored on the
+                // build context so this op's commit-phase GC sweep
+                // cascades it to orphan deletes.
+                ComponentProcessingAction::new_build(
+                    providers.clone(),
+                    full_reprocess,
+                    live,
+                    on_error.clone(),
+                ),
             );
             let inner_handle = child
                 .run_in_background(processor, context, on_error, None)


### PR DESCRIPTION
## Summary
- Resolves the spec's §4.2 gap: orphan-delete failures during a `coco.mount`-mounted parent's commit-phase GC sweep now route through the parent's exception handler chain (previously: `error!` log + swallow).
- Symmetric with the existing `ComponentDeleteContext::on_error` cascade used by `App.drop()`: `ComponentBuildContext` gains the same field; `launch_child_component_gc` reads via a new unified `processing_action_on_error()` accessor.
- One handler, two surfaces — the same `on_error` passed to `Component::mount` catches both the child's own task failure (existing) and orphan-delete failures from the child's commit (new). `LiveComponentController::update_full` / `Op::Update` mirror the same pattern. `use_mount` and root `App::update` pass `None` (preserves the prior log+swallow default by design).

## Test plan
- [x] New `test_orphan_delete_failure_routes_through_parent_handler` in test_exception_handlers.py confirms the cascade.
- [x] Toggling `launch_child_component_gc` back to `delete_action_on_error()` confirms the test fails without the fix (`seen == []` + framework's default `error!` print).
- [x] Full `pytest python/` — 674 passed, 138 skipped, 0 failed locally.
- [x] `cargo test`, `uv run mypy` clean.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
