### PR TITLE
fix(postgres): use halfvec op classes for indexes

### DIFF
--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -128,19 +128,29 @@ def _vector_encoder(value: Any) -> str:
 
 
 _PGVECTOR_TYPE_BASES: frozenset[str] = frozenset({"vector", "halfvec"})
-_PGVECTOR_TYPE_PREFIXES: frozenset[str] = frozenset(
-    {f"{base}(" for base in _PGVECTOR_TYPE_BASES}
-)
+
+
+def _pgvector_type_base(pg_type: str) -> str | None:
+    """
+    Return the pgvector type base for a PostgreSQL type, if any.
+
+    Supports both dimensioned and undimensioned pgvector types, e.g. `vector`,
+    `vector(384)`, `halfvec`, and `halfvec(384)`.
+    """
+    t = pg_type.lower().strip()
+    for base in _PGVECTOR_TYPE_BASES:
+        if t == base or t.startswith(f"{base}("):
+            return base
+    return None
 
 
 def _is_pgvector_pg_type(pg_type: str) -> bool:
     """
-    Return True if `pg_type` is a pgvector type (`vector(n)`, ...).
+    Return True if `pg_type` is a pgvector type (`vector(n)`, `halfvec(n)`, ...).
 
     This is used for extension checks and validation.
     """
-    t = pg_type.lower().strip()
-    return any(t.startswith(p) for p in _PGVECTOR_TYPE_PREFIXES)
+    return _pgvector_type_base(pg_type) is not None
 
 
 class _TypeMapping(NamedTuple):
@@ -393,16 +403,39 @@ class _RowAction(NamedTuple):
 
 # --- Vector Index Attachment ---
 
-_METRIC_OP_CLASS: dict[str, str] = {
-    "cosine": "vector_cosine_ops",
-    "l2": "vector_l2_ops",
-    "ip": "vector_ip_ops",
+_PGVECTOR_OP_CLASS: dict[str, dict[str, str]] = {
+    "vector": {
+        "cosine": "vector_cosine_ops",
+        "l2": "vector_l2_ops",
+        "ip": "vector_ip_ops",
+    },
+    "halfvec": {
+        "cosine": "halfvec_cosine_ops",
+        "l2": "halfvec_l2_ops",
+        "ip": "halfvec_ip_ops",
+    },
 }
+
+
+def _pgvector_op_class(column: str, pg_type: str, metric: str) -> str:
+    type_base = _pgvector_type_base(pg_type)
+    if type_base is None:
+        raise ValueError(
+            f"Column '{column}' has PostgreSQL type '{pg_type}', which is not a pgvector type."
+        )
+
+    try:
+        return _PGVECTOR_OP_CLASS[type_base][metric]
+    except KeyError as e:
+        raise ValueError(
+            f"Unsupported pgvector metric '{metric}' for PostgreSQL type '{pg_type}'."
+        ) from e
 
 
 class _VectorIndexSpec(NamedTuple):
     column: str
     metric: str
+    op_class: str
     method: str
     lists: int | None
     m: int | None
@@ -450,7 +483,6 @@ class _VectorIndexHandler:
                     table_name = _qualified_table_name(
                         self._table_name, self._schema_name
                     )
-                    op_class = _METRIC_OP_CLASS[action.spec.metric]
                     with_params: list[str] = []
                     if action.spec.method == "ivfflat":
                         if action.spec.lists is not None:
@@ -467,7 +499,7 @@ class _VectorIndexHandler:
                     )
                     sql = (
                         f"CREATE INDEX {index_name} ON {table_name} "
-                        f'USING {action.spec.method} ("{action.spec.column}" {op_class})'
+                        f'USING {action.spec.method} ("{action.spec.column}" {action.spec.op_class})'
                         f"{with_clause}"
                     )
                     await conn.execute(sql)
