### PR TITLE
fix(engine): submit after child readiness

### DIFF
--- a/python/tests/core/test_component_submit_order.py
+++ b/python/tests/core/test_component_submit_order.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Collection
+
+import cocoindex as coco
+
+from tests import common
+from tests.common.target_states import GlobalDictTarget
+
+coco_env = common.create_test_env(__file__)
+
+
+class _ParentOrderingStore:
+    def __init__(self) -> None:
+        self.observed_child_ready: list[bool] = []
+        self._lock = threading.Lock()
+
+    def clear(self) -> None:
+        with self._lock:
+            self.observed_child_ready.clear()
+
+    def _sink(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[str, Any]],
+        /,
+    ) -> None:
+        del context_provider, actions
+        with self._lock:
+            self.observed_child_ready.append("child" in GlobalDictTarget.store.data)
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: Any | coco.NonExistenceType,
+        prev_possible_records: Collection[Any],
+        prev_may_be_missing: bool,
+    ) -> coco.TargetReconcileOutput[tuple[str, Any], Any] | None:
+        assert isinstance(key, str)
+        if coco.is_non_existence(desired_state):
+            return None
+        if not prev_may_be_missing and all(
+            prev == desired_state for prev in prev_possible_records
+        ):
+            return None
+        return coco.TargetReconcileOutput(
+            action=(key, desired_state),
+            sink=coco.TargetActionSink.from_fn(self._sink),
+            tracking_record=desired_state,
+        )
+
+
+_parent_ordering_store = _ParentOrderingStore()
+_parent_ordering_provider = coco.register_root_target_states_provider(
+    "test_target_state/parent_submit_after_children", _parent_ordering_store
+)
+
+
+@coco.fn
+async def _delayed_child_target() -> None:
+    await asyncio.sleep(0.05)
+    coco.declare_target_state(GlobalDictTarget.target_state("child", "ready"))
+
+
+async def _parent_with_background_child() -> None:
+    await coco.mount(coco.component_subpath("child"), _delayed_child_target)
+    coco.declare_target_state(_parent_ordering_provider.target_state("parent", "ready"))
+
+
+def test_parent_submit_waits_for_background_child_ready() -> None:
+    GlobalDictTarget.store.clear()
+    _parent_ordering_store.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_parent_submit_waits_for_background_child_ready",
+            environment=coco_env,
+        ),
+        _parent_with_background_child,
+    )
+
+    app.update_blocking()
+
+    assert "child" in GlobalDictTarget.store.data
+    assert _parent_ordering_store.observed_child_ready == [True]

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -790,8 +790,9 @@ impl<Prof: EngineProfile> Component<Prof> {
         let result = {
             let reported_processor_name = &mut reported_processor_name;
             async move {
-                // Acquire the semaphore to ensure `process()` and `commit_effects()` cannot happen in parallel.
-                let ret_n_submit_output = {
+                // Acquire the semaphore to ensure `process()` and `submit()` cannot overlap
+                // with another execution of the same component.
+                let (ret, submit_output, children_outcome) = {
                     let _permit = self.inner.build_semaphore.acquire().await?;
 
                     // Eagerly load all function-memo entries for this component
@@ -817,38 +818,35 @@ impl<Prof: EngineProfile> Component<Prof> {
                             .map(Some),
                         None => Ok(None),
                     };
-                    match ret {
-                        Ok(ret) => {
-                            let submit_output = submit(processor_context, processor, |name| {
-                                if reported_processor_name.is_none() {
-                                    processing_stats.update(&name, |stats| {
-                                        stats.num_execution_starts += 1;
-                                    });
-                                    *reported_processor_name = Some(Cow::Owned(name.to_string()));
-                                }
-                            })
-                            .await?;
-                            Ok((ret, submit_output))
+
+                    // Wait until children components ready before submitting this
+                    // component's target states and child-existence reconciliation.
+                    let components_readiness = processor_context.components_readiness();
+                    components_readiness.set_build_done();
+                    let mut children_outcome = components_readiness
+                        .readiness()
+                        .wait()
+                        .await
+                        .clone()
+                        .into_result()?;
+
+                    // Merge children's logic deps into this component's context before
+                    // post-submit memoization stores this component's dependency set.
+                    processor_context
+                        .merge_logic_deps(std::mem::take(&mut children_outcome.logic_deps));
+
+                    let ret = ret?;
+                    let submit_output = submit(processor_context, processor, |name| {
+                        if reported_processor_name.is_none() {
+                            processing_stats.update(&name, |stats| {
+                                stats.num_execution_starts += 1;
+                            });
+                            *reported_processor_name = Some(Cow::Owned(name.to_string()));
                         }
-                        Err(err) => Err(err),
-                    }
-                };
-
-                // Wait until children components ready.
-                let components_readiness = processor_context.components_readiness();
-                components_readiness.set_build_done();
-                let mut children_outcome = components_readiness
-                    .readiness()
-                    .wait()
-                    .await
-                    .clone()
-                    .into_result()?;
-
-                // Merge children's logic deps into this component's context.
-                processor_context
-                    .merge_logic_deps(std::mem::take(&mut children_outcome.logic_deps));
-
-                let (ret, submit_output) = ret_n_submit_output?;
+                    })
+                    .await?;
+                    Ok::<_, Error>((ret, submit_output, children_outcome))
+                }?;
                 let build_output = match ret {
                     Some(ret) => {
                         if !children_outcome.has_exception {


### PR DESCRIPTION
## Summary
- Wait for child component readiness before submitting parent target states.
- Keep component submit serialized under the build semaphore.
- Add a regression test for parent sink ordering.

## Test plan
- `uv run pytest python/tests`
- commit hook: cargo fmt, ruff format, mypy, maturin develop, cargo test, pytest
