### PR TITLE
fix(progress_display): render no-TTY progress on refresh interval only

### DIFF
--- a/rust/core/src/engine/app.rs
+++ b/rust/core/src/engine/app.rs
@@ -51,6 +51,13 @@ impl<T: Send + 'static> AppOpHandle<T> {
         Ok(*self.version_rx.borrow())
     }
 
+    /// Waits until the operation terminates, ignoring intermediate changes.
+    /// Unlike `changed()`, this only resolves on termination, so callers that
+    /// don't care about every update aren't woken on every version bump.
+    pub async fn wait_terminated(&self) {
+        self.stats.wait_terminated().await;
+    }
+
     /// Awaits the task completion and returns the result.
     pub async fn result(self) -> Result<T> {
         self.task

--- a/rust/core/src/engine/progress_display.rs
+++ b/rust/core/src/engine/progress_display.rs
@@ -489,7 +489,7 @@ async fn show_progress_pty<T: Send + 'static>(
 
 /// Plain text fallback (non-TTY, Windows).
 async fn show_progress_plain<T: Send + 'static>(
-    mut handle: AppOpHandle<T>,
+    handle: AppOpHandle<T>,
     options: ProgressDisplayOptions,
     live: bool,
     start_time: Instant,
@@ -499,19 +499,15 @@ async fn show_progress_plain<T: Send + 'static>(
 
     loop {
         tokio::select! {
-            result = handle.changed() => {
-                let version = match result {
-                    Ok(v) => v,
-                    Err(_) => break,
-                };
-                if version >= TERMINATED_VERSION {
-                    break;
-                }
+            // Only wakes on termination, not on every stats change, so the
+            // refresh timer is what drives rendering in the no-TTY case.
+            // On termination we exit immediately and fall through to the
+            // final stats below.
+            () = handle.wait_terminated() => break,
+            () = &mut sleep_fut => {
+                sleep_fut.set(tokio::time::sleep(options.refresh_interval));
             }
-            () = &mut sleep_fut => {}
         }
-
-        sleep_fut.set(tokio::time::sleep(options.refresh_interval));
 
         let snapshot = handle.stats_snapshot();
         if snapshot.ready && ready_time.is_none() {

--- a/rust/core/src/engine/stats.rs
+++ b/rust/core/src/engine/stats.rs
@@ -52,6 +52,10 @@ pub struct ProcessingStats {
     inner: Arc<Mutex<VersionedProcessingStats>>,
     version_tx: watch::Sender<u64>,
     version_rx: watch::Receiver<u64>,
+    /// Fires exactly once, on termination. Separate from `version_*` so that
+    /// terminated-only waiters aren't woken on every stats update.
+    terminated_tx: watch::Sender<bool>,
+    terminated_rx: watch::Receiver<bool>,
 }
 
 impl Default for ProcessingStats {
@@ -63,10 +67,13 @@ impl Default for ProcessingStats {
 impl ProcessingStats {
     pub fn new() -> Self {
         let (version_tx, version_rx) = watch::channel(0u64);
+        let (terminated_tx, terminated_rx) = watch::channel(false);
         Self {
             inner: Arc::new(Mutex::new(VersionedProcessingStats::default())),
             version_tx,
             version_rx,
+            terminated_tx,
+            terminated_rx,
         }
     }
 
@@ -103,7 +110,20 @@ impl ProcessingStats {
 
     /// Signal that the processing task has fully terminated.
     pub fn notify_terminated(&self) {
+        // The version channel carries the sentinel for change-tracking
+        // consumers (e.g. the TTY display, which wants every update anyway);
+        // the dedicated terminated channel is for terminated-only waiters.
         let _ = self.version_tx.send(TERMINATED_VERSION);
+        let _ = self.terminated_tx.send(true);
+    }
+
+    /// Resolves only when the operation has terminated. Because the underlying
+    /// channel fires exactly once, the waiter isn't woken on intermediate
+    /// stats updates (unlike the version channel).
+    pub async fn wait_terminated(&self) {
+        let mut rx = self.terminated_rx.clone();
+        // Err means the sender was dropped, which we also treat as terminated.
+        let _ = rx.wait_for(|terminated| *terminated).await;
     }
 
     /// Subscribe to version change notifications.


### PR DESCRIPTION
## Summary
- In the non-TTY progress path (e.g. `> log.txt`), render progress only on the refresh interval instead of on every stats change, which previously flooded the output.
- Exit the loop immediately on termination so final stats print without waiting for the next tick.
- Add a dedicated single-shot terminated channel to `ProcessingStats` (separate from the per-version watch channel) and expose `AppOpHandle::wait_terminated`, so the no-TTY waiter isn't woken on every stats bump. The version channel keeps its `TERMINATED_VERSION` sentinel for the TTY display, which wants every update anyway.

## Test plan
- CI (`cargo test`)
- Manual: run an app with stdout redirected to a file and confirm progress lines appear at the refresh interval, not on every change.
