### PR TITLE
fix(engine): don't force prev_may_be_missing on multi-state items

### DIFF
--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -109,6 +109,16 @@ async def _row_count(pool: "asyncpg.Pool", table_name: str) -> int:
         return int(row["cnt"])
 
 
+async def _table_columns(pool: "asyncpg.Pool", table_name: str) -> set[str]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = $1 AND table_schema = 'public'",
+            table_name,
+        )
+        return {str(row["column_name"]) for row in rows}
+
+
 async def _drop_table(pool: "asyncpg.Pool", table_name: str) -> None:
     async with pool.acquire() as conn:
         await conn.execute(f'DROP TABLE IF EXISTS "{table_name}" CASCADE')
@@ -676,4 +686,82 @@ async def test_postgres_strips_nul_in_text_and_jsonb(pg_env: _PgEnv) -> None:
         }
 
     finally:
+        await _drop_table(pool, table_name)
+
+
+@pytest.mark.asyncio
+async def test_postgres_column_drop_retries_after_failed_attempt(
+    pg_env: _PgEnv,
+) -> None:
+    """A column drop that fails (here, blocked by a dependent view) leaves the
+    table's tracking item with multiple possible states on disk. A later run,
+    once the dependency is gone, must still recompute the column-level diff and
+    actually drop the column — it must NOT treat the prior states as missing and
+    short-circuit into a no-op ``CREATE TABLE IF NOT EXISTS``.
+
+    Scenario:
+      t1: create table with columns (id, value, extra).
+      t2: remove "extra" from the schema, but a view depends on it, so the
+          ``DROP COLUMN`` fails. The table item is left with possible states
+          [(id, value, extra), (id, value)].
+      t3: drop the view, run again -> "extra" must actually be dropped.
+    """
+    pool = pg_env.pool
+    coco_env = pg_env.coco_env
+    table_name = _unique_name("test_col_drop")
+    view_name = _unique_name("test_col_drop_view")
+
+    include_extra = True
+
+    def _schema() -> "postgres.TableSchema[dict[str, Any]]":
+        columns = {
+            "id": postgres.ColumnDef("text", nullable=False),
+            "value": postgres.ColumnDef("text"),
+        }
+        if include_extra:
+            columns["extra"] = postgres.ColumnDef("text")
+        return postgres.TableSchema(columns=columns, primary_key=["id"])
+
+    try:
+
+        async def declare_fn() -> None:
+            await coco.use_mount(
+                coco.component_subpath("setup", "table"),
+                postgres.declare_table_target,
+                _PG_DB_KEY,
+                table_name,
+                _schema(),
+            )
+
+        app = coco.App(
+            coco.AppConfig(name=f"test_col_drop_{table_name}", environment=coco_env),
+            declare_fn,
+        )
+
+        # t1: create table with id, value, extra.
+        await app.update()
+        assert await _table_columns(pool, table_name) == {"id", "value", "extra"}
+
+        # Create a view that depends on column "extra" so DROP COLUMN fails.
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f'CREATE VIEW "{view_name}" AS SELECT "extra" FROM "{table_name}"'
+            )
+
+        # t2: drop "extra" -> blocked by the dependent view, so the run fails.
+        include_extra = False
+        with pytest.raises(Exception):
+            await app.update()
+        # The column is still present because the drop failed.
+        assert "extra" in await _table_columns(pool, table_name)
+
+        # t3: remove the dependency, run again. The column drop must now happen.
+        async with pool.acquire() as conn:
+            await conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
+        await app.update()
+        assert await _table_columns(pool, table_name) == {"id", "value"}
+
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
         await _drop_table(pool, table_name)

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -652,6 +652,62 @@ def test_proceed_with_failed_creation() -> None:
 
 
 ##################################################################################
+# Test for prev_may_be_missing after a failed update
+
+
+def test_prev_may_be_missing_after_failed_update() -> None:
+    """A failed sink_apply leaves the target-state item with multiple possible
+    states on disk (the value it had before the failed attempt, plus the value
+    it tried to write). Both of those are real prior sink states — the actual
+    sink content is guaranteed to be one of them — so a later run that observes
+    these possible states must NOT set ``prev_may_be_missing=True``.
+
+    Scenario:
+      t1: declare a=1 (committed) -> possible states [1].
+      t2: declare a=2, leaf sink fails -> possible states left as [1, 2].
+      t3: declare a=2 again, sink ok -> reconcile must see prev=[1, 2] with
+          prev_may_be_missing=False (not True).
+    """
+    DictsTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_prev_may_be_missing_after_failed_update", environment=coco_env
+        ),
+        _declare_dicts_data_together,
+    )
+
+    # t1: insert a=1.
+    _source_data["D1"] = {"a": 1}
+    app.update_blocking()
+    assert DictsTarget.store.data == {
+        "D1": {"a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True)},
+    }
+
+    # t2: update a=2, but make the leaf sink for D1 fail. The failed attempt
+    # leaves the item with two possible states [1, 2] on disk; the sink itself
+    # is untouched, so a=1 is still what's stored.
+    _source_data["D1"]["a"] = 2
+    leaf_store = DictsTarget.store._stores["D1"]
+    try:
+        leaf_store.sink_exception = True
+        with pytest.raises(Exception):
+            app.update_blocking()
+    finally:
+        leaf_store.sink_exception = False
+    assert DictsTarget.store.data["D1"]["a"].data == 1
+
+    # t3: declare a=2 again; the sink now succeeds. The item carries possible
+    # states [1, 2], but both are real prior sink values, so prev_may_be_missing
+    # must be False.
+    app.update_blocking()
+    assert DictsTarget.store.data == {
+        "D1": {"a": DictDataWithPrev(data=2, prev=[1, 2], prev_may_be_missing=False)},
+    }
+
+
+##################################################################################
 # Test for cleanup of partially-built components
 
 

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -845,18 +845,20 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
             };
 
             // Compute prev_states and prev_may_be_missing uniformly from prev_item.