@@ -1236,9 +1268,15 @@ class TableTarget(
         """
         if name is None:
             name = column
+        col_def = self._table_schema.columns.get(column)
+        if col_def is None:
+            raise ValueError(
+                f"Column '{column}' not found in table schema: {list(self._table_schema.columns.keys())}"
+            )
         spec = _VectorIndexSpec(
             column=column,
             metric=metric,
+            op_class=_pgvector_op_class(column, col_def.type, metric),
             method=method,
             lists=lists,
             m=m,

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -78,6 +78,20 @@ async def _index_info(pool: "asyncpg.Pool", index_name: str) -> dict[str, Any] |
         return dict(row) if row else None
 
 
+async def _index_opclass_names(pool: "asyncpg.Pool", index_name: str) -> list[str]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT opc.opcname "
+            "FROM pg_index i "
+            "JOIN pg_class c ON i.indexrelid = c.oid "
+            "JOIN generate_series(0, i.indnatts - 1) AS s(n) ON true "
+            "JOIN pg_opclass opc ON opc.oid = i.indclass[s.n] "
+            "WHERE c.relname = $1 ORDER BY s.n",
+            index_name,
+        )
+        return [str(row["opcname"]) for row in rows]
+
+
 async def _table_exists(pool: "asyncpg.Pool", table_name: str) -> bool:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
@@ -158,6 +172,15 @@ class VectorRow:
     content: str
     embedding: Annotated[
         NDArray[np.float32], VectorSchema(dtype=np.dtype(np.float32), size=4)
+    ]
+
+
+@dataclass
+class HalfVectorRow:
+    id: str
+    content: str
+    embedding: Annotated[
+        NDArray[np.float16], VectorSchema(dtype=np.dtype(np.float16), size=4)
     ]
 
 
@@ -298,6 +321,59 @@ async def test_postgres_declare_vector_index_fingerprint_no_change(
         info2 = await _index_info(pool, pg_index_name)
         assert info2 is not None
         assert info2["amname"] == "ivfflat"
+
+    finally:
+        await _drop_table(pool, table_name)
+
+
+@pytest.mark.asyncio
+async def test_postgres_declare_halfvec_vector_index_uses_halfvec_opclass(
+    pg_env: _PgEnv,
+) -> None:
+    """halfvec columns need halfvec_* pgvector operator classes."""
+    pool = pg_env.pool
+    coco_env = pg_env.coco_env
+    table_name = _unique_name("test_halfvec_idx")
+    logical_name = "idx1"
+    pg_index_name = f"{table_name}__vector__{logical_name}"
+
+    try:
+
+        async def declare_fn() -> None:
+            table = await coco.use_mount(
+                coco.component_subpath("setup", "table"),
+                postgres.declare_table_target,
+                _PG_DB_KEY,
+                table_name,
+                await postgres.TableSchema.from_class(
+                    HalfVectorRow, primary_key=["id"]
+                ),
+            )
+            table.declare_row(
+                row=HalfVectorRow(
+                    id="1",
+                    content="hello",
+                    embedding=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float16),
+                )
+            )
+            table.declare_vector_index(
+                name=logical_name,
+                column="embedding",
+                metric="cosine",
+                method="ivfflat",
+            )
+
+        app = coco.App(
+            coco.AppConfig(name=f"test_halfvec_idx_{table_name}", environment=coco_env),
+            declare_fn,
+        )
+
+        await app.update()
+
+        info = await _index_info(pool, pg_index_name)
+        assert info is not None, f"Index {pg_index_name} should exist"
+        assert info["amname"] == "ivfflat"
+        assert await _index_opclass_names(pool, pg_index_name) == ["halfvec_cosine_ops"]
 
     finally:
         await _drop_table(pool, table_name)


### PR DESCRIPTION
## Summary
- Resolve pgvector index operator classes from both column type and metric.
- Use `halfvec_*_ops` for `halfvec` columns while preserving `vector_*_ops` for `vector` columns.
- Add a Postgres regression test that verifies halfvec cosine indexes use `halfvec_cosine_ops`.

## Test plan
- `uv run pytest python/tests/connectors/test_postgres_target.py::test_postgres_declare_vector_index python/tests/connectors/test_postgres_target.py::test_postgres_declare_halfvec_vector_index_uses_halfvec_opclass -q`
- `uv run ruff format --check python/cocoindex/connectors/postgres/_target.py python/tests/connectors/test_postgres_target.py`
- `uv run ruff check --ignore F821 python/cocoindex/connectors/postgres/_target.py python/tests/connectors/test_postgres_target.py`
- CI.
