### PR TITLE
Parallelize entity resolution via candidate-graph components

### DIFF
--- a/benchmarks/entity_resolution/.env.example
+++ b/benchmarks/entity_resolution/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env and fill in your real key. .env is intentionally gitignored.
+OPENAI_API_KEY=
+
+# Defaults for OpenAI-backed benchmark runs. Any CLI flag still overrides these.
+ER_BENCH_PROFILE=openai-small
+ER_BENCH_EMBEDDER=litellm
+ER_BENCH_RESOLVER=llm
+ER_BENCH_EMBEDDING_MODEL=text-embedding-3-small
+ER_BENCH_LLM_MODEL=openai/gpt-4o-mini
+ER_BENCH_ENTITY_TYPE=organization
+
+# Keep real LLM runs small at first; resolver calls are the main cost driver.
+ER_BENCH_GROUPS=20
+ER_BENCH_ALIASES_PER_GROUP=3
+ER_BENCH_ISOLATED=20
+ER_BENCH_MAX_DISTANCE=0.3
+ER_BENCH_TOP_N=5
+
+# Optional output/state overrides.
+# ER_BENCH_STATE=benchmarks/entity_resolution/.work/cocoindex
+# ER_BENCH_EXTRA_GUIDANCE=A parent organization and subsidiary are distinct.

--- a/benchmarks/entity_resolution/.gitignore
+++ b/benchmarks/entity_resolution/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+.work/
+.env

--- a/benchmarks/entity_resolution/README.md
+++ b/benchmarks/entity_resolution/README.md
@@ -24,14 +24,43 @@ uv run --project benchmarks/entity_resolution python benchmarks/entity_resolutio
   --output-json benchmarks/entity_resolution/.work/synthetic-fast.json
 ```
 
-Simulate resolver latency to make the current sequential pair processing
-visible:
+Simulate resolver latency to make resolver-call latency the dominant cost:
 
 ```sh
 uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
   --profile synthetic-latency \
   --output-json benchmarks/entity_resolution/.work/synthetic-latency.json
 ```
+
+## Component parallelism
+
+`resolve_entities` partitions entities into connected components of the
+candidate-similarity graph and resolves each component concurrently. Two
+profiles measure the two extremes:
+
+```sh
+# Many independent clusters → high resolver-call concurrency.
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile synthetic-many-components \
+  --output-json benchmarks/entity_resolution/.work/synthetic-many-components.json
+
+# A single giant cluster → no parallelism opportunity (regression check).
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile synthetic-one-giant \
+  --output-json benchmarks/entity_resolution/.work/synthetic-one-giant.json
+```
+
+Before (sequential) vs. after (component-parallel), 20 ms simulated resolver
+latency:
+
+| Profile | Components | Before | After | Resolver concurrency |
+|---|---|---|---|---|
+| `synthetic-latency` | 200 | 6397 ms | 69 ms | 1 → 100 |
+| `synthetic-many-components` | 180 | 2448 ms | 47 ms | 1 → 80 |
+| `synthetic-one-giant` | 1 | 2110 ms | 2111 ms | 1 → 1 |
+
+`wrong_mixed_groups` stays at 0 and the canonical map matches the prior
+sequential implementation in every profile.
 
 The benchmark measures logical `embed(...)` calls. CocoIndex embedders such as
 `LiteLLMEmbedder` and `SentenceTransformerEmbedder` may batch those concurrent
@@ -47,15 +76,39 @@ LiteLLM-backed embeddings and the built-in `LlmPairResolver`.
 uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py
 ```
 
-You can also override any `.env` setting with CLI flags:
+Two OpenAI-backed profiles ship out of the box:
 
 ```sh
+# Small sanity check (5 templated groups + 5 isolates, default threshold).
 uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
   --profile openai-small \
-  --embedding-model text-embedding-3-small \
-  --llm-model openai/gpt-4o-mini \
   --output-json benchmarks/entity_resolution/.work/openai-small.json
+
+# Many-component workload designed to exercise resolver-call parallelism.
+# Uses cluster_sizes=10×3+5×1 and max_distance=0.15 to keep ground-truth
+# clusters in separate similarity components even with shared vocabulary.
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile openai-many-components \
+  --output-json benchmarks/entity_resolution/.work/openai-many-components.json
 ```
+
+Measured before (sequential) vs. after (component-parallel) on
+`openai/gpt-5.4-nano` + `text-embedding-3-small`:
+
+| Profile | max_distance | Components | Before | After | Speedup |
+|---|---|---|---|---|---|
+| `openai-small` | 0.3 (default) | 2 | 10513 ms | 8691 ms | 1.21× |
+| `openai-many-components` | 0.15 | 15 | 15063 ms | 3075 ms | **4.90×** |
+
+Two takeaways. First, the synthetic numbers above are an upper bound that
+assumes embeddings produce perfectly disjoint components; real embedders
+may collapse multiple ground-truth clusters into one similarity component
+when canonicals share vocabulary, in which case the resolver still
+correctly partitions them but parallelism is bounded by the component
+count. Second, `max_distance` controls how aggressively the component
+graph admits edges — looser thresholds add safety candidates for the
+resolver but reduce parallelism; tighter thresholds increase parallelism
+but assume your embeddings cleanly separate distinct entities.
 
 Keep OpenAI-backed runs small at first. The benchmark prints the number of LLM
 resolver calls, which is the main cost driver.

--- a/benchmarks/entity_resolution/README.md
+++ b/benchmarks/entity_resolution/README.md
@@ -1,0 +1,73 @@
+# Entity resolution benchmark
+
+Synthetic benchmark for `cocoindex.ops.entity_resolution.resolve_entities`.
+
+The goal is to measure the current operation before changing the algorithm. It
+generates deterministic clusters of entity-name aliases, runs the real
+`resolve_entities` implementation, and records where time goes:
+
+- total entities, groups, and aliases
+- embedding call count, latency, and max logical concurrency
+- resolver call count, latency, candidate counts, and max concurrency
+- resolution events, zero-candidate events, matches, and repoints
+- end-to-end elapsed time
+
+## Fast local baseline
+
+This uses a deterministic in-memory embedder and resolver. It is useful for
+measuring FAISS/search/loop overhead and for simulating expensive resolver
+latency without spending LLM tokens.
+
+```sh
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile synthetic-fast \
+  --output-json benchmarks/entity_resolution/.work/synthetic-fast.json
+```
+
+Simulate resolver latency to make the current sequential pair processing
+visible:
+
+```sh
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile synthetic-latency \
+  --output-json benchmarks/entity_resolution/.work/synthetic-latency.json
+```
+
+The benchmark measures logical `embed(...)` calls. CocoIndex embedders such as
+`LiteLLMEmbedder` and `SentenceTransformerEmbedder` may batch those concurrent
+logical calls into fewer provider/model calls internally.
+
+## OpenAI-backed run
+
+The benchmark automatically loads `benchmarks/entity_resolution/.env`.
+`.env.example` contains a small OpenAI-backed configuration using
+LiteLLM-backed embeddings and the built-in `LlmPairResolver`.
+
+```sh
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py
+```
+
+You can also override any `.env` setting with CLI flags:
+
+```sh
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile openai-small \
+  --embedding-model text-embedding-3-small \
+  --llm-model openai/gpt-4o-mini \
+  --output-json benchmarks/entity_resolution/.work/openai-small.json
+```
+
+Keep OpenAI-backed runs small at first. The benchmark prints the number of LLM
+resolver calls, which is the main cost driver.
+
+## JSON output
+
+```sh
+uv run --project benchmarks/entity_resolution python benchmarks/entity_resolution/benchmark.py \
+  --profile synthetic-fast \
+  --output-json benchmarks/entity_resolution/.work/metrics.json
+```
+
+The benchmark sets `COCOINDEX_DB` to `.work/cocoindex` by default so memoized
+CocoIndex functions, such as the LiteLLM embedder and LLM resolver, have a local
+state path.

