### PR TITLE
Fix LanceDB optimize scheduling

### DIFF
--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -389,17 +389,17 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
             if self._num_applied_mutations >= self._num_transactions_before_optimize:
                 self._schedule_optimize_locked(table)
 
-    async def _schedule_optimize(self, table: lancedb.table.AsyncTable) -> None:
-        """Schedule a background table optimization if one is not already running."""
-        async with self._optimize_lock:
-            self._schedule_optimize_locked(table)
-
     def _schedule_optimize_locked(self, table: lancedb.table.AsyncTable) -> None:
         if self._optimize_task is not None and not self._optimize_task.done():
             return
-        self._optimize_task = asyncio.create_task(self._run_optimize(table))
+        num_mutations_to_consume = self._num_applied_mutations
+        self._optimize_task = asyncio.create_task(
+            self._run_optimize(table, num_mutations_to_consume)
+        )
 
-    async def _run_optimize(self, table: lancedb.table.AsyncTable) -> None:
+    async def _run_optimize(
+        self, table: lancedb.table.AsyncTable, num_mutations_to_consume: int
+    ) -> None:
         succeeded = False
         try:
             await table.optimize()
@@ -413,10 +413,19 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
                 if asyncio.current_task() is self._optimize_task:
                     self._optimize_task = None
                     if succeeded:
-                        self._num_applied_mutations = 0
+                        self._num_applied_mutations = max(
+                            0,
+                            self._num_applied_mutations - num_mutations_to_consume,
+                        )
+                        if (
+                            self._num_applied_mutations
+                            >= self._num_transactions_before_optimize
+                        ):
+                            self._schedule_optimize_locked(table)
                     else:
