### PR TITLE
feat(engine): let report_to_stdout configure the refresh interval

### DIFF
--- a/docs/src/content/docs/advanced_topics/progress_monitoring.mdx
+++ b/docs/src/content/docs/advanced_topics/progress_monitoring.mdx
@@ -5,7 +5,7 @@ description: >
   and watch(), and split a run into separately-reported scopes with stats_group().
 ---
 
-Most runs only need the basics covered in [App](../programming_guide/app#updating-an-app): awaiting `app.update()` for the result, or the built-in stdout progress display — `report_to_stdout=True` on `app.update_blocking()` (or the CLI), or `await coco.show_progress(handle)` with the async API.
+Most runs only need the basics covered in [App](../programming_guide/app#updating-an-app): awaiting `app.update()` for the result, or the built-in stdout progress display — `report_to_stdout=True` on `app.update_blocking()` (or the CLI), or `await coco.show_progress(handle)` with the async API. `report_to_stdout` accepts a `timedelta` to set the refresh interval (`True` uses the default); `show_progress` takes a `refresh_interval` keyword.
 
 This page covers the **structured** progress APIs for cases that need more: a daemon streaming progress to a client, a custom dashboard, or splitting a large pipeline into independently-reported phases.
 
@@ -84,7 +84,7 @@ async def app_main(docs_dir, code_dir, target):
         await coco.mount_each(process_code, files.items(), target)
 ```
 
-With `report_to_stdout=True`, the group's progress is also printed to stdout, labeled by its title, alongside the main `report_to_stdout` display without disrupting it.
+With `report_to_stdout=True`, the group's progress is also printed to stdout, labeled by its title, alongside the main `report_to_stdout` display without disrupting it. Pass a `timedelta` instead of `True` to set the group's refresh interval.
 
 The block yields a `StatsGroupHandle` with the same `stats()` and `watch()` as `UpdateHandle` (a group has no return value, so there's no `result()`):
 

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -57,7 +57,7 @@ result = app.update_blocking()
 **Parameters:**
 
 - `live` option keeps the app running after the initial scan so live components can continue watching for changes. See [Live Mode](./live_mode).
-- `report_to_stdout` option prints periodic progress updates during execution.
+- `report_to_stdout` option prints periodic progress updates during execution. Pass `True` for the default refresh interval, or a `timedelta` to set it.
 - `full_reprocess` option reprocesses everything and invalidates existing caches. This forces all components to re-execute and all target states to be re-applied, even if they haven't changed.
 
 When you update an App, CocoIndex:

--- a/python/cocoindex/_internal/app.py
+++ b/python/cocoindex/_internal/app.py
@@ -4,6 +4,7 @@ import os
 import threading
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import (
     Any,
     Callable,
@@ -28,6 +29,7 @@ from .update_stats import (
     UpdateStatus,
     _StatsView,
     _decode_update_stats,
+    _resolve_report_to_stdout,
     _TERMINATED_VERSION,
 )
 
@@ -149,10 +151,18 @@ class DropHandle(_StatsView[core.DropHandle]):
         return self.result().__await__()
 
 
-async def show_progress(handle: UpdateHandle[R]) -> R:
-    """Run the operation with progress display. Consumes the handle."""
+async def show_progress(
+    handle: UpdateHandle[R], *, refresh_interval: timedelta | None = None
+) -> R:
+    """Run the operation with progress display (async). Consumes the handle.
+
+    ``refresh_interval`` overrides the default refresh interval.
+    """
     core_handle = await handle._ensure_started()
-    pyvalue: Any = await core.show_progress(core_handle)
+    refresh_interval_secs = (
+        refresh_interval.total_seconds() if refresh_interval is not None else None
+    )
+    pyvalue: Any = await core.show_progress(core_handle, refresh_interval_secs)
     return pyvalue.get(fn_ret_deserializer(handle._main_fn))  # type: ignore[no-any-return]
 
 
@@ -293,7 +303,7 @@ class App(Generic[P, R]):
     def update_blocking(
         self,
         *,
-        report_to_stdout: bool = False,
+        report_to_stdout: bool | timedelta = False,
         full_reprocess: bool = False,
         live: bool = False,
     ) -> R:
@@ -301,7 +311,9 @@ class App(Generic[P, R]):
         Update the app synchronously (run the app once to process all pending changes).
 
         Args:
-            report_to_stdout: If True, periodically report processing stats to stdout.
+            report_to_stdout: If truthy, periodically report processing stats to
+                stdout. Pass a ``timedelta`` to set the refresh interval; ``True``
+                uses the default interval.
             full_reprocess: If True, reprocess everything and invalidate existing caches.
             live: If True, run in live mode (live components continue processing
                 after mark_ready).
@@ -314,11 +326,13 @@ class App(Generic[P, R]):
         processor = create_core_component_processor(
             self._main_fn, env, root_path, self._app_args, self._app_kwargs
         )
+        report, refresh_interval_secs = _resolve_report_to_stdout(report_to_stdout)
         pyvalue: Any = core_app.update(
             processor,
             full_reprocess=full_reprocess,
             host_ctx=env._context_provider,
-            report_to_stdout=report_to_stdout,
+            report_to_stdout=report,
+            refresh_interval_secs=refresh_interval_secs,
             live=live,
         )
         return pyvalue.get(fn_ret_deserializer(self._main_fn))  # type: ignore[no-any-return]
@@ -335,7 +349,7 @@ class App(Generic[P, R]):
         drop_handle = core_app.drop_async(env._context_provider)
         await drop_handle.result()
 
-    def drop_blocking(self, *, report_to_stdout: bool = False) -> None:
+    def drop_blocking(self, *, report_to_stdout: bool | timedelta = False) -> None:
         """
         Drop the app synchronously, reverting all its target states and clearing its database.
 
@@ -344,7 +358,14 @@ class App(Generic[P, R]):
         - Clear the app's internal state database
 
         Args:
-            report_to_stdout: If True, periodically report processing stats to stdout.
+            report_to_stdout: If truthy, periodically report processing stats to
+                stdout. Pass a ``timedelta`` to set the refresh interval; ``True``
+                uses the default interval.
         """
         env, core_app = self._get_core_env_app_sync()
-        core_app.drop(env._context_provider, report_to_stdout=report_to_stdout)
+        report, refresh_interval_secs = _resolve_report_to_stdout(report_to_stdout)
+        core_app.drop(
+            env._context_provider,
+            report_to_stdout=report,
+            refresh_interval_secs=refresh_interval_secs,
+        )

--- a/python/cocoindex/_internal/component_ctx.py
+++ b/python/cocoindex/_internal/component_ctx.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import (
     AsyncIterator,
     Awaitable,
@@ -21,7 +22,7 @@ from cocoindex._internal.environment import Environment
 
 from . import core
 from .stable_path import StableKey
-from .update_stats import StatsGroupHandle
+from .update_stats import StatsGroupHandle, _resolve_report_to_stdout
 
 _logger = logging.getLogger(__name__)
 
@@ -422,7 +423,7 @@ def get_component_context() -> ComponentContext:
 
 @contextlib.contextmanager
 def stats_group(
-    title: str, *, report_to_stdout: bool = False
+    title: str, *, report_to_stdout: bool | timedelta = False
 ) -> Generator[StatsGroupHandle, None, None]:
     """Aggregate the stats of everything mounted within this scope separately,
     under ``title``, split out of the enclosing report.
@@ -430,9 +431,10 @@ def stats_group(
     The returned handle mirrors ``UpdateHandle``'s ``stats()`` / ``watch()``.
     Entering and exiting the block only bound *member registration* — exit is
     non-blocking; the group becomes ready asynchronously once the body has
-    exited and all members are ready. With ``report_to_stdout=True`` the group
+    exited and all members are ready. With ``report_to_stdout`` truthy the group
     is also rendered as plain, title-prefixed log lines (interleaved above the
-    progress region when a TTY display is active).
+    progress region when a TTY display is active); pass a ``timedelta`` to set
+    the refresh interval.
 
     This is a plain (synchronous) ``with`` block — like ``component_subpath`` —
     even though the body typically ``await``s ``mount``/``use_mount``.
@@ -445,8 +447,9 @@ def stats_group(
             ...
     """
     current_ctx = get_context_from_ctx()
+    report, refresh_interval_secs = _resolve_report_to_stdout(report_to_stdout)
     derived_core_ctx, core_handle = current_ctx._core_processor_ctx.begin_stats_group(
-        title, report_to_stdout
+        title, report, refresh_interval_secs
     )
     new_ctx = current_ctx._with_core_processor_ctx(derived_core_ctx)
     tok = _context_var.set(new_ctx)

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -93,7 +93,10 @@ class ComponentProcessorContext:
     ) -> dict[Fingerprint, list[Any]]: ...
     async def next_id(self, key: StableKey | None = None) -> int: ...
     def begin_stats_group(
-        self, title: str, report_to_stdout: bool
+        self,
+        title: str,
+        report_to_stdout: bool,
+        refresh_interval_secs: float | None = None,
     ) -> tuple[ComponentProcessorContext, StatsGroupHandle]: ...
     def end_stats_group(self) -> None: ...
 
@@ -204,7 +207,9 @@ class StatsGroupHandle:
     def stats_snapshot(self) -> tuple[int, bool, dict[str, dict[str, int]]]: ...
     def changed(self) -> Coroutine[Any, Any, int]: ...
 
-def show_progress(handle: UpdateHandle) -> Coroutine[Any, Any, StoredValue]: ...
+def show_progress(
+    handle: UpdateHandle, refresh_interval_secs: float | None = None
+) -> Coroutine[Any, Any, StoredValue]: ...
 
 # --- App ---
 class App:
@@ -217,6 +222,7 @@ class App:
         full_reprocess: bool = False,
         host_ctx: Any = None,
         report_to_stdout: bool = False,
+        refresh_interval_secs: float | None = None,
         live: bool = False,
     ) -> StoredValue: ...
     def update_async(
@@ -226,7 +232,12 @@ class App:
         live: bool = False,
         host_ctx: Any = None,
     ) -> UpdateHandle: ...
-    def drop(self, host_ctx: Any = None, report_to_stdout: bool = False) -> None: ...
+    def drop(
+        self,
+        host_ctx: Any = None,
+        report_to_stdout: bool = False,
+        refresh_interval_secs: float | None = None,
+    ) -> None: ...
     def drop_async(self, host_ctx: Any = None) -> DropHandle: ...
 
 # --- LiveComponentController ---

--- a/python/cocoindex/_internal/update_stats.py
+++ b/python/cocoindex/_internal/update_stats.py
@@ -2,11 +2,30 @@ from __future__ import annotations
 
 import enum as _enum
 from collections.abc import AsyncIterator, Coroutine
+from datetime import timedelta
 from typing import Any, Generic, NamedTuple, Protocol, TypeVar
 
 R = TypeVar("R")
 
 _TERMINATED_VERSION = 2**64 - 1  # u64::MAX
+
+
+def _resolve_report_to_stdout(
+    report_to_stdout: bool | timedelta,
+) -> tuple[bool, float | None]:
+    """Normalize a ``bool | timedelta`` progress flag into
+    ``(enabled, refresh_interval_secs)`` for the core boundary.
+
+    - ``False`` → ``(False, None)`` (no report)
+    - ``True`` → ``(True, None)`` (report at the default interval)
+    - ``timedelta`` → ``(True, secs)`` (report at that interval; must be positive)
+    """
+    if isinstance(report_to_stdout, timedelta):
+        secs = report_to_stdout.total_seconds()
+        if secs <= 0:
+            raise ValueError("report_to_stdout interval must be a positive duration")
+        return True, secs
+    return bool(report_to_stdout), None
 
 
 class _CoreStatsHandle(Protocol):

--- a/python/tests/core/test_stats_group.py
+++ b/python/tests/core/test_stats_group.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from typing import Any
 
 import pytest
 
 import cocoindex as coco
+from cocoindex._internal.update_stats import _resolve_report_to_stdout
 from tests.common import create_test_env
 from tests.common.target_states import GlobalDictTarget
 
@@ -349,3 +351,44 @@ async def test_stats_group_live_member_termination() -> None:
     assert grp_keys, "live member should report into the group"
     assert not (grp_keys & root_keys)
     assert GlobalDictTarget.store.data["live"].data == 1
+
+
+# --- 12. report_to_stdout: bool | timedelta ---
+
+
+def test_resolve_report_to_stdout() -> None:
+    assert _resolve_report_to_stdout(False) == (False, None)
+    assert _resolve_report_to_stdout(True) == (True, None)
+    assert _resolve_report_to_stdout(timedelta(seconds=5)) == (True, 5.0)
+    assert _resolve_report_to_stdout(timedelta(milliseconds=250)) == (True, 0.25)
+    for bad in (timedelta(0), timedelta(seconds=-1)):
+        with pytest.raises(ValueError, match="positive duration"):
+            _resolve_report_to_stdout(bad)
+
+
+@coco.fn()
+async def _main_report_interval() -> None:
+    with coco.stats_group(
+        "Indexing", report_to_stdout=timedelta(milliseconds=50)
+    ) as sg:
+        _captured["sg"] = sg
+        for k in ("a", "b"):
+            await coco.mount(coco.component_subpath(f"ri_{k}"), _emit_grp, k, ord(k))
+
+
+@pytest.mark.asyncio
+async def test_stats_group_report_to_stdout_interval(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    _reset()
+    app = coco.App(
+        coco.AppConfig(name="test_sg_report_interval", environment=coco_env),
+        _main_report_interval,
+    )
+    handle = app.update()
+    await handle.result()
+    await asyncio.sleep(0.2)
+    out = capfd.readouterr().out
+    # A custom refresh interval still produces the labeled group report.
+    assert "[Stats: Indexing]" in out
+    assert "(terminated)" in out

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -372,6 +372,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         &self,
         title: String,
         report_to_stdout: bool,
+        refresh_interval_secs: Option<f64>,
     ) -> (ComponentProcessorContext<Prof>, ProcessingStats) {
         let group = Arc::new(StatsGroup::new());
         let group_stats = group.stats().clone();
@@ -413,6 +414,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
                 group_stats.clone(),
                 title,
                 live,
+                refresh_interval_secs,
             );
         }
 

--- a/rust/core/src/engine/progress_display.rs
+++ b/rust/core/src/engine/progress_display.rs
@@ -30,6 +30,19 @@ impl Default for ProgressDisplayOptions {
     }
 }
 
+impl ProgressDisplayOptions {
+    /// Build options from an optional refresh interval in seconds — `None`
+    /// (or a non-positive value) falls back to the default interval.
+    pub fn from_refresh_secs(refresh_interval_secs: Option<f64>) -> Self {
+        match refresh_interval_secs {
+            Some(secs) if secs > 0.0 => Self {
+                refresh_interval: Duration::from_secs_f64(secs),
+            },
+            _ => Self::default(),
+        }
+    }
+}
+
 /// Format a single component stats line.
 pub fn format_component_line(
     name: &str,
@@ -590,9 +603,14 @@ fn render_plain_block(
 /// Always plain scrolling output: when a root PTY display is active its reader
 /// captures and interleaves these writes above the progress region; otherwise
 /// they scroll directly. Self-terminates when the group terminates.
-pub(crate) fn spawn_group_plain_report(stats: ProcessingStats, title: String, live: bool) {
+pub(crate) fn spawn_group_plain_report(
+    stats: ProcessingStats,
+    title: String,
+    live: bool,
+    refresh_interval_secs: Option<f64>,
+) {
     get_runtime().spawn(async move {
-        let options = ProgressDisplayOptions::default();
+        let options = ProgressDisplayOptions::from_refresh_secs(refresh_interval_secs);
         render_plain(&stats, Some(&title), live, &options, Instant::now()).await;
     });
 }

--- a/rust/py/src/app.rs
+++ b/rust/py/src/app.rs
@@ -249,7 +249,7 @@ impl PyApp {
         Ok(PyUpdateHandle::new(handle))
     }
 
-    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, report_to_stdout=false, live=false))]
+    #[pyo3(signature = (root_processor, full_reprocess, host_ctx, report_to_stdout=false, refresh_interval_secs=None, live=false))]
     pub fn update(
         &self,
         py: Python<'_>,
@@ -257,6 +257,7 @@ impl PyApp {
         full_reprocess: bool,
         host_ctx: Py<PyAny>,
         report_to_stdout: bool,
+        refresh_interval_secs: Option<f64>,
         live: bool,
     ) -> PyResult<PyStoredValue> {
         let app = self.0.clone();
@@ -272,9 +273,12 @@ impl PyApp {
                     .context("failed to start app update")
                     .into_py_result()?;
                 if report_to_stdout {
-                    rust_show_progress(handle, ProgressDisplayOptions::default())
-                        .await
-                        .into_py_result()
+                    rust_show_progress(
+                        handle,
+                        ProgressDisplayOptions::from_refresh_secs(refresh_interval_secs),
+                    )
+                    .await
+                    .into_py_result()
                 } else {
                     handle.result().await.into_py_result()
                 }
@@ -292,12 +296,13 @@ impl PyApp {
         Ok(PyDropHandle::new(handle))
     }
 
-    #[pyo3(signature = (host_ctx, report_to_stdout=false))]
+    #[pyo3(signature = (host_ctx, report_to_stdout=false, refresh_interval_secs=None))]
     pub fn drop(
         &self,
         py: Python<'_>,
         host_ctx: Py<PyAny>,
         report_to_stdout: bool,
+        refresh_interval_secs: Option<f64>,
     ) -> PyResult<()> {
         let app = self.0.clone();
         let host_ctx = Arc::new(host_ctx);
@@ -308,9 +313,12 @@ impl PyApp {
                     .context("failed to start app drop")
                     .into_py_result()?;
                 if report_to_stdout {
-                    rust_show_progress(handle, ProgressDisplayOptions::default())
-                        .await
-                        .into_py_result()
+                    rust_show_progress(
+                        handle,
+                        ProgressDisplayOptions::from_refresh_secs(refresh_interval_secs),
+                    )
+                    .await
+                    .into_py_result()
                 } else {
                     handle.result().await.into_py_result()
                 }
@@ -322,7 +330,12 @@ impl PyApp {
 /// Awaits the update handle with progress display. Returns the result.
 /// Consumes the handle.
 #[pyfunction]
-pub fn show_progress<'py>(py: Python<'py>, handle: &PyUpdateHandle) -> PyResult<Bound<'py, PyAny>> {
+#[pyo3(signature = (handle, refresh_interval_secs=None))]
+pub fn show_progress<'py>(
+    py: Python<'py>,
+    handle: &PyUpdateHandle,
+    refresh_interval_secs: Option<f64>,
+) -> PyResult<Bound<'py, PyAny>> {
     let op_handle = handle
         .handle
         .lock()
@@ -330,9 +343,12 @@ pub fn show_progress<'py>(py: Python<'py>, handle: &PyUpdateHandle) -> PyResult<
         .take()
         .ok_or_else(|| PyRuntimeError::new_err("handle already consumed"))?;
     future_into_py(py, async move {
-        let ret = rust_show_progress(op_handle, ProgressDisplayOptions::default())
-            .await
-            .into_py_result()?;
+        let ret = rust_show_progress(
+            op_handle,
+            ProgressDisplayOptions::from_refresh_secs(refresh_interval_secs),
+        )
+        .await
+        .into_py_result()?;
         Ok(ret)
     })
 }

--- a/rust/py/src/context.rs
+++ b/rust/py/src/context.rs
@@ -38,12 +38,16 @@ impl PyComponentProcessorContext {
     /// Open a stats group rooted at this context. Returns the derived context
     /// (whose mounts aggregate into the group, split out of the enclosing
     /// scope) and a `StatsGroupHandle` for `stats()`/`watch()`.
+    #[pyo3(signature = (title, report_to_stdout, refresh_interval_secs=None))]
     fn begin_stats_group(
         &self,
         title: String,
         report_to_stdout: bool,
+        refresh_interval_secs: Option<f64>,
     ) -> (PyComponentProcessorContext, PyStatsGroupHandle) {
-        let (derived, stats) = self.0.begin_stats_group(title, report_to_stdout);
+        let (derived, stats) =
+            self.0
+                .begin_stats_group(title, report_to_stdout, refresh_interval_secs);
         (
             PyComponentProcessorContext(derived),
             PyStatsGroupHandle::new(stats),


### PR DESCRIPTION
## Summary
- `report_to_stdout` now accepts `bool | timedelta` on `App.update_blocking()`, `App.drop_blocking()`, and `coco.stats_group()`: `True` = default refresh interval, a `timedelta` = custom interval, `False` = off. The async `coco.show_progress()` gains a `refresh_interval: timedelta | None` keyword.
- A shared `_resolve_report_to_stdout()` normalizes the union into `(enabled, refresh_interval_secs)` at the PyO3 boundary (a non-positive duration raises `ValueError`); the Rust default stays authoritative via a new `ProgressDisplayOptions::from_refresh_secs(Option<f64>)`. Threaded through `update`/`drop`/`show_progress` and `begin_stats_group` → `spawn_group_plain_report`.
- Docs (`app.mdx`, `progress_monitoring.mdx`) and `core.pyi` stubs updated.

## Test plan
- CI (`cargo test`, `mypy`, `pytest`).
- New tests: `test_resolve_report_to_stdout` (normalizer + non-positive validation) and `test_stats_group_report_to_stdout_interval` (the `timedelta` path end-to-end).