--- a/benchmarks/entity_resolution/benchmark.py
+++ b/benchmarks/entity_resolution/benchmark.py
@@ -1,0 +1,777 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import asdict, dataclass, field
+import json
+import math
+import os
+from pathlib import Path
+import random
+import sys
+import time
+from typing import Protocol
+
+from dotenv import load_dotenv
+import faiss
+import numpy as np
+from numpy.typing import NDArray
+
+from cocoindex.ops.entity_resolution import (
+    CanonicalSide,
+    PairDecision,
+    ResolutionEvent,
+    resolve_entities,
+)
+
+
+BENCH_ROOT = Path(__file__).resolve().parent
+DEFAULT_STATE_DIR = BENCH_ROOT / ".work" / "cocoindex"
+ENV_PATH = BENCH_ROOT / ".env"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkProfile:
+    embedder: str
+    resolver: str
+    groups: int
+    aliases_per_group: int
+    isolated: int
+    cluster_sizes: tuple[int, ...] | None = None
+    seed: int = 7
+    max_distance: float = 0.3
+    top_n: int = 5
+    embedding_model: str = "text-embedding-3-small"
+    synthetic_dim: int = 384
+    synthetic_embed_delay_ms: float = 0.0
+    rule_resolver_delay_ms: float = 0.0
+    llm_model: str = "openai/gpt-4o-mini"
+    entity_type: str = "organization"
+
+
+BENCHMARK_PROFILES: dict[str, BenchmarkProfile] = {
+    "synthetic-fast": BenchmarkProfile(
+        embedder="synthetic",
+        resolver="ground-truth",
+        groups=100,
+        aliases_per_group=4,
+        isolated=100,
+    ),
+    "synthetic-latency": BenchmarkProfile(
+        embedder="synthetic",
+        resolver="ground-truth",
+        groups=100,
+        aliases_per_group=4,
+        isolated=100,
+        rule_resolver_delay_ms=20.0,
+    ),
+    "synthetic-many-components": BenchmarkProfile(
+        embedder="synthetic",
+        resolver="ground-truth",
+        groups=0,
+        aliases_per_group=0,
+        isolated=0,
+        cluster_sizes=tuple([2] * 50 + [3] * 30 + [1] * 100),
+        rule_resolver_delay_ms=20.0,
+    ),
+    "synthetic-one-giant": BenchmarkProfile(
+        embedder="synthetic",
+        resolver="ground-truth",
+        groups=0,
+        aliases_per_group=0,
+        isolated=0,
+        cluster_sizes=(100,),
+        rule_resolver_delay_ms=20.0,
+    ),
+    "openai-small": BenchmarkProfile(
+        embedder="litellm",
+        resolver="llm",
+        groups=5,
+        aliases_per_group=3,
+        isolated=5,
+    ),
+}
+
+_PROFILE_OPTIONS = {
+    "embedder": "--embedder",
+    "resolver": "--resolver",
+    "groups": "--groups",
+    "aliases_per_group": "--aliases-per-group",
+    "isolated": "--isolated",
+    "cluster_sizes": "--cluster-sizes",
+    "seed": "--seed",
+    "max_distance": "--max-distance",
+    "top_n": "--top-n",
+    "embedding_model": "--embedding-model",
+    "synthetic_dim": "--synthetic-dim",
+    "synthetic_embed_delay_ms": "--synthetic-embed-delay-ms",
+    "rule_resolver_delay_ms": "--rule-resolver-delay-ms",
+    "llm_model": "--llm-model",
+    "entity_type": "--entity-type",
+}
+
+
+class Embedder(Protocol):
+    async def embed(self, text: str) -> NDArray[np.float32]: ...
+
+
+class PairResolver(Protocol):
+    async def __call__(self, entity: str, candidates: list[str]) -> PairDecision: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SyntheticDataset:
+    entities: list[str]
+    expected_canonical: dict[str, str]
+    grouped_entities: dict[str, list[str]]
+
+
+@dataclass(slots=True)
+class TimedCallMetrics:
+    calls: int = 0
+    total_ms: float = 0.0
+    max_ms: float = 0.0
+    max_concurrency: int = 0
+    latencies_ms: list[float] = field(default_factory=list)
+
+    def record(self, latency_ms: float) -> None:
+        self.calls += 1
+        self.total_ms += latency_ms
+        self.max_ms = max(self.max_ms, latency_ms)
+        self.latencies_ms.append(latency_ms)
+
+    def summary(self) -> dict[str, float | int]:
+        return {
+            "calls": self.calls,
+            "total_ms": round(self.total_ms, 3),
+            "avg_ms": round(self.total_ms / self.calls, 3) if self.calls else 0.0,
+            "p50_ms": round(_percentile(self.latencies_ms, 50), 3),
+            "p95_ms": round(_percentile(self.latencies_ms, 95), 3),
+            "max_ms": round(self.max_ms, 3),
+            "max_concurrency": self.max_concurrency,
+        }
+
+
+@dataclass(slots=True)
+class ResolverMetrics:
+    timing: TimedCallMetrics = field(default_factory=TimedCallMetrics)
+    total_candidates: int = 0
+    max_candidates: int = 0
+    matched: int = 0
+    no_match: int = 0
+    candidate_counts: list[int] = field(default_factory=list)
+
+    def record(self, candidates: list[str], decision: PairDecision) -> None:
+        count = len(candidates)
+        self.total_candidates += count
+        self.max_candidates = max(self.max_candidates, count)
+        self.candidate_counts.append(count)
+        if decision.matched is None:
+            self.no_match += 1
+        else:
+            self.matched += 1
+
+    def summary(self) -> dict[str, float | int]:
+        timing = self.timing.summary()
+        return {
+            **timing,
+            "matched": self.matched,
+            "no_match": self.no_match,
+            "total_candidates": self.total_candidates,
+            "avg_candidates": (
+                round(self.total_candidates / self.timing.calls, 3)
+                if self.timing.calls
+                else 0.0
+            ),
+            "p50_candidates": round(_percentile(self.candidate_counts, 50), 3),
+            "p95_candidates": round(_percentile(self.candidate_counts, 95), 3),
+            "max_candidates": self.max_candidates,
+        }
+
+
+@dataclass(slots=True)
+class EventMetrics:
+    events: int = 0
+    zero_candidate_events: int = 0
+    resolver_events: int = 0
+    seeded_events: int = 0
+    repointed_events: int = 0
+
+    def on_resolution(self, event: ResolutionEvent) -> None:
+        self.events += 1
+        if not event.candidates:
+            self.zero_candidate_events += 1
+        if event.decision is not None:
+            self.resolver_events += 1
+        if event.seeded:
+            self.seeded_events += 1
+        if event.repointed is not None:
+            self.repointed_events += 1
+
+
+class TimedEmbedder:
+    def __init__(self, embedder: Embedder) -> None:
+        self._embedder = embedder
+        self.metrics = TimedCallMetrics()
+        self._active = 0
+        self.captured: dict[str, NDArray[np.float32]] = {}
+
+    async def embed(self, text: str) -> NDArray[np.float32]:
+        self._active += 1
+        self.metrics.max_concurrency = max(self.metrics.max_concurrency, self._active)
+        start = time.perf_counter()
+        try:
+            vec = await self._embedder.embed(text)
+            self.captured[text] = vec
+            return vec
+        finally:
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            self.metrics.record(latency_ms)
+            self._active -= 1
+
+
+class TimedResolver:
+    def __init__(self, resolver: PairResolver) -> None:
+        self._resolver = resolver
+        self.metrics = ResolverMetrics()
+        self._active = 0
+
+    async def __call__(self, entity: str, candidates: list[str]) -> PairDecision:
+        self._active += 1
+        self.metrics.timing.max_concurrency = max(
+            self.metrics.timing.max_concurrency, self._active
+        )
+        start = time.perf_counter()
+        try:
+            decision = await self._resolver(entity, candidates)
+        finally:
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            self.metrics.timing.record(latency_ms)
+            self._active -= 1
+        self.metrics.record(candidates, decision)
+        return decision
+
+
+class SyntheticEmbedder:
+    def __init__(
+        self,
+        dataset: SyntheticDataset,
+        *,
+        dim: int,
+        seed: int,
+        delay_ms: float,
+    ) -> None:
+        self._vectors = _build_vectors(dataset, dim=dim, seed=seed)
+        self._delay_s = delay_ms / 1000.0
+
+    async def embed(self, text: str) -> NDArray[np.float32]:
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        else:
+            await asyncio.sleep(0)
+        return self._vectors[text]
+
+
+class GroundTruthResolver:
+    def __init__(self, dataset: SyntheticDataset, *, delay_ms: float) -> None:
+        self._expected_canonical = dataset.expected_canonical
+        self._delay_s = delay_ms / 1000.0
+
+    async def __call__(self, entity: str, candidates: list[str]) -> PairDecision:
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+
+        entity_canonical = self._expected_canonical[entity]
+        for candidate in candidates:
+            if self._expected_canonical[candidate] == entity_canonical:
+                canonical_side = (
+                    CanonicalSide.NEW
+                    if entity == entity_canonical and candidate != entity
+                    else CanonicalSide.MATCHED
+                )
+                return PairDecision(matched=candidate, canonical=canonical_side)
+        return PairDecision()
+
+
+def _percentile(values: list[float] | list[int], percentile: int) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return float(values[0])
+    sorted_values = sorted(values)
+    rank = (len(sorted_values) - 1) * percentile / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = rank - lower
+    return float(sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight)
+
+
+def _slug(index: int) -> str:
+    prefixes = [
+        "Acme",
+        "Northwind",
+        "Bluepeak",
+        "Vertex",
+        "Redwood",
+        "Summit",
+        "Brightline",
+        "Silverline",
+        "Evergreen",
+        "Nimbus",
+    ]
+    nouns = [
+        "Analytics",
+        "Robotics",
+        "Systems",
+        "Networks",
+        "Research",
+        "Labs",
+        "Capital",
+        "Health",
+        "Energy",
+        "Logistics",
+    ]
+    return f"{prefixes[index % len(prefixes)]} {nouns[(index // len(prefixes)) % len(nouns)]} {index:04d}"
+
+
+def _aliases(canonical: str, aliases_per_group: int) -> list[str]:
+    variants = [
+        canonical,
+        f"{canonical}, Inc.",
+        f"{canonical} Incorporated",
+        f"{canonical} LLC",
+        f"The {canonical} Group",
+        f"{canonical} Co.",
+        f"{canonical} Corporation",
+        f"{canonical} Ltd.",
+    ]
+    if aliases_per_group <= len(variants):
+        return variants[:aliases_per_group]
+    extra = [
+        f"{canonical} Alias {i:02d}" for i in range(aliases_per_group - len(variants))
+    ]
+    return variants + extra
+
+
+def generate_dataset(
+    *,
+    groups: int,
+    aliases_per_group: int,
+    isolated: int,
+    seed: int,
+    cluster_sizes: tuple[int, ...] | None = None,
+) -> SyntheticDataset:
+    expected_canonical: dict[str, str] = {}
+    grouped_entities: dict[str, list[str]] = {}
+
+    if cluster_sizes is not None:
+        for cluster_idx, size in enumerate(cluster_sizes):
+            if size < 1:
+                raise ValueError(
+                    f"cluster_sizes entries must be >= 1; got {size} at index {cluster_idx}"
+                )
+            canonical = _slug(cluster_idx)
+            aliases = _aliases(canonical, size)
+            grouped_entities[canonical] = aliases
+            for alias in aliases:
+                expected_canonical[alias] = canonical
+    else:
+        for group_idx in range(groups):
+            canonical = _slug(group_idx)
+            aliases = _aliases(canonical, aliases_per_group)
+            grouped_entities[canonical] = aliases
+            for alias in aliases:
+                expected_canonical[alias] = canonical
+
+        for isolated_idx in range(isolated):
+            canonical = f"Isolated Entity {isolated_idx:04d}"
+            grouped_entities[canonical] = [canonical]
+            expected_canonical[canonical] = canonical
+
+    entities = list(expected_canonical)
+    random.Random(seed).shuffle(entities)
+    return SyntheticDataset(
+        entities=entities,
+        expected_canonical=expected_canonical,
+        grouped_entities=grouped_entities,
+    )
+
+
+def _build_vectors(
+    dataset: SyntheticDataset,
+    *,
+    dim: int,
+    seed: int,
+) -> dict[str, NDArray[np.float32]]:
+    rng = np.random.default_rng(seed)
+    vectors: dict[str, NDArray[np.float32]] = {}
+    for canonical, entities in dataset.grouped_entities.items():
+        base = rng.normal(size=dim).astype(np.float32)
+        base /= np.linalg.norm(base)
+        for alias_idx, entity in enumerate(entities):
+            noise = rng.normal(scale=0.015, size=dim).astype(np.float32)
+            noise += (alias_idx + 1) * 0.0001
+            vec = base + noise
+            vec /= np.linalg.norm(vec)
+            vectors[entity] = vec.astype(np.float32)
+    return vectors
+
+
+def _count_wrong_groups(
+    groups: dict[str, set[str]], expected_canonical: dict[str, str]
+) -> int:
+    wrong = 0
+    for members in groups.values():
+        expected = {expected_canonical[member] for member in members}
+        if len(expected) != 1:
+            wrong += 1
+    return wrong
+
+
+def _count_candidate_components(
+    captured: dict[str, NDArray[np.float32]],
+    *,
+    max_distance: float,
+) -> int:
+    """Connected components of the candidate-edge graph (post-hoc, benchmark-only).
+
+    Build a transient FAISS index over the embeddings actually used by the run,
+    range-search at the similarity threshold, and union-find the edges. This
+    captures the parallelism opportunity available to a component-graph resolver:
+    each component is a set of entities that *could* share a candidate.
+    """
+    if not captured:
+        return 0
+    names = list(captured)
+    dim = int(captured[names[0]].shape[-1])
+    matrix = np.stack(
+        [np.asarray(captured[n], dtype=np.float32).reshape(-1) for n in names]
+    ).astype(np.float32)
+    faiss.normalize_L2(matrix)
+    index = faiss.IndexFlatIP(dim)
+    index.add(matrix)
+    threshold = 1.0 - max_distance
+    lims, _scores, idxs = index.range_search(matrix, threshold)
+
+    parent = list(range(len(names)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for i in range(len(names)):
+        for slot in range(int(lims[i]), int(lims[i + 1])):
+            j = int(idxs[slot])
+            if j > i:
+                union(i, j)
+
+    return len({find(i) for i in range(len(names))})
+
+
+def _load_litellm_embedder(model: str) -> Embedder:
+    from cocoindex.ops.litellm import LiteLLMEmbedder
+
+    return LiteLLMEmbedder(model)
+
+
+def _load_sentence_transformer_embedder(model: str) -> Embedder:
+    from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
+
+    return SentenceTransformerEmbedder(model)
+
+
+def _load_llm_resolver(
+    *,
+    model: str,
+    entity_type: str | None,
+    extra_guidance: str | None,
+) -> PairResolver:
+    from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
+
+    return LlmPairResolver(
+        model=model,
+        entity_type=entity_type,
+        extra_guidance=extra_guidance,
+    )
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None else int(value)
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None else float(value)
+
+
+def _env_str(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+def _env_path(name: str, default: Path) -> Path:
+    value = os.environ.get(name)
+    return default if value is None else Path(value)
+
+
+def _parse_cluster_sizes(value: str) -> tuple[int, ...]:
+    parts = [part.strip() for part in value.split(",")]
+    return tuple(int(part) for part in parts if part)
+
+
+def _cli_has_option(option: str) -> bool:
+    return any(arg == option or arg.startswith(f"{option}=") for arg in sys.argv[1:])
+
+
+def _apply_profile(args: argparse.Namespace) -> None:
+    if args.profile is None:
+        return
+    profile = BENCHMARK_PROFILES[args.profile]
+    for field_name, option in _PROFILE_OPTIONS.items():
+        if not _cli_has_option(option):
+            setattr(args, field_name, getattr(profile, field_name))
+
+
+def parse_args() -> argparse.Namespace:
+    load_dotenv(ENV_PATH)
+    parser = argparse.ArgumentParser(
+        description="Run a synthetic benchmark for CocoIndex entity resolution."
+    )
+    parser.add_argument(
+        "--profile",
+        choices=sorted(BENCHMARK_PROFILES),
+        default=os.environ.get("ER_BENCH_PROFILE"),
+        help=(
+            "Use a repeatable benchmark profile. Profile defaults override .env "
+            "values, and explicit CLI flags override profile defaults."
+        ),
+    )
+    parser.add_argument("--groups", type=int, default=_env_int("ER_BENCH_GROUPS", 100))
+    parser.add_argument(
+        "--aliases-per-group",
+        type=int,
+        default=_env_int("ER_BENCH_ALIASES_PER_GROUP", 4),
+    )
+    parser.add_argument(
+        "--isolated", type=int, default=_env_int("ER_BENCH_ISOLATED", 100)
+    )
+    cluster_sizes_default_env = os.environ.get("ER_BENCH_CLUSTER_SIZES")
+    parser.add_argument(
+        "--cluster-sizes",
+        type=_parse_cluster_sizes,
+        default=(
+            _parse_cluster_sizes(cluster_sizes_default_env)
+            if cluster_sizes_default_env
+            else None
+        ),
+        help=(
+            "Comma-separated list of per-cluster sizes (e.g. '2,2,3,1,1'). "
+            "When set, overrides --groups/--aliases-per-group/--isolated."
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=_env_int("ER_BENCH_SEED", 7))
+    parser.add_argument(
+        "--max-distance",
+        type=float,
+        default=_env_float("ER_BENCH_MAX_DISTANCE", 0.3),
+    )
+    parser.add_argument("--top-n", type=int, default=_env_int("ER_BENCH_TOP_N", 5))
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=_env_path("ER_BENCH_STATE", DEFAULT_STATE_DIR),
+    )
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument(
+        "--embedder",
+        choices=["synthetic", "litellm", "sentence-transformers"],
+        default=_env_str("ER_BENCH_EMBEDDER", "synthetic"),
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default=_env_str("ER_BENCH_EMBEDDING_MODEL", "text-embedding-3-small"),
+    )
+    parser.add_argument(
+        "--synthetic-dim", type=int, default=_env_int("ER_BENCH_SYNTHETIC_DIM", 384)
+    )
+    parser.add_argument(
+        "--synthetic-embed-delay-ms",
+        type=float,
+        default=_env_float("ER_BENCH_SYNTHETIC_EMBED_DELAY_MS", 0.0),
+    )
+    parser.add_argument(
+        "--resolver",
+        choices=["ground-truth", "llm"],
+        default=_env_str("ER_BENCH_RESOLVER", "ground-truth"),
+    )
+    parser.add_argument(
+        "--rule-resolver-delay-ms",
+        type=float,
+        default=_env_float("ER_BENCH_RULE_RESOLVER_DELAY_MS", 0.0),
+    )
+    parser.add_argument(
+        "--llm-model", default=_env_str("ER_BENCH_LLM_MODEL", "openai/gpt-4o-mini")
+    )
+    parser.add_argument(
+        "--entity-type", default=_env_str("ER_BENCH_ENTITY_TYPE", "organization")
+    )
+    parser.add_argument(
+        "--extra-guidance", default=os.environ.get("ER_BENCH_EXTRA_GUIDANCE")
+    )
+    args = parser.parse_args()
+    _apply_profile(args)
+    return args
+
+
+def _build_embedder(args: argparse.Namespace, dataset: SyntheticDataset) -> Embedder:
+    if args.embedder == "synthetic":
+        return SyntheticEmbedder(
+            dataset,
+            dim=args.synthetic_dim,
+            seed=args.seed,
+            delay_ms=args.synthetic_embed_delay_ms,
+        )
+    if args.embedder == "litellm":
+        return _load_litellm_embedder(args.embedding_model)
+    return _load_sentence_transformer_embedder(args.embedding_model)
+
+
+def _build_resolver(
+    args: argparse.Namespace, dataset: SyntheticDataset
+) -> PairResolver:
+    if args.resolver == "ground-truth":
+        return GroundTruthResolver(dataset, delay_ms=args.rule_resolver_delay_ms)
+    return _load_llm_resolver(
+        model=args.llm_model,
+        entity_type=args.entity_type,
+        extra_guidance=args.extra_guidance,
+    )
+
+
+async def run_benchmark(args: argparse.Namespace) -> dict[str, object]:
+    args.state.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("COCOINDEX_DB", str(args.state))
+
+    dataset = generate_dataset(
+        groups=args.groups,
+        aliases_per_group=args.aliases_per_group,
+        isolated=args.isolated,
+        seed=args.seed,
+        cluster_sizes=args.cluster_sizes,
+    )
+    timed_embedder = TimedEmbedder(_build_embedder(args, dataset))
+    timed_resolver = TimedResolver(_build_resolver(args, dataset))
+    events = EventMetrics()
+
+    start = time.perf_counter()
+    result = await resolve_entities(
+        dataset.entities,
+        embedder=timed_embedder,
+        resolve_pair=timed_resolver,
+        on_resolution=events.on_resolution,
+        max_distance=args.max_distance,
+        top_n=args.top_n,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    groups = result.groups()
+    candidate_components = _count_candidate_components(
+        timed_embedder.captured, max_distance=args.max_distance
+    )
+    metrics: dict[str, object] = {
+        "elapsed_ms": round(elapsed_ms, 3),
+        "config": {
+            "profile": args.profile,
+            "groups": args.groups,
+            "aliases_per_group": args.aliases_per_group,
+            "isolated": args.isolated,
+            "cluster_sizes": (
+                list(args.cluster_sizes) if args.cluster_sizes is not None else None
+            ),
+            "entities": len(dataset.entities),
+            "embedder": args.embedder,
+            "embedding_model": args.embedding_model,
+            "resolver": args.resolver,
+            "llm_model": args.llm_model if args.resolver == "llm" else None,
+            "max_distance": args.max_distance,
+            "top_n": args.top_n,
+        },
+        "embedding": timed_embedder.metrics.summary(),
+        "resolver": timed_resolver.metrics.summary(),
+        "events": asdict(events),
+        "result": {
+            "resolved_entities": len(result),
+            "canonicals": len(result.canonicals()),
+            "groups": len(groups),
+            "wrong_mixed_groups": _count_wrong_groups(
+                groups, dataset.expected_canonical
+            ),
+            "candidate_components": candidate_components,
+        },
+    }
+    return metrics
+
+
+def _print_summary(metrics: dict[str, object]) -> None:
+    config = metrics["config"]
+    embedding = metrics["embedding"]
+    resolver = metrics["resolver"]
+    events = metrics["events"]
+    result = metrics["result"]
+    if not isinstance(config, dict):
+        raise TypeError("config metrics must be a dict")
+    if not isinstance(embedding, dict):
+        raise TypeError("embedding metrics must be a dict")
+    if not isinstance(resolver, dict):
+        raise TypeError("resolver metrics must be a dict")
+    if not isinstance(events, dict):
+        raise TypeError("event metrics must be a dict")
+    if not isinstance(result, dict):
+        raise TypeError("result metrics must be a dict")
+
+    rows = [
+        ("entities", config["entities"]),
+        ("elapsed_ms", metrics["elapsed_ms"]),
+        ("embed_calls", embedding["calls"]),
+        ("embed_total_ms", embedding["total_ms"]),
+        ("embed_max_concurrency", embedding["max_concurrency"]),
+        ("resolver_calls", resolver["calls"]),
+        ("resolver_total_ms", resolver["total_ms"]),
+        ("resolver_avg_ms", resolver["avg_ms"]),
+        ("resolver_max_concurrency", resolver["max_concurrency"]),
+        ("resolver_avg_candidates", resolver["avg_candidates"]),
+        ("events_without_candidates", events["zero_candidate_events"]),
+        ("canonicals", result["canonicals"]),
+        ("wrong_mixed_groups", result["wrong_mixed_groups"]),
+        ("candidate_components", result["candidate_components"]),
+    ]
+    width = max(len(name) for name, _value in rows)
+    for name, value in rows:
+        print(f"{name:{width}}  {value}")
+
+
+def main() -> None:
+    args = parse_args()
+    metrics = asyncio.run(run_benchmark(args))
+    _print_summary(metrics)
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        print(f"\nWrote metrics to {args.output_json}")
+    else:
+        print("\nFull metrics:")
+        print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/entity_resolution/benchmark.py
+++ b/benchmarks/entity_resolution/benchmark.py
@@ -461,8 +461,9 @@ def _count_candidate_components(
     faiss.normalize_L2(matrix)
     index = faiss.IndexFlatIP(dim)
     index.add(matrix)
-    threshold = 1.0 - max_distance
-    lims, _scores, idxs = index.range_search(matrix, threshold)
+    threshold = np.float32(1.0 - max_distance)
+    radius = float(np.nextafter(threshold, np.float32(-np.inf)))
+    lims, _scores, idxs = index.range_search(matrix, radius)
 
     parent = list(range(len(names)))
 

--- a/benchmarks/entity_resolution/benchmark.py
+++ b/benchmarks/entity_resolution/benchmark.py
@@ -45,7 +45,7 @@ class BenchmarkProfile:
     synthetic_dim: int = 384
     synthetic_embed_delay_ms: float = 0.0
     rule_resolver_delay_ms: float = 0.0
-    llm_model: str = "openai/gpt-4o-mini"
+    llm_model: str = "openai/gpt-5.4-nano"
     entity_type: str = "organization"
 
 
@@ -89,6 +89,15 @@ BENCHMARK_PROFILES: dict[str, BenchmarkProfile] = {
         groups=5,
         aliases_per_group=3,
         isolated=5,
+    ),
+    "openai-many-components": BenchmarkProfile(
+        embedder="litellm",
+        resolver="llm",
+        groups=0,
+        aliases_per_group=0,
+        isolated=0,
+        cluster_sizes=tuple([3] * 10 + [1] * 5),
+        max_distance=0.15,
     ),
 }
 

--- a/benchmarks/entity_resolution/pyproject.toml
+++ b/benchmarks/entity_resolution/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "entity_resolution_benchmark"
+version = "0.1.0"
+description = "Synthetic benchmark for CocoIndex entity resolution"
+requires-python = ">=3.11"
+dependencies = [
+    "cocoindex[entity_resolution_llm]",
+]
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+cocoindex = {path = "../../", editable = true}

--- a/docs/src/content/docs/ops/entity_resolution.mdx
+++ b/docs/src/content/docs/ops/entity_resolution.mdx
@@ -111,7 +111,7 @@ result = await resolve_entities(
 
 ## Events
 
-Pass `on_resolution` to receive a `ResolutionEvent` for each entity as resolution proceeds — useful for streaming progress logs:
+Pass `on_resolution` to receive a `ResolutionEvent` for each entity. Events are delivered once resolution finishes, in the same order the sequential implementation would have emitted them (PREFERRED: sorted by entity; PINNED: pass-1 existings first then pass-2 non-existings):
 
 ```python
 from cocoindex.ops.entity_resolution import ResolutionEvent
@@ -144,7 +144,7 @@ Each event includes:
 | `resolve_pair` | `PairResolver` | *(required)* | Pair-resolution callback. See [`LlmPairResolver`](#llmpairresolver) for the built-in option. |
 | `is_existing_canonical` | `Callable[[str], bool] \| None` | `None` | Sync predicate for existing-canonical detection. |
 | `existing_policy` | `ExistingCanonicalPolicy` | `PINNED` | How to treat existing canonicals. Ignored when `is_existing_canonical` is `None`. |
-| `on_resolution` | `Callable[[ResolutionEvent], None] \| None` | `None` | Sync callback fired per entity in real time. |
+| `on_resolution` | `Callable[[ResolutionEvent], None] \| None` | `None` | Sync callback fired once per entity after resolution finishes, in deterministic per-policy order. |
 | `max_distance` | `float` | `0.3` | Cosine distance threshold (similarity >= 0.7). |
 | `top_n` | `int` | `5` | Max candidates surfaced per entity. |
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -525,9 +525,14 @@ async def resolve_entities(
     )
 
     dedup: dict[str, str | None] = {}
+    # Pre-allocated per-component event lists. Storing the lists in the
+    # parent scope (instead of returning them from each task) keeps
+    # already-emitted events reachable even if a sibling task gets
+    # cancelled mid-flight — important for preserving partial-failure
+    # observability through on_resolution.
+    per_component_events: list[list[ResolutionEvent]] = [[] for _ in components]
 
-    async def _run_one(member_idxs: list[int]) -> list[ResolutionEvent]:
-        events: list[ResolutionEvent] = []
+    async def _run_one(events: list[ResolutionEvent], member_idxs: list[int]) -> None:
         component_index = _CandidateIndex(
             dim=dim,
             dedup=dedup,
@@ -544,7 +549,6 @@ async def resolve_entities(
             resolve_pair=resolve_pair,
             emit=events.append,
         )
-        return events
 
     # Cancel sibling component tasks on the first exception. Bare
     # asyncio.gather lets siblings keep running after the exception has
@@ -553,31 +557,46 @@ async def resolve_entities(
     # TaskGroup would also achieve this but wraps the exception in
     # BaseExceptionGroup, hiding the original type from callers; spelling
     # the cancellation out preserves the original exception.
-    tasks: list[_asyncio.Task[list[ResolutionEvent]]] = [
-        _asyncio.create_task(_run_one(members)) for members in components
+    tasks: list[_asyncio.Task[None]] = [
+        _asyncio.create_task(_run_one(events, members))
+        for events, members in zip(per_component_events, components)
     ]
     try:
-        per_component_events = await _asyncio.gather(*tasks)
+        await _asyncio.gather(*tasks)
     except BaseException:
         for task in tasks:
             if not task.done():
                 task.cancel()
         if tasks:
             await _asyncio.gather(*tasks, return_exceptions=True)
+        # Even on partial failure, surface the events that completed
+        # before the exception. Otherwise on_resolution loses every
+        # already-resolved entity, breaking observability the prior
+        # single-pass implementation provided via real-time emission.
+        if on_resolution is not None:
+            _deliver_events(per_component_events, existing_policy, on_resolution)
         raise
 
     if on_resolution is not None:
-        merged: list[ResolutionEvent] = [
-            e for events in per_component_events for e in events
-        ]
-        if existing_policy == ExistingCanonicalPolicy.PINNED:
-            merged.sort(key=lambda e: (not e.seeded, e.entity))
-        else:
-            merged.sort(key=lambda e: e.entity)
-        for event in merged:
-            on_resolution(event)
+        _deliver_events(per_component_events, existing_policy, on_resolution)
 
     return ResolvedEntities(dedup)
+
+
+def _deliver_events(
+    per_component_events: list[list[ResolutionEvent]],
+    existing_policy: ExistingCanonicalPolicy,
+    on_resolution: _Callable[[ResolutionEvent], None],
+) -> None:
+    merged: list[ResolutionEvent] = [
+        e for events in per_component_events for e in events
+    ]
+    if existing_policy == ExistingCanonicalPolicy.PINNED:
+        merged.sort(key=lambda e: (not e.seeded, e.entity))
+    else:
+        merged.sort(key=lambda e: e.entity)
+    for event in merged:
+        on_resolution(event)
 
 
 def _new_wins(

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -430,7 +430,15 @@ def _partition_components(
     matrix = _np.stack([v.reshape(-1) for v in normalized_vecs]).astype(_np.float32)
     index = _faiss.IndexFlatIP(dim)
     index.add(matrix)
-    lims, _scores, idxs = index.range_search(matrix, 1.0 - max_distance)
+    # FAISS IndexFlatIP.range_search is strict (returns pairs with score >
+    # radius). The runtime _CandidateIndex.search filter is inclusive
+    # (score >= threshold). Stepping the radius one float32 below the
+    # threshold ensures the boundary-equal pairs that the runtime would
+    # surface are also captured by the partition, preserving the
+    # superset invariant at the exact equality boundary.
+    threshold = _np.float32(1.0 - max_distance)
+    radius = float(_np.nextafter(threshold, _np.float32(-_np.inf)))
+    lims, _scores, idxs = index.range_search(matrix, radius)
 
     parent = list(range(n))
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -181,6 +181,155 @@ class _EntityInfo:
         self.is_existing = is_existing
 
 
+@_dataclasses.dataclass(frozen=True, slots=True)
+class _DecisionApplication:
+    canonical: str
+    repointed: str | None = None
+
+
+class _CandidateIndex:
+    """FAISS index plus canonical-chain aware candidate lookup."""
+
+    __slots__ = ("_dedup", "_index", "_indexed_names", "_max_distance", "_top_n")
+
+    def __init__(
+        self,
+        *,
+        dim: int,
+        dedup: dict[str, str | None],
+        max_distance: float,
+        top_n: int,
+    ) -> None:
+        self._dedup = dedup
+        self._index = _faiss.IndexFlatIP(dim)
+        self._indexed_names: list[str] = []
+        self._max_distance = max_distance
+        self._top_n = top_n
+
+    def add(self, info: _EntityInfo) -> None:
+        self._index.add(info.normalized_vec)
+        self._indexed_names.append(info.name)
+
+    def search(self, info: _EntityInfo) -> list[str]:
+        if self._index.ntotal == 0 or self._top_n <= 0:
+            return []
+        threshold = 1.0 - self._max_distance
+        k = min(self._top_n, self._index.ntotal)
+
+        while True:
+            scores, idxs = self._index.search(info.normalized_vec, k)
+            candidates = self._distinct_canonicals(scores[0], idxs[0], threshold, info)
+            if len(candidates) >= self._top_n:
+                return candidates
+            if k >= self._index.ntotal or scores[0][-1] < threshold:
+                return candidates
+            k = min(self._index.ntotal, max(k + 1, k * 2))
+
+    def _distinct_canonicals(
+        self,
+        scores: _NDArray[_np.float32],
+        idxs: _NDArray[_np.int64],
+        threshold: float,
+        info: _EntityInfo,
+    ) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for score, idx in zip(scores, idxs):
+            if idx < 0 or score < threshold:
+                continue
+            canonical = _chain_walk(self._dedup, self._indexed_names[idx])
+            if canonical == info.name or canonical in seen:
+                continue
+            seen.add(canonical)
+            out.append(canonical)
+        return out
+
+
+def _chain_walk(dedup: dict[str, str | None], name: str) -> str:
+    current = name
+    while True:
+        target = dedup.get(current)
+        if target is None:
+            return current
+        current = target
+
+
+def _validate_pair_decision(
+    *,
+    entity: str,
+    candidates: list[str],
+    decision: PairDecision,
+) -> None:
+    if decision.matched is not None and (
+        decision.matched not in candidates or decision.matched == entity
+    ):
+        raise ValueError(
+            f"resolve_pair returned matched={decision.matched!r}, "
+            f"which is not in candidates={candidates!r}. This is a "
+            f"contract violation (see requirement.md)."
+        )
+
+
+def _apply_pair_decision(
+    *,
+    info: _EntityInfo,
+    decision: PairDecision,
+    entity_map: dict[str, _EntityInfo],
+    dedup: dict[str, str | None],
+    existing_policy: ExistingCanonicalPolicy,
+) -> _DecisionApplication:
+    if decision.matched is None:
+        dedup[info.name] = None
+        return _DecisionApplication(canonical=info.name)
+
+    matched = decision.matched
+    if _new_wins(
+        entity_info=info,
+        matched_info=entity_map[matched],
+        decision=decision,
+        existing_policy=existing_policy,
+    ):
+        dedup[info.name] = None
+        dedup[matched] = info.name
+        return _DecisionApplication(canonical=info.name, repointed=matched)
+
+    dedup[info.name] = matched
+    return _DecisionApplication(canonical=matched)
+
+
+def _event_for_seeded_existing(info: _EntityInfo) -> ResolutionEvent:
+    return ResolutionEvent(
+        entity=info.name,
+        canonical=info.name,
+        candidates=[],
+        seeded=True,
+    )
+
+
+def _event_for_new_canonical(info: _EntityInfo) -> ResolutionEvent:
+    return ResolutionEvent(
+        entity=info.name,
+        canonical=info.name,
+        candidates=[],
+    )
+
+
+def _event_for_pair_decision(
+    *,
+    info: _EntityInfo,
+    candidates: list[str],
+    decision: PairDecision,
+    application: _DecisionApplication,
+) -> ResolutionEvent:
+    return ResolutionEvent(
+        entity=info.name,
+        canonical=application.canonical,
+        candidates=candidates,
+        decision=decision,
+        repointed=application.repointed,
+    )
+
+
 async def resolve_entities(
     entities: _Iterable[str],
     *,
@@ -220,51 +369,17 @@ async def resolve_entities(
             ),
         )
 
-    dim = int(raw_embeddings[0].shape[-1])
-    index = _faiss.IndexFlatIP(dim)
-    indexed_names: list[str] = []
     dedup: dict[str, str | None] = {}
+    candidate_index = _CandidateIndex(
+        dim=int(raw_embeddings[0].shape[-1]),
+        dedup=dedup,
+        max_distance=max_distance,
+        top_n=top_n,
+    )
 
     def _emit(event: ResolutionEvent) -> None:
         if on_resolution is not None:
             on_resolution(event)
-
-    def _add_to_index(info: _EntityInfo) -> None:
-        index.add(info.normalized_vec)
-        indexed_names.append(info.name)
-
-    def _chain_walk(name: str) -> str:
-        current = name
-        while True:
-            target = dedup.get(current)
-            if target is None:
-                return current
-            current = target
-
-    def _search_candidates(info: _EntityInfo) -> list[str]:
-        if index.ntotal == 0 or top_n <= 0:
-            return []
-        threshold = 1.0 - max_distance
-        k = min(top_n, index.ntotal)
-
-        while True:
-            scores, idxs = index.search(info.normalized_vec, k)
-            seen: set[str] = set()
-            out: list[str] = []
-            for score, idx in zip(scores[0], idxs[0]):
-                if idx < 0 or score < threshold:
-                    continue
-                canonical = _chain_walk(indexed_names[idx])
-                if canonical == info.name or canonical in seen:
-                    continue
-                seen.add(canonical)
-                out.append(canonical)
-                if len(out) >= top_n:
-                    return out
-
-            if k >= index.ntotal or scores[0][-1] < threshold:
-                return out
-            k = min(index.ntotal, max(k + 1, k * 2))
 
     if existing_policy == ExistingCanonicalPolicy.PINNED:
         pass_1 = [i for i in entity_map.values() if i.is_existing]
@@ -275,71 +390,38 @@ async def resolve_entities(
 
     for info in pass_1:
         dedup[info.name] = None
-        _add_to_index(info)
-        _emit(
-            ResolutionEvent(
-                entity=info.name,
-                canonical=info.name,
-                candidates=[],
-                seeded=True,
-            )
-        )
+        candidate_index.add(info)
+        _emit(_event_for_seeded_existing(info))
 
     for info in pass_2:
-        candidates = _search_candidates(info)
+        candidates = candidate_index.search(info)
 
         if not candidates:
             dedup[info.name] = None
-            _add_to_index(info)
-            _emit(
-                ResolutionEvent(
-                    entity=info.name,
-                    canonical=info.name,
-                    candidates=[],
-                )
-            )
+            candidate_index.add(info)
+            _emit(_event_for_new_canonical(info))
             continue
 
         decision = await resolve_pair(info.name, candidates)
-
-        if decision.matched is not None and (
-            decision.matched not in candidates or decision.matched == info.name
-        ):
-            raise ValueError(
-                f"resolve_pair returned matched={decision.matched!r}, "
-                f"which is not in candidates={candidates!r}. This is a "
-                f"contract violation (see requirement.md)."
-            )
-
-        if decision.matched is None:
-            dedup[info.name] = None
-            canonical = info.name
-            repointed: str | None = None
-        else:
-            matched = decision.matched
-            if _new_wins(
-                entity_info=info,
-                matched_info=entity_map[matched],
-                decision=decision,
-                existing_policy=existing_policy,
-            ):
-                dedup[info.name] = None
-                dedup[matched] = info.name
-                canonical = info.name
-                repointed = matched
-            else:
-                dedup[info.name] = matched
-                canonical = matched
-                repointed = None
-
-        _add_to_index(info)
+        _validate_pair_decision(
+            entity=info.name,
+            candidates=candidates,
+            decision=decision,
+        )
+        application = _apply_pair_decision(
+            info=info,
+            decision=decision,
+            entity_map=entity_map,
+            dedup=dedup,
+            existing_policy=existing_policy,
+        )
+        candidate_index.add(info)
         _emit(
-            ResolutionEvent(
-                entity=info.name,
-                canonical=canonical,
+            _event_for_pair_decision(
+                info=info,
                 candidates=candidates,
                 decision=decision,
-                repointed=repointed,
+                application=application,
             )
         )
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -546,9 +546,25 @@ async def resolve_entities(
         )
         return events
 
-    per_component_events = await _asyncio.gather(
-        *(_run_one(members) for members in components)
-    )
+    # Cancel sibling component tasks on the first exception. Bare
+    # asyncio.gather lets siblings keep running after the exception has
+    # already propagated to the caller, leaking resolver calls (and any
+    # LLM cost they incur) for results that will never be observed. A
+    # TaskGroup would also achieve this but wraps the exception in
+    # BaseExceptionGroup, hiding the original type from callers; spelling
+    # the cancellation out preserves the original exception.
+    tasks: list[_asyncio.Task[list[ResolutionEvent]]] = [
+        _asyncio.create_task(_run_one(members)) for members in components
+    ]
+    try:
+        per_component_events = await _asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await _asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
     if on_resolution is not None:
         merged: list[ResolutionEvent] = [

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -252,6 +252,12 @@ class _CandidateIndex:
                 continue
             seen.add(canonical)
             out.append(canonical)
+            if len(out) >= self._top_n:
+                # ``top_n`` bounds the candidate list size — the public
+                # docs frame it as a maximum. Stop as soon as we have
+                # enough distinct canonicals so the backfill loop in
+                # ``search`` returns exactly ``top_n`` and never more.
+                break
         return out
 
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -102,6 +102,12 @@ class PairResolver(_typing.Protocol):
     the threshold. Must return a :class:`PairDecision` whose ``matched`` is
     either None or one of the supplied ``candidates`` (else
     ``resolve_entities`` raises :exc:`ValueError`).
+
+    ``__call__`` may be invoked concurrently. ``resolve_entities`` partitions
+    entities into independent components and resolves them in parallel, so a
+    resolver instance can see overlapping ``__call__`` invocations. Built-in
+    resolvers are concurrency-safe; custom implementations with mutable
+    internal state should guard it accordingly.
     """
 
     async def __call__(
@@ -392,6 +398,62 @@ async def _resolve_component(
         )
 
 
+def _partition_components(
+    entity_list: list[str],
+    normalized_vecs: list[_NDArray[_np.float32]],
+    *,
+    max_distance: float,
+) -> list[list[int]]:
+    """Connected components of the conservative candidate-edge graph.
+
+    Edges: every (i, j) pair with cosine similarity ≥ ``1 - max_distance``.
+    This is a superset of any edge the runtime greedy ``_CandidateIndex``
+    could ever surface (which only ever filters down via chain-walk). Extra
+    edges reduce parallelism but cannot change correctness; missing edges
+    can change behavior, so we must not under-approximate.
+
+    Returns a list of components, each as a sorted list of indexes into
+    ``entity_list``. The component list itself is sorted by lex-min entity
+    name so downstream dispatch is deterministic.
+    """
+    n = len(entity_list)
+    if n == 0:
+        return []
+    if n == 1:
+        return [[0]]
+
+    dim = int(normalized_vecs[0].shape[-1])
+    matrix = _np.stack([v.reshape(-1) for v in normalized_vecs]).astype(_np.float32)
+    index = _faiss.IndexFlatIP(dim)
+    index.add(matrix)
+    lims, _scores, idxs = index.range_search(matrix, 1.0 - max_distance)
+
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for i in range(n):
+        for slot in range(int(lims[i]), int(lims[i + 1])):
+            j = int(idxs[slot])
+            if j <= i:
+                continue
+            ri, rj = find(i), find(j)
+            if ri != rj:
+                parent[ri] = rj
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return sorted(
+        groups.values(),
+        key=lambda members: entity_list[members[0]],
+    )
+
+
 async def resolve_entities(
     entities: _Iterable[str],
     *,
@@ -404,6 +466,18 @@ async def resolve_entities(
     top_n: int = 5,
 ) -> ResolvedEntities:
     """Resolve a set of raw entity names into a canonical dedup map.
+
+    Resolution proceeds in three phases. First, all entities are embedded
+    concurrently. Second, a transient FAISS index partitions entities into
+    connected components of the candidate-similarity graph — entities in
+    different components can never compare to each other under any chain
+    walk. Third, each component is resolved by an independent greedy runner
+    (same algorithm as the single-component case) and runners execute
+    concurrently. Within a component, processing order is deterministic
+    (sorted by entity name); across components, the ``on_resolution``
+    callback fires in the same per-policy order as the single-component
+    case (PREFERRED: globally sorted; PINNED: all existings first sorted,
+    then all non-existings sorted).
 
     See ``specs/entity_resolution/requirement.md`` for the full contract,
     including existing-canonical policies (PINNED / PREFERRED),
@@ -418,6 +492,7 @@ async def resolve_entities(
     )
 
     entity_map: dict[str, _EntityInfo] = {}
+    normalized_vecs: list[_NDArray[_np.float32]] = []
     for name, raw_vec in zip(entity_list, raw_embeddings):
         vec = raw_vec.reshape(1, -1).copy()
         _faiss.normalize_L2(vec)
@@ -430,28 +505,49 @@ async def resolve_entities(
                 else False
             ),
         )
+        normalized_vecs.append(vec)
+
+    dim = int(raw_embeddings[0].shape[-1])
+    components = _partition_components(
+        entity_list, normalized_vecs, max_distance=max_distance
+    )
 
     dedup: dict[str, str | None] = {}
-    candidate_index = _CandidateIndex(
-        dim=int(raw_embeddings[0].shape[-1]),
-        dedup=dedup,
-        max_distance=max_distance,
-        top_n=top_n,
+
+    async def _run_one(member_idxs: list[int]) -> list[ResolutionEvent]:
+        events: list[ResolutionEvent] = []
+        component_index = _CandidateIndex(
+            dim=dim,
+            dedup=dedup,
+            max_distance=max_distance,
+            top_n=top_n,
+        )
+        infos = [entity_map[entity_list[i]] for i in member_idxs]
+        await _resolve_component(
+            infos,
+            entity_map=entity_map,
+            dedup=dedup,
+            candidate_index=component_index,
+            existing_policy=existing_policy,
+            resolve_pair=resolve_pair,
+            emit=events.append,
+        )
+        return events
+
+    per_component_events = await _asyncio.gather(
+        *(_run_one(members) for members in components)
     )
 
-    def _emit(event: ResolutionEvent) -> None:
-        if on_resolution is not None:
+    if on_resolution is not None:
+        merged: list[ResolutionEvent] = [
+            e for events in per_component_events for e in events
+        ]
+        if existing_policy == ExistingCanonicalPolicy.PINNED:
+            merged.sort(key=lambda e: (not e.seeded, e.entity))
+        else:
+            merged.sort(key=lambda e: e.entity)
+        for event in merged:
             on_resolution(event)
-
-    await _resolve_component(
-        list(entity_map.values()),
-        entity_map=entity_map,
-        dedup=dedup,
-        candidate_index=candidate_index,
-        existing_policy=existing_policy,
-        resolve_pair=resolve_pair,
-        emit=_emit,
-    )
 
     return ResolvedEntities(dedup)
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -346,6 +346,22 @@ def _event_for_pair_decision(
     )
 
 
+@_dataclasses.dataclass(frozen=True, slots=True)
+class _ComponentEvents:
+    """Per-component events split by resolution phase.
+
+    The split is the source of truth for cross-component ordering. The
+    PINNED contract is 'all pass-1 (seeded existings) first, then all
+    pass-2 (non-existings)', and storing the phases separately means the
+    merge step does not have to infer phase from a derived field on
+    ResolutionEvent (which historically conflated `seeded=True` with
+    'belongs in pass-1').
+    """
+
+    pass_1: list[ResolutionEvent]
+    pass_2: list[ResolutionEvent]
+
+
 async def _resolve_component(
     infos: list[_EntityInfo],
     *,
@@ -354,14 +370,14 @@ async def _resolve_component(
     candidate_index: _CandidateIndex,
     existing_policy: ExistingCanonicalPolicy,
     resolve_pair: PairResolver,
-    emit: _Callable[[ResolutionEvent], None],
+    events: _ComponentEvents,
 ) -> None:
     """Greedy two-pass resolution over one connected component (or one
     entire input, when no graph partitioning has happened yet).
 
-    Mutates ``dedup`` and the supplied ``candidate_index``. ``entity_map``
-    is read-only for canonical-selection lookups during decision
-    application.
+    Mutates ``dedup``, ``candidate_index``, and ``events`` in place.
+    ``entity_map`` is read-only for canonical-selection lookups during
+    decision application.
     """
     if existing_policy == ExistingCanonicalPolicy.PINNED:
         pass_1 = [i for i in infos if i.is_existing]
@@ -373,7 +389,7 @@ async def _resolve_component(
     for info in pass_1:
         dedup[info.name] = None
         candidate_index.add(info)
-        emit(_event_for_seeded_existing(info))
+        events.pass_1.append(_event_for_seeded_existing(info))
 
     for info in pass_2:
         candidates = candidate_index.search(info)
@@ -381,7 +397,7 @@ async def _resolve_component(
         if not candidates:
             dedup[info.name] = None
             candidate_index.add(info)
-            emit(_event_for_new_canonical(info))
+            events.pass_2.append(_event_for_new_canonical(info))
             continue
 
         decision = await resolve_pair(info.name, candidates)
@@ -398,7 +414,7 @@ async def _resolve_component(
             existing_policy=existing_policy,
         )
         candidate_index.add(info)
-        emit(
+        events.pass_2.append(
             _event_for_pair_decision(
                 info=info,
                 candidates=candidates,
@@ -531,14 +547,16 @@ async def resolve_entities(
     )
 
     dedup: dict[str, str | None] = {}
-    # Pre-allocated per-component event lists. Storing the lists in the
+    # Pre-allocated per-component event records. Storing the lists in the
     # parent scope (instead of returning them from each task) keeps
     # already-emitted events reachable even if a sibling task gets
     # cancelled mid-flight — important for preserving partial-failure
     # observability through on_resolution.
-    per_component_events: list[list[ResolutionEvent]] = [[] for _ in components]
+    per_component_events: list[_ComponentEvents] = [
+        _ComponentEvents(pass_1=[], pass_2=[]) for _ in components
+    ]
 
-    async def _run_one(events: list[ResolutionEvent], member_idxs: list[int]) -> None:
+    async def _run_one(events: _ComponentEvents, member_idxs: list[int]) -> None:
         component_index = _CandidateIndex(
             dim=dim,
             dedup=dedup,
@@ -553,7 +571,7 @@ async def resolve_entities(
             candidate_index=component_index,
             existing_policy=existing_policy,
             resolve_pair=resolve_pair,
-            emit=events.append,
+            events=events,
         )
 
     # Cancel sibling component tasks on the first exception. Bare
@@ -580,11 +598,11 @@ async def resolve_entities(
         # already-resolved entity, breaking observability the prior
         # single-pass implementation provided via real-time emission.
         if on_resolution is not None:
-            _deliver_events(per_component_events, existing_policy, on_resolution)
+            _deliver_events(per_component_events, on_resolution)
         raise
 
     if on_resolution is not None:
-        _deliver_events(per_component_events, existing_policy, on_resolution)
+        _deliver_events(per_component_events, on_resolution)
 
     # Rebuild the dedup map in sorted entity order. Concurrent component
     # runners populated the shared dict in scheduler-interleaved order;
@@ -596,18 +614,26 @@ async def resolve_entities(
 
 
 def _deliver_events(
-    per_component_events: list[list[ResolutionEvent]],
-    existing_policy: ExistingCanonicalPolicy,
+    per_component_events: list[_ComponentEvents],
     on_resolution: _Callable[[ResolutionEvent], None],
 ) -> None:
-    merged: list[ResolutionEvent] = [
-        e for events in per_component_events for e in events
-    ]
-    if existing_policy == ExistingCanonicalPolicy.PINNED:
-        merged.sort(key=lambda e: (not e.seeded, e.entity))
-    else:
-        merged.sort(key=lambda e: e.entity)
-    for event in merged:
+    # PINNED requires 'all pass-1 first, then all pass-2'. PREFERRED's
+    # pass_1 lists are always empty (the policy only seeds in PINNED), so
+    # the same two-phase emit collapses to a single sorted stream there.
+    # Using the explicit phase lists — rather than inferring from
+    # ``ResolutionEvent.seeded`` — keeps the ordering invariant tied to
+    # the source of truth in _resolve_component.
+    pass_1 = sorted(
+        (e for events in per_component_events for e in events.pass_1),
+        key=lambda e: e.entity,
+    )
+    pass_2 = sorted(
+        (e for events in per_component_events for e in events.pass_2),
+        key=lambda e: e.entity,
+    )
+    for event in pass_1:
+        on_resolution(event)
+    for event in pass_2:
         on_resolution(event)
 
 

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -242,22 +242,29 @@ async def resolve_entities(
             current = target
 
     def _search_candidates(info: _EntityInfo) -> list[str]:
-        if index.ntotal == 0:
+        if index.ntotal == 0 or top_n <= 0:
             return []
-        k = min(top_n, index.ntotal)
-        scores, idxs = index.search(info.normalized_vec, k)
         threshold = 1.0 - max_distance
-        seen: set[str] = set()
-        out: list[str] = []
-        for score, idx in zip(scores[0], idxs[0]):
-            if idx < 0 or score < threshold:
-                continue
-            canonical = _chain_walk(indexed_names[idx])
-            if canonical == info.name or canonical in seen:
-                continue
-            seen.add(canonical)
-            out.append(canonical)
-        return out
+        k = min(top_n, index.ntotal)
+
+        while True:
+            scores, idxs = index.search(info.normalized_vec, k)
+            seen: set[str] = set()
+            out: list[str] = []
+            for score, idx in zip(scores[0], idxs[0]):
+                if idx < 0 or score < threshold:
+                    continue
+                canonical = _chain_walk(indexed_names[idx])
+                if canonical == info.name or canonical in seen:
+                    continue
+                seen.add(canonical)
+                out.append(canonical)
+                if len(out) >= top_n:
+                    return out
+
+            if k >= index.ntotal or scores[0][-1] < threshold:
+                return out
+            k = min(index.ntotal, max(k + 1, k * 2))
 
     if existing_policy == ExistingCanonicalPolicy.PINNED:
         pass_1 = [i for i in entity_map.values() if i.is_existing]

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -68,8 +68,12 @@ class ExistingCanonicalPolicy(_enum.StrEnum):
 
 @_dataclasses.dataclass(frozen=True, slots=True)
 class ResolutionEvent:
-    """A single entity's resolution outcome. Emitted in real time as
-    ``resolve_entities`` proceeds."""
+    """A single entity's resolution outcome. ``resolve_entities`` collects
+    one event per resolved entity and invokes ``on_resolution`` for each
+    one after all components finish, in the same order the prior
+    single-pass implementation used (PREFERRED: sorted by entity name;
+    PINNED: pass-1 existings first then pass-2 non-existings, each in
+    sorted order)."""
 
     entity: str
     """The entity just resolved."""

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -586,7 +586,13 @@ async def resolve_entities(
     if on_resolution is not None:
         _deliver_events(per_component_events, existing_policy, on_resolution)
 
-    return ResolvedEntities(dedup)
+    # Rebuild the dedup map in sorted entity order. Concurrent component
+    # runners populated the shared dict in scheduler-interleaved order;
+    # exposing that as ResolvedEntities iteration order would be a
+    # behavioral regression vs the prior single-pass implementation that
+    # iterated `sorted(set(entities))`.
+    ordered_dedup: dict[str, str | None] = {name: dedup[name] for name in entity_list}
+    return ResolvedEntities(ordered_dedup)
 
 
 def _deliver_events(

--- a/python/cocoindex/ops/entity_resolution/__init__.py
+++ b/python/cocoindex/ops/entity_resolution/__init__.py
@@ -330,6 +330,68 @@ def _event_for_pair_decision(
     )
 
 
+async def _resolve_component(
+    infos: list[_EntityInfo],
+    *,
+    entity_map: dict[str, _EntityInfo],
+    dedup: dict[str, str | None],
+    candidate_index: _CandidateIndex,
+    existing_policy: ExistingCanonicalPolicy,
+    resolve_pair: PairResolver,
+    emit: _Callable[[ResolutionEvent], None],
+) -> None:
+    """Greedy two-pass resolution over one connected component (or one
+    entire input, when no graph partitioning has happened yet).
+
+    Mutates ``dedup`` and the supplied ``candidate_index``. ``entity_map``
+    is read-only for canonical-selection lookups during decision
+    application.
+    """
+    if existing_policy == ExistingCanonicalPolicy.PINNED:
+        pass_1 = [i for i in infos if i.is_existing]
+        pass_2 = [i for i in infos if not i.is_existing]
+    else:
+        pass_1 = []
+        pass_2 = infos
+
+    for info in pass_1:
+        dedup[info.name] = None
+        candidate_index.add(info)
+        emit(_event_for_seeded_existing(info))
+
+    for info in pass_2:
+        candidates = candidate_index.search(info)
+
+        if not candidates:
+            dedup[info.name] = None
+            candidate_index.add(info)
+            emit(_event_for_new_canonical(info))
+            continue
+
+        decision = await resolve_pair(info.name, candidates)
+        _validate_pair_decision(
+            entity=info.name,
+            candidates=candidates,
+            decision=decision,
+        )
+        application = _apply_pair_decision(
+            info=info,
+            decision=decision,
+            entity_map=entity_map,
+            dedup=dedup,
+            existing_policy=existing_policy,
+        )
+        candidate_index.add(info)
+        emit(
+            _event_for_pair_decision(
+                info=info,
+                candidates=candidates,
+                decision=decision,
+                application=application,
+            )
+        )
+
+
 async def resolve_entities(
     entities: _Iterable[str],
     *,
@@ -381,49 +443,15 @@ async def resolve_entities(
         if on_resolution is not None:
             on_resolution(event)
 
-    if existing_policy == ExistingCanonicalPolicy.PINNED:
-        pass_1 = [i for i in entity_map.values() if i.is_existing]
-        pass_2 = [i for i in entity_map.values() if not i.is_existing]
-    else:
-        pass_1 = []
-        pass_2 = list(entity_map.values())
-
-    for info in pass_1:
-        dedup[info.name] = None
-        candidate_index.add(info)
-        _emit(_event_for_seeded_existing(info))
-
-    for info in pass_2:
-        candidates = candidate_index.search(info)
-
-        if not candidates:
-            dedup[info.name] = None
-            candidate_index.add(info)
-            _emit(_event_for_new_canonical(info))
-            continue
-
-        decision = await resolve_pair(info.name, candidates)
-        _validate_pair_decision(
-            entity=info.name,
-            candidates=candidates,
-            decision=decision,
-        )
-        application = _apply_pair_decision(
-            info=info,
-            decision=decision,
-            entity_map=entity_map,
-            dedup=dedup,
-            existing_policy=existing_policy,
-        )
-        candidate_index.add(info)
-        _emit(
-            _event_for_pair_decision(
-                info=info,
-                candidates=candidates,
-                decision=decision,
-                application=application,
-            )
-        )
+    await _resolve_component(
+        list(entity_map.values()),
+        entity_map=entity_map,
+        dedup=dedup,
+        candidate_index=candidate_index,
+        existing_policy=existing_policy,
+        resolve_pair=resolve_pair,
+        emit=_emit,
+    )
 
     return ResolvedEntities(dedup)
 

--- a/python/cocoindex/ops/entity_resolution/llm_resolver.py
+++ b/python/cocoindex/ops/entity_resolution/llm_resolver.py
@@ -6,6 +6,8 @@ validation-and-retry loop.
 
 from __future__ import annotations
 
+import typing as _typing
+
 import pydantic as _pydantic
 
 import cocoindex as _coco
@@ -80,6 +82,7 @@ class LlmPairResolver:
         self._retries = retries
         self._system_prompt = _build_prompt(entity_type, extra_guidance)
         self._memo_key = _coco.memo_fingerprint((model, entity_type, extra_guidance))
+        self._client: _typing.Any | None = None
 
     @_coco.fn(memo=True, logic_tracking="self")
     async def __call__(
@@ -94,17 +97,13 @@ class LlmPairResolver:
             + "\n".join(f"  - {c!r}" for c in candidates)
         )
 
-        client = _instructor.from_litellm(
-            _litellm.acompletion, mode=_instructor.Mode.JSON
-        )
-
         messages: list[dict[str, str]] = [
             {"role": "system", "content": self._system_prompt},
             {"role": "user", "content": user_message},
         ]
 
         for attempt in range(1 + self._retries):
-            result = await client.chat.completions.create(
+            result = await self._get_client().chat.completions.create(
                 model=self._model,
                 response_model=_LlmResponse,
                 messages=messages,
@@ -124,6 +123,28 @@ class LlmPairResolver:
 
     def __coco_memo_key__(self) -> object:
         return self._memo_key
+
+    def __getstate__(self) -> dict[str, _typing.Any]:
+        return {
+            "model": self._model,
+            "retries": self._retries,
+            "system_prompt": self._system_prompt,
+            "memo_key": self._memo_key,
+        }
+
+    def __setstate__(self, state: dict[str, _typing.Any]) -> None:
+        self._model = state["model"]
+        self._retries = state["retries"]
+        self._system_prompt = state["system_prompt"]
+        self._memo_key = state["memo_key"]
+        self._client = None
+
+    def _get_client(self) -> _typing.Any:
+        if self._client is None:
+            self._client = _instructor.from_litellm(
+                _litellm.acompletion, mode=_instructor.Mode.JSON
+            )
+        return self._client
 
 
 def _build_prompt(entity_type: str | None, extra_guidance: str | None) -> str:

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -547,6 +547,57 @@ async def test_on_resolution_decision_field() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_order_preferred_mode_is_sorted_by_entity() -> None:
+    """PREFERRED policy: events emit in sorted(set(entities)) order.
+
+    Locks in the callback order so a future component-graph runner can
+    parallelize across components without changing user-visible event order.
+    """
+    embedder = MockEmbedder([{"A", "B"}, {"C", "D"}])
+    resolver = ScriptedResolver(
+        {
+            ("B", frozenset({"A"})): PairDecision(matched="A"),
+            ("D", frozenset({"C"})): PairDecision(matched="C"),
+        }
+    )
+    events, on_res = capture_events()
+    await resolve_entities(
+        entities={"D", "C", "B", "A"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        existing_policy=ExistingCanonicalPolicy.PREFERRED,
+        on_resolution=on_res,
+    )
+    assert [e.entity for e in events] == ["A", "B", "C", "D"]
+
+
+@pytest.mark.asyncio
+async def test_event_order_pinned_mode_pass1_then_pass2_each_sorted() -> None:
+    """PINNED policy: all pass-1 (existings) events emit first in sorted
+    order, then all pass-2 (non-existings) events in sorted order. Commit 3
+    parallelism must preserve this exact two-phase order."""
+    embedder = MockEmbedder([{"A", "B"}, {"C", "D"}])
+    resolver = ScriptedResolver(
+        {
+            ("A", frozenset({"B"})): PairDecision(matched="B"),
+            ("C", frozenset({"D"})): PairDecision(matched="D"),
+        }
+    )
+    events, on_res = capture_events()
+    await resolve_entities(
+        entities={"A", "B", "C", "D"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        is_existing_canonical=lambda n: n in {"B", "D"},
+        existing_policy=ExistingCanonicalPolicy.PINNED,
+        on_resolution=on_res,
+    )
+    # pass_1 existings in sorted order: B, D; then pass_2 non-existings: A, C.
+    assert [e.entity for e in events] == ["B", "D", "A", "C"]
+    assert [e.seeded for e in events] == [True, True, False, False]
+
+
+@pytest.mark.asyncio
 async def test_on_resolution_exception_aborts() -> None:
     embedder = MockEmbedder([{"A"}, {"B"}, {"C"}])
     resolver = ScriptedResolver({})

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -547,6 +548,56 @@ async def test_on_resolution_decision_field() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolver_partitions_oversized_component_into_multiple_canonicals() -> None:
+    """A single FAISS component contains two ground-truth clusters; the
+    resolver rejects cross-cluster candidates and the algorithm produces
+    the right partition.
+
+    Mirrors what real embedders do when canonicals share vocabulary
+    (e.g. "Acme Analytics" and "Northwind Analytics" both ride the
+    "Analytics" axis). FAISS groups them; the LLM tells them apart. This
+    test exercises the no-match path of the greedy loop inside a single
+    oversized component — a regime the orthogonal MockEmbedder defaults
+    don't naturally produce.
+    """
+    embedder = MockEmbedder([{"a", "b", "c", "d"}])
+    decisions = {
+        ("b", frozenset({"a"})): PairDecision(matched="a"),
+        ("c", frozenset({"a"})): PairDecision(),
+        ("d", frozenset({"a", "c"})): PairDecision(matched="c"),
+    }
+    result = await resolve_entities(
+        entities={"a", "b", "c", "d"},
+        embedder=embedder,
+        resolve_pair=ScriptedResolver(decisions),
+    )
+    assert result.to_dict() == {"a": None, "b": "a", "c": None, "d": "c"}
+    assert result.canonicals() == {"a", "c"}
+
+
+@pytest.mark.asyncio
+async def test_pinned_existings_in_one_component_attach_correctly() -> None:
+    """Two PINNED existings sit in the same FAISS component as their
+    non-existing aliases; the resolver chooses which existing each alias
+    attaches to. Verifies PINNED's two-phase order (existings seeded
+    first) combined with resolver-driven partitioning inside one
+    component."""
+    embedder = MockEmbedder([{"M1", "M2", "X1", "X2"}])
+    decisions = {
+        ("X1", frozenset({"M1", "M2"})): PairDecision(matched="M1"),
+        ("X2", frozenset({"M1", "M2"})): PairDecision(matched="M2"),
+    }
+    result = await resolve_entities(
+        entities={"M1", "M2", "X1", "X2"},
+        embedder=embedder,
+        resolve_pair=ScriptedResolver(decisions),
+        is_existing_canonical=lambda n: n in {"M1", "M2"},
+        existing_policy=ExistingCanonicalPolicy.PINNED,
+    )
+    assert result.to_dict() == {"M1": None, "M2": None, "X1": "M1", "X2": "M2"}
+
+
+@pytest.mark.asyncio
 async def test_event_order_preferred_mode_is_sorted_by_entity() -> None:
     """PREFERRED policy: events emit in sorted(set(entities)) order.
 
@@ -595,6 +646,180 @@ async def test_event_order_pinned_mode_pass1_then_pass2_each_sorted() -> None:
     # pass_1 existings in sorted order: B, D; then pass_2 non-existings: A, C.
     assert [e.entity for e in events] == ["B", "D", "A", "C"]
     assert [e.seeded for e in events] == [True, True, False, False]
+
+
+@dataclass(frozen=True)
+class _ParityScenario:
+    """One input to the parity test: drives both the parallel-dispatch and
+    forced-single-component paths and asserts identical dedup maps."""
+
+    name: str
+    entities: set[str]
+    embedder: MockEmbedder
+    resolve_pair: ScriptedResolver
+    is_existing_canonical: Callable[[str], bool] | None = None
+    existing_policy: ExistingCanonicalPolicy = ExistingCanonicalPolicy.PINNED
+    top_n: int = 5
+
+
+def _build_parity_scenarios() -> list[_ParityScenario]:
+    scenarios: list[_ParityScenario] = []
+
+    pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2"), ("D1", "D2")]
+    scenarios.append(
+        _ParityScenario(
+            name="many_small_components",
+            entities={n for p in pairs for n in p},
+            embedder=MockEmbedder([{a, b} for a, b in pairs]),
+            resolve_pair=ScriptedResolver(
+                {(b, frozenset({a})): PairDecision(matched=a) for a, b in pairs}
+            ),
+        )
+    )
+
+    scenarios.append(
+        _ParityScenario(
+            name="preferred_mixed_existing",
+            entities={"A", "B", "C", "D", "E"},
+            embedder=MockEmbedder([{"A", "B", "C"}, {"D", "E"}]),
+            resolve_pair=ScriptedResolver(
+                {
+                    ("B", frozenset({"A"})): PairDecision(matched="A"),
+                    ("C", frozenset({"A"})): PairDecision(matched="A"),
+                    ("E", frozenset({"D"})): PairDecision(
+                        matched="D", canonical=CanonicalSide.NEW
+                    ),
+                }
+            ),
+            is_existing_canonical=lambda n: n == "A",
+            existing_policy=ExistingCanonicalPolicy.PREFERRED,
+        )
+    )
+
+    scenarios.append(
+        _ParityScenario(
+            name="pinned_two_existings_two_new",
+            entities={"A", "B", "X", "Y"},
+            embedder=MockEmbedder([{"A", "X"}, {"B", "Y"}]),
+            resolve_pair=ScriptedResolver(
+                {
+                    ("X", frozenset({"A"})): PairDecision(matched="A"),
+                    ("Y", frozenset({"B"})): PairDecision(matched="B"),
+                }
+            ),
+            is_existing_canonical=lambda n: n in {"A", "B"},
+            existing_policy=ExistingCanonicalPolicy.PINNED,
+        )
+    )
+
+    isolates_embedder = MockEmbedder([{"A", "B"}, {"C", "D"}])
+    isolates_embedder.add_isolated("solo1", axis=10)
+    isolates_embedder.add_isolated("solo2", axis=11)
+    scenarios.append(
+        _ParityScenario(
+            name="isolates_and_clusters_mixed",
+            entities={"A", "B", "C", "D", "solo1", "solo2"},
+            embedder=isolates_embedder,
+            resolve_pair=ScriptedResolver(
+                {
+                    ("B", frozenset({"A"})): PairDecision(matched="A"),
+                    ("D", frozenset({"C"})): PairDecision(matched="C"),
+                }
+            ),
+        )
+    )
+
+    return scenarios
+
+
+_PARITY_SCENARIOS = _build_parity_scenarios()
+
+
+async def _run_resolve(scenario: _ParityScenario) -> dict[str, str | None]:
+    result = await resolve_entities(
+        entities=scenario.entities,
+        embedder=scenario.embedder,
+        resolve_pair=scenario.resolve_pair,
+        is_existing_canonical=scenario.is_existing_canonical,
+        existing_policy=scenario.existing_policy,
+        top_n=scenario.top_n,
+    )
+    return result.to_dict()
+
+
+@pytest.mark.parametrize(
+    "scenario", _PARITY_SCENARIOS, ids=lambda s: s.name
+)
+@pytest.mark.asyncio
+async def test_parallel_dispatch_matches_forced_single_component(
+    scenario: _ParityScenario, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Feed the same input through both the real component-graph dispatch
+    and a forced one-big-component dispatch; assert byte-identical dedup
+    maps. The one-component dispatch is the pure greedy path with no
+    partitioning, so equality here proves the partitioning + parallel
+    runner does not perturb canonical selection.
+    """
+    parallel_dedup = await _run_resolve(scenario)
+
+    import cocoindex.ops.entity_resolution as er
+
+    def _one_component(
+        entity_list: list[str],
+        normalized_vecs: list[NDArray[np.float32]],
+        *,
+        max_distance: float,
+    ) -> list[list[int]]:
+        return [list(range(len(entity_list)))] if entity_list else []
+
+    monkeypatch.setattr(er, "_partition_components", _one_component)
+    single_component_dedup = await _run_resolve(scenario)
+
+    assert parallel_dedup == single_component_dedup, (
+        f"scenario {scenario.name!r}: parallel and single-component dedup maps differ"
+    )
+
+
+@pytest.mark.asyncio
+async def test_independent_components_resolve_concurrently() -> None:
+    """Disjoint similarity components must overlap their resolver calls.
+
+    Uses 5 vertex-disjoint 2-entity clusters. Each second-entity match is one
+    resolver call. A resolver that yields the event loop between increment
+    and decrement of an "active" counter records the peak observed
+    concurrency; a sequential implementation would observe peak=1.
+    """
+    pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2"), ("D1", "D2"), ("E1", "E2")]
+    embedder = MockEmbedder([{a, b} for a, b in pairs])
+    decisions = {
+        (b, frozenset({a})): PairDecision(matched=a) for a, b in pairs
+    }
+
+    active = 0
+    peak = 0
+
+    async def resolver(entity: str, candidates: list[str]) -> PairDecision:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        # Yield once so other component tasks reach this point before we
+        # return. asyncio.sleep(0) re-schedules the current task at the back
+        # of the ready queue without any wall-clock dependency.
+        await asyncio.sleep(0)
+        active -= 1
+        return decisions[(entity, frozenset(candidates))]
+
+    result = await resolve_entities(
+        entities={n for pair in pairs for n in pair},
+        embedder=embedder,
+        resolve_pair=resolver,
+    )
+    assert peak >= 2, f"expected concurrent resolver calls, observed peak={peak}"
+    # And the partitioning didn't break correctness — every pair merged.
+    canonicals = result.canonicals()
+    assert len(canonicals) == 5
+    for a, b in pairs:
+        assert result.canonical_of(a) == result.canonical_of(b)
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -548,7 +548,9 @@ async def test_on_resolution_decision_field() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolver_partitions_oversized_component_into_multiple_canonicals() -> None:
+async def test_resolver_partitions_oversized_component_into_multiple_canonicals() -> (
+    None
+):
     """A single FAISS component contains two ground-truth clusters; the
     resolver rejects cross-cluster candidates and the algorithm produces
     the right partition.
@@ -747,9 +749,7 @@ async def _run_resolve(scenario: _ParityScenario) -> dict[str, str | None]:
     return result.to_dict()
 
 
-@pytest.mark.parametrize(
-    "scenario", _PARITY_SCENARIOS, ids=lambda s: s.name
-)
+@pytest.mark.parametrize("scenario", _PARITY_SCENARIOS, ids=lambda s: s.name)
 @pytest.mark.asyncio
 async def test_parallel_dispatch_matches_forced_single_component(
     scenario: _ParityScenario, monkeypatch: pytest.MonkeyPatch
@@ -791,9 +791,7 @@ async def test_independent_components_resolve_concurrently() -> None:
     """
     pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2"), ("D1", "D2"), ("E1", "E2")]
     embedder = MockEmbedder([{a, b} for a, b in pairs])
-    decisions = {
-        (b, frozenset({a})): PairDecision(matched=a) for a, b in pairs
-    }
+    decisions = {(b, frozenset({a})): PairDecision(matched=a) for a, b in pairs}
 
     active = 0
     peak = 0

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -881,6 +881,43 @@ async def test_resolver_error_cancels_sibling_components() -> None:
 
 
 @pytest.mark.asyncio
+async def test_on_resolution_receives_partial_events_on_resolver_error() -> None:
+    """When one component's resolve_pair raises, the events emitted by
+    components that finished before the failure must still be delivered to
+    on_resolution. Otherwise observability into 'which entities completed
+    successfully' is lost — a regression vs the pre-parallelization
+    real-time emission semantics.
+    """
+    pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2")]
+    embedder = MockEmbedder([{a, b} for a, b in pairs])
+
+    # Stagger resolver latency so two components finish before the failing
+    # one raises.
+    delays = {"A2": 0.0, "B2": 0.0, "C2": 0.05}
+    matches = {"A2": "A1", "B2": "B1"}
+
+    async def resolver(entity: str, candidates: list[str]) -> PairDecision:
+        await asyncio.sleep(delays[entity])
+        if entity == "C2":
+            raise RuntimeError("boom")
+        return PairDecision(matched=matches[entity])
+
+    events, on_res = capture_events()
+    with pytest.raises(RuntimeError, match="boom"):
+        await resolve_entities(
+            entities={n for pair in pairs for n in pair},
+            embedder=embedder,
+            resolve_pair=resolver,
+            on_resolution=on_res,
+        )
+
+    delivered = {e.entity for e in events}
+    assert {"A1", "A2", "B1", "B2"}.issubset(delivered), (
+        f"completed events were not delivered: {delivered}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_on_resolution_exception_aborts() -> None:
     embedder = MockEmbedder([{"A"}, {"B"}, {"C"}])
     resolver = ScriptedResolver({})

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -315,15 +315,11 @@ async def test_candidate_search_respects_top_n_upper_bound() -> None:
             "Z": (1.0, 0.0),
         }
     )
-    resolver = ScriptedResolver(
-        {
-            ("B", frozenset({"A"})): PairDecision(),
-            ("C", frozenset({"A", "B"})): PairDecision(),
-            ("D", frozenset({"A", "B"})): PairDecision(),
-            ("E", frozenset({"A", "B"})): PairDecision(),
-            ("Z", frozenset({"A", "B"})): PairDecision(),
-        }
-    )
+    calls: list[tuple[str, list[str]]] = []
+
+    async def resolver(entity: str, candidates: list[str]) -> PairDecision:
+        calls.append((entity, candidates))
+        return PairDecision()
 
     await resolve_entities(
         entities={"A", "B", "C", "D", "E", "Z"},
@@ -332,7 +328,7 @@ async def test_candidate_search_respects_top_n_upper_bound() -> None:
         top_n=2,
     )
 
-    for _, candidates in resolver.calls:
+    for _, candidates in calls:
         assert len(candidates) <= 2, f"top_n=2 violated: resolver got {candidates!r}"
 
 

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -16,7 +16,6 @@ from cocoindex.ops.entity_resolution import (  # noqa: E402
     ExistingCanonicalPolicy,
     PairDecision,
     ResolutionEvent,
-    ResolvedEntities,
     resolve_entities,
 )
 
@@ -136,6 +135,37 @@ async def test_single_entity() -> None:
 
 
 @pytest.mark.asyncio
+async def test_duplicates_collapsed_and_processed_in_sorted_order() -> None:
+    embedder = MockEmbedder([{"A", "B"}])
+    resolver = ScriptedResolver({("B", frozenset({"A"})): PairDecision(matched="A")})
+    events, on_res = capture_events()
+
+    result = await resolve_entities(
+        entities=["B", "A", "B", "A"],
+        embedder=embedder,
+        resolve_pair=resolver,
+        on_resolution=on_res,
+    )
+
+    assert len(result) == 2
+    assert result.to_dict() == {"A": None, "B": "A"}
+    assert [event.entity for event in events] == ["A", "B"]
+    assert resolver.calls == [("B", ["A"])]
+
+
+@pytest.mark.asyncio
+async def test_resolved_entities_unknown_name_raises_key_error() -> None:
+    result = await resolve_entities(
+        entities={"A"},
+        embedder=MockEmbedder([{"A"}]),
+        resolve_pair=ScriptedResolver({}),
+    )
+
+    with pytest.raises(KeyError, match="unknown"):
+        result.canonical_of("unknown")
+
+
+@pytest.mark.asyncio
 async def test_no_matches_all_canonical() -> None:
     # Three distinct groups → no matches expected
     embedder = MockEmbedder([{"A"}, {"B"}, {"C"}])
@@ -147,6 +177,38 @@ async def test_no_matches_all_canonical() -> None:
     )
     assert result.canonicals() == {"A", "B", "C"}
     assert resolver.calls == []  # no candidates above threshold
+
+
+@pytest.mark.asyncio
+async def test_max_distance_threshold_excludes_candidate() -> None:
+    embedder = VectorEmbedder({"A": (1.0, 0.0), "B": (0.8, 0.6)})
+    resolver = ScriptedResolver({})
+
+    result = await resolve_entities(
+        entities={"A", "B"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        max_distance=0.1,
+    )
+
+    assert result.canonicals() == {"A", "B"}
+    assert resolver.calls == []
+
+
+@pytest.mark.asyncio
+async def test_top_n_zero_disables_candidate_search() -> None:
+    embedder = MockEmbedder([{"A", "B"}])
+    resolver = ScriptedResolver({})
+
+    result = await resolve_entities(
+        entities={"A", "B"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        top_n=0,
+    )
+
+    assert result.canonicals() == {"A", "B"}
+    assert resolver.calls == []
 
 
 @pytest.mark.asyncio
@@ -371,6 +433,36 @@ async def test_mode3_binding_pass2_existing_wins() -> None:
     )
     assert result.canonical_of("B") == "A"
     assert result.canonicals() == {"A"}
+
+
+@pytest.mark.asyncio
+async def test_mode3_binding_new_can_repoint_non_existing_canonical() -> None:
+    # PINNED only locks existing canonicals. If the matched canonical is not
+    # existing, the resolver can still promote the new entity.
+    embedder = MockEmbedder([{"A", "B"}])
+    resolver = ScriptedResolver(
+        {
+            ("B", frozenset({"A"})): PairDecision(
+                matched="A", canonical=CanonicalSide.NEW
+            )
+        }
+    )
+    events, on_res = capture_events()
+
+    result = await resolve_entities(
+        entities={"A", "B"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        is_existing_canonical=lambda n: False,
+        existing_policy=ExistingCanonicalPolicy.PINNED,
+        on_resolution=on_res,
+    )
+
+    assert result.canonical_of("A") == "B"
+    assert result.canonical_of("B") == "B"
+    assert result.canonicals() == {"B"}
+    b_event = next(e for e in events if e.entity == "B")
+    assert b_event.repointed == "A"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -606,6 +606,32 @@ async def test_on_resolution_decision_field() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolved_entities_iteration_order_is_sorted() -> None:
+    """The dedup map is mutated by concurrent component runners in
+    scheduler-interleaved order. Iteration order, however, must stay
+    sorted-by-entity so callers using ``for name in result`` or
+    ``result.to_dict()`` see deterministic results across runs."""
+    pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2"), ("D1", "D2"), ("E1", "E2")]
+    embedder = MockEmbedder([{a, b} for a, b in pairs])
+
+    async def resolver(entity: str, candidates: list[str]) -> PairDecision:
+        # Asymmetric delays force the components to finish out of order;
+        # without re-ordering, the dedup dict would reflect interleaved
+        # writes from the asyncio scheduler.
+        await asyncio.sleep(0.01 if entity > "C2" else 0.0)
+        return PairDecision(matched=candidates[0])
+
+    result = await resolve_entities(
+        entities={n for pair in pairs for n in pair},
+        embedder=embedder,
+        resolve_pair=resolver,
+    )
+
+    keys = list(result)
+    assert keys == sorted(keys)
+
+
+@pytest.mark.asyncio
 async def test_resolver_partitions_oversized_component_into_multiple_canonicals() -> (
     None
 ):

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -197,6 +197,28 @@ async def test_max_distance_threshold_excludes_candidate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_partition_includes_edges_at_exact_threshold() -> None:
+    # Two L2-normalized vectors with cosine similarity exactly 1 - max_distance.
+    # FAISS IndexFlatIP.range_search uses strict `> radius`, while the runtime
+    # _CandidateIndex.search filter is inclusive `>= threshold`. Without the
+    # nextafter step-down, the partition would drop this boundary edge and
+    # place A and B in disjoint components, while the sequential implementation
+    # would have surfaced B as a candidate of A.
+    embedder = VectorEmbedder({"A": (1.0, 0.0), "B": (0.5, float(np.sqrt(0.75)))})
+    resolver = ScriptedResolver({("B", frozenset({"A"})): PairDecision(matched="A")})
+
+    result = await resolve_entities(
+        entities={"A", "B"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        max_distance=0.5,
+    )
+
+    assert result.to_dict() == {"A": None, "B": "A"}
+    assert resolver.calls == [("B", ["A"])]
+
+
+@pytest.mark.asyncio
 async def test_top_n_zero_disables_candidate_search() -> None:
     embedder = MockEmbedder([{"A", "B"}])
     resolver = ScriptedResolver({})

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -59,6 +59,18 @@ class MockEmbedder:
         return self._vectors[text]
 
 
+class VectorEmbedder:
+    """Embedder backed by explicit vectors for ranking-sensitive tests."""
+
+    def __init__(self, vectors: dict[str, tuple[float, ...]]) -> None:
+        self._vectors = {
+            name: np.array(vector, dtype=np.float32) for name, vector in vectors.items()
+        }
+
+    async def embed(self, text: str) -> NDArray[np.float32]:
+        return self._vectors[text]
+
+
 @dataclass
 class ScriptedResolver:
     """PairResolver with pre-scripted decisions per (entity, candidates) call.
@@ -201,6 +213,37 @@ async def test_multi_hop_chain() -> None:
     assert result.canonical_of("B") == "A"
     assert result.canonical_of("C") == "A"
     assert result.groups() == {"A": {"A", "B", "C"}}
+
+
+@pytest.mark.asyncio
+async def test_candidate_search_continues_until_distinct_canonicals() -> None:
+    embedder = VectorEmbedder(
+        {
+            "A": (1.0, 0.0),
+            "A1": (1.0, 0.0),
+            "A2": (1.0, 0.0),
+            "X": (0.8, 0.6),
+            "Z": (1.0, 0.0),
+        }
+    )
+    resolver = ScriptedResolver(
+        {
+            ("A1", frozenset({"A"})): PairDecision(matched="A"),
+            ("A2", frozenset({"A"})): PairDecision(matched="A"),
+            ("X", frozenset({"A"})): PairDecision(),
+            ("Z", frozenset({"A", "X"})): PairDecision(matched="X"),
+        }
+    )
+
+    result = await resolve_entities(
+        entities={"A", "A1", "A2", "X", "Z"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        top_n=2,
+    )
+
+    assert result.canonical_of("Z") == "X"
+    assert ("Z", ["A", "X"]) in resolver.calls
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -843,6 +843,44 @@ async def test_independent_components_resolve_concurrently() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolver_error_cancels_sibling_components() -> None:
+    """If one component's resolve_pair raises, sibling component coroutines
+    must be cancelled — not allowed to keep firing resolver calls in the
+    background after resolve_entities has already raised.
+    """
+    pairs = [("A1", "A2"), ("B1", "B2"), ("C1", "C2"), ("D1", "D2"), ("E1", "E2")]
+    embedder = MockEmbedder([{a, b} for a, b in pairs])
+
+    started = 0
+    completed_normally = 0
+
+    async def resolver(entity: str, candidates: list[str]) -> PairDecision:
+        nonlocal started, completed_normally
+        started += 1
+        if entity == "A2":
+            await asyncio.sleep(0)
+            raise RuntimeError("boom")
+        await asyncio.sleep(1.0)
+        completed_normally += 1
+        return PairDecision(matched=candidates[0])
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await resolve_entities(
+            entities={n for pair in pairs for n in pair},
+            embedder=embedder,
+            resolve_pair=resolver,
+        )
+
+    # Give any leaked siblings a chance to run to completion.
+    await asyncio.sleep(0.2)
+    assert started >= 2, "test setup: at least the failing call should have started"
+    assert completed_normally == 0, (
+        f"sibling resolver calls were not cancelled: started={started}, "
+        f"completed_normally={completed_normally}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_on_resolution_exception_aborts() -> None:
     embedder = MockEmbedder([{"A"}, {"B"}, {"C"}])
     resolver = ScriptedResolver({})

--- a/python/tests/ops/test_entity_resolution.py
+++ b/python/tests/ops/test_entity_resolution.py
@@ -301,6 +301,42 @@ async def test_multi_hop_chain() -> None:
 
 
 @pytest.mark.asyncio
+async def test_candidate_search_respects_top_n_upper_bound() -> None:
+    # Six near-identical entities and top_n=2: the backfill loop must not
+    # return more than two candidates to the resolver, matching the public
+    # docs that frame top_n as the maximum candidates surfaced per entity.
+    embedder = VectorEmbedder(
+        {
+            "A": (1.0, 0.0),
+            "B": (1.0, 0.0),
+            "C": (1.0, 0.0),
+            "D": (1.0, 0.0),
+            "E": (1.0, 0.0),
+            "Z": (1.0, 0.0),
+        }
+    )
+    resolver = ScriptedResolver(
+        {
+            ("B", frozenset({"A"})): PairDecision(),
+            ("C", frozenset({"A", "B"})): PairDecision(),
+            ("D", frozenset({"A", "B"})): PairDecision(),
+            ("E", frozenset({"A", "B"})): PairDecision(),
+            ("Z", frozenset({"A", "B"})): PairDecision(),
+        }
+    )
+
+    await resolve_entities(
+        entities={"A", "B", "C", "D", "E", "Z"},
+        embedder=embedder,
+        resolve_pair=resolver,
+        top_n=2,
+    )
+
+    for _, candidates in resolver.calls:
+        assert len(candidates) <= 2, f"top_n=2 violated: resolver got {candidates!r}"
+
+
+@pytest.mark.asyncio
 async def test_candidate_search_continues_until_distinct_canonicals() -> None:
     embedder = VectorEmbedder(
         {


### PR DESCRIPTION
## Summary

- Partitions entities into connected components of the candidate-similarity graph (FAISS `range_search` + union-find), then resolves each component independently via `asyncio.gather`. Components are vertex-disjoint by construction, so dedup-map writes never conflict and the output is byte-for-byte identical to the prior sequential implementation. Resolver-call concurrency goes from 1 to (≈ component count).
- Event-callback ordering is preserved exactly: per-component runners collect events locally, then `resolve_entities` emits them in the same per-policy sort order the single-pass implementation used (PREFERRED: globally sorted; PINNED: pass-1 existings first then pass-2 non-existings, each sorted).
- Adds the benchmark scaffolding needed to actually *measure* the gain — `BenchmarkProfile` system, asymmetric `cluster_sizes` knob, `candidate_components` metric (range_search + union-find over captured embeddings, computed post-hoc inside the benchmark), and the `synthetic-many-components` / `synthetic-one-giant` / `openai-many-components` profiles.
- Follow-up fixes preserve the sequential edge-case semantics under parallel dispatch: exact-threshold candidate edges stay in the same component, resolver failures cancel sibling component work, already-completed events are still delivered before reraising, `ResolvedEntities` iteration remains deterministic, `top_n` remains a hard cap on surfaced candidates, and PINNED event ordering now tracks pass phases explicitly.

## Why `range_search` instead of `top-N` for graph edges

`top_n` caps the number of distinct canonical candidates surfaced to the resolver, but `_CandidateIndex.search` may inspect more than `top_n` raw vector hits to backfill after chain-walking aliases to canonicals. Building the partition graph from only top-N raw hits could miss threshold edges the runtime search would later surface, silently changing behavior. `range_search` builds the full threshold graph instead: extra edges only reduce parallelism, while missing edges can change correctness.

One subtlety: FAISS `IndexFlatIP.range_search` uses a strict `score > radius` boundary, while runtime candidate filtering keeps `score >= threshold`. The partition and benchmark component counter step the radius one float32 below the threshold so exact-boundary candidate edges are included.

## Measured Speedups

Synthetic (20 ms simulated resolver latency):

| Profile | Components | Before | After | Speedup |
|---|---|---|---|---|
| `synthetic-latency` | 200 | 6397 ms | 69 ms | **93×** |
| `synthetic-many-components` | 180 | 2448 ms | 47 ms | **52×** |
| `synthetic-one-giant` | 1 | 2110 ms | 2111 ms | 1.0× (no regression) |

Real OpenAI (`openai/gpt-5.4-nano` + `text-embedding-3-small`):

| Profile | `max_distance` | Components | Before | After | Speedup |
|---|---|---|---|---|---|
| `openai-small` | 0.3 | 2 | 10513 ms | 8691 ms | 1.21× |
| `openai-many-components` | 0.15 | 15 | 15063 ms | 3075 ms | **4.90×** |

`wrong_mixed_groups = 0` and canonical counts identical to the sequential implementation in every profile. Note: real-world speedup is bounded by `candidate_components`, which depends on both `max_distance` and how clustery the embedder is for your data — see the README in `benchmarks/entity_resolution/` for the threshold-sensitivity discussion.

## Change Structure

The branch is organized as a benchmark-first implementation with follow-up correctness commits:

1. Benchmark scaffolding: deterministic synthetic profiles, OpenAI-backed profiles, `cluster_sizes`, post-hoc `candidate_components`, and README numbers.
2. Candidate search improvements: backfill for distinct canonicals after chain-walking aliases, while preserving `top_n` as the maximum surfaced candidate count.
3. Refactors: extract `_CandidateIndex`, helper functions, event builders, and `_resolve_component` so the parallel dispatch change stays reviewable.
4. Parallel dispatch: partition entities by the conservative threshold graph and resolve independent components concurrently, with parity and concurrency tests.
5. Event/API semantics: document post-resolution event delivery order, keep PINNED phase ordering explicit, preserve deterministic `ResolvedEntities` iteration, and deliver completed partial events on resolver failure.
6. Error/correctness fixes: include exact-threshold graph edges, cancel sibling component tasks on resolver error, and keep benchmark component counting aligned with resolver partitioning.

## Test Plan

- [x] `uv run pytest python/tests/ops/test_entity_resolution.py python/tests/ops/test_llm_pair_resolver.py` — 42 passed
- [x] `uv run mypy python/cocoindex/ops/entity_resolution python/tests/ops/test_entity_resolution.py benchmarks/entity_resolution/benchmark.py` — clean
- [x] `uv run ruff check benchmarks/entity_resolution/benchmark.py python/cocoindex/ops/entity_resolution python/tests/ops/test_entity_resolution.py` — clean
- [x] `uv run ruff format --check benchmarks/entity_resolution/benchmark.py python/cocoindex/ops/entity_resolution python/tests/ops/test_entity_resolution.py` — clean
- [x] All four synthetic benchmark profiles match the README numbers within wall-clock jitter
- [x] Both OpenAI benchmark profiles produce identical structural metrics (components, canonicals, resolver_calls, max_concurrency, wrong_mixed_groups) to the README values
- [x] **Parity check**: a parametrized test runs every scenario through both the real component-graph dispatch and a monkey-patched single-component dispatch, asserting byte-identical dedup maps. The single-component dispatch is exactly the pre-partitioning sequential code, so equality is a strong correctness oracle.
- [x] **Concurrency check**: a dedicated test confirms peak in-flight resolver calls reaches ≥ 2 on disjoint components
