### PR TITLE
refactor(live_component): keep _AutoRefresh.__name__ honest via __coco_subpath_name__

### DIFF
--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -112,6 +112,23 @@ _ValueT = TypeVar("_ValueT")
 _ChildHandlerT = TypeVar("_ChildHandlerT", bound="TargetHandler[Any, Any, Any] | None")
 
 
+def _default_subpath_name(processor_fn: Any) -> str | None:
+    """Resolve the default subpath name for a mount target.
+
+    Honors an explicit ``__coco_subpath_name__`` attribute (set by wrappers
+    like ``coco.auto_refresh`` so the wrapper class can keep an honest
+    ``__name__`` while still mounting under the wrapped function's name),
+    falling back to ``__name__``.
+    """
+    name = getattr(processor_fn, "__coco_subpath_name__", None)
+    if isinstance(name, str):
+        return name
+    name = getattr(processor_fn, "__name__", None)
+    if isinstance(name, str):
+        return name
+    return None
+
+
 class ComponentMountHandle:
     """Handle for processing unit(s) started with `mount()` or `mount_each()`. Allows waiting until ready."""
 
@@ -223,7 +240,7 @@ async def use_mount(*pos_args: Any, **kwargs: Any) -> Any:
     else:
         processor_fn = pos_args[0]
         args = pos_args[1:]
-        name = getattr(processor_fn, "__name__", None)
+        name = _default_subpath_name(processor_fn)
         if name is None:
             raise TypeError(
                 "use_mount() requires a ComponentSubpath when the function has no "
@@ -333,7 +350,7 @@ async def mount(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
     else:
         processor_fn = pos_args[0]
         args = pos_args[1:]
-        name = getattr(processor_fn, "__name__", None)
+        name = _default_subpath_name(processor_fn)
         if name is None:
             raise TypeError(
                 "mount() requires a ComponentSubpath when the function has no "
@@ -423,7 +440,7 @@ async def mount_each(*pos_args: Any, **kwargs: Any) -> ComponentMountHandle:
         fn = pos_args[0]
         items = pos_args[1]
         extra_args = pos_args[2:]
-        name = getattr(fn, "__name__", None)
+        name = _default_subpath_name(fn)
         if name is None:
             raise TypeError(
                 "mount_each() requires a ComponentSubpath when the function has no "

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -586,6 +586,5 @@ def auto_refresh(
                 await asyncio.sleep(sleep_seconds)
                 await operator.update_full()
 
-    _AutoRefresh.__name__ = f"AutoRefresh[{fn_name}]"
-    _AutoRefresh.__qualname__ = _AutoRefresh.__name__
+    _AutoRefresh.__coco_subpath_name__ = fn_name  # type: ignore[attr-defined]
     return _AutoRefresh


### PR DESCRIPTION
## Summary

- `coco.auto_refresh` no longer rewrites `_AutoRefresh.__name__` to the wrapped fn's name. That trick gave the right component subpath but lied about class identity — tracebacks and the `processor_name` in `_resolve_exception_handler` reported the wrapper as if it were the wrapped fn, hiding the live-loop layer when something went wrong inside the scaffold.
- Introduce an opt-in `__coco_subpath_name__` attribute. `mount` / `use_mount` / `mount_each` now consult it (via a new `_default_subpath_name()` helper) before falling back to `__name__`. `auto_refresh` sets it to the wrapped fn's name and leaves `__name__` alone.
- User-visible subpath is unchanged: `coco.mount(coco.auto_refresh(sync_users, ...))` still mounts under `sync_users`, matching the "observationally identical to mounting `process_fn` directly" guarantee. The same mechanism is now available to other wrappers or user-defined `LiveComponent` classes.

## Test plan

- CI (`pytest python/tests/core/test_auto_refresh.py` + broader core suite + `mypy`).
