### PR TITLE
feat(lancedb): optimize v1 target periodically

### DIFF
--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -80,6 +80,7 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: Literal["system", "user"] = "system",
+    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT, coco.PendingS]
 ```
 
@@ -89,6 +90,7 @@ def declare_table_target(
 - `table_name` — Name of the table.
 - `table_schema` — Schema definition including columns and primary key (see [Table Schema](#table-schema-from-python-class)).
 - `managed_by` — Whether CocoIndex manages the table lifecycle (`"system"`) or assumes it exists (`"user"`).
+- `num_transactions_before_optimize` — Number of successful row mutation batches before scheduling a background LanceDB `table.optimize()` call.
 
 **Returns:** A pending `TableTarget`. Use the convenience wrapper `await lancedb.mount_table_target(LANCE_DB, table_name, table_schema)` to resolve.
 

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -8,7 +8,9 @@ This module provides a two-level target state system for LanceDB:
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -51,6 +53,8 @@ from cocoindex.resources import schema as res_schema
 import msgspec
 
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
+
+_logger = logging.getLogger(__name__)
 
 # Type aliases
 _RowKey = tuple[Any, ...]  # Primary key values as tuple
@@ -327,6 +331,10 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
     _conn: LanceAsyncConnection
     _table_name: str
     _table_schema: TableSchema
+    _num_transactions_before_optimize: int
+    _num_applied_mutations: int
+    _optimize_lock: asyncio.Lock
+    _optimize_task: asyncio.Task[None] | None
     _sink: coco.TargetActionSink[_RowAction]
 
     def __init__(
@@ -334,10 +342,15 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         conn: LanceAsyncConnection,
         table_name: str,
         table_schema: TableSchema,
+        num_transactions_before_optimize: int,
     ) -> None:
         self._conn = conn
         self._table_name = table_name
         self._table_schema = table_schema
+        self._num_transactions_before_optimize = num_transactions_before_optimize
+        self._num_applied_mutations = 0
+        self._optimize_lock = asyncio.Lock()
+        self._optimize_task = None
         self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
 
     async def _apply_actions(
@@ -366,6 +379,45 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         # Process deletes
         if deletes:
             await self._execute_deletes(table, deletes)
+
+        await self._maybe_optimize(table)
+
+    async def _maybe_optimize(self, table: lancedb.table.AsyncTable) -> None:
+        """Periodically optimize the table after successful mutation batches."""
+        async with self._optimize_lock:
+            self._num_applied_mutations += 1
+            if self._num_applied_mutations >= self._num_transactions_before_optimize:
+                self._schedule_optimize_locked(table)
+
+    async def _schedule_optimize(self, table: lancedb.table.AsyncTable) -> None:
+        """Schedule a background table optimization if one is not already running."""
+        async with self._optimize_lock:
+            self._schedule_optimize_locked(table)
+
+    def _schedule_optimize_locked(self, table: lancedb.table.AsyncTable) -> None:
+        if self._optimize_task is not None and not self._optimize_task.done():
+            return
+        self._optimize_task = asyncio.create_task(self._run_optimize(table))
+
+    async def _run_optimize(self, table: lancedb.table.AsyncTable) -> None:
+        succeeded = False
+        try:
+            await table.optimize()
+            succeeded = True
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.exception(
+                "Exception in optimizing LanceDB table %s", self._table_name
+            )
+        finally:
+            async with self._optimize_lock:
+                if asyncio.current_task() is self._optimize_task:
+                    self._optimize_task = None
+                    if succeeded:
+                        self._num_applied_mutations = 0
+                    else:
+                        self._num_applied_mutations = (
+                            self._num_transactions_before_optimize
+                        )
 
     async def _execute_upserts(
         self,
@@ -489,6 +541,7 @@ class _TableSpec:
 
     table_schema: TableSchema[Any]
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+    num_transactions_before_optimize: int = 50
 
 
 class _ColumnState(msgspec.Struct, frozen=True, array_like=True):
@@ -584,13 +637,13 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                     continue
 
                 spec = action.spec
-                outputs[i] = coco.ChildTargetDef(
-                    handler=_RowHandler(
-                        conn=conn,
-                        table_name=key.table_name,
-                        table_schema=spec.table_schema,
-                    )
+                handler = _RowHandler(
+                    conn=conn,
+                    table_name=key.table_name,
+                    table_schema=spec.table_schema,
+                    num_transactions_before_optimize=spec.num_transactions_before_optimize,
                 )
+                outputs[i] = coco.ChildTargetDef(handler=handler)
 
                 if action.main_action in ("insert", "upsert", "replace"):
                     await self._create_table(
@@ -599,7 +652,9 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                         spec.table_schema,
                         if_not_exists=(action.main_action == "upsert"),
                     )
-                    continue
+
+                table = await conn.open_table(key.table_name)
+                await handler._schedule_optimize(table)
 
         return outputs
 
@@ -792,6 +847,7 @@ def table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+    num_transactions_before_optimize: int = 50,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a LanceDB table target.
@@ -804,14 +860,20 @@ def table_target(
         table_name: Name of the table.
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" or "user".
+        num_transactions_before_optimize: Number of successful row mutation batches
+            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TargetState that can be passed to ``mount_target()``.
     """
+    if num_transactions_before_optimize <= 0:
+        raise ValueError("num_transactions_before_optimize must be positive")
+
     key = _TableKey(db_key=db.key, table_name=table_name)
     spec = _TableSpec(
         table_schema=table_schema,
         managed_by=managed_by,
+        num_transactions_before_optimize=num_transactions_before_optimize,
     )
     return _table_provider.target_state(key, spec)
 
@@ -822,6 +884,7 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a LanceDB table.
@@ -832,12 +895,20 @@ def declare_table_target(
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" (CocoIndex creates/drops it)
                     or "user" (table must exist, CocoIndex only manages rows).
+        num_transactions_before_optimize: Number of successful row mutation batches
+            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TableTarget that can be used to declare rows.
     """
     provider = coco.declare_target_state_with_child(
-        table_target(db, table_name, table_schema, managed_by=managed_by)
+        table_target(
+            db,
+            table_name,
+            table_schema,
+            managed_by=managed_by,
+            num_transactions_before_optimize=num_transactions_before_optimize,
+        )
     )
     return TableTarget(provider, table_schema)
 
@@ -848,6 +919,7 @@ async def mount_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.
@@ -859,12 +931,20 @@ async def mount_table_target(
         table_name: Name of the table.
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" or "user".
+        num_transactions_before_optimize: Number of successful row mutation batches
+            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TableTarget that can be used to declare rows.
     """
     provider = await coco.mount_target(
-        table_target(db, table_name, table_schema, managed_by=managed_by)
+        table_target(
+            db,
+            table_name,
+            table_schema,
+            managed_by=managed_by,
+            num_transactions_before_optimize=num_transactions_before_optimize,
+        )
     )
     return TableTarget(provider, table_schema)
 

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -1,0 +1,188 @@
+"""Tests for LanceDB target connector."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+try:
+    import pyarrow as pa  # type: ignore
+    from cocoindex.connectors import lancedb
+    from cocoindex.connectors.lancedb import _target
+
+    HAS_LANCEDB = True
+except ImportError:
+    HAS_LANCEDB = False
+
+requires_lancedb = pytest.mark.skipif(
+    not HAS_LANCEDB, reason="lancedb dependencies not installed"
+)
+
+
+if HAS_LANCEDB:
+
+    class _FakeAsyncTable:
+        def __init__(
+            self,
+            *,
+            block: asyncio.Event | None = None,
+            fail_once: bool = False,
+        ) -> None:
+            self.optimize_count = 0
+            self._block = block
+            self._fail_once = fail_once
+
+        async def optimize(self) -> None:
+            self.optimize_count += 1
+            if self._block is not None:
+                await self._block.wait()
+            if self._fail_once:
+                self._fail_once = False
+                raise RuntimeError("optimize failed")
+
+    class _FakeAsyncConnection:
+        def __init__(self) -> None:
+            self.table = _FakeAsyncTable()
+
+        async def table_names(self) -> list[str]:
+            return ["test_table"]
+
+        async def open_table(self, table_name: str) -> _FakeAsyncTable:
+            assert table_name == "test_table"
+            return self.table
+
+    class _FakeContextProvider:
+        def __init__(self, conn: _FakeAsyncConnection) -> None:
+            self._conn = conn
+
+        def get(self, key: str, t: type[Any] | None = None) -> _FakeAsyncConnection:
+            assert key == "test_db"
+            return self._conn
+
+    async def _wait_for_optimize_task(handler: _target._RowHandler) -> None:
+        task = handler._optimize_task
+        if task is not None:
+            await task
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_optimizes_after_configured_mutation_count() -> None:
+    table_schema = lancedb.TableSchema(
+        columns={
+            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+            "name": lancedb.ColumnDef(type=pa.string()),
+        },
+        primary_key=["id"],
+    )
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=table_schema,
+        num_transactions_before_optimize=2,
+    )
+    table = _FakeAsyncTable()
+
+    await handler._maybe_optimize(cast(Any, table))
+    assert table.optimize_count == 0
+
+    await handler._maybe_optimize(cast(Any, table))
+    await _wait_for_optimize_task(handler)
+    assert table.optimize_count == 1
+
+    await handler._maybe_optimize(cast(Any, table))
+    await _wait_for_optimize_task(handler)
+    assert table.optimize_count == 1
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_does_not_overlap_optimize_tasks() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+        num_transactions_before_optimize=1,
+    )
+    unblock = asyncio.Event()
+    table = _FakeAsyncTable(block=unblock)
+
+    await handler._maybe_optimize(cast(Any, table))
+    await asyncio.sleep(0)
+    assert table.optimize_count == 1
+
+    await handler._maybe_optimize(cast(Any, table))
+    await asyncio.sleep(0)
+    assert table.optimize_count == 1
+
+    unblock.set()
+    await _wait_for_optimize_task(handler)
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_retries_after_optimize_failure() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+        num_transactions_before_optimize=1,
+    )
+    table = _FakeAsyncTable(fail_once=True)
+
+    await handler._maybe_optimize(cast(Any, table))
+    await _wait_for_optimize_task(handler)
+    assert table.optimize_count == 1
+
+    await handler._maybe_optimize(cast(Any, table))
+    await _wait_for_optimize_task(handler)
+    assert table.optimize_count == 2
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_table_handler_schedules_initial_optimize() -> None:
+    conn = _FakeAsyncConnection()
+    handler = _target._TableHandler()
+    action = _target._TableAction(
+        key=_target._TableKey(db_key="test_db", table_name="test_table"),
+        spec=_target._TableSpec(
+            table_schema=_make_table_schema(),
+            managed_by=_target.target.ManagedBy.USER,
+            num_transactions_before_optimize=50,
+        ),
+        main_action=None,
+        sub_actions={},
+    )
+
+    await handler._apply_actions(cast(Any, _FakeContextProvider(conn)), [action])
+    await asyncio.sleep(0)
+
+    assert conn.table.optimize_count == 1
+
+
+@requires_lancedb
+def test_table_target_rejects_non_positive_optimize_interval() -> None:
+    with pytest.raises(
+        ValueError, match="num_transactions_before_optimize must be positive"
+    ):
+        lancedb.table_target(
+            db=cast(Any, None),
+            table_name="test_table",
+            table_schema=_make_table_schema(),
+            num_transactions_before_optimize=0,
+        )
+
+
+if HAS_LANCEDB:
+
+    def _make_table_schema() -> lancedb.TableSchema[dict[str, Any]]:
+        return lancedb.TableSchema(
+            columns={
+                "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+                "name": lancedb.ColumnDef(type=pa.string()),
+            },
+            primary_key=["id"],
+        )

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -9,6 +9,7 @@ import pytest
 
 try:
     import pyarrow as pa  # type: ignore
+    from cocoindex.connectorkits import target
     from cocoindex.connectors import lancedb
     from cocoindex.connectors.lancedb import _target
 
@@ -150,7 +151,7 @@ async def test_table_handler_schedules_initial_optimize() -> None:
         key=_target._TableKey(db_key="test_db", table_name="test_table"),
         spec=_target._TableSpec(
             table_schema=_make_table_schema(),
-            managed_by=_target.target.ManagedBy.USER,
+            managed_by=target.ManagedBy.USER,
             num_transactions_before_optimize=50,
         ),
         main_action=None,


### PR DESCRIPTION
## Summary

Add periodic LanceDB table optimization to the v1 target connector, matching the v0 behavior added in #1466.

- Adds `num_transactions_before_optimize` to the v1 LanceDB table target APIs, defaulting to 50.
- Schedules background `table.optimize()` calls after successful row mutation batches reach the configured threshold.
- Documents the new option and adds unit coverage for the cadence and parameter validation.

## Validation

- `ruff check python/cocoindex/connectors/lancedb/_target.py python/tests/connectors/test_lancedb_target.py`
- `python -m py_compile python/cocoindex/connectors/lancedb/_target.py python/tests/connectors/test_lancedb_target.py`
- `git diff --check`

Targeted pytest with `uv run --group build-test --extra lancedb pytest python/tests/connectors/test_lancedb_target.py -q` could not complete locally because dependency downloads for large wheels such as `lancedb`/`pyarrow` repeatedly stalled or timed out in this environment.

Fixes #2002
