### PR TITLE
refactor(error): add Error::replica + HostError::try_clone

### DIFF
--- a/python/tests/core/test_function_batching.py
+++ b/python/tests/core/test_function_batching.py
@@ -305,6 +305,59 @@ async def test_batching_out_of_component() -> None:
 
 
 # ============================================================================
+# Error propagation: exception type + traceback survive for all callers
+# ============================================================================
+
+
+class _CustomBatchError(Exception):
+    """Distinct type so we can assert it survives the batch round-trip."""
+
+
+@pytest.mark.asyncio
+async def test_batching_error_preserves_type_for_all_callers() -> None:
+    """A raising batched impl propagates the *same* exception type to every
+    concurrent caller — including the residual recipients the batcher fans
+    the failure out to — not a flattened RuntimeError.
+
+    Regression for the PyErr-through-residuals fix: residuals used to come
+    back as RuntimeError with the original type and traceback lost. Only the
+    first caller in a batch ever saw the real exception.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @coco.fn.as_async(batching=True)
+    async def failing(inputs: list[int]) -> list[int]:
+        started.set()
+        await release.wait()
+        raise _CustomBatchError("boom")
+
+    # First call runs inline and blocks inside the impl, keeping the queue
+    # busy so the next two calls queue into a single pending batch.
+    task1 = asyncio.create_task(failing(1))
+    await started.wait()
+
+    task2 = asyncio.create_task(failing(2))
+    task3 = asyncio.create_task(failing(3))
+    await asyncio.sleep(0.05)  # let task2/task3 enqueue behind the inline call
+
+    release.set()
+
+    results = await asyncio.gather(task1, task2, task3, return_exceptions=True)
+
+    # Every caller — inline (task1), first batch recipient (task2), and
+    # residual recipient (task3) — sees the original exception type, with
+    # its message intact.
+    for r in results:
+        assert isinstance(r, _CustomBatchError), (
+            f"expected _CustomBatchError, got {type(r).__name__}: {r!r}"
+        )
+        assert str(r) == "boom"
+        # Traceback is preserved (clone_ref keeps the original exception).
+        assert r.__traceback__ is not None
+
+
+# ============================================================================
 # Async batching tests
 # ============================================================================
 

--- a/rust/py_utils/src/error.rs
+++ b/rust/py_utils/src/error.rs
@@ -73,6 +73,14 @@ impl cocoindex_utils::error::HostError for HostedPyErr {
             self.0.is_instance(py, &cancelled_cls)
         })
     }
+
+    fn try_clone(&self) -> Option<Box<dyn cocoindex_utils::error::HostError>> {
+        // `PyErr::clone_ref` shares the underlying Python exception object
+        // (type + value + traceback), so every batch residual recipient gets
+        // the original error — catchable by type, with the full Python
+        // traceback intact — instead of a flattened string.
+        Python::attach(|py| Some(Box::new(HostedPyErr(self.0.clone_ref(py))) as _))
+    }
 }
 
 fn cerror_to_pyerr(err: CError) -> PyErr {

--- a/rust/utils/src/batching.rs
+++ b/rust/utils/src/batching.rs
@@ -6,7 +6,7 @@ use tokio::sync::{oneshot, watch};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{Instrument, Span, error};
 
-use crate::error::{Error, ResidualError, Result};
+use crate::error::{Error, Result};
 use crate::internal_bail;
 
 #[async_trait]
@@ -125,11 +125,13 @@ impl<R: Runner + 'static> BatcherData<R> {
             Err(err) => {
                 let mut senders_iter = batch.output_txs.into_iter();
                 if let Some(sender) = senders_iter.next() {
-                    if senders_iter.len() > 0 {
-                        let residual_err = ResidualError::new(&err);
-                        for sender in senders_iter {
-                            sender.send(Err(residual_err.clone().into())).ok();
-                        }
+                    // Hand the original to the first recipient; every other
+                    // recipient gets an `Error::replica` — a faithful copy
+                    // that preserves a clonable structural error (e.g. a
+                    // Python `PyErr` with its type + traceback) and flattens
+                    // only what can't be cloned.
+                    for sender in senders_iter {
+                        sender.send(Err(err.replica())).ok();
                     }
                     sender.send(Err(err)).ok();
                 }

--- a/rust/utils/src/error.rs
+++ b/rust/utils/src/error.rs
@@ -18,6 +18,17 @@ pub trait HostError: Any + StdError + Send + Sync + 'static {
     fn is_cancelled(&self) -> bool {
         false
     }
+
+    /// Produce a fresh boxed copy of this host error, when the host
+    /// representation supports cloning. Used by the batcher to fan a single
+    /// failure out to every recipient of a batch *without* flattening the
+    /// structural error — e.g. a Python `PyErr` keeps its exception type and
+    /// traceback, so all batched callers (not just the first) can `except`
+    /// it by type. Default `None` falls back to a string-only
+    /// [`ResidualError`].
+    fn try_clone(&self) -> Option<Box<dyn HostError>> {
+        None
+    }
 }
 
 /// Concrete `HostError` representing a host-language-agnostic cancellation.
@@ -38,12 +49,21 @@ impl HostError for CancelledError {
     fn is_cancelled(&self) -> bool {
         true
     }
+
+    fn try_clone(&self) -> Option<Box<dyn HostError>> {
+        // Unit struct — cloning keeps cancellation flavor on batch residuals
+        // (otherwise a residual would flatten to a non-cancellation error).
+        Some(Box::new(CancelledError))
+    }
 }
 
 pub enum Error {
     Context { msg: String, source: Box<SError> },
     HostLang(Box<dyn HostError>),
-    Client { msg: String, bt: Backtrace },
+    // `bt` is shared via `Arc` so `Error::replica` can clone a `Client` error
+    // while keeping the original capture site (capturing afresh would point
+    // at the replica call instead).
+    Client { msg: String, bt: Arc<Backtrace> },
     Internal(anyhow::Error),
 }
 
@@ -84,7 +104,7 @@ impl Error {
     pub fn client(msg: impl Into<String>) -> Self {
         Self::Client {
             msg: msg.into(),
-            bt: Backtrace::capture(),
+            bt: Arc::new(Backtrace::capture()),
         }
     }
 
@@ -109,7 +129,7 @@ impl Error {
 
     pub fn backtrace(&self) -> Option<&Backtrace> {
         match self {
-            Error::Client { bt, .. } => Some(bt),
+            Error::Client { bt, .. } => Some(bt.as_ref()),
             Error::Internal(e) => Some(e.backtrace()),
             Error::Context { source, .. } => source.0.backtrace(),
             Error::HostLang(_) => None,
@@ -130,6 +150,42 @@ impl Error {
             return host_err.is_cancelled();
         }
         false
+    }
+
+    /// Produce a best-effort independent copy of this error.
+    ///
+    /// `Error` isn't `Clone` — `anyhow::Error` and `Backtrace` aren't — but
+    /// several places need to report one failure to multiple consumers: the
+    /// batcher fans a single error out to every member of a batch, and
+    /// [`SharedError`] hands the same failure to every awaiter of a component
+    /// result. This does the next best thing:
+    ///
+    /// - A host-language error that can clone itself ([`HostError::try_clone`],
+    ///   e.g. a Python `PyErr`) is cloned faithfully — preserving its
+    ///   exception type, payload, traceback, and cancellation flavor.
+    /// - `Context` layers are preserved, recursively replicating the source so
+    ///   a clonable host error wrapped in context is still cloned faithfully.
+    /// - `Client` errors keep their variant (so request-vs-internal
+    ///   classification survives), sharing the original backtrace via `Arc`.
+    /// - An `Internal` (`anyhow`) error — which can't be cloned — flattens to a
+    ///   [`ResidualError`] capturing its rendered `Display` + `Debug` text.
+    pub fn replica(&self) -> Error {
+        match self {
+            Error::Context { msg, source } => Error::Context {
+                msg: msg.clone(),
+                source: Box::new(SError(source.0.replica())),
+            },
+            Error::HostLang(host) => match host.try_clone() {
+                Some(cloned) => Error::HostLang(cloned),
+                None => Error::internal(ResidualError::new(self)),
+            },
+            Error::Client { msg, bt } => Error::Client {
+                msg: msg.clone(),
+                // Share the original capture site rather than re-capturing here.
+                bt: bt.clone(),
+            },
+            Error::Internal(_) => Error::internal(ResidualError::new(self)),
+        }
     }
 
     pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -301,7 +357,11 @@ impl ResidualError {
     pub fn new<Err: Display + Debug>(err: &Err) -> Self {
         Self(Arc::new(ResidualErrorData {
             message: err.to_string(),
-            debug: err.to_string(),
+            // Capture Debug so the richer form survives the flatten. (Host
+            // errors that can clone themselves — e.g. a Python `PyErr` — skip
+            // this path entirely; see `HostError::try_clone` and the batcher.
+            // This is the fallback for errors that can't be cloned.)
+            debug: format!("{:?}", err),
         }))
     }
 }
@@ -321,8 +381,11 @@ impl Debug for ResidualError {
 impl StdError for ResidualError {}
 
 enum SharedErrorState {
+    /// The original error — handed to the first extractor.
     Error(Error),
-    ResidualErrorMessage(ResidualError),
+    /// A [`Error::replica`] left behind after the original was extracted;
+    /// every later extractor gets a fresh replica of it.
+    Replica(Error),
 }
 
 #[derive(Clone)]
@@ -335,22 +398,15 @@ impl SharedError {
 
     fn extract_error(&self) -> Error {
         let mut state = self.0.lock().unwrap();
-        let mut_state = &mut *state;
-
-        let residual_err = match mut_state {
-            SharedErrorState::ResidualErrorMessage(err) => {
-                // Already extracted; return a generic internal error with the residual message.
-                return Error::internal(err.clone());
-            }
-            SharedErrorState::Error(err) => ResidualError::new(err),
+        // Build the replacement first (immutable borrow), then swap it in.
+        let replacement = match &*state {
+            // First extraction: leave a replica behind, hand out the original.
+            SharedErrorState::Error(err) => SharedErrorState::Replica(err.replica()),
+            // Already extracted: hand out a fresh replica, leave state as-is.
+            SharedErrorState::Replica(err) => return err.replica(),
         };
-
-        let orig_state = std::mem::replace(
-            mut_state,
-            SharedErrorState::ResidualErrorMessage(residual_err),
-        );
-        let SharedErrorState::Error(err) = orig_state else {
-            panic!("Expected shared error state to hold Error");
+        let SharedErrorState::Error(err) = std::mem::replace(&mut *state, replacement) else {
+            unreachable!("matched SharedErrorState::Error above")
         };
         err
     }
@@ -360,8 +416,7 @@ impl Debug for SharedError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let state = self.0.lock().unwrap();
         match &*state {
-            SharedErrorState::Error(err) => Debug::fmt(err, f),
-            SharedErrorState::ResidualErrorMessage(err) => Debug::fmt(err, f),
+            SharedErrorState::Error(err) | SharedErrorState::Replica(err) => Debug::fmt(err, f),
         }
     }
 }
@@ -370,8 +425,7 @@ impl Display for SharedError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let state = self.0.lock().unwrap();
         match &*state {
-            SharedErrorState::Error(err) => Display::fmt(err, f),
-            SharedErrorState::ResidualErrorMessage(err) => Display::fmt(err, f),
+            SharedErrorState::Error(err) | SharedErrorState::Replica(err) => Display::fmt(err, f),
         }
     }
 }
@@ -517,6 +571,24 @@ mod tests {
     impl StdError for MockHostError {}
     impl HostError for MockHostError {}
 
+    /// Host error that supports `try_clone` — stands in for a Python `PyErr`
+    /// in `replica` tests without needing a Python interpreter.
+    #[derive(Debug)]
+    struct CloneableMockHostError(String);
+
+    impl Display for CloneableMockHostError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "CloneableMockHostError: {}", self.0)
+        }
+    }
+
+    impl StdError for CloneableMockHostError {}
+    impl HostError for CloneableMockHostError {
+        fn try_clone(&self) -> Option<Box<dyn HostError>> {
+            Some(Box::new(CloneableMockHostError(self.0.clone())))
+        }
+    }
+
     #[test]
     fn test_client_error_creation() {
         let err = Error::client("invalid input");
@@ -552,6 +624,68 @@ mod tests {
         } else {
             panic!("Expected HostLang variant");
         }
+    }
+
+    #[test]
+    fn test_replica_preserves_cloneable_host_error() {
+        let err = Error::host(CloneableMockHostError("boom".to_string()));
+        let replica = err.replica();
+        let Error::HostLang(host) = replica.without_contexts() else {
+            panic!("expected HostLang");
+        };
+        let any: &dyn Any = host.as_ref();
+        assert_eq!(
+            any.downcast_ref::<CloneableMockHostError>().unwrap().0,
+            "boom"
+        );
+    }
+
+    #[test]
+    fn test_replica_flattens_non_cloneable_host_error() {
+        // MockHostError uses the default try_clone() == None.
+        let err = Error::host(MockHostError("boom".to_string()));
+        let replica = err.replica();
+        assert!(matches!(replica, Error::Internal(_)));
+        assert_eq!(replica.to_string(), "MockHostError: boom");
+    }
+
+    #[test]
+    fn test_replica_preserves_client_variant() {
+        let replica = Error::client("bad request").replica();
+        assert!(matches!(&replica, Error::Client { msg, .. } if msg == "bad request"));
+    }
+
+    #[test]
+    fn test_replica_flattens_internal_error() {
+        let replica = Error::internal_msg("kaboom").replica();
+        assert!(matches!(replica, Error::Internal(_)));
+        assert_eq!(replica.to_string(), "kaboom");
+    }
+
+    #[test]
+    fn test_replica_preserves_context_and_inner_host_error() {
+        let err = Error::host(CloneableMockHostError("deep".to_string()))
+            .context("layer 1")
+            .context("layer 2");
+        let replica = err.replica();
+        // Context structure preserved...
+        assert!(matches!(&replica, Error::Context { msg, .. } if msg == "layer 2"));
+        // ...and the inner host error is still cloned through the contexts.
+        let Error::HostLang(host) = replica.without_contexts() else {
+            panic!("expected HostLang under context");
+        };
+        let any: &dyn Any = host.as_ref();
+        assert_eq!(
+            any.downcast_ref::<CloneableMockHostError>().unwrap().0,
+            "deep"
+        );
+    }
+
+    #[test]
+    fn test_replica_preserves_cancellation() {
+        let err = Error::cancelled();
+        assert!(err.is_cancelled());
+        assert!(err.replica().is_cancelled());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Error` isn't `Clone` (`anyhow::Error` and `Backtrace` aren't), but two
places need to share one failure across multiple consumers:

- The batcher fans a batch failure out to every batched caller.
- `SharedError` hands the same failure to every awaiter of a result.

Previously, both sites flattened all-but-the-first recipient's copy to a
`ResidualError` — a struct holding only the rendered Display / Debug
text. For a tunneled Python exception (`HostedPyErr` wrapping a `PyErr`),
this meant the original exception type and traceback only reached the
first recipient; every other batched caller saw a generic `RuntimeError`
with no way to `except` by type or inspect the Python frames.

This PR introduces `Error::replica()` as the shared "best-effort
independent copy" helper, and routes both call sites through it.

## Changes

### `HostError::try_clone`

Add an opt-in `try_clone(&self) -> Option<Box<dyn HostError>>` method to
the `HostError` trait (default `None`). Two impls:

- `CancelledError` (unit struct) — trivial clone, so cancellation flavor
  is preserved through batch residuals (previously lost — a cancellation
  flattened through a residual surfaced as a `RuntimeError` instead of
  `asyncio.CancelledError`; this is a latent-bug fix).
- `HostedPyErr` (Python) — uses `PyErr::clone_ref` under `Python::attach`,
  which shares the underlying exception object (type + value + traceback).

### `Error::replica()`

A method on `Error` that produces a best-effort independent copy:

- `Context { msg, source }` → recursively replicated (so a clonable host
  error wrapped in context layers stays faithful).
- `HostLang(host)` → `host.try_clone()` if `Some`, else fall back to a
  `ResidualError`.
- `Client { msg, bt }` → keeps the variant (so 400-vs-500 classification
  survives), sharing `bt` via `Arc` (see next bullet).
- `Internal(anyhow)` → flattens to `ResidualError` (anyhow isn't `Clone`).

### `Error::Client.bt: Backtrace → Arc<Backtrace>`

`Backtrace` isn't `Clone`. Re-capturing in `replica` would point at the
replica call site, not the original error site. Wrapping in `Arc` lets
`replica` share the original capture site at zero cost.

### Use `replica()` in the two fan-out call sites

- `BatcherData::run_batch` — residual recipients now get `err.replica()`
  instead of `ResidualError::new(&err).into()`. The first recipient still
  gets the original.
- `SharedError::extract_error` — the bespoke "leave a `ResidualError`
  behind" state machine is replaced with `err.replica()`. The
  `SharedErrorState::ResidualErrorMessage` variant becomes
  `Replica(Error)` (now holds an `Error`, not a `ResidualError`).

## Tests

- 6 unit tests for `Error::replica` covering each variant
  (clonable host error preserved; non-clonable host error flattens;
  `Client` variant survives; `Internal` flattens; context-wrapping
  preserves the inner clonable host error; cancellation preserved).
- 1 Python regression test (`test_batching_error_preserves_type_for_all_callers`)
  that forces a multi-member batch failure and asserts every caller
  (inline, first residual, residual) gets the same exception type with
  `__traceback__` intact.

## Compatibility

- `HostError::try_clone` has a default `None` impl, so existing
  `HostError` implementors keep compiling unchanged.
- `Error::Client.bt`'s type change is internal to the enum; no public
  API takes/returns a `Backtrace` by value, so callers are unaffected.
- `SharedError`'s public API (`new`, `Debug`, `Display`, `From<Error>`,
  internal `extract_error`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
