### PR TITLE
refactor(state_store): remove ReadTxn from API; standalone reads per call

### DIFF
--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -588,9 +588,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         }
         let app_store = self.app_ctx().app_store();
         let path = self.stable_path();
-        let mut rtxn = self.app_ctx().env().read_txn().await?;
-        let rows = app_store.list_fn_memos(&mut rtxn, path).await?;
-        drop(rtxn);
+        let rows = app_store.list_fn_memos(path).await?;
         self.update_building_state(|s| {
             s.fn_memos.populate(rows);
             Ok(())

--- a/rust/core/src/engine/environment.rs
+++ b/rust/core/src/engine/environment.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::profile::EngineProfile,
     engine::target_state::TargetStateProviderRegistry,
     prelude::*,
-    state_store::{AppStore, ReadTxn, Storage, StorageSettings, WriteTxn},
+    state_store::{AppStore, Storage, StorageSettings, WriteTxn},
 };
 
 use cocoindex_utils::fingerprint::Fingerprint;
@@ -65,12 +65,6 @@ impl<Prof: EngineProfile> Environment<Prof> {
 
     pub fn storage(&self) -> &Storage {
         &self.inner.storage
-    }
-
-    /// Open a read transaction. Delegates to [`Storage::read_txn`] which
-    /// handles transient and stale-reader retry.
-    pub async fn read_txn(&self) -> Result<ReadTxn<'_>> {
-        self.inner.storage.read_txn().await
     }
 
     /// Run a batched write transaction. Delegates to [`Storage::run_txn`].

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -22,7 +22,7 @@ use crate::state::stable_path_set::{ChildStablePathSet, StablePathSet};
 use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
-use crate::state_store::{AnyTxn, AppStore, WriteTxn};
+use crate::state_store::{AppStore, WriteTxn};
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 
@@ -88,8 +88,7 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
     let app_store = comp_ctx.app_ctx().app_store();
     let path = comp_ctx.stable_path();
     {
-        let mut rtxn = comp_ctx.app_ctx().env().read_txn().await?;
-        let Some(memo_bytes) = app_store.read_component_memo(&mut rtxn, path).await? else {
+        let Some(memo_bytes) = app_store.read_component_memo(path).await? else {
             return Ok(None);
         };
         let memo_info: db_schema::ComponentMemoizationInfo<'_> = from_msgpack_slice(&memo_bytes)?;
@@ -173,7 +172,8 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
         .run_txn(move |wtxn| {
             Box::pin(async move {
                 let encoded = {
-                    let Some(existing_bytes) = app_store.read_component_memo(wtxn, &path).await?
+                    let Some(existing_bytes) =
+                        app_store.read_component_memo_in_txn(wtxn, &path).await?
                     else {
                         return Ok(());
                     };
@@ -331,7 +331,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                     .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;
                 let tracking_info_bytes = self
                     .app_store
-                    .read_tracking_info(&mut *wtxn, &self.component_path)
+                    .read_tracking_info_in_txn(&mut *wtxn, &self.component_path)
                     .await?
                     .ok_or_else(|| internal_error!("tracking info not found for commit"))?;
                 let mut tracking_info: db_schema::StablePathEntryTrackingInfo<'_> =
@@ -462,7 +462,7 @@ impl<Prof: EngineProfile> Committer<Prof> {
                 .flat_map(|set| set.children.into_iter());
             let existing_children = self
                 .app_store
-                .list_child_existence(&mut *wtxn, &path_info.path)
+                .list_child_existence_in_txn(&mut *wtxn, &path_info.path)
                 .await?;
             let mut existing_iter = existing_children.into_iter();
 
@@ -604,20 +604,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
         // The `Arc` makes cloning cheap regardless of how many
         // descendants we spawn.
         let cascaded_on_error = self.component_ctx.processing_action_on_error();
-        // Hold the read txn only for as long as it takes to read tombstones,
-        // then drop it before spawning + awaiting child delete tasks. Each
-        // recursively-spawned child delete opens its own read txn, so any
-        // backend whose `ReadTxn` pins a shared resource (e.g. a connection
-        // from a fixed-size pool) would otherwise hit a fanout-driven
-        // deadlock: every connection held by a parent waiting for a child
-        // that can't acquire one. LMDB-only builds don't suffer this, but
-        // the lifetime discipline is correct either way.
-        let tombstones = {
-            let mut rtxn = self.component_ctx.app_ctx().env().read_txn().await?;
-            self.app_store
-                .list_tombstones(&mut rtxn, &self.component_path)
-                .await?
-        };
+        // Standalone snapshot read — `list_tombstones` opens its own
+        // fresh `RoTxn` internally.
+        let tombstones = self.app_store.list_tombstones(&self.component_path).await?;
         let mut handles = Vec::with_capacity(tombstones.len());
         for relative_path in tombstones {
             let stable_path = self.component_path.concat(relative_path.as_ref());
@@ -834,7 +823,9 @@ async fn pre_commit<Prof: EngineProfile>(
     }
 
     let mut id_reservation = IdReservation::new(&TARGET_ID_KEY);
-    let tracking_info_bytes = app_store.read_tracking_info(wtxn, stable_path).await?;
+    let tracking_info_bytes = app_store
+        .read_tracking_info_in_txn(wtxn, stable_path)
+        .await?;
     let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'_>> = tracking_info_bytes
         .as_deref()
         .map(from_msgpack_slice)
@@ -885,7 +876,7 @@ async fn pre_commit<Prof: EngineProfile>(
                 continue;
             }
             let Some(owner_info) = app_store
-                .read_target_state_owner(wtxn, &target_state_path)
+                .read_target_state_owner_in_txn(wtxn, &target_state_path)
                 .await?
             else {
                 continue;
@@ -895,7 +886,7 @@ async fn pre_commit<Prof: EngineProfile>(
             }
             if !old_tracking_cache.contains_key(&owner_info.component_path) {
                 let Some(old_bytes) = app_store
-                    .read_tracking_info(wtxn, &owner_info.component_path)
+                    .read_tracking_info_in_txn(wtxn, &owner_info.component_path)
                     .await?
                 else {
                     continue;
@@ -988,7 +979,7 @@ async fn pre_commit<Prof: EngineProfile>(
                 // back into the cache, and flag the owner as modified. One
                 // deferred write per old owner is emitted after Phase 1.
                 match app_store
-                    .read_target_state_owner(wtxn, &target_state_path)
+                    .read_target_state_owner_in_txn(wtxn, &target_state_path)
                     .await?
                 {
                     Some(owner_info) if owner_info.component_path != *stable_path => {
@@ -1547,7 +1538,8 @@ async fn rollback_pending_tokens<Prof: EngineProfile>(
             .env()
             .run_txn(move |wtxn| {
                 Box::pin(async move {
-                    let Some(bytes) = app_store.read_tracking_info(wtxn, &path).await? else {
+                    let Some(bytes) = app_store.read_tracking_info_in_txn(wtxn, &path).await?
+                    else {
                         return Ok(());
                     };
                     let encoded = {
@@ -1660,13 +1652,15 @@ pub(crate) async fn ensure_path_node_type(
         .await
 }
 
-async fn get_path_node_type<T: AnyTxn>(
+async fn get_path_node_type(
     app_store: &AppStore,
-    rtxn: &mut T,
+    wtxn: &mut WriteTxn<'_>,
     parent_path: StablePathRef<'_>,
     key: &StableKey,
 ) -> Result<Option<db_schema::StablePathNodeType>> {
-    app_store.read_path_node_type(rtxn, parent_path, key).await
+    app_store
+        .read_path_node_type_in_txn(wtxn, parent_path, key)
+        .await
 }
 
 /// Walk every entry in the function-memo cache and produce the set of

--- a/rust/core/src/engine/id_sequencer.rs
+++ b/rust/core/src/engine/id_sequencer.rs
@@ -149,7 +149,7 @@ impl IdReservation {
             Some(n) => n,
             slot @ None => {
                 let current = app_store
-                    .peek_id_sequence(wtxn, self.key)
+                    .peek_id_sequence_in_txn(wtxn, self.key)
                     .await?
                     .unwrap_or(1);
                 slot.insert(current)

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -10,9 +10,7 @@ use futures::stream::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
 pub async fn list_stable_paths<Prof: EngineProfile>(app: &App<Prof>) -> Result<Vec<StablePath>> {
-    let app_store = app.app_ctx().app_store();
-    let mut rtxn = app.app_ctx().env().storage().read_txn_for_inspect().await?;
-    app_store.list_all_stable_paths(&mut rtxn).await
+    app.app_ctx().app_store().list_all_stable_paths().await
 }
 
 /// Represents a stable path with metadata (e.g. node type); more properties may be added.

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -1,14 +1,27 @@
 //! Per-app handle within a [`Storage`](super::Storage).
 //!
-//! An `AppStore` is a cheap-clone token that identifies which app's entries
-//! a typed I/O operation reads or writes. Methods are paired with a
-//! [`WriteTxn`](super::WriteTxn) or [`ReadTxn`](super::ReadTxn) (or
-//! anything implementing [`AnyTxn`](super::AnyTxn) for the read-only ops),
-//! and the txn parameter always comes first.
+//! An `AppStore` is a cheap-clone token that carries the per-app heed
+//! `Database` plus a clone of the parent `Env` so standalone read
+//! methods can open their own `RoTxn` (with `MDB_READERS_FULL` retry)
+//! without the caller having to manage the transaction.
 //!
-//! All I/O methods are `async fn`. The current LMDB implementation is
-//! synchronous internally — the returned futures never yield — but the
-//! async signature future-proofs the API.
+//! Read methods come in two flavors:
+//!
+//! * **`*_in_txn(wtxn, ...)`** — reads inside a write transaction; see
+//!   uncommitted writes in the same txn. Used by `pre_commit` and
+//!   friends inside `run_txn` bodies.
+//! * **Standalone `read_*(...)` / `list_*(...)`** — open their own snapshot
+//!   internally. Used by callers that aren't inside a write txn (memo
+//!   lookups, GC sweeps, inspection).
+//!
+//! Only operations actually invoked from both contexts in production
+//! expose both shapes (today: just `read_component_memo`). Methods
+//! invoked from one context only get only the corresponding flavor.
+//!
+//! All I/O methods are `async fn`. LMDB is synchronous internally — the
+//! returned futures never yield except where the standalone reader's
+//! `MDB_READERS_FULL` retry pauses — but the async signature
+//! future-proofs the API.
 
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
@@ -20,29 +33,83 @@ use crate::state::db_schema::{
 };
 use crate::state::stable_path::{StableKey, StablePath, StablePathPrefix, StablePathRef};
 use crate::state::target_state_path::TargetStatePath;
-use crate::state_store::txn::{AnyTxn, ReadTxn, WriteTxn};
+use crate::state_store::txn::WriteTxn;
 
 /// LMDB database handle. Keys and values are opaque bytes; logical
 /// key/value schemas live in [`crate::state::db_schema`].
 pub(crate) type Database = heed::Database<heed::types::Bytes, heed::types::Bytes>;
 
-/// Per-app handle within a `Storage`.
+/// Per-app handle within a `Storage`. Carries both the `Database` and a
+/// clone of the parent `Env` so standalone read methods can open their
+/// own `RoTxn` without the caller having to do so.
 #[derive(Clone)]
 pub struct AppStore {
     pub(crate) db: Database,
+    pub(crate) env: heed::Env<heed::WithoutTls>,
 }
 
 impl AppStore {
-    pub(crate) fn new(db: Database) -> Self {
-        Self { db }
+    pub(crate) fn new(db: Database, env: heed::Env<heed::WithoutTls>) -> Self {
+        Self { db, env }
     }
 
-    /// Internal accessor for typed-entity methods. External callers reach
-    /// the underlying state through method calls, not the raw `Database`.
+    /// Internal accessor for cursor-iteration code (e.g.
+    /// `Storage::spawn_iter_stable_paths_with_node_type`) that needs the
+    /// raw heed handle.
     pub(crate) fn db(&self) -> Database {
         self.db
     }
+
+    /// Open a fresh LMDB read transaction with `MDB_READERS_FULL` retry
+    /// (two-phase: short retry → clear stale readers → retry
+    /// indefinitely). Used by the standalone read methods and by the
+    /// streaming inspection iter.
+    pub async fn read_txn(&self) -> Result<heed::RoTxn<'_, heed::WithoutTls>> {
+        let env = &self.env;
+        let try_open = || async {
+            match env.read_txn() {
+                Ok(txn) => cocoindex_utils::retryable::Ok(txn),
+                Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
+                    warn!("LMDB readers full, retrying");
+                    Err(cocoindex_utils::retryable::Error::retryable(
+                        internal_error!("LMDB readers full"),
+                    ))
+                }
+                Err(e) => Err(cocoindex_utils::retryable::Error::not_retryable(e)),
+            }
+        };
+
+        // Phase 1: short timeout for transient concurrency.
+        match cocoindex_utils::retryable::run(&try_open, &READ_TXN_RETRY_PHASE1).await {
+            Ok(txn) => return Ok(txn),
+            Err(e) if !e.is_retryable => return Err(e.into()),
+            Err(_) => {}
+        }
+
+        // Phase 2: clear stale readers, then retry indefinitely.
+        let cleared = env.clear_stale_readers()?;
+        if cleared > 0 {
+            warn!("Cleared {cleared} stale LMDB readers");
+        }
+        cocoindex_utils::retryable::run(&try_open, &READ_TXN_RETRY_PHASE2)
+            .await
+            .map_err(Into::into)
+    }
 }
+
+static READ_TXN_RETRY_PHASE1: cocoindex_utils::retryable::RetryOptions =
+    cocoindex_utils::retryable::RetryOptions {
+        retry_timeout: Some(std::time::Duration::from_secs(3)),
+        initial_backoff: std::time::Duration::from_millis(10),
+        max_backoff: std::time::Duration::from_secs(1),
+    };
+
+static READ_TXN_RETRY_PHASE2: cocoindex_utils::retryable::RetryOptions =
+    cocoindex_utils::retryable::RetryOptions {
+        retry_timeout: None,
+        initial_backoff: std::time::Duration::from_millis(10),
+        max_backoff: std::time::Duration::from_secs(1),
+    };
 
 // --- Key encoding helpers (internal) -------------------------------------
 
@@ -101,17 +168,18 @@ fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
 // --- Tracking info -------------------------------------------------------
 
 impl AppStore {
-    /// Read raw tracking-info bytes. Returns owned bytes (`Vec<u8>`) so the
-    /// caller can deserialize from a local buffer and avoid keeping the txn
-    /// borrowed for the deserialized struct's lifetime. Callers typically
-    /// then do `from_msgpack_slice::<StablePathEntryTrackingInfo>(&bytes)`.
-    pub async fn read_tracking_info<T: AnyTxn>(
+    /// Read raw tracking-info bytes inside an open write txn. Returns
+    /// owned bytes (`Vec<u8>`) so the caller can deserialize from a
+    /// local buffer and avoid keeping the txn borrowed for the
+    /// deserialized struct's lifetime. Callers typically then do
+    /// `from_msgpack_slice::<StablePathEntryTrackingInfo>(&bytes)`.
+    pub async fn read_tracking_info_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
     ) -> Result<Option<Vec<u8>>> {
         let key = key_tracking_info(path)?;
-        Ok(txn.db_get_bytes(self.db(), &key)?.map(<[u8]>::to_vec))
+        Ok(self.db().get(&**txn, &key)?.map(<[u8]>::to_vec))
     }
 
     /// Write pre-serialized tracking info. Callers serialize externally so
@@ -143,15 +211,24 @@ impl AppStore {
 // --- Component memoization -----------------------------------------------
 
 impl AppStore {
-    /// Read raw component-memo bytes. See [`Self::read_tracking_info`] for
-    /// the owned-bytes return rationale.
-    pub async fn read_component_memo<T: AnyTxn>(
+    /// Read raw component-memo bytes inside an open write txn. Sees
+    /// uncommitted writes in the same txn. Used by the engine's memo
+    /// invalidation path.
+    pub async fn read_component_memo_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         path: &StablePath,
     ) -> Result<Option<Vec<u8>>> {
         let key = key_component_memo(path)?;
-        Ok(txn.db_get_bytes(self.db(), &key)?.map(<[u8]>::to_vec))
+        Ok(self.db().get(&**txn, &key)?.map(<[u8]>::to_vec))
+    }
+
+    /// Read raw component-memo bytes from a fresh snapshot. Used by the
+    /// memoization-check fast path outside `run_txn`.
+    pub async fn read_component_memo(&self, path: &StablePath) -> Result<Option<Vec<u8>>> {
+        let rtxn = self.read_txn().await?;
+        let key = key_component_memo(path)?;
+        Ok(self.db().get(&rtxn, &key)?.map(<[u8]>::to_vec))
     }
 
     /// Write a pre-serialized component memo. Callers serialize externally
@@ -182,18 +259,14 @@ impl AppStore {
 // --- Function memoization ------------------------------------------------
 
 impl AppStore {
-    /// List every function memo under `path`. Returns owned `(fp, value)`
-    /// pairs from a single prefix scan. Matches the shape of
-    /// [`Self::list_child_existence`] and [`Self::list_tombstones`].
-    pub async fn list_fn_memos(
-        &self,
-        txn: &mut ReadTxn<'_>,
-        path: &StablePath,
-    ) -> Result<Vec<(Fingerprint, Vec<u8>)>> {
+    /// List every function memo under `path` from a fresh snapshot. Used
+    /// by the per-component `fn_memos` loader outside `run_txn`.
+    pub async fn list_fn_memos(&self, path: &StablePath) -> Result<Vec<(Fingerprint, Vec<u8>)>> {
+        let rtxn = self.read_txn().await?;
         let prefix = key_fn_memo_prefix(path)?;
         let db = self.db();
         let mut out = Vec::new();
-        for entry in db.prefix_iter(&**txn, &prefix)? {
+        for entry in db.prefix_iter(&rtxn, &prefix)? {
             let (raw_key, raw_val) = entry?;
             let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
             out.push((fp, raw_val.to_vec()));
@@ -249,14 +322,14 @@ impl AppStore {
 // --- Child existence -----------------------------------------------------
 
 impl AppStore {
-    pub async fn read_child_existence<T: AnyTxn>(
+    pub async fn read_child_existence_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
         child_key: &StableKey,
     ) -> Result<Option<ChildExistenceInfo>> {
         let key = key_child_existence(parent, child_key)?;
-        let data = txn.db_get_bytes(self.db(), &key)?;
+        let data = self.db().get(&**txn, &key)?;
         data.map(from_msgpack_slice).transpose().map_err(Into::into)
     }
 
@@ -289,14 +362,14 @@ impl AppStore {
     /// encoding via `storekey` is order-preserving). Used by
     /// `Committer::update_existence` for the sorted-merge against the
     /// in-memory declared children.
-    pub async fn list_child_existence<T: AnyTxn>(
+    pub async fn list_child_existence_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         parent: &StablePath,
     ) -> Result<Vec<(StableKey, ChildExistenceInfo)>> {
         let prefix = key_child_existence_prefix(parent)?;
         let mut out = Vec::new();
-        for entry in txn.db_prefix_iter(self.db(), &prefix)? {
+        for entry in self.db().prefix_iter(&**txn, &prefix)? {
             let (raw_key, raw_value) = entry?;
             let stable_key: StableKey = storekey::decode(raw_key[prefix.len()..].as_ref())?;
             let info: ChildExistenceInfo = from_msgpack_slice(raw_value)?;
@@ -331,16 +404,14 @@ impl AppStore {
         Ok(())
     }
 
-    /// Relative paths of all tombstones for `parent`. Used by
-    /// `Committer::launch_child_component_gc` to find which children need GC.
-    pub async fn list_tombstones<T: AnyTxn>(
-        &self,
-        txn: &mut T,
-        parent: &StablePath,
-    ) -> Result<Vec<StablePath>> {
+    /// Relative paths of all tombstones for `parent`, from a fresh
+    /// snapshot. Used by `Committer::launch_child_component_gc` to find
+    /// which children need GC.
+    pub async fn list_tombstones(&self, parent: &StablePath) -> Result<Vec<StablePath>> {
+        let rtxn = self.read_txn().await?;
         let prefix = key_tombstone_prefix(parent)?;
         let mut out = Vec::new();
-        for entry in txn.db_prefix_iter(self.db(), &prefix)? {
+        for entry in self.db().prefix_iter(&rtxn, &prefix)? {
             let (raw_key, _) = entry?;
             let relative: StablePath = storekey::decode(raw_key[prefix.len()..].as_ref())?;
             out.push(relative);
@@ -368,13 +439,13 @@ impl AppStore {
 // --- Inverted target-state owner index -----------------------------------
 
 impl AppStore {
-    pub async fn read_target_state_owner<T: AnyTxn>(
+    pub async fn read_target_state_owner_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         path: &TargetStatePath,
     ) -> Result<Option<TargetStateOwnerInfo>> {
         let key = key_target_state_owner(path)?;
-        let data = txn.db_get_bytes(self.db(), &key)?;
+        let data = self.db().get(&**txn, &key)?;
         data.map(from_msgpack_slice).transpose().map_err(Into::into)
     }
 
@@ -406,13 +477,13 @@ impl AppStore {
 // --- ID sequencer --------------------------------------------------------
 
 impl AppStore {
-    pub async fn peek_id_sequence<T: AnyTxn>(
+    pub async fn peek_id_sequence_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         key: &StableKey,
     ) -> Result<Option<u64>> {
         let db_key = key_id_sequencer(key)?;
-        let data = txn.db_get_bytes(self.db(), &db_key)?;
+        let data = self.db().get(&**txn, &db_key)?;
         match data {
             None => Ok(None),
             Some(bytes) => {
@@ -444,7 +515,10 @@ impl AppStore {
         key: &StableKey,
         count: u64,
     ) -> Result<u64> {
-        let current_next_id = self.peek_id_sequence(&mut *txn, key).await?.unwrap_or(1);
+        let current_next_id = self
+            .peek_id_sequence_in_txn(&mut *txn, key)
+            .await?
+            .unwrap_or(1);
         self.write_id_sequence(txn, key, current_next_id + count)
             .await?;
         Ok(current_next_id)
@@ -465,14 +539,16 @@ impl AppStore {
 impl AppStore {
     /// Looks up the node type of `parent_path/key` by reading the parent's
     /// child-existence entry. Used by `pre_commit` path-existence checks.
-    pub async fn read_path_node_type<T: AnyTxn>(
+    pub async fn read_path_node_type_in_txn(
         &self,
-        txn: &mut T,
+        txn: &mut WriteTxn<'_>,
         parent_path: StablePathRef<'_>,
         key: &StableKey,
     ) -> Result<Option<StablePathNodeType>> {
         let parent_owned: StablePath = parent_path.into();
-        let info = self.read_child_existence(txn, &parent_owned, key).await?;
+        let info = self
+            .read_child_existence_in_txn(txn, &parent_owned, key)
+            .await?;
         Ok(info.map(|i| i.node_type))
     }
 
@@ -491,7 +567,9 @@ impl AppStore {
         target_node_type: StablePathNodeType,
     ) -> Result<()> {
         let parent_owned: StablePath = parent_path.into();
-        let existing = self.read_child_existence(txn, &parent_owned, key).await?;
+        let existing = self
+            .read_child_existence_in_txn(txn, &parent_owned, key)
+            .await?;
         let existing_node_type = existing.as_ref().map(|i| i.node_type);
         match (existing_node_type, target_node_type) {
             (None, _) | (Some(StablePathNodeType::Directory), StablePathNodeType::Component) => {
@@ -528,14 +606,15 @@ impl AppStore {
 
 impl AppStore {
     /// Scan all stable-path entries in this app and return one path per
-    /// component / directory.
-    pub async fn list_all_stable_paths(&self, txn: &mut ReadTxn<'_>) -> Result<Vec<StablePath>> {
+    /// component / directory, from a fresh snapshot.
+    pub async fn list_all_stable_paths(&self) -> Result<Vec<StablePath>> {
+        let rtxn = self.read_txn().await?;
         let encoded_key_prefix =
             DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
         let db = self.db();
-        let mut result = Vec::new();
+        let mut out = Vec::new();
         let mut last_prefix: Option<Vec<u8>> = None;
-        for entry in db.prefix_iter(&**txn, &encoded_key_prefix)? {
+        for entry in db.prefix_iter(&rtxn, &encoded_key_prefix)? {
             let (raw_key, _) = entry?;
             if let Some(last_prefix) = &last_prefix
                 && raw_key.starts_with(last_prefix)
@@ -543,12 +622,15 @@ impl AppStore {
                 continue;
             }
             let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
-            let DbEntryKey::StablePath(path, _) = key else {
-                internal_bail!("Expected StablePath, got {key:?}");
+            let path = match key {
+                DbEntryKey::StablePath(path, _) => path,
+                other => {
+                    return Err(internal_error!("Expected StablePath, got {other:?}"));
+                }
             };
             last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
-            result.push(path);
+            out.push(path);
         }
-        Ok(result)
+        Ok(out)
     }
 }

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -14,4 +14,4 @@ mod txn;
 
 pub use app_store::AppStore;
 pub use storage::{Storage, StorageSettings};
-pub use txn::{AnyTxn, ReadTxn, WriteTxn};
+pub use txn::WriteTxn;

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -11,34 +11,67 @@ use crate::state::db_schema::{
 };
 use crate::state::stable_path::{StablePath, StablePathPrefix, StablePathRef};
 use crate::state_store::app_store::{AppStore, Database};
-use crate::state_store::txn::{ReadTxn, WriteTxn};
+use crate::state_store::txn::WriteTxn;
 
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 use cocoindex_utils::deser::from_msgpack_slice;
-use cocoindex_utils::retryable;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
 const DEFAULT_MAX_DBS: u32 = 1024;
 const DEFAULT_MAP_SIZE: usize = 0x1_0000_0000; // 4GiB
 
-/// Phase 1: short timeout to handle transient concurrency.
-static READ_TXN_RETRY_PHASE1: retryable::RetryOptions = retryable::RetryOptions {
-    retry_timeout: Some(Duration::from_secs(3)),
-    initial_backoff: Duration::from_millis(10),
-    max_backoff: Duration::from_secs(1),
-};
+/// Sync sibling of [`AppStore::read_txn`]'s `MDB_READERS_FULL` retry,
+/// for use inside `spawn_blocking` where the async retry helper isn't
+/// reachable. Same two-phase policy.
+fn open_read_txn_sync_with_retry(
+    env: &heed::Env<heed::WithoutTls>,
+) -> Result<heed::RoTxn<'_, heed::WithoutTls>> {
+    use std::time::{Duration, Instant};
 
-/// Phase 2: after clearing stale readers, retry indefinitely.
-static READ_TXN_RETRY_PHASE2: retryable::RetryOptions = retryable::RetryOptions {
-    retry_timeout: None,
-    initial_backoff: Duration::from_millis(10),
-    max_backoff: Duration::from_secs(1),
-};
+    const INITIAL_BACKOFF: Duration = Duration::from_millis(10);
+    const MAX_BACKOFF: Duration = Duration::from_secs(1);
+    const PHASE1_TIMEOUT: Duration = Duration::from_secs(3);
+
+    // Phase 1: short timeout for transient concurrency.
+    let phase1_start = Instant::now();
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        match env.read_txn() {
+            Ok(txn) => return Ok(txn),
+            Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
+                if phase1_start.elapsed() >= PHASE1_TIMEOUT {
+                    break;
+                }
+                warn!("LMDB readers full, retrying");
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // Phase 2: clear stale readers, then retry indefinitely.
+    let cleared = env.clear_stale_readers()?;
+    if cleared > 0 {
+        warn!("Cleared {cleared} stale LMDB readers");
+    }
+    backoff = INITIAL_BACKOFF;
+    loop {
+        match env.read_txn() {
+            Ok(txn) => return Ok(txn),
+            Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
+                warn!("LMDB readers still full after clearing stale readers, retrying");
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
 
 fn default_max_dbs() -> u32 {
     DEFAULT_MAX_DBS
@@ -205,7 +238,7 @@ impl Storage {
             .db_env
             .create_database(&mut wtxn, Some(app_name))?;
         wtxn.commit()?;
-        Ok(AppStore::new(db))
+        Ok(AppStore::new(db, self.inner.db_env.clone()))
     }
 
     /// Open the per-app sub-database by name, or `None` if it doesn't exist.
@@ -213,70 +246,28 @@ impl Storage {
     pub async fn open_app_store_by_name(&self, app_name: &str) -> Result<Option<AppStore>> {
         let rtxn = self.inner.db_env.read_txn()?;
         let db: Option<Database> = self.inner.db_env.open_database(&rtxn, Some(app_name))?;
-        Ok(db.map(AppStore::new))
+        let env = self.inner.db_env.clone();
+        Ok(db.map(|db| AppStore::new(db, env)))
     }
 
-    /// Open a read transaction with automatic retry on `MDB_READERS_FULL`.
-    ///
-    /// Two-phase strategy:
-    /// 1. Retry with a short timeout — handles transient reader slot contention.
-    /// 2. If phase 1 times out, call `clear_stale_readers()` to reclaim slots
-    ///    from dead processes, then retry indefinitely.
-    pub async fn read_txn(&self) -> Result<ReadTxn<'_>> {
-        let db_env = &self.inner.db_env;
-        let try_read_txn = || async {
-            match db_env.read_txn() {
-                Ok(txn) => retryable::Ok(txn),
-                Err(heed::Error::Mdb(heed::MdbError::ReadersFull)) => {
-                    warn!("Storage readers full, retrying");
-                    Err(retryable::Error::retryable(internal_error!(
-                        "Storage readers full"
-                    )))
-                }
-                Err(e) => Err(retryable::Error::not_retryable(e)),
-            }
-        };
-
-        // Phase 1: short timeout for transient concurrency.
-        match retryable::run(&try_read_txn, &READ_TXN_RETRY_PHASE1).await {
-            Ok(txn) => return Ok(ReadTxn::new(txn)),
-            Err(e) if !e.is_retryable => return Err(e.into()),
-            Err(_) => {}
-        }
-
-        // Phase 2: clear stale readers, then retry indefinitely.
-        let cleared = db_env.clear_stale_readers()?;
-        if cleared > 0 {
-            warn!("Cleared {cleared} stale storage readers");
-        }
-        retryable::run(&try_read_txn, &READ_TXN_RETRY_PHASE2)
-            .await
-            .map(ReadTxn::new)
-            .map_err(Into::into)
-    }
-
-    /// Non-retrying read txn for inspection use. Callers tolerate
-    /// `MDB_READERS_FULL` at a higher level rather than going through the
-    /// engine's two-phase retry path.
-    pub async fn read_txn_for_inspect(&self) -> Result<ReadTxn<'_>> {
-        Ok(ReadTxn::new(self.inner.db_env.read_txn()?))
-    }
-
-    /// Spawn a thread that streams every `(StablePath, node_type)` entry
-    /// from `app_store` via a channel. A dedicated thread is needed because
-    /// LMDB read transactions and cursors are `!Send`.
+    /// Stream every `(StablePath, node_type)` entry from `app_store` via
+    /// a channel. Runs on `tokio::task::spawn_blocking` because the LMDB
+    /// cursor (`RoPrefix`) wraps a raw `*mut MDB_cursor` and is `!Send`,
+    /// so the cursor can't be held across an `.await`. The sync loop on
+    /// the blocking-pool thread uses `blocking_send` for backpressure.
+    /// The rtxn open uses the same `MDB_READERS_FULL` retry policy as
+    /// [`AppStore::read_txn`], but sync (since we're off the runtime).
     pub async fn spawn_iter_stable_paths_with_node_type(
         &self,
         app_store: AppStore,
     ) -> tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>> {
         let (tx, rx) = tokio::sync::mpsc::channel(128);
-        let storage = self.clone();
 
-        std::thread::spawn(move || {
+        tokio::task::spawn_blocking(move || {
             let result: Result<()> = (|| {
                 let encoded_key_prefix =
                     DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-                let txn = storage.inner.db_env.read_txn()?;
+                let txn = open_read_txn_sync_with_retry(&app_store.env)?;
                 let db = app_store.db();
 
                 let mut last_prefix: Option<Vec<u8>> = None;

--- a/rust/core/src/state_store/txn.rs
+++ b/rust/core/src/state_store/txn.rs
@@ -1,14 +1,14 @@
-//! Read and write transaction wrappers.
+//! Write transaction wrapper.
 //!
-//! These wrap the underlying LMDB transaction types so engine code outside
-//! `state_store/` doesn't see `heed::*`. The wrappers `Deref` to the inner
-//! heed types so internal call sites (within this module) can still reach
-//! the heed API.
+//! Wraps the underlying LMDB `heed::RwTxn` so engine code outside
+//! `state_store/` doesn't see `heed::*`. Derefs to the inner heed type
+//! so internal call sites (within this module) can still reach the
+//! heed API.
 //!
-//! The [`AnyTxn`] trait lets read-only [`AppStore`](super::AppStore) methods
-//! be called from either a `ReadTxn` or `WriteTxn` context.
-
-use crate::state_store::app_store::Database;
+//! Read access doesn't have a wrapper type: standalone read methods on
+//! [`AppStore`](super::AppStore) open a fresh `heed::RoTxn` internally
+//! per call, and in-write-txn reads (`*_in_txn`) take this [`WriteTxn`]
+//! directly. There is no public read-transaction handle.
 
 use std::ops::{Deref, DerefMut};
 
@@ -35,92 +35,5 @@ impl<'env> Deref for WriteTxn<'env> {
 impl<'env> DerefMut for WriteTxn<'env> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-/// Read transaction wrapper. Opened from [`Storage::read_txn`](super::Storage::read_txn).
-pub struct ReadTxn<'env>(pub(crate) heed::RoTxn<'env, heed::WithoutTls>);
-
-impl<'env> ReadTxn<'env> {
-    pub(crate) fn new(inner: heed::RoTxn<'env, heed::WithoutTls>) -> Self {
-        Self(inner)
-    }
-}
-
-impl<'env> Deref for ReadTxn<'env> {
-    type Target = heed::RoTxn<'env, heed::WithoutTls>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// Marker trait for operations that only need read access. Implemented by
-/// both `ReadTxn` and `WriteTxn` so `AppStore` read methods can be called
-/// from either context without separate variants.
-///
-/// The trait is sealed — only the two wrapper types implement it. The hidden
-/// methods are accessed within this module via `pub(crate)` visibility.
-///
-/// The methods take `&mut self`. They don't actually mutate the txn — but
-/// the LMDB-backed transactions wrap `!Sync` raw pointers, so a `&Self`
-/// borrow would make any async future capturing this txn `!Send`. Using
-/// `&mut self` keeps borrows `Send`, at the cost of forcing read methods to
-/// be called sequentially (which they are anyway — there's no parallelism
-/// to lose).
-pub trait AnyTxn: sealed::Sealed {
-    #[doc(hidden)]
-    fn db_get_bytes<'a>(
-        &'a mut self,
-        db: Database,
-        key: &[u8],
-    ) -> crate::prelude::Result<Option<&'a [u8]>>;
-
-    #[doc(hidden)]
-    fn db_prefix_iter<'a>(
-        &'a mut self,
-        db: Database,
-        prefix: &[u8],
-    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>>;
-}
-
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::ReadTxn<'_> {}
-    impl Sealed for super::WriteTxn<'_> {}
-}
-
-impl<'env> AnyTxn for ReadTxn<'env> {
-    fn db_get_bytes<'a>(
-        &'a mut self,
-        db: Database,
-        key: &[u8],
-    ) -> crate::prelude::Result<Option<&'a [u8]>> {
-        Ok(db.get(&self.0, key)?)
-    }
-
-    fn db_prefix_iter<'a>(
-        &'a mut self,
-        db: Database,
-        prefix: &[u8],
-    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {
-        Ok(db.prefix_iter(&self.0, prefix)?)
-    }
-}
-
-impl<'env> AnyTxn for WriteTxn<'env> {
-    fn db_get_bytes<'a>(
-        &'a mut self,
-        db: Database,
-        key: &[u8],
-    ) -> crate::prelude::Result<Option<&'a [u8]>> {
-        Ok(db.get(&self.0, key)?)
-    }
-
-    fn db_prefix_iter<'a>(
-        &'a mut self,
-        db: Database,
-        prefix: &[u8],
-    ) -> crate::prelude::Result<heed::RoPrefix<'a, heed::types::Bytes, heed::types::Bytes>> {
-        Ok(db.prefix_iter(&self.0, prefix)?)
     }
 }


### PR DESCRIPTION
## Summary
- `AppStore` read methods now come in two flavors: `*_in_txn(wtxn, ...)` for reads inside a write transaction (see uncommitted writes); standalone `xxx(...)` that open their own snapshot internally. `Storage::read_txn` / `read_txn_for_inspect` / `Environment::read_txn` and the `ReadTxn` / `AnyTxn` types are removed — production never used multi-statement snapshot consistency.
- `AppStore` now carries a clone of the parent `Env` so standalone reads open their own `RoTxn` (the `MDB_READERS_FULL` two-phase retry moved here from `Storage`).
- `spawn_iter_stable_paths_with_node_type` moved from `std::thread::spawn` to `tokio::task::spawn_blocking`. The sync-thread design is still right (the LMDB cursor `RoPrefix` wraps a raw `*mut MDB_cursor` and is `!Send`, so it can't be held across `.await` on a tokio task), just expressed idiomatically. Same retry policy now applied to the rtxn open.

## Test plan
- CI (cargo test, mypy, pytest).
- Engine code that previously did `let mut rtxn = env.read_txn().await?; app_store.read_x(&mut rtxn, ...)` now calls `app_store.read_x(...)` directly; in-write-txn callers updated to `app_store.read_x_in_txn(wtxn, ...)`.
