### PR TITLE
fix(serde): register _frombuffer under numpy 1.x and 2.x paths

### DIFF
--- a/python/cocoindex/_internal/serde.py
+++ b/python/cocoindex/_internal/serde.py
@@ -77,10 +77,21 @@ def _register_builtin_types() -> None:
             _UNPICKLE_SAFE_GLOBALS[(_dtype_sub.__module__, _dtype_sub.__qualname__)] = (
                 _dtype_sub
             )
-        _core_numeric = getattr(np, "_core", None)
-        if _core_numeric is not None:
-            _frombuffer = getattr(_core_numeric.numeric, "_frombuffer", None)
+        _numeric = None
+        for _root_name in ("_core", "core"):
+            _root = getattr(np, _root_name, None)
+            if _root is None:
+                continue
+            _candidate = getattr(_root, "numeric", None)
+            if _candidate is not None:
+                _numeric = _candidate
+                break
+        if _numeric is not None:
+            _frombuffer = getattr(_numeric, "_frombuffer", None)
             if _frombuffer is not None:
+                _UNPICKLE_SAFE_GLOBALS[("numpy.core.numeric", "_frombuffer")] = (
+                    _frombuffer
+                )
                 _UNPICKLE_SAFE_GLOBALS[("numpy._core.numeric", "_frombuffer")] = (
                     _frombuffer
                 )


### PR DESCRIPTION
  ## Description

  The restricted unpickler only registered `_frombuffer` under the numpy 2.x module path (`numpy._core.numeric`) and only attempted lookup via
  `np._core`. On numpy 1.x: lookup fails entirely (nothing registered), and pickled ndarrays reference `numpy.core.numeric` anyway — so the 2.x key
  wouldn't match even if registered.

  Resolve numpy's `numeric` submodule under either layout and register `_frombuffer` under both pickle key paths so ndarrays unpickle cleanly
  regardless of which numpy major version pickled them.

  ## Motivation

  Surfaces on environments stuck on numpy 1.x — notably Intel Mac, where `torch==2.2.2` (the last available wheel) pins `numpy<2`. Initial `ccc index`
   succeeds, but every subsequent `ccc index` after a file edit errors with `Forbidden global during unpickling: numpy.core.numeric._frombuffer` when
  reading back memoized embeddings. Verified locally on `cocoindex==1.0.6` / `numpy==1.26.4` / `torch==2.2.2` — incremental reindex completes cleanly
  with the patch.

  ## Breaking change

  No. Pure additive change to the unpickler allowlist; the existing 2.x key is still registered.

  ## Related issue

  Fixes #2011