-                        self._num_applied_mutations = (
-                            self._num_transactions_before_optimize
+                        self._num_applied_mutations = max(
+                            self._num_applied_mutations,
+                            self._num_transactions_before_optimize,
                         )
 
     async def _execute_upserts(
@@ -652,9 +661,6 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                         spec.table_schema,
                         if_not_exists=(action.main_action == "upsert"),
                     )
-
-                table = await conn.open_table(key.table_name)
-                await handler._schedule_optimize(table)
 
         return outputs
 

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -44,15 +44,34 @@ if HAS_LANCEDB:
                 raise RuntimeError("optimize failed")
 
     class _FakeAsyncConnection:
-        def __init__(self) -> None:
+        def __init__(self, *, table_exists: bool = True) -> None:
             self.table = _FakeAsyncTable()
+            self.table_exists = table_exists
+            self.open_table_count = 0
+            self.create_table_count = 0
+            self.drop_table_count = 0
 
         async def table_names(self) -> list[str]:
-            return ["test_table"]
+            return ["test_table"] if self.table_exists else []
 
         async def open_table(self, table_name: str) -> _FakeAsyncTable:
             assert table_name == "test_table"
+            self.open_table_count += 1
             return self.table
+
+        async def create_table(
+            self, table_name: str, data: Any, *, mode: str
+        ) -> _FakeAsyncTable:
+            assert table_name == "test_table"
+            assert mode == "overwrite"
+            self.create_table_count += 1
+            self.table_exists = True
+            return self.table
+
+        async def drop_table(self, table_name: str) -> None:
+            assert table_name == "test_table"
+            self.drop_table_count += 1
+            self.table_exists = False
 
     class _FakeContextProvider:
         def __init__(self, conn: _FakeAsyncConnection) -> None:
@@ -124,6 +143,37 @@ async def test_row_handler_does_not_overlap_optimize_tasks() -> None:
 
 @pytest.mark.asyncio
 @requires_lancedb
+async def test_row_handler_preserves_mutations_during_optimize() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+        num_transactions_before_optimize=2,
+    )
+    unblock = asyncio.Event()
+    table = _FakeAsyncTable(block=unblock)
+
+    await handler._maybe_optimize(cast(Any, table))
+    assert table.optimize_count == 0
+
+    await handler._maybe_optimize(cast(Any, table))
+    await asyncio.sleep(0)
+    assert table.optimize_count == 1
+
+    await handler._maybe_optimize(cast(Any, table))
+    await asyncio.sleep(0)
+    assert table.optimize_count == 1
+
+    unblock.set()
+    await _wait_for_optimize_task(handler)
+
+    await handler._maybe_optimize(cast(Any, table))
+    await _wait_for_optimize_task(handler)
+    assert table.optimize_count == 2
+
+
+@pytest.mark.asyncio
+@requires_lancedb
 async def test_row_handler_retries_after_optimize_failure() -> None:
     handler = _target._RowHandler(
         conn=cast(Any, None),
@@ -144,7 +194,7 @@ async def test_row_handler_retries_after_optimize_failure() -> None:
 
 @pytest.mark.asyncio
 @requires_lancedb
-async def test_table_handler_schedules_initial_optimize() -> None:
+async def test_table_handler_skips_optimize_for_existing_table() -> None:
     conn = _FakeAsyncConnection()
     handler = _target._TableHandler()
     action = _target._TableAction(
@@ -161,7 +211,32 @@ async def test_table_handler_schedules_initial_optimize() -> None:
     await handler._apply_actions(cast(Any, _FakeContextProvider(conn)), [action])
     await asyncio.sleep(0)
 
-    assert conn.table.optimize_count == 1
+    assert conn.open_table_count == 0
+    assert conn.table.optimize_count == 0
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_table_handler_does_not_optimize_new_table_before_row_mutations() -> None:
+    conn = _FakeAsyncConnection(table_exists=False)
+    handler = _target._TableHandler()
+    action = _target._TableAction(
+        key=_target._TableKey(db_key="test_db", table_name="test_table"),
+        spec=_target._TableSpec(
+            table_schema=_make_table_schema(),
+            managed_by=target.ManagedBy.SYSTEM,
+            num_transactions_before_optimize=50,
+        ),
+        main_action="insert",
+        sub_actions={},
+    )
+
+    await handler._apply_actions(cast(Any, _FakeContextProvider(conn)), [action])
+    await asyncio.sleep(0)
+
+    assert conn.create_table_count == 1
+    assert conn.open_table_count == 0
+    assert conn.table.optimize_count == 0
 
 
 @requires_lancedb


### PR DESCRIPTION
## Summary

This PR improves two things with the update introduced in #2008:
- Avoids unconditional `table.optimize()` calls when a table is created or reconciled with no row writes.
- Preserves mutation counts that accrue while an optimize task is already running, so sustained writes keep the intended cadence.

No public API changes.

## Why this PR?

The new LanceDB optimize cadence did not fully match what it documented: users could get background `table.optimize()` calls when no row mutation batch had happened, while continual, sustained writes could also cause mutation batches to be dropped from the scheduling counter while an optimize job was ongoing.

The updates in this makes LanceDB optimization scheduling strictly mutation-driven and preserves the optimize cadence under write load. It removes the unconditional table-level optimize/compaction that ran during table reconciliation/creation, and changes the row-level counter so mutations that happen during an active optimize still count toward the next optimize. This reduces avoidable startup/reconcile overhead and avoids under-optimizing during sustained write workloads, without changing the public API.

## Testing

I ran the focused LanceDB target tests with the LanceDB dependency enabled:

```bash
uv run --extra lancedb pytest python/tests/connectors/test_lancedb_target.py
```

I also ran the broader Python validation suite to ensure nothing broke:
```bash
uv run mypy
uv run pytest python/
```

(Passed).

## Atomic example to confirm behaviour

I ran a minimal smoke script locally that performs two CocoIndex updates into a temp LanceDB table:

- First update inserts rows a and b
- Second update updates a, deletes b, and inserts c


```py
"""Minimal CocoIndex -> LanceDB update smoke experiment.

Run from the repo root:

    uv run --extra lancedb python dev/lancedb_cocoindex_update_smoke.py
"""

from __future__ import annotations

import asyncio
from dataclasses import dataclass
from pathlib import Path
import shutil
import tempfile
from typing import Any

import pyarrow as pa

import cocoindex as coco
from cocoindex.connectors import lancedb as coco_lancedb


LANCE_DB = coco.ContextKey[coco_lancedb.LanceAsyncConnection]("smoke_lancedb")
TABLE_NAME = "documents"


@dataclass
class Document:
    doc_id: str
    title: str
    body: str
    version: int


DOCUMENTS: list[Document] = []


def _table_schema() -> coco_lancedb.TableSchema[Document]:
    return coco_lancedb.TableSchema(
        columns={
            "doc_id": coco_lancedb.ColumnDef(type=pa.string(), nullable=False),
            "title": coco_lancedb.ColumnDef(type=pa.string(), nullable=False),
            "body": coco_lancedb.ColumnDef(type=pa.string(), nullable=False),
            "version": coco_lancedb.ColumnDef(type=pa.int64(), nullable=False),
        },
        primary_key=["doc_id"],
    )


@coco.fn
async def app_main() -> None:
    table = await coco_lancedb.mount_table_target(
        LANCE_DB,
        table_name=TABLE_NAME,
        table_schema=_table_schema(),
        num_transactions_before_optimize=1,
    )
    for doc in DOCUMENTS:
        table.declare_row(row=doc)


async def _read_rows(conn: coco_lancedb.LanceAsyncConnection) -> list[dict[str, Any]]:
    table = await conn.open_table(TABLE_NAME)
    rows = await table.query().select(["doc_id", "title", "body", "version"]).to_list()
    return sorted(rows, key=lambda row: row["doc_id"])


async def _run() -> None:
    root = Path(tempfile.mkdtemp(prefix="coco-lancedb-smoke-"))
    lance_uri = str(root / "lancedb")
    state_db = root / "cocoindex.lmdb"

    conn = await coco_lancedb.connect_async(lance_uri)
    ctx = coco.ContextProvider()
    ctx.provide(LANCE_DB, conn)
    env = coco.Environment(coco.Settings(db_path=state_db), context_provider=ctx)
    app = coco.App(
        coco.AppConfig(name="lancedb_update_smoke", environment=env), app_main
    )

    try:
        DOCUMENTS[:] = [
            Document("a", "Alpha", "first version", 1),
            Document("b", "Beta", "will be deleted", 1),
        ]
        await app.update()
        await asyncio.sleep(1.0)
        print("after first update:", await _read_rows(conn))

        DOCUMENTS[:] = [
            Document("a", "Alpha", "second version", 2),
            Document("c", "Gamma", "new row", 1),
        ]
        await app.update()
        await asyncio.sleep(1.0)
        print("after second update:", await _read_rows(conn))
        print(f"temp workspace cleaned: {root}")
    finally:
        conn.close()
        shutil.rmtree(root, ignore_errors=True)


if __name__ == "__main__":
    asyncio.run(_run())
```

This produces the following two rows:
```py
Document("a", "Alpha", "first version", 1)
Document("b", "Beta", "will be deleted", 1)
```

Observed final rows after delete and new append.

```json
[
    {"doc_id": "a", "title": "Alpha", "body": "second version", "version": 2},
    {"doc_id": "c", "title": "Gamma", "body": "new row", "version": 1},
]
```

The result is as expected! 