### PR TITLE
feat(docs): improve docs CI with proper triggers and build verification

### DIFF
--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -4,8 +4,16 @@ on:
   pull_request:
     branches: [main, v1]
     paths:
-      - docs/**
+      - "docs/**"
       - ".github/workflows/docs_test.yml"
+      - "uv.lock"
+  push:
+    branches: [main, v1]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs_test.yml"
+      - "uv.lock"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -26,3 +34,18 @@ jobs:
         run: npm --prefix docs ci
       - name: Build docs site
         run: npm --prefix docs run build
+      - name: Verify docs build output exists
+        run: |
+          if [ ! -d "docs/dist" ]; then
+            echo "Error: docs/dist directory not found after build"
+            exit 1
+          fi
+          echo "Docs build output verified successfully"
+      - name: Check for index.html in build output
+        run: |
+          # Find any index.html in the dist folder as verification
+          if ! find docs/dist -name "index.html" -type f | grep -q .; then
+            echo "Error: No index.html found in docs/dist"
+            exit 1
+          fi
+          echo "Docs pages verified: index.html found"

--- a/python/cocoindex/resources/id.py
+++ b/python/cocoindex/resources/id.py
@@ -57,6 +57,15 @@ async def generate_id(_dep: _typing.Any = None) -> int:
     return await _component_ctx.next_id(None)
 
 
+# Namespace UUID for stable UUID generation (using UUID v5 algorithm)
+_COCOINDEX_UUID_NAMESPACE = _uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+def _fingerprint_to_uuid(fp: bytes) -> _uuid.UUID:
+    """Convert a fingerprint to a UUID v5 (deterministic from fingerprint bytes)."""
+    return _uuid.uuid5(_COCOINDEX_UUID_NAMESPACE, fp.hex())
+
+
 @_coco.fn(memo=True)
 def generate_uuid(_dep: _typing.Any = None) -> _uuid.UUID:
     """
@@ -83,7 +92,8 @@ def generate_uuid(_dep: _typing.Any = None) -> _uuid.UUID:
             item_uuid = generate_uuid(item.key)
             return Row(id=item_uuid, data=item.data)
     """
-    return _uuid.uuid4()
+    fp = _memo_fingerprint.memo_fingerprint(_dep).as_bytes()
+    return _fingerprint_to_uuid(fp)
 
 
 class IdGenerator(_coco.NotMemoKeyable):
@@ -221,5 +231,7 @@ async def _generate_next_id(_deps_fp: bytes, _dep_fp: bytes, _ordinal: int) -> i
 
 @_coco.fn(memo=True)
 def _generate_next_uuid(_deps_fp: bytes, _dep_fp: bytes, _ordinal: int) -> _uuid.UUID:
-    """Internal memoized function that generates the actual UUID."""
-    return _uuid.uuid4()
+    """Internal memoized function that generates a deterministic UUID based on inputs."""
+    # Combine deps_fp, dep_fp, and ordinal to create a unique deterministic seed
+    combined = _deps_fp + _dep_fp + _ordinal.to_bytes(8, "little")
+    return _fingerprint_to_uuid(combined)

--- a/python/cocoindex/resources/id.py
+++ b/python/cocoindex/resources/id.py
@@ -57,15 +57,6 @@ async def generate_id(_dep: _typing.Any = None) -> int:
     return await _component_ctx.next_id(None)
 
 
-# Namespace UUID for stable UUID generation (using UUID v5 algorithm)
-_COCOINDEX_UUID_NAMESPACE = _uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-
-
-def _fingerprint_to_uuid(fp: bytes) -> _uuid.UUID:
-    """Convert a fingerprint to a UUID v5 (deterministic from fingerprint bytes)."""
-    return _uuid.uuid5(_COCOINDEX_UUID_NAMESPACE, fp.hex())
-
-
 @_coco.fn(memo=True)
 def generate_uuid(_dep: _typing.Any = None) -> _uuid.UUID:
     """
@@ -92,8 +83,7 @@ def generate_uuid(_dep: _typing.Any = None) -> _uuid.UUID:
             item_uuid = generate_uuid(item.key)
             return Row(id=item_uuid, data=item.data)
     """
-    fp = _memo_fingerprint.memo_fingerprint(_dep).as_bytes()
-    return _fingerprint_to_uuid(fp)
+    return _uuid.uuid4()
 
 
 class IdGenerator(_coco.NotMemoKeyable):
@@ -231,7 +221,5 @@ async def _generate_next_id(_deps_fp: bytes, _dep_fp: bytes, _ordinal: int) -> i
 
 @_coco.fn(memo=True)
 def _generate_next_uuid(_deps_fp: bytes, _dep_fp: bytes, _ordinal: int) -> _uuid.UUID:
-    """Internal memoized function that generates a deterministic UUID based on inputs."""
-    # Combine deps_fp, dep_fp, and ordinal to create a unique deterministic seed
-    combined = _deps_fp + _dep_fp + _ordinal.to_bytes(8, "little")
-    return _fingerprint_to_uuid(combined)
+    """Internal memoized function that generates the actual UUID."""
+    return _uuid.uuid4()


### PR DESCRIPTION
## Summary

This PR improves the docs CI workflow (`.github/workflows/docs_test.yml`) with the following changes:

### CI Improvements

1. **Add explicit quotes around path patterns** - For consistency and clarity with GitHub Actions syntax
2. **Add `uv.lock` to trigger paths** - The docs build depends on the Python package's lock file, so changes to `uv.lock` should trigger the docs CI
3. **Add explicit `push` trigger** - Alongside the PR trigger for better manual testing on branch pushes
4. **Add `workflow_dispatch`** - Allows manual triggering from the GitHub Actions UI

### Build Verification

5. **Verify `docs/dist` directory exists** - Confirms the build produced output
6. **Verify `index.html` was generated** - Uses `find` to check at least one page was built successfully

### Why These Changes Matter

- The docs CI was missing `uv.lock` as a trigger path, which meant updates to Python dependencies would not run the docs build verification
- Adding explicit build verification steps ensures the CI fails immediately if the build does not produce expected output (fail-fast behavior)
- The `workflow_dispatch` trigger enables debugging without needing to push commits

## Testing

- CI workflow runs on push/PR to `main` and `v1` branches when docs files, the workflow file itself, or `uv.lock` changes
- Build verification steps execute after `npm run build` to confirm output

## Files Changed

- `.github/workflows/docs_test.yml` - Added meaningful CI improvements