-            // `prev_item.is_pending()` (multi-state) means the prior lifecycle's
-            // sink_apply / commit didn't finish — could be a crash on a different
-            // process or a `rollback_pending_tokens` after a sink_apply failure
-            // here. In either case the sink may not reflect what's tracked, so
-            // force `prev_may_be_missing = true`.
+            // A `Deleted` entry among the states means the sink may be absent —
+            // e.g. a prior delete whose sink_apply succeeded but whose commit
+            // didn't finish (crash, or a `rollback_pending_tokens` after a later
+            // failure). Multi-state on its own does NOT imply missing: every
+            // value the sink could hold is already among `prev_states`, so the
+            // handler's own `all(prev == desired)` check decides whether to act.
             let (prev_states, prev_may_be_missing) = if let Some(ref prev_item) = prev_item {
                 let schema_version_mismatch = match parent_provider_gen {
                     Some(pg) => prev_item.provider_schema_version != pg.provider_schema_version,
                     None => false,
                 };
-                let prev_may_be_missing =
-                    full_reprocess || schema_version_mismatch || prev_item.is_pending();
+                let prev_may_be_missing = full_reprocess
+                    || schema_version_mismatch
+                    || prev_item.states.iter().any(|(_, s)| s.is_deleted());
                 let prev_states = prev_item
                     .states
                     .iter()
@@ -1035,7 +1037,6 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
                 .map(|s_bytes| Prof::TargetStateTrackingRecord::from_bytes(s_bytes))
                 .collect::<Result<Vec<_>>>()?;
 
-            let prev_may_be_missing = prev_may_be_missing || item.is_pending();
             let recon_output = target_states_provider
                 .handler()
                 .ok_or_else(|| {

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -290,9 +290,15 @@ impl<'a> TargetStateInfoItem<'a> {
     /// True iff this item's `states` carries an unsettled push from a
     /// pre_commit that hasn't been finalized by `commit_in_txn`'s retention
     /// pass — either an in-flight modification by *this* process, a crashed
-    /// prior process, or a rolled-back failed attempt. Used to force
-    /// `prev_may_be_missing = true` on reconcile so the sink gets a fresh
-    /// upsert/delete instead of a short-circuit "no change" decision.
+    /// prior process, or a rolled-back failed attempt.
+    ///
+    /// Used in the pre_commit detection sub-pass to recognize a *live*
+    /// in-flight lifecycle (paired with `pending_process_token == self`).
+    /// It does NOT drive `prev_may_be_missing`: multi-state means the sink
+    /// holds one of the enumerated `states`, all of which are passed to
+    /// reconcile as `prev_states`, so the handler's own `all(prev == desired)`
+    /// check decides whether an action is needed. The "sink may be absent"
+    /// case is signalled separately by a `Deleted` entry among the states.
     ///
     /// Invariant: at rest (after a successful `commit_in_txn`), every item
     /// has `states.len() <= 1`. Retention always reduces the vec by dropping


### PR DESCRIPTION
## Summary
- `pre_commit` was setting `prev_may_be_missing = ... || item.is_pending()` (multi-state), introduced in #1996. But multi-state only means the sink holds one of the enumerated states — all already passed to reconcile as `prev_states` — so the handler's own `all(prev == desired)` check decides whether to act. Forcing `prev_may_be_missing` on multi-state is wrong.
- For the postgres composite-state handler this was a **permanent divergence**: a failed `DROP COLUMN` leaves the table item multi-state, and on the next run the forced `prev_may_be_missing` pushed the composite main action to `"upsert"`, suppressing the per-column sub-diff — the column was never dropped while tracking recorded it as gone.
- Fix: drop the `is_pending()` clause from both `pre_commit` phases. The "sink may be absent" case is signalled separately by a `Deleted` entry among the states, so Phase 1 now uses `states.any(is_deleted)` (matching Phase 2, which already had it). `is_pending()` survives only in the detection sub-pass for live-token detection.

## Test plan
- `test_prev_may_be_missing_after_failed_update` (core): a failed update leaves possible states `[1, 2]`; a re-declare must see `prev_may_be_missing=False`. Fails on the buggy code, passes after the fix.
- `test_postgres_column_drop_retries_after_failed_attempt` (postgres, testcontainers): a `DROP COLUMN` blocked by a dependent view must still drop the column on a later run once the dependency is removed. Fails on the buggy code (column never dropped), passes after the fix.
- Full `cargo test` workspace + `python/tests/core/test_component_target_states.py` + `python/tests/connectors/test_postgres_target.py` green locally.
