### PR TITLE
refactor(engine,state_store): port unified-precommit + PrecommitSession from cocoindex-plus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,12 @@ async def pool(pg_dsn: str) -> Any:
     await p.close()
 ```
 
+### LMDB write paths
+
+- All LMDB writes must go through `Storage::run_txn` (uses the single-writer batcher).
+- Do not open a heed write txn directly or wrap the env in a separate mutex/semaphore — bypassing the batcher loses fsync coalescing and regresses concurrent-submit throughput by 10-100×.
+- LMDB has no savepoints. If a sub-operation needs to "abort," handle it at the body level (e.g. return a sentinel result without writing); never attempt per-body rollback inside the batcher.
+
 ### Sync vs Async
 
 The Rust core (`rust/core`, `rust/utils`) uses **async-first** design with Tokio. The `rust/py` crate bridges Rust async to Python, offering both sync and async APIs:

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -21,8 +21,8 @@ use crate::state::target_state_path::{
     TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
 };
 use crate::state_store::{
-    AppStore, CommitPlan, ExistenceReconciler, OwnerStateForPreempt, PrecommitReadPlan,
-    PrecommitWritePlan, SubmitSession, WriteTxn, reconcile_child_existence,
+    AppStore, CommitPlan, ExistenceReconciler, OwnerStateForPreempt, PrecommitClaimTargetsPlan,
+    PrecommitReadPlan, PrecommitWritePlan, WriteTxn, reconcile_child_existence,
 };
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
@@ -343,16 +343,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
     }
 
     /// Build the engine-side decisions for Phase 4 commit and run
-    /// them through [`SubmitSession::commit`] using the caller-
-    /// supplied session (opened by `submit()` at the start of the
-    /// submit lifecycle). The session opens its own write txn, applies
-    /// the plan's writes (tracking-info, fn-memo flush, target-owner
-    /// cleanup), and invokes the `ExistenceReconciler` callback to
-    /// walk the child-existence tree atomically inside the same txn.
-    /// Then launches Phase 5 GC.
+    /// them through [`AppStore::commit`](crate::state_store::AppStore::commit).
+    /// The AppStore opens its own write txn, applies the plan's writes
+    /// (tracking-info, fn-memo flush, target-owner cleanup), and
+    /// invokes the `ExistenceReconciler` callback to walk the
+    /// child-existence tree atomically inside the same txn. Then
+    /// launches Phase 5 GC.
     async fn commit(
         self,
-        session: SubmitSession,
         child_path_set: Option<ChildStablePathSet>,
         fn_memos: FnMemoCache<Prof>,
         curr_version: Option<u64>,
@@ -362,9 +360,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
         // Engine-side decisions: read existing tracking_info, prune by
         // version retention, clear pending_process_token, version-
-        // converge — produce final bytes the session will write. Per-
+        // converge — produce final bytes the AppStore will write. Per-
         // component exclusivity means no concurrent writer can change
-        // `__track` between this standalone read and `session.commit`.
+        // `__track` between this standalone read and `app_store.commit`.
         let (new_tracking_info, target_owners_to_delete) =
             self.build_commit_writes(curr_version).await?;
 
@@ -386,8 +384,8 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
         // Reconciler closure: walks `child_path_set` against on-disk
         // `__cex` rows, writes diffs and tombstones. Runs inside the
-        // session's commit txn so the existence diff is atomic with the
-        // rest of the commit plan.
+        // AppStore's commit txn so the existence diff is atomic with
+        // the rest of the commit plan.
         let app_store = self.app_store.clone();
         let component_path = self.component_path.clone();
         let cps = child_path_set;
@@ -397,7 +395,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
             })
         });
 
-        session.commit(plan, reconciler).await?;
+        self.app_store
+            .commit(&self.component_path, plan, reconciler)
+            .await?;
 
         // Phase 5 GC: snapshot-read tombstones and spawn child delete
         // operations. Outside the commit txn — tombstones are durable
@@ -599,30 +599,36 @@ enum PreCommitOutcome<Prof: EngineProfile> {
     PendingRetry,
 }
 
-/// Result of one attempt at the engine `pre_commit` retry loop:
-/// either the precommit txn committed (session + output in hand) or
-/// the engine detected `PendingRetry`. Other errors surface as
-/// `Err(_)` and are matched on at the loop level.
-enum PrecommitAttempt<Prof: EngineProfile> {
-    Committed {
-        session: SubmitSession,
-        output: PreCommitOutput<Prof>,
-    },
-    PendingRetry,
+/// Captures bundle shared into the precommit callback closure. Every
+/// field is `O(1)` to clone (Arc-internal or persistent data structure)
+/// so the body's per-call `Arc::clone(&captures)` is cheap. LMDB never
+/// retries the callback, but the bundle's `Fn`-friendly shape keeps the
+/// closure structurally aligned with retry-capable backends.
+struct PreCommitCaptures<Prof: EngineProfile> {
+    app_store: AppStore,
+    stable_path: StablePath,
+    processor_name: Option<Arc<str>>,
+    contained_target_state_paths: Arc<HashSet<TargetStatePath>>,
+    target_states_providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+    declared_target_states:
+        Arc<tokio::sync::Mutex<BTreeMap<TargetStatePath, DeclaredTargetState<Prof>>>>,
 }
 
 /// Engine-side reconcile body. Takes precomputed reads from
-/// [`SubmitSession::precommit_read`] (existing tracking_info,
-/// declared-target owners, preempted-owner tracking blobs) and
-/// returns the [`PrecommitWritePlan`] that the caller threads into
-/// [`SubmitSession::precommit_write`].
+/// [`PrecommitSession::precommit_read`] and
+/// [`PrecommitSession::precommit_claim_targets`] (existing tracking_info,
+/// declared-target owners, preempted-owner tracking blobs) and returns
+/// the [`PrecommitWritePlan`] that the caller returns from the
+/// [`AppStore::precommit`](crate::state_store::AppStore::precommit)
+/// callback for the AppStore to apply + commit.
 ///
 /// Delete-mode preflight (`delete_component_memo` + node-type check)
-/// runs outside, in [`submit`], before the session is opened — the
-/// `demote_component_only` decision lives there too.
+/// runs outside, in [`submit`], before the precommit txn is opened —
+/// the `demote_component_only` decision lives there too.
 #[allow(clippy::too_many_arguments)]
-async fn pre_commit<Prof: EngineProfile>(
+async fn pre_commit<'tracking, Prof: EngineProfile>(
     app_store: &AppStore,
+    wtxn: &mut WriteTxn<'_>,
     process_token: u128,
     stable_path: &StablePath,
     full_reprocess: bool,
@@ -633,27 +639,25 @@ async fn pre_commit<Prof: EngineProfile>(
         tokio::sync::Mutex<BTreeMap<TargetStatePath, DeclaredTargetState<Prof>>>,
     >,
     declared_paths_all: Vec<TargetStatePath>,
-    existing_tracking_info_bytes: Option<Vec<u8>>,
-    current_owners: BTreeMap<TargetStatePath, Option<StablePath>>,
+    mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'tracking>>,
+    prior_owners: BTreeMap<TargetStatePath, Option<StablePath>>,
     preempted_owner_states: BTreeMap<StablePath, OwnerStateForPreempt>,
 ) -> Result<PreCommitOutcome<Prof>> {
     let mut actions_by_sinks = HashMap::<Prof::TargetActionSink, SinkInput<Prof>>::new();
     let mut processor_name_for_del: Option<String> = None;
 
-    // Flatten `current_owners` to drop `None` entries (paths with no
+    // Flatten `prior_owners` to drop `None` entries (paths with no
     // existing owner row). The detection sub-pass + Phase 1 preempt
-    // branch only look at non-self owners; storing `Option` would force
-    // every lookup to double-deref.
-    let bulk_target_owners: HashMap<TargetStatePath, StablePath> = current_owners
+    // branch only look at non-self owners; storing `Option` would
+    // force every lookup to double-deref. Note: `prior_owners` only
+    // contains entries for `paths_to_claim` (the subset of declared
+    // paths the engine just decided to claim); paths self already owns
+    // per `tracking_info` are absent from the map and treated as
+    // "owner == self" by construction.
+    let bulk_target_owners: HashMap<TargetStatePath, StablePath> = prior_owners
         .into_iter()
         .filter_map(|(k, v)| v.map(|owner| (k, owner)))
         .collect();
-
-    let mut tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'_>> =
-        existing_tracking_info_bytes
-            .as_deref()
-            .map(from_msgpack_slice)
-            .transpose()?;
 
     // Old-owner tracking_info bytes were prefetched by the session.
     // The cache is per-owner-path; the detection sub-pass and Phase 1
@@ -727,9 +731,6 @@ async fn pre_commit<Prof: EngineProfile>(
         return Ok(PreCommitOutcome::PendingRetry);
     }
     let mut modified_old_owners: HashSet<StablePath> = HashSet::new();
-    // Writes collected during the body; flushed into `PrecommitWritePlan`
-    // at the end so the session can apply them inside its precommit txn.
-    let mut target_owners_to_upsert: BTreeMap<TargetStatePath, StablePath> = BTreeMap::new();
     let previously_exists = tracking_info.is_some();
     if let Some(tracking_info) = &mut tracking_info {
         if let Some(processor_name) = processor_name {
@@ -791,7 +792,6 @@ async fn pre_commit<Prof: EngineProfile>(
             // (either fresh insert or preempted from another component).
             // When provider_id changed, the old entry (under old_pid) stays for Phase 2
             // to skip (stale) and commit to prune.
-            let is_new_to_component = existing_item.is_none();
 
             // Obtain prev_item: either from this component's existing entry or via preempt.
             // Owner info comes from the pre-fetched `bulk_target_owners` map (no
@@ -911,7 +911,12 @@ async fn pre_commit<Prof: EngineProfile>(
                     let existing_gen = provider_generation.clone().unwrap_or_default();
                     let new_gen = match recon_output.child_invalidation {
                         Some(ChildInvalidation::Destructive) => {
-                            let new_id = app_store.reserve_id_range(&TARGET_ID_KEY, 1).await?;
+                            // Inside the open precommit WTxn — use the
+                            // in-txn variant to avoid nesting another
+                            // batched WTxn on LMDB (would deadlock).
+                            let new_id = app_store
+                                .reserve_id_range_in_txn(wtxn, &TARGET_ID_KEY, 1)
+                                .await?;
                             TargetStateProviderGeneration {
                                 provider_id: new_id,
                                 provider_schema_version: 0,
@@ -973,13 +978,11 @@ async fn pre_commit<Prof: EngineProfile>(
                 }
             }
 
-            // Collect item for re-insertion after Phase 2.
+            // Collect item for re-insertion after Phase 2. The
+            // `__target` claim for `is_new_to_component` paths was
+            // already handed off to `precommit_claim_targets` via the
+            // pre-flight `paths_to_claim` filter in `submit()`.
             if let Some(item) = prev_item {
-                // Inverted tracking upsert — collected into the precommit
-                // write plan, applied inside the session's precommit txn.
-                if is_new_to_component {
-                    target_owners_to_upsert.insert(target_state_path.clone(), stable_path.clone());
-                }
                 items_to_insert.push((lookup_key, item));
             }
         }
@@ -1091,9 +1094,10 @@ async fn pre_commit<Prof: EngineProfile>(
     let (curr_version, new_tracking_info_bytes) = curr_version;
 
     // Collect modified preempted-owner blobs from `old_tracking_cache`
-    // into the write plan. The session's precommit_write writes them
-    // alongside the self tracking_info in the same txn, collapsing N
-    // preempts of one owner into one upsert.
+    // into the write plan. The backend writes them alongside the self
+    // tracking_info in the same precommit txn (the apply step inside
+    // `precommit(callback)`), collapsing N preempts of one owner into
+    // one upsert.
     let mut preempted_owner_updates: BTreeMap<StablePath, Vec<u8>> = BTreeMap::new();
     for path in modified_old_owners {
         let encoded = old_tracking_cache
@@ -1104,8 +1108,8 @@ async fn pre_commit<Prof: EngineProfile>(
 
     // Provider-generation updates: buffered into the output, applied
     // by `submit()` after the precommit txn commits — so a retry of
-    // precommit (a fresh session.precommit_read on PendingRetry)
-    // doesn't trip the `OnceLock::set` "already set" guard.
+    // precommit (a fresh precommit_read on PendingRetry) doesn't trip
+    // the `OnceLock::set` "already set" guard.
     Ok(PreCommitOutcome::Done {
         output: PreCommitOutput {
             curr_version,
@@ -1117,7 +1121,6 @@ async fn pre_commit<Prof: EngineProfile>(
         write_plan: PrecommitWritePlan {
             self_path: stable_path.clone(),
             new_tracking_info: new_tracking_info_bytes,
-            target_owners_to_upsert,
             preempted_owner_updates,
         },
     })
@@ -1200,7 +1203,7 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     // or persistent data structures).
     let app_store = comp_ctx.app_ctx().app_store().clone();
     let stable_path = comp_ctx.stable_path().clone();
-    let processor_name_owned: Option<String> = processor_name.map(|s| s.to_owned());
+    let processor_name_owned: Option<Arc<str>> = processor_name.map(Arc::from);
 
     // Delete-mode preflight (was in `pre_commit` body pre-Session).
     // The early-return / `demote_component_only` decision needs to
@@ -1235,77 +1238,128 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     // marker.
     let declared_target_states = Arc::new(tokio::sync::Mutex::new(declared_target_states));
 
-    // Open the submit session and drive Phase 2 (precommit_read →
-    // engine reconcile → precommit_write).
+    // Open the precommit txn via `AppStore::precommit` and drive
+    // Phase 2 inside the callback: precommit_read + engine reconcile +
+    // precommit_claim_targets, returning either `Some((plan, output))`
+    // (AppStore applies + commits) or `None` (PendingRetry → AppStore
+    // contributes no writes).
     //
     // Retry condition: `PendingRetry` — application-layer signal that
     // another in-process pre_commit holds a live token on a contested
     // target path. Bounded by `MAX_PENDING_RETRIES` (the other side
     // either commits or aborts in finite time).
     //
-    // Each retry attempt opens a fresh session; LMDB's read-snapshot
-    // precommit_read has nothing to roll back on retry.
-    let (mut session_opt, pre_commit_out): (Option<SubmitSession>, PreCommitOutput<Prof>) = {
+    // Each retry re-enters `precommit` from scratch; LMDB's
+    // read-snapshot precommit_read has nothing to roll back on retry.
+    let pre_commit_out: PreCommitOutput<Prof> = {
         let mut pending_backoff = std::time::Duration::from_millis(5);
         const MAX_PENDING_RETRIES: u32 = 8;
         let mut pending_attempt: u32 = 0;
         loop {
-            // Body runs as a single fallible block so we can dispatch
-            // on the failure kind below.
-            let attempt: Result<PrecommitAttempt<Prof>> = async {
-                // The eager `__cex` upsert (Phase 1) ran earlier from
-                // `component.rs` via `eager_existence_upsert`, so the
-                // session opens straight into Phase 2.
-                let mut session = app_store
-                    .begin_submit(stable_path.clone(), process_token)
-                    .await?;
+            // Per-attempt captures bundle. Every field is `O(1)` to
+            // clone (Arc-internal or persistent data structure), so
+            // the body's per-call `Arc::clone(&captures)` is cheap.
+            let captures: Arc<PreCommitCaptures<Prof>> = Arc::new(PreCommitCaptures {
+                app_store: app_store.clone(),
+                stable_path: stable_path.clone(),
+                processor_name: processor_name_owned.clone(),
+                contained_target_state_paths: Arc::clone(&contained_target_state_paths),
+                target_states_providers: target_states_providers.clone(),
+                declared_target_states: Arc::clone(&declared_target_states),
+            });
 
-                let declared_paths_all: Vec<TargetStatePath> = {
-                    let guard = declared_target_states.lock().await;
-                    guard.keys().cloned().collect()
-                };
-                let reads = session
-                    .precommit_read(PrecommitReadPlan {
-                        self_path: stable_path.clone(),
-                        self_token: process_token,
-                        declared_target_states: declared_paths_all.clone(),
+            // The eager `__cex` upsert (Phase 1) ran earlier from
+            // `component.rs` via `eager_existence_upsert`, so this
+            // drops straight into Phase 2.
+            let output: Option<PreCommitOutput<Prof>> = app_store
+                .precommit(&stable_path, move |wtxn, session| {
+                    let c = Arc::clone(&captures);
+                    Box::pin(async move {
+                        let declared_paths_all: Vec<TargetStatePath> = {
+                            let guard = c.declared_target_states.lock().await;
+                            guard.keys().cloned().collect()
+                        };
+                        let reads = session
+                            .precommit_read(
+                                wtxn,
+                                PrecommitReadPlan {
+                                    self_path: c.stable_path.clone(),
+                                    self_token: process_token,
+                                },
+                            )
+                            .await?;
+
+                        // Deserialize the existing tracking record once; the
+                        // bytes stay alive in `existing_tracking_info_bytes`
+                        // for the remainder of this attempt. Engine-side
+                        // filter: only paths not already in self's tracking
+                        // need a `__target` touch (per spec §4.1
+                        // per-component exclusivity), so warm reprocess
+                        // collapses to zero `__target` round-trips.
+                        let existing_tracking_info_bytes = reads.existing_tracking_info;
+                        let tracking_info: Option<db_schema::StablePathEntryTrackingInfo<'_>> =
+                            existing_tracking_info_bytes
+                                .as_deref()
+                                .map(from_msgpack_slice)
+                                .transpose()?;
+                        let existing_paths: std::collections::HashSet<TargetStatePath> =
+                            tracking_info
+                                .as_ref()
+                                .map(|info| {
+                                    info.target_state_items
+                                        .keys()
+                                        .map(|k| k.target_state_path.clone())
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                        let paths_to_claim: Vec<TargetStatePath> = declared_paths_all
+                            .iter()
+                            .filter(|p| !existing_paths.contains(*p))
+                            .cloned()
+                            .collect();
+
+                        let claim = session
+                            .precommit_claim_targets(
+                                wtxn,
+                                PrecommitClaimTargetsPlan {
+                                    self_path: c.stable_path.clone(),
+                                    paths_to_claim,
+                                },
+                            )
+                            .await?;
+
+                        let outcome = pre_commit(
+                            &c.app_store,
+                            wtxn,
+                            process_token,
+                            &c.stable_path,
+                            full_reprocess,
+                            c.processor_name.as_deref(),
+                            &c.contained_target_state_paths,
+                            &c.target_states_providers,
+                            Arc::clone(&c.declared_target_states),
+                            declared_paths_all,
+                            tracking_info,
+                            claim.prior_owners,
+                            claim.preempted_owner_states,
+                        )
+                        .await?;
+
+                        Ok(match outcome {
+                            PreCommitOutcome::Done { output, write_plan } => {
+                                Some((write_plan, output))
+                            }
+                            PreCommitOutcome::PendingRetry => None,
+                        })
                     })
-                    .await?;
-
-                let outcome = pre_commit(
-                    &app_store,
-                    process_token,
-                    &stable_path,
-                    full_reprocess,
-                    processor_name_owned.as_deref(),
-                    &contained_target_state_paths,
-                    &target_states_providers,
-                    Arc::clone(&declared_target_states),
-                    declared_paths_all,
-                    reads.existing_tracking_info,
-                    reads.current_owners,
-                    reads.preempted_owner_states,
-                )
+                })
                 .await?;
 
-                match outcome {
-                    PreCommitOutcome::Done { output, write_plan } => {
-                        session.precommit_write(write_plan).await?;
-                        Ok(PrecommitAttempt::Committed { session, output })
-                    }
-                    PreCommitOutcome::PendingRetry => {
-                        drop(session);
-                        Ok(PrecommitAttempt::PendingRetry)
-                    }
-                }
-            }
-            .await;
-
-            match attempt {
-                Ok(PrecommitAttempt::Committed { session, output }) => {
-                    break (Some(session), output);
-                }
-                Ok(PrecommitAttempt::PendingRetry) => {
+            match output {
+                Some(output) => break output,
+                None => {
+                    // PendingRetry: AppStore contributed no writes. Back
+                    // off, retry.
                     pending_attempt += 1;
                     if pending_attempt >= MAX_PENDING_RETRIES {
                         client_bail!(
@@ -1318,7 +1372,6 @@ pub(crate) async fn submit<Prof: EngineProfile>(
                     pending_backoff =
                         std::cmp::min(pending_backoff * 2, std::time::Duration::from_millis(200));
                 }
-                Err(e) => return Err(e),
             }
         }
     };
@@ -1338,8 +1391,9 @@ pub(crate) async fn submit<Prof: EngineProfile>(
         child_provider.set_provider_generation(new_gen)?;
     }
 
-    // Sink apply. On failure the session (still in hand) cleans up
-    // the stage marker.
+    // Sink apply. On failure we clear the stage marker so a
+    // subsequent precommit doesn't see a stale token from this
+    // attempt.
     let sink_result: Result<()> = async {
         let host_runtime_ctx = comp_ctx.app_ctx().env().host_runtime_ctx();
         for (sink, input) in actions_by_sinks {
@@ -1378,34 +1432,20 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     .await;
 
     if let Err(e) = sink_result {
-        if let Some(s) = session_opt.take() {
-            if let Err(cleanup_err) = s.cleanup().await {
-                error!(
-                    "session cleanup after sink_apply failure for {}: {:?}",
-                    comp_ctx.stable_path(),
-                    cleanup_err
-                );
-                // Continue with retry-helper fallback so the in-flight
-                // marker doesn't strand subsequent pre_commits.
-                cleanup_pending_token(comp_ctx, process_token).await;
-            }
-        } else {
-            cleanup_pending_token(comp_ctx, process_token).await;
-        }
+        cleanup_pending_token(comp_ctx, process_token).await;
         return Err(e);
     }
 
-    // Commit. Consumes the session.
-    let session = session_opt
-        .take()
-        .ok_or_else(|| internal_error!("session missing at commit"))?;
+    // Commit. `AppStore::commit` is a normal trait method — no
+    // session handoff needed.
     let committer = Committer::new(comp_ctx, &target_states_providers, demote_component_only)?;
     if let Err(e) = committer
-        .commit(session, child_path_set, fn_memos, curr_version)
+        .commit(child_path_set, fn_memos, curr_version)
         .await
     {
-        // Session was consumed (Ok or Err mid-commit). Use the
-        // helper, which opens a fresh session for cleanup retry.
+        // The commit txn either committed or rolled back before
+        // returning Err — either way the stage marker may still be
+        // live, so clear it via the retry helper.
         cleanup_pending_token(comp_ctx, process_token).await;
         return Err(e);
     }
@@ -1426,8 +1466,8 @@ pub(crate) async fn submit<Prof: EngineProfile>(
 
 /// Clear this component's `pending_process_token` field in the
 /// tracking-info blob. Called when sink_apply or commit failed
-/// between `session.precommit_write` and a successful
-/// `session.commit`.
+/// between the successful precommit txn and a successful
+/// `app_store.commit`.
 ///
 /// Without this, the token the precommit wrote would deadlock any
 /// future pre_commit in this process that touches an overlapping
@@ -1439,12 +1479,13 @@ pub(crate) async fn submit<Prof: EngineProfile>(
 /// the sink-tracking divergence the failure may have caused gets
 /// re-reconciled.
 ///
-/// Each iteration opens a fresh `SubmitSession` and calls
-/// `session.cleanup()`. Retried indefinitely with exponential
-/// backoff — every failure is logged but the function does not
-/// return until the cleanup succeeds. If the process exits while
-/// this is still retrying, the next process picks up the leftover
-/// state via the same `is_pending()` check.
+/// Each iteration calls
+/// [`AppStoreTrait::clear_stage_marker`](crate::state_store::AppStoreTrait::clear_stage_marker).
+/// Retried indefinitely with exponential backoff — every failure is
+/// logged but the function does not return until the cleanup
+/// succeeds. If the process exits while this is still retrying, the
+/// next process picks up the leftover state via the same
+/// `is_pending()` check.
 async fn cleanup_pending_token<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     process_token: u128,
@@ -1453,12 +1494,7 @@ async fn cleanup_pending_token<Prof: EngineProfile>(
     let path = comp_ctx.stable_path().clone();
     let mut backoff = std::time::Duration::from_millis(10);
     loop {
-        let result: Result<()> = async {
-            let session = app_store.begin_submit(path.clone(), process_token).await?;
-            session.cleanup().await
-        }
-        .await;
-        match result {
+        match app_store.clear_stage_marker(&path, process_token).await {
             Ok(()) => return,
             Err(e) => {
                 error!(

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -227,7 +227,8 @@ impl AppStore {
     /// Standalone snapshot read of raw tracking-info bytes — no
     /// caller-managed txn. Engine `Committer` uses this to fetch the
     /// post-pre_commit tracking_info for prune+converge, then hands
-    /// the new bytes to [`SubmitSession::commit`] via the plan.
+    /// the new bytes to [`AppStoreTrait::commit`](super::AppStoreTrait::commit)
+    /// via the plan.
     pub async fn read_tracking_info(&self, path: &StablePath) -> Result<Option<Vec<u8>>> {
         let rtxn = self.read_txn().await?;
         let key = key_tracking_info(path)?;
@@ -257,35 +258,6 @@ impl AppStore {
         let key = key_tracking_info(path)?;
         self.db().delete(&mut **txn, &key)?;
         Ok(())
-    }
-
-    /// Stage-with-read primitive. Reads the existing blob; if it has a
-    /// `pending_process_token` field, returns it (don't overwrite —
-    /// somebody else is in flight). Otherwise reports the slot as
-    /// claimed by `self_token`.
-    ///
-    /// LMDB's single-writer model means no concurrent stagers can race
-    /// us. The actual persistence of `self_token` is deferred to the
-    /// eventual `write_tracking_info_raw` at end of pre-commit, where
-    /// the engine encodes `pending_process_token = Some(self_token)`
-    /// into the blob. No extra write here.
-    pub async fn stage_and_read_tracking_in_txn(
-        &self,
-        txn: &mut WriteTxn<'_>,
-        path: &StablePath,
-        self_token: u128,
-    ) -> Result<(Option<Vec<u8>>, u128)> {
-        let key = key_tracking_info(path)?;
-        let raw = self.db().get(&**txn, &key)?.map(<[u8]>::to_vec);
-        let existing_token = match raw.as_deref() {
-            Some(bytes) => {
-                let info: crate::state::db_schema::StablePathEntryTrackingInfo<'_> =
-                    cocoindex_utils::deser::from_msgpack_slice(bytes)?;
-                info.pending_process_token
-            }
-            None => None,
-        };
-        Ok((raw, existing_token.unwrap_or(self_token)))
     }
 
     /// Cleanup primitive: read the blob, clear `pending_process_token`
@@ -393,7 +365,7 @@ impl AppStore {
     /// Delete the component-memo row outside a caller-supplied txn.
     /// Routed through the single-writer batcher so concurrent
     /// callers coalesce into one underlying write txn (the same
-    /// invariant `LmdbSubmitSession`'s write phases rely on; opening
+    /// invariant the LMDB precommit/commit phases rely on; opening
     /// `env.write_txn()` here would serialize every Delete-mode
     /// preflight through heed's writer mutex with no amortization).
     pub async fn delete_component_memo(&self, path: &StablePath) -> Result<()> {
@@ -909,19 +881,6 @@ impl AppStore {
         _known_parent_path: &StablePath,
     ) -> Result<()> {
         self.ensure_existence_chain_standalone(path).await
-    }
-
-    /// Open a per-component submit session.
-    pub async fn begin_submit(
-        &self,
-        component_path: StablePath,
-        process_token: u128,
-    ) -> Result<crate::state_store::SubmitSession> {
-        Ok(crate::state_store::submit_session::SubmitSession::new(
-            self.clone(),
-            component_path,
-            process_token,
-        ))
     }
 
     /// Spawn a background task that streams every `(StablePath,

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -16,7 +16,8 @@ mod txn;
 pub use app_store::AppStore;
 pub use storage::{Storage, StorageSettings};
 pub use submit_session::{
-    CommitPlan, ExistenceReconciler, OwnerStateForPreempt, PrecommitReadPlan, PrecommitReadResult,
-    PrecommitWritePlan, SubmitSession, reconcile_child_existence,
+    CommitPlan, ExistenceReconciler, OwnerStateForPreempt, PrecommitClaimTargetsPlan,
+    PrecommitClaimTargetsResult, PrecommitReadPlan, PrecommitReadResult, PrecommitSession,
+    PrecommitWritePlan, reconcile_child_existence,
 };
 pub use txn::WriteTxn;

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -1,13 +1,36 @@
-//! Per-component submit session: drives the state-store side of one
-//! `submit()` call through pre-commit and commit phases.
+//! Per-component submit lifecycle on the state-store side: the engine
+//! drives Phase 2 (precommit) and Phase 4 (commit / cleanup) through
+//! three [`AppStore`] methods — `precommit`, `commit`,
+//! `clear_stage_marker`.
 //!
 //! Spec: [`specs/store/submit_session.md`](../../../../specs/store/submit_session.md).
 //!
+//! ## Two scopes
+//!
+//! The lifecycle splits into two **disjoint scopes** with different
+//! ownership rules:
+//!
+//! - **Txn-scoped** — [`PrecommitSession`] is a *value* that lives only
+//!   between BEGIN and COMMIT of the precommit txn. Its two methods
+//!   (`precommit_read`, `precommit_claim_targets`) are meaningful only
+//!   while the txn is open; holding `&mut PrecommitSession` is the
+//!   type-level proof of that. Per-attempt mutable state (`paths_to_claim`
+//!   stash) lives directly on `&mut self` — no `Mutex`, no `Arc` —
+//!   because no other task ever touches it.
+//! - **Call-scoped on [`AppStore`]** — `precommit`, `commit`,
+//!   `clear_stage_marker` are inherent methods on `AppStore` (the per-app
+//!   handle). Each call is a standalone, self-contained operation
+//!   parameterized by `component_path` (and, for `clear_stage_marker`,
+//!   `process_token`) and opens/closes its own txn(s). No persistent
+//!   submit handle threads across the three methods — what ties them
+//!   together is the engine code in `engine::execution::submit`, which
+//!   calls them with matching args.
+//!
 //! ## Lifecycle
 //!
-//! Phase 1 (eager `__cex` upsert) is not a session method — see
-//! `engine::execution::eager_existence_upsert`, which runs at the
-//! start of every Build before the user processor. The session owns
+//! Phase 1 (eager `__cex` upsert) is not an `AppStore`-submit method —
+//! see `engine::execution::eager_existence_upsert`, which runs at the
+//! start of every Build before the user processor. The `AppStore` owns
 //! phases 2 and 4:
 //!
 //! ```text
@@ -15,28 +38,29 @@
 //!        ↓                              before user processor runs
 //!   [user processor runs]
 //!        ↓
-//!   AppStore::begin_submit(component_path, process_token)
-//!        ↓
-//!   precommit_read(PrecommitReadPlan) ← Phase 2 step a: snapshot read of
-//!                                       existing tracking info, target
-//!                                       owners, and preempted-owner state
-//!        ↓
-//!   [engine reconciles in-memory, builds plan]
-//!        ↓
-//!   precommit_write(PrecommitWritePlan) ← Phase 2 step b: write tracking_info
-//!                                       + owner upserts + preempted updates
+//!   AppStore::precommit(component_path,
+//!     callback(&mut WriteTxn, &mut PrecommitSession) -> Option<(plan, output)>)
+//!     ├─ opens batched precommit WTxn (single-writer, coalesced)
+//!     ├─ engine callback runs inside it:
+//!     │   ├─ session.precommit_read
+//!     │   ├─ [engine reconciles in-memory]
+//!     │   ├─ session.precommit_claim_targets
+//!     │   └─ → Some((plan, output)) | None (PendingRetry)
+//!     └─ applies plan writes + commits, or contributes no writes on None.
 //!        ↓
 //!   [sink_apply runs]
 //!        ↓
-//!   commit(CommitPlan, reconciler)    ← Phase 4: apply finalized writes,
-//!                                       invoke reconciler for the child-
-//!                                       existence diff, all in one txn.
-//!                                       Or:
-//!   cleanup()                         ← Phase 4 failure: clear stage marker.
+//!   AppStore::commit(component_path, CommitPlan, reconciler)
+//!                                     ← Phase 4 success: open commit txn,
+//!                                       apply finalized writes, invoke
+//!                                       reconciler for child-existence
+//!                                       diff, COMMIT.
+//!                                     Or:
+//!   AppStore::clear_stage_marker(component_path, process_token)
+//!                                     ← Phase 4 failure: clear stage marker.
 //!
-//!   [Phase 5 + 6 driven separately via AppStore::cleanup_tombstone and
-//!    AppStore::finalize_memoization — each its own small txn with no
-//!    session-scoped state.]
+//!   [Phase 5 + 6 driven separately via AppStore methods — each its own
+//!    small txn with no submit-scoped state.]
 //! ```
 
 use std::cmp::Ordering;
@@ -50,8 +74,7 @@ use cocoindex_utils::fingerprint::Fingerprint;
 
 use crate::prelude::*;
 use crate::state::db_schema::{
-    ChildExistenceInfo, DbEntryKey, StablePathEntryKey, StablePathEntryTrackingInfo,
-    StablePathNodeType, TargetStateOwnerInfo,
+    ChildExistenceInfo, StablePathEntryTrackingInfo, StablePathNodeType,
 };
 use crate::state::stable_path::{StableKey, StablePath, StablePathRef};
 use crate::state::stable_path_set::{ChildStablePathSet, StablePathSet};
@@ -60,161 +83,154 @@ use crate::state_store::AppStore;
 use crate::state_store::WriteTxn;
 
 // ---------------------------------------------------------------------------
-// Phase 2 — Pre-commit (split into read + write to bracket engine's reconcile)
+// Phase 2 — Pre-commit plans + session
 // ---------------------------------------------------------------------------
 //
 // Phase 1 (eager `__cex` existence bit) is *not* a session phase. The
 // engine writes the component's own existence row (and any missing
 // ancestors) before the user processor runs — see
 // `engine::execution::eager_existence_upsert`. Doing it outside the
-// session keeps the session API focused on precommit/commit, and
+// session keeps the AppStore API focused on precommit/commit and
 // matches `internal_states.md §3.1`.
 
-/// Inputs to [`SubmitSession::precommit_read`].
+/// Inputs to [`PrecommitSession::precommit_read`].
 pub struct PrecommitReadPlan {
-    /// Self path, for filtering "owner != self" entries before
-    /// surfacing them as preempts.
+    /// Self path. Stage marker scope.
     pub self_path: StablePath,
-    /// This process's stage token (`u128`). Carried in the
-    /// `pending_process_token` field of the on-disk tracking-info
-    /// blob.
+    /// This process's stage token. Stored in the on-disk tracking-info
+    /// blob's `pending_process_token` field.
     pub self_token: u128,
-    /// Target-state paths this component declared in the current build.
-    /// Backend bulk-reads `__target` to learn current owners; for any
-    /// owner != `self_path`, also bulk-reads that owner's `__track` row
-    /// so the engine can decide preempt vs. PendingRetry.
-    pub declared_target_states: Vec<TargetStatePath>,
 }
 
-/// Output of [`SubmitSession::precommit_read`].
+/// Output of [`PrecommitSession::precommit_read`]. Pure read — the
+/// engine uses `existing_tracking_info` to determine which declared
+/// target-state paths are new (i.e. not already self-owned in
+/// `__target`) before calling
+/// [`PrecommitSession::precommit_claim_targets`].
 pub struct PrecommitReadResult {
     /// Existing committed tracking-info bytes for `self_path`. `None`
     /// if no row yet.
     pub existing_tracking_info: Option<Vec<u8>>,
-    /// Pending-stage token observed on `self_path` — `self_token` if
-    /// no other writer is in flight, otherwise the other writer's
-    /// token. The engine compares it to `self_token` to detect the
-    /// "another process is in flight on this same component" case.
-    /// (Intra-process is already serialized by the per-component
-    /// semaphore, so a mismatch implies a different process.)
+    /// Pending-stage token observed on `self_path` — `self_token` if no
+    /// other writer is in flight, otherwise the other writer's token.
+    /// The engine compares it to `self_token` to detect the "another
+    /// process is in flight on this same component" case. (Intra-process
+    /// is already serialized by the per-component semaphore, so a
+    /// mismatch implies a different process.)
     pub post_stage_token: u128,
-    /// For each declared target-state path: the current owner, or
-    /// `None` if no row exists yet.
-    pub current_owners: BTreeMap<TargetStatePath, Option<StablePath>>,
-    /// For each unique non-self owner discovered in `current_owners`:
+}
+
+/// Inputs to [`PrecommitSession::precommit_claim_targets`].
+pub struct PrecommitClaimTargetsPlan {
+    pub self_path: StablePath,
+    /// Subset of the engine's declared target-state paths that the
+    /// engine knows are **not** already in self's existing tracking
+    /// record (i.e. not already self-owned in `__target`). Under
+    /// per-component exclusivity, self's tracking record is the
+    /// authoritative source for what self owns in `__target`, so
+    /// already-owned paths don't need a touch and we save the lookup.
+    pub paths_to_claim: Vec<TargetStatePath>,
+}
+
+/// Output of [`PrecommitSession::precommit_claim_targets`].
+pub struct PrecommitClaimTargetsResult {
+    /// For each entry in `paths_to_claim`: the prior owner that the
+    /// claim displaced.
+    ///
+    /// - `None` — no row existed before; fresh insert.
+    /// - `Some(self_path)` — `__target` already held self (crash-recovery
+    ///   path: a previous attempt landed the upsert but didn't finalize).
+    /// - `Some(other)` — cross-component preempt; engine consults
+    ///   `preempted_owner_states` to decide PendingRetry vs. takeover.
+    ///
+    /// Paths **not** in `paths_to_claim` are absent from the map; the
+    /// engine treats their owner as self by construction.
+    pub prior_owners: BTreeMap<TargetStatePath, Option<StablePath>>,
+    /// For each unique non-self owner discovered in `prior_owners`:
     /// their tracking-info bytes and pending-stage token. Engine
-    /// combines `staged_token == Some(self_token)` with its own
-    /// per-item `is_pending()` check to decide live-writer vs.
-    /// preemptable.
+    /// combines `staged_token == Some(self_token)` with its own per-item
+    /// `is_pending()` check to decide live-writer vs. preemptable.
     pub preempted_owner_states: BTreeMap<StablePath, OwnerStateForPreempt>,
 }
 
 /// One preempted other-component owner's relevant state.
 pub struct OwnerStateForPreempt {
-    /// Committed tracking-info bytes for that owner. `None` if the
-    /// row is missing.
+    /// Committed tracking-info bytes for that owner. `None` if the row
+    /// is missing.
     pub tracking_info: Option<Vec<u8>>,
-    /// The owner's `pending_process_token` from its tracking-info
-    /// blob.
+    /// The owner's `pending_process_token` from its tracking-info blob.
     pub staged_token: Option<u128>,
 }
 
-/// Inputs to [`SubmitSession::precommit_write`].
+/// Engine's "go ahead and commit" output from the precommit callback.
+/// The backend applies these writes inside the same txn the callback
+/// ran in, then commits.
+///
+/// `__target` claims do **not** appear here — they're already known to
+/// the AppStore from `precommit_claim_targets` (LMDB stashed
+/// `paths_to_claim` on the `PrecommitSession`; the apply step drains
+/// it).
 pub struct PrecommitWritePlan {
-    /// Self path (echo of `PrecommitReadPlan::self_path`).
+    /// Self path.
     pub self_path: StablePath,
-    /// New `__track.value` bytes for this component. `None` skips the
+    /// New tracking-info bytes for this component. `None` skips the
     /// write (e.g. nothing to track yet).
     pub new_tracking_info: Option<Vec<u8>>,
-    /// `(target_state_path, owner_component_path)` upserts on `__target`.
-    pub target_owners_to_upsert: BTreeMap<TargetStatePath, StablePath>,
     /// For each preempted other-owner: their new tracking-info bytes
     /// (with the preempted item removed by the engine).
     pub preempted_owner_updates: BTreeMap<StablePath, Vec<u8>>,
 }
 
 // ---------------------------------------------------------------------------
-// Phase 4 — Commit
+// PrecommitSession — txn-scoped Phase 2 calls
 // ---------------------------------------------------------------------------
 
-/// Inputs to [`SubmitSession::commit`].
-pub struct CommitPlan {
-    /// Final `StablePathEntryTrackingInfo` bytes for self. `None` in
-    /// `Delete` mode (backend deletes the `__track` row instead).
-    pub new_tracking_info: Option<Vec<u8>>,
-    /// Bulk upserts on `__target`.
-    pub target_owners_to_upsert: Vec<(TargetStatePath, StablePath)>,
-    /// Bulk deletes from `__target` (pruned-item cleanup).
-    pub target_owners_to_delete: Vec<TargetStatePath>,
-    /// If true, prefix-delete all `__fnmemo` rows for self before
-    /// applying the writes/deletes below.
-    pub fn_memo_clear_all_first: bool,
-    pub fn_memo_writes: Vec<(Fingerprint, Vec<u8>)>,
-    pub fn_memo_deletes: Vec<Fingerprint>,
-    /// In-memory child tree after this build. Backend feeds it to
-    /// `existence_reconciler` (see [`SubmitSession::commit`]) inside
-    /// its commit txn, so the children-`__cex` read + tombstone
-    /// writes happen atomically with the other commit writes.
-    /// `None` skips existence reconciliation (e.g. `demote_component_only`).
-    pub child_path_set: Option<Arc<ChildStablePathSet>>,
-}
-
-/// Callback the backend invokes inside its commit txn to run the
-/// child-existence diff. Engine constructs this closure with all
-/// captures it needs (component path, child_path_set, an `AppStore`
-/// clone) and passes it to [`SubmitSession::commit`]. The closure
-/// receives the open `WriteTxn` and walks the in-memory tree, reads
-/// `__cex` per parent, writes deltas + tombstones — see
-/// [`crate::engine::existence::reconcile_child_existence`].
+/// Txn-scoped handle for the Phase 2 read calls. Lives only inside the
+/// precommit txn body opened by [`AppStore::precommit`]; holding the
+/// `&mut PrecommitSession` is the type-level proof that the txn is open.
 ///
-/// Lifetime: the closure runs strictly inside the backend's commit
-/// txn, so the `&'a mut WriteTxn<'env>` borrow is bounded by the
-/// callback's await suspension scope. The body's future is `'a`-tied
-/// so it can't outlive the borrow.
-pub type ExistenceReconciler =
-    Box<dyn for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<()>> + Send>;
-
-// ---------------------------------------------------------------------------
-// SubmitSession (concrete)
-// ---------------------------------------------------------------------------
-
-/// Per-component submit session. Drives Phase 2 (pre-commit read +
-/// write) and Phase 4 (commit / cleanup) against the LMDB AppStore.
-/// Open with [`AppStore::begin_submit`].
-pub struct SubmitSession {
+/// Per-attempt mutable state (`paths_to_claim`) lives directly on the
+/// `&mut self` — no `Mutex`, no `Arc` — because the engine callback is
+/// the only caller and runs single-threaded inside the txn body.
+pub struct PrecommitSession {
     app_store: AppStore,
-    component_path: StablePath,
-    process_token: u128,
+    /// Populated by [`Self::precommit_claim_targets`] and drained by
+    /// [`AppStore::precommit`]'s apply step. LMDB has no per-body
+    /// savepoints, so `precommit_claim_targets` can't write the
+    /// `__target` upserts directly — if the engine then returns `None`
+    /// (PendingRetry), those writes would already be in the WTxn with
+    /// no way to roll them back. The apply step is the first point
+    /// where the go/no-go is known, so the writes wait there.
+    paths_to_claim: Option<Vec<TargetStatePath>>,
 }
 
-impl SubmitSession {
-    pub(in crate::state_store) fn new(
-        app_store: AppStore,
-        component_path: StablePath,
-        process_token: u128,
-    ) -> Self {
+impl PrecommitSession {
+    fn new(app_store: AppStore) -> Self {
         Self {
             app_store,
-            component_path,
-            process_token,
+            paths_to_claim: None,
         }
     }
 
-    /// Phase 2 step a: snapshot read of existing tracking_info,
-    /// declared target owners, and preempted-owner tracking-info bytes.
-    /// Returns everything the engine needs to reconcile in-memory.
-    ///
-    /// LMDB uses MVCC, so the snapshot is consistent. Per-component
-    /// intra-process exclusivity rules out a concurrent writer
-    /// touching these rows between this read and the subsequent
-    /// `precommit_write`.
-    pub async fn precommit_read(&mut self, plan: PrecommitReadPlan) -> Result<PrecommitReadResult> {
-        let rtxn = self.app_store.read_txn().await?;
-        let db = self.app_store.db();
-
-        // 1. Read existing tracking_info + extract pending token.
-        let tracking_key = key_tracking_info(&plan.self_path)?;
-        let raw = db.get(&rtxn, &tracking_key)?.map(<[u8]>::to_vec);
+    /// Phase 2 step a: stage self's tracking-info row and return the
+    /// existing committed `value` plus the pending-stage token. Pure
+    /// read in LMDB (single-writer; the next `__track` write happens at
+    /// the apply step); `__target` is not touched here so the engine
+    /// can use `existing_tracking_info` to filter the upcoming claim
+    /// set down to paths self doesn't already own.
+    pub async fn precommit_read(
+        &mut self,
+        wtxn: &mut WriteTxn<'_>,
+        plan: PrecommitReadPlan,
+    ) -> Result<PrecommitReadResult> {
+        // Read tracking-info from the engine-owned WTxn. Under
+        // per-component exclusivity, the row can't be modified by
+        // another writer between phases, but reading from the WTxn gets
+        // us read-your-own-writes for free.
+        let raw = self
+            .app_store
+            .read_tracking_info_in_txn(wtxn, &plan.self_path)
+            .await?;
         let existing_pending = match raw.as_deref() {
             Some(bytes) => {
                 let info: StablePathEntryTrackingInfo<'_> = from_msgpack_slice(bytes)?;
@@ -224,30 +240,56 @@ impl SubmitSession {
         };
         let post_stage_token = existing_pending.unwrap_or(plan.self_token);
 
-        // 2. Read current owners for each declared target.
-        let mut current_owners: BTreeMap<TargetStatePath, Option<StablePath>> = BTreeMap::new();
-        let mut preempted_set: BTreeSet<StablePath> = BTreeSet::new();
-        for tsp in &plan.declared_target_states {
-            let key = key_target_state_owner(tsp)?;
-            let owner_path = match db.get(&rtxn, &key)? {
-                Some(bytes) => {
-                    let info: TargetStateOwnerInfo = from_msgpack_slice(bytes)?;
-                    if info.component_path != plan.self_path {
-                        preempted_set.insert(info.component_path.clone());
-                    }
-                    Some(info.component_path)
-                }
-                None => None,
-            };
-            current_owners.insert(tsp.clone(), owner_path);
+        Ok(PrecommitReadResult {
+            existing_tracking_info: raw,
+            post_stage_token,
+        })
+    }
+
+    /// Phase 2 step b: read prior owners and preempted-owner tracking
+    /// rows for `paths_to_claim`. The actual `__target` upserts are
+    /// deferred to [`AppStore::precommit`]'s apply step (LMDB has no
+    /// per-body savepoints — if the engine then returns `None`, those
+    /// writes can't be rolled back, so we wait until the go/no-go is
+    /// known). The reads here use the engine-owned WTxn for
+    /// read-your-own-writes.
+    pub async fn precommit_claim_targets(
+        &mut self,
+        wtxn: &mut WriteTxn<'_>,
+        plan: PrecommitClaimTargetsPlan,
+    ) -> Result<PrecommitClaimTargetsResult> {
+        self.paths_to_claim = Some(plan.paths_to_claim.clone());
+
+        if plan.paths_to_claim.is_empty() {
+            return Ok(PrecommitClaimTargetsResult {
+                prior_owners: BTreeMap::new(),
+                preempted_owner_states: BTreeMap::new(),
+            });
         }
 
-        // 3. Read tracking_info for each preempted owner.
+        let mut prior_owners: BTreeMap<TargetStatePath, Option<StablePath>> = BTreeMap::new();
+        let mut preempted_set: BTreeSet<StablePath> = BTreeSet::new();
+        for tsp in &plan.paths_to_claim {
+            let prior_owner = self
+                .app_store
+                .read_target_state_owner_in_txn(wtxn, tsp)
+                .await?
+                .map(|info| info.component_path);
+            if let Some(ref op) = prior_owner
+                && op != &plan.self_path
+            {
+                preempted_set.insert(op.clone());
+            }
+            prior_owners.insert(tsp.clone(), prior_owner);
+        }
+
         let mut preempted_owner_states: BTreeMap<StablePath, OwnerStateForPreempt> =
             BTreeMap::new();
         for owner_path in &preempted_set {
-            let key = key_tracking_info(owner_path)?;
-            let owner_raw = db.get(&rtxn, &key)?.map(<[u8]>::to_vec);
+            let owner_raw = self
+                .app_store
+                .read_tracking_info_in_txn(wtxn, owner_path)
+                .await?;
             let staged_token = match owner_raw.as_deref() {
                 Some(bytes) => {
                     let info: StablePathEntryTrackingInfo<'_> = from_msgpack_slice(bytes)?;
@@ -264,58 +306,145 @@ impl SubmitSession {
             );
         }
 
-        Ok(PrecommitReadResult {
-            existing_tracking_info: raw,
-            post_stage_token,
-            current_owners,
+        Ok(PrecommitClaimTargetsResult {
+            prior_owners,
             preempted_owner_states,
         })
     }
+}
 
-    /// Phase 2 step b: apply engine's writes (tracking_info + target
-    /// owners + preempted-owner updates). Routed through the
-    /// single-writer batcher.
-    pub async fn precommit_write(&mut self, plan: PrecommitWritePlan) -> Result<()> {
-        let app_store = self.app_store.clone();
-        self.app_store
-            .run_in_batcher(move |wtxn| {
+// ---------------------------------------------------------------------------
+// Phase 4 — Commit
+// ---------------------------------------------------------------------------
+
+/// Inputs to [`AppStore::commit`].
+pub struct CommitPlan {
+    /// Final tracking-info bytes for self. `None` in `Delete` mode
+    /// (AppStore deletes the row instead).
+    pub new_tracking_info: Option<Vec<u8>>,
+    /// Bulk upserts on `__target`.
+    pub target_owners_to_upsert: Vec<(TargetStatePath, StablePath)>,
+    /// Bulk deletes from `__target` (pruned-item cleanup).
+    pub target_owners_to_delete: Vec<TargetStatePath>,
+    /// If true, prefix-delete all `__fnmemo` rows for self before
+    /// applying the writes/deletes below.
+    pub fn_memo_clear_all_first: bool,
+    pub fn_memo_writes: Vec<(Fingerprint, Vec<u8>)>,
+    pub fn_memo_deletes: Vec<Fingerprint>,
+    /// In-memory child tree after this build. AppStore feeds it to
+    /// `existence_reconciler` (see [`AppStore::commit`]) inside its
+    /// commit txn, so the children-`__cex` read + tombstone writes
+    /// happen atomically with the other commit writes. `None` skips
+    /// existence reconciliation (e.g. `demote_component_only`).
+    pub child_path_set: Option<Arc<ChildStablePathSet>>,
+}
+
+/// Callback the AppStore invokes inside its commit txn to run the
+/// child-existence diff. Engine constructs this closure with all
+/// captures it needs (component path, child_path_set, an `AppStore`
+/// clone) and passes it to [`AppStore::commit`]. The closure receives
+/// the open `WriteTxn` and walks the in-memory tree, reads `__cex` per
+/// parent, writes deltas + tombstones — see
+/// [`reconcile_child_existence`].
+///
+/// Lifetime: the closure runs strictly inside the commit txn, so the
+/// `&'a mut WriteTxn<'env>` borrow is bounded by the callback's await
+/// suspension scope. The body's future is `'a`-tied so it can't outlive
+/// the borrow.
+pub type ExistenceReconciler =
+    Box<dyn for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<()>> + Send>;
+
+// ---------------------------------------------------------------------------
+// AppStore methods — Phase 2 driver + Phase 4 commit / cleanup
+// ---------------------------------------------------------------------------
+
+impl AppStore {
+    /// Phase 2 driver. Opens a batched precommit WTxn, runs `callback`
+    /// inside it with a fresh [`PrecommitSession`], applies the
+    /// returned [`PrecommitWritePlan`] and commits — or contributes no
+    /// writes if the callback returns `None` (PendingRetry; the batched
+    /// WTxn still commits whatever other bodies wrote).
+    ///
+    /// Routes through [`crate::state_store::Storage::run_txn`] so
+    /// concurrent precommits coalesce into one WTxn → one fsync (per
+    /// AGENTS.md "LMDB write paths"). LMDB has no savepoints — to
+    /// "abort" on PendingRetry, the body contributes no writes.
+    ///
+    /// The callback is `Fn` (not `FnOnce`) for shape parity with
+    /// retry-capable backends; LMDB's batcher never retries the body,
+    /// so it's invoked at most once per call here. Captures consumed by
+    /// the body must be cloned inside the closure (typically a few
+    /// `Arc::clone`s).
+    pub async fn precommit<T, F>(
+        &self,
+        component_path: &StablePath,
+        callback: F,
+    ) -> Result<Option<T>>
+    where
+        T: Send + 'static,
+        F: for<'a, 'env> Fn(
+                &'a mut WriteTxn<'env>,
+                &'a mut PrecommitSession,
+            ) -> BoxFuture<'a, Result<Option<(PrecommitWritePlan, T)>>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let app_store = self.clone();
+        let component_path_outer = component_path.clone();
+        let callback = Arc::new(callback);
+
+        self.storage
+            .run_txn(move |wtxn: &mut WriteTxn<'_>| {
+                let app_store = app_store.clone();
+                let component_path = component_path_outer.clone();
+                let callback = Arc::clone(&callback);
                 Box::pin(async move {
-                    if let Some(bytes) = plan.new_tracking_info.as_ref() {
-                        app_store
-                            .write_tracking_info_raw(wtxn, &plan.self_path, bytes)
-                            .await?;
+                    let mut session = PrecommitSession::new(app_store.clone());
+                    let cb_result = callback(wtxn, &mut session).await?;
+                    match cb_result {
+                        Some((plan, output)) => {
+                            // Apply __target claims (the work deferred from
+                            // `precommit_claim_targets`).
+                            if let Some(paths) = session.paths_to_claim.take() {
+                                for path in paths {
+                                    app_store
+                                        .upsert_target_state_owner(wtxn, &path, &component_path)
+                                        .await?;
+                                }
+                            }
+                            if let Some(bytes) = plan.new_tracking_info.as_ref() {
+                                app_store
+                                    .write_tracking_info_raw(wtxn, &plan.self_path, bytes)
+                                    .await?;
+                            }
+                            for (owner_path, bytes) in plan.preempted_owner_updates {
+                                app_store
+                                    .write_tracking_info_raw(wtxn, &owner_path, &bytes)
+                                    .await?;
+                            }
+                            Ok(Some(output))
+                        }
+                        None => Ok(None),
                     }
-                    for (target_path, owner_path) in plan.target_owners_to_upsert {
-                        app_store
-                            .upsert_target_state_owner(wtxn, &target_path, &owner_path)
-                            .await?;
-                    }
-                    for (owner_path, bytes) in plan.preempted_owner_updates {
-                        app_store
-                            .write_tracking_info_raw(wtxn, &owner_path, &bytes)
-                            .await?;
-                    }
-                    Ok(())
                 })
             })
             .await
     }
 
-    /// Phase 4 success: apply finalized writes, then invoke
-    /// `existence_reconciler` for the child-existence diff — all in
-    /// one write txn so the reconciler's per-parent `__cex` reads see
-    /// the same snapshot as the plan writes that just happened.
-    ///
-    /// Consumes self.
+    /// Phase 4 success: open commit txn, apply finalized writes, invoke
+    /// `existence_reconciler` for the child-existence diff — all in one
+    /// write txn so the reconciler's per-parent `__cex` reads see the
+    /// same snapshot as the plan writes that just happened.
     pub async fn commit(
-        self,
+        &self,
+        component_path: &StablePath,
         plan: CommitPlan,
         existence_reconciler: ExistenceReconciler,
     ) -> Result<()> {
-        let app_store = self.app_store.clone();
-        let component_path = self.component_path.clone();
-        self.app_store
-            .storage
+        let app_store = self.clone();
+        let component_path = component_path.clone();
+        self.storage
             .run_txn(move |wtxn: &mut WriteTxn<'_>| {
                 Box::pin(async move {
                     if let Some(bytes) = plan.new_tracking_info.as_ref() {
@@ -357,29 +486,15 @@ impl SubmitSession {
 
     /// Phase 4 failure: clear the stage marker so a subsequent
     /// pre-commit doesn't see our stale token as a live in-flight
-    /// writer. Idempotent. Consumes self.
-    pub async fn cleanup(self) -> Result<()> {
-        self.app_store
-            .clear_staged_tracking(&self.component_path, self.process_token)
+    /// writer. Idempotent.
+    pub async fn clear_stage_marker(
+        &self,
+        component_path: &StablePath,
+        process_token: u128,
+    ) -> Result<()> {
+        self.clear_staged_tracking(component_path, process_token)
             .await
     }
-}
-
-// LMDB key encoders for the session's snapshot reads. Mirror the
-// private helpers in `app_store.rs` (kept tiny; if they ever drift,
-// fix at the source).
-
-fn key_tracking_info(path: &StablePath) -> Result<Vec<u8>> {
-    storekey::encode_vec(&DbEntryKey::StablePath(
-        path.clone(),
-        StablePathEntryKey::TrackingInfo,
-    ))
-    .map_err(|e| internal_error!("encode tracking_info key: {e}"))
-}
-
-fn key_target_state_owner(path: &TargetStatePath) -> Result<Vec<u8>> {
-    storekey::encode_vec(&DbEntryKey::TargetState(path.clone()))
-        .map_err(|e| internal_error!("encode target_state_owner key: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -400,11 +515,10 @@ fn key_target_state_owner(path: &TargetStatePath) -> Result<Vec<u8>> {
 /// Sibling-by-sibling sorted-merge per level so each `__cex` read is
 /// O(N children) per parent and the writes are bounded by changes.
 ///
-/// Used by [`SubmitSession::commit`] implementations: the backend opens
-/// the commit txn, then invokes the engine-supplied
-/// [`ExistenceReconciler`] which in turn calls this function. Lives on
-/// the storage side because the entire logic only depends on the state
-/// layer (no engine concepts).
+/// Used by [`AppStore::commit`]: the AppStore opens the commit txn,
+/// then invokes the engine-supplied [`ExistenceReconciler`] which in
+/// turn calls this function. Lives on the storage side because the
+/// entire logic only depends on the state layer (no engine concepts).
 pub async fn reconcile_child_existence<'a>(
     wtxn: &mut WriteTxn<'_>,
     app_store: &AppStore,


### PR DESCRIPTION
## Summary

- Replaces the two-phase `SubmitSession::precommit_read` → `precommit_write` split with a single-txn callback shape driven by `AppStore::precommit(component_path, callback)`. The callback runs the engine's reconcile inside the precommit WTxn and returns either `Some((plan, output))` (AppStore applies + commits) or `None` (PendingRetry → AppStore contributes no writes). One precommit txn now spans the read, claim, and write phases atomically.
- Splits the txn-scoped phase work onto a new `PrecommitSession` value that exists only inside the txn body. Holding `&mut PrecommitSession` is the type-level proof the txn is open. Its two methods are `precommit_read` and `precommit_claim_targets` — the latter is new and replaces the in-line target-owner reads that used to live in `precommit_read`.
- Engine-side filter: `submit()` now builds `paths_to_claim` as `declared_paths − existing_paths_in_tracking_info`, so warm reprocess collapses to zero `__target` reads when self already owns every declared path.
- `Committer::commit` no longer threads a session; it calls `AppStore::commit(...)` directly. Phase 4 success/failure both go through `AppStore::commit` / `AppStore::clear_stage_marker`. `AppStore::begin_submit` is removed (no persistent submit handle needed anymore).
- `pre_commit` takes the open `&mut WriteTxn` so its destructive-invalidation path uses `reserve_id_range_in_txn`, avoiding the nested-batched-WTxn deadlock when called inside the precommit txn body.

Ports cocoindex-plus #156, #158, #159 to OSS.

## Test plan

- `cargo build -p cocoindex_core` — clean
- `cargo test -p cocoindex_core` — 32/32 pass (31 lib + 1 telemetry shutdown)
- `uv run maturin develop && uv run pytest python/` — 682 pass / 150 skip (unchanged)
- All pre-commit hooks pass (cargo fmt, mypy, ruff, maturin develop, cargo test, pytest)
