### PR TITLE
ci: keep build-test worktree clean

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -36,6 +36,11 @@ jobs:
           RUSTC_WRAPPER: "sccache"
 
         steps:
+        - name: Disable Git autocrlf on Windows
+          if: runner.os == 'Windows'
+          shell: bash
+          run: git config --global core.autocrlf false
+
         - uses: actions/checkout@v6
           with:
             fetch-depth: 1
@@ -72,13 +77,14 @@ jobs:
         - name: Install uv
           uses: astral-sh/setup-uv@v7
 
-        - name: Remove .python-version if exists
-          # Ensure uv uses Python from PATH (set by setup-python) rather than a pinned version
-          shell: bash
-          run: rm -f .python-version
-
         - name: Sync Python dependencies
-          run: uv sync --no-dev --group ci --no-install-project
+          shell: bash
+          run: |
+            uv sync \
+              --python "$(python -c 'import sys; print(sys.executable)')" \
+              --no-dev \
+              --group ci \
+              --no-install-project
 
         - name: Install prek
           uses: j178/prek-action@v2

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -42,13 +42,16 @@ _SKIP_WINDOWS_FREE_THREADED_MULTI_ENV = pytest.mark.skipif(
 
 
 def run_cli(
-    *args: str, check: bool = True, input: str | None = None
+    *args: str,
+    check: bool = True,
+    input: str | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a cocoindex CLI command and return the result."""
     cmd = ["cocoindex", *args]
     result = subprocess.run(
         cmd,
-        cwd=TEST_DIR,
+        cwd=cwd if cwd is not None else TEST_DIR,
         capture_output=True,
         text=True,
         check=False,
@@ -604,35 +607,35 @@ class TestUpdateFlags:
         third = stamp_path.read_text()
         assert third != first, "--full-reprocess should force rewrite even if unchanged"
 
-    def test_full_reprocess_deleted_target_not_resurrected(self) -> None:
+    def test_full_reprocess_deleted_target_not_resurrected(
+        self, tmp_path: Path
+    ) -> None:
         """Test that --full-reprocess doesn't keep deleted targets alive via memo reuse."""
         app_path = "./full_reprocess_app.py"
-        target_a_path = TEST_DIR / "out_full_reprocess" / "target_a.txt"
-        target_b_path = TEST_DIR / "out_full_reprocess" / "target_b.txt"
+        (tmp_path / "full_reprocess_app.py").write_text(
+            (TEST_DIR / "full_reprocess_app.py").read_text()
+        )
+        target_a_path = tmp_path / "out_full_reprocess" / "target_a.txt"
+        target_b_path = tmp_path / "out_full_reprocess" / "target_b.txt"
 
         # First run: create both targets A and B
-        run_cli("update", app_path)
+        run_cli("update", app_path, cwd=tmp_path)
         assert target_a_path.exists(), "target_a.txt should exist after first run"
         assert target_b_path.exists(), "target_b.txt should exist after first run"
 
         # Modify the app to only create A (remove B)
-        # We'll do this by creating a modified version of the app
-        original_content = (TEST_DIR / app_path).read_text()
-        modified_content = original_content.replace(
-            "create_b: bool = True", "create_b: bool = False"
+        (tmp_path / "full_reprocess_app.py").write_text(
+            (tmp_path / "full_reprocess_app.py")
+            .read_text()
+            .replace("create_b: bool = True", "create_b: bool = False")
         )
-        (TEST_DIR / app_path).write_text(modified_content)
 
-        try:
-            # Run with --full-reprocess: B should be deleted, not kept alive by old memos
-            run_cli("update", app_path, "--full-reprocess")
-            assert target_a_path.exists(), "target_a.txt should still exist"
-            assert not target_b_path.exists(), (
-                "target_b.txt should be deleted, not kept alive by old memos"
-            )
-        finally:
-            # Restore original content
-            (TEST_DIR / app_path).write_text(original_content)
+        # Run with --full-reprocess: B should be deleted, not kept alive by old memos
+        run_cli("update", app_path, "--full-reprocess", cwd=tmp_path)
+        assert target_a_path.exists(), "target_a.txt should still exist"
+        assert not target_b_path.exists(), (
+            "target_b.txt should be deleted, not kept alive by old memos"
+        )
 
 
 class TestFullReprocess:
@@ -657,35 +660,35 @@ class TestFullReprocess:
         third = stamp_path.read_text()
         assert third != first, "--full-reprocess should force rewrite even if unchanged"
 
-    def test_full_reprocess_deleted_target_not_resurrected(self) -> None:
+    def test_full_reprocess_deleted_target_not_resurrected(
+        self, tmp_path: Path
+    ) -> None:
         """Test that --full-reprocess doesn't keep deleted targets alive via memo reuse."""
         app_path = "./full_reprocess_app.py"
-        target_a_path = TEST_DIR / "out_full_reprocess" / "target_a.txt"
-        target_b_path = TEST_DIR / "out_full_reprocess" / "target_b.txt"
+        (tmp_path / "full_reprocess_app.py").write_text(
+            (TEST_DIR / "full_reprocess_app.py").read_text()
+        )
+        target_a_path = tmp_path / "out_full_reprocess" / "target_a.txt"
+        target_b_path = tmp_path / "out_full_reprocess" / "target_b.txt"
 
         # First run: create both targets A and B
-        run_cli("update", app_path)
+        run_cli("update", app_path, cwd=tmp_path)
         assert target_a_path.exists(), "target_a.txt should exist after first run"
         assert target_b_path.exists(), "target_b.txt should exist after first run"
 
         # Modify the app to only create A (remove B)
-        # We'll do this by creating a modified version of the app
-        original_content = (TEST_DIR / app_path).read_text()
-        modified_content = original_content.replace(
-            "create_b: bool = True", "create_b: bool = False"
+        (tmp_path / "full_reprocess_app.py").write_text(
+            (tmp_path / "full_reprocess_app.py")
+            .read_text()
+            .replace("create_b: bool = True", "create_b: bool = False")
         )
-        (TEST_DIR / app_path).write_text(modified_content)
 
-        try:
-            # Run with --full-reprocess: B should be deleted, not kept alive by old memos
-            run_cli("update", app_path, "--full-reprocess")
-            assert target_a_path.exists(), "target_a.txt should still exist"
-            assert not target_b_path.exists(), (
-                "target_b.txt should be deleted, not kept alive by old memos"
-            )
-        finally:
-            # Restore original content
-            (TEST_DIR / app_path).write_text(original_content)
+        # Run with --full-reprocess: B should be deleted, not kept alive by old memos
+        run_cli("update", app_path, "--full-reprocess", cwd=tmp_path)
+        assert target_a_path.exists(), "target_a.txt should still exist"
+        assert not target_b_path.exists(), (
+            "target_b.txt should be deleted, not kept alive by old memos"
+        )
 
 
 class TestDropQuiet:


### PR DESCRIPTION
## Summary
- Stop deleting the tracked `.python-version` file in build-test CI; pass the `setup-python` interpreter directly to `uv sync` so matrix Python selection still wins.
- Disable Git's `autocrlf` on Windows runners before checkout, so Python files stay LF on disk and don't fight with ruff-format. See "Windows note" below.
- Tighten the CLI `--full-reprocess` tests (`test_full_reprocess_deleted_target_not_resurrected`, both copies) to copy their throwaway `full_reprocess_app.py` into `tmp_path` and run cocoindex with `cwd=tmp_path` + a relative path. The old pattern mutated the file in `TEST_DIR` with a `finally`-restore (worktree noise during hooks). Adds an optional `cwd` kwarg to `run_cli`.

## Windows note
PR #2026 (last `.py` change to land) didn't hit the CRLF/ruff interaction because it only changed a single comment line in a file ruff didn't otherwise want to reformat. This PR triggers ruff to rewrite `test_cli.py` for the pre-existing `assert (...)` reformats it picks up, so the autocrlf interaction surfaces. Disabling autocrlf on the runner is the surgical fix; `.gitattributes` would also work but is broader scope.

## Test plan
- Local prek hooks on the touched files.
- CI matrix (Linux/macOS/Windows × Python 3.11/3.14).
