### PR TITLE
feat(resources): support negated exclude patterns

### DIFF
--- a/docs/src/content/docs/common_resources/data_types.mdx
+++ b/docs/src/content/docs/common_resources/data_types.mdx
@@ -127,7 +127,7 @@ matcher = PatternFilePathMatcher(
 **Parameters:**
 
 - `included_patterns` — Glob patterns ([globset](https://docs.rs/globset) syntax) for files to include. Use `**/*.ext` to match at any depth. If `None`, all files are included.
-- `excluded_patterns` — Glob patterns ([globset](https://docs.rs/globset) syntax) for files/directories to exclude. Excluded directories are not traversed.
+- `excluded_patterns` — Glob patterns ([globset](https://docs.rs/globset) syntax) for files/directories to exclude. Excluded directories are not traversed. Prefix a pattern with `!` to re-include matching paths after a broader exclude pattern; rules are evaluated in order, and the last matching exclude rule wins.
 
 :::note
 Patterns use [globset](https://docs.rs/globset) semantics: `*.py` matches only in the root directory; use `**/*.py` to match at any depth.

--- a/docs/src/content/docs/connectors/localfs.mdx
+++ b/docs/src/content/docs/connectors/localfs.mdx
@@ -127,6 +127,16 @@ async for file in localfs.walk_dir("/path/to/project", recursive=True, path_matc
     await process(file)
 ```
 
+`excluded_patterns` also supports a leading `!` to keep exceptions after a broader exclude. Rules are evaluated in order, so the last matching exclude rule wins:
+
+```python
+# Exclude dot-directories, but keep GitHub workflow files
+matcher = PatternFilePathMatcher(
+    included_patterns=["**/*.yml", "**/*.yaml"],
+    excluded_patterns=["**/.*", "!**/.github/**"],
+)
+```
+
 ### Live file watching
 
 When `live=True`, `items()` returns a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) instead of a plain `AsyncIterable`. Combined with [`mount_each()`](../programming_guide/processing_component#mount_each), this enables automatic incremental file watching — new, modified, and deleted files are processed without a full rescan:

--- a/python/cocoindex/resources/file.py
+++ b/python/cocoindex/resources/file.py
@@ -30,7 +30,6 @@ from cocoindex._internal.typing import (
     NonExistenceType as _NonExistenceType,
     is_non_existence as _is_non_existence,
 )
-from cocoindex import StableKey as _StableKey
 from cocoindex.connectorkits.fingerprint import fingerprint_bytes as _fingerprint_bytes
 
 # Type variable for the resolved path type (e.g., pathlib.Path for local filesystem)
@@ -234,6 +233,7 @@ class PatternFilePathMatcher(FilePathMatcher):
     - `**/*.py` — matches Python files at any depth
     - `*.py` — matches Python files only in the root directory
     - `**/.*` — matches dot-prefixed entries (hidden files/dirs) at any depth
+    - `!**/.github/**` — re-includes paths matched by an earlier exclude pattern
     - `{*.md,*.txt}` — matches multiple extensions using alternation
     """
 
@@ -250,7 +250,8 @@ class PatternFilePathMatcher(FilePathMatcher):
                 to be included. Use ``**/*.ext`` to match at any depth.
             excluded_patterns: Glob patterns (globset syntax) matching full path of files
                 and directories to be excluded. If a directory is excluded, all files and
-                subdirectories within it are also excluded.
+                subdirectories within it are also excluded. Prefix a pattern with ``!``
+                to re-include matching paths after a broader exclude pattern.
 
         Raises:
             ValueError: If any pattern is invalid.

--- a/python/tests/resources/test_file_path_matcher.py
+++ b/python/tests/resources/test_file_path_matcher.py
@@ -80,6 +80,25 @@ class TestPatternFilePathMatcherExclude:
         assert not matcher.is_file_included(PurePath("test_main.py"))
         assert not matcher.is_file_included(PurePath("tests/test_main.py"))
 
+    def test_negated_exclude_reincludes_file(self) -> None:
+        matcher = PatternFilePathMatcher(
+            included_patterns=["**/*.tmp"],
+            excluded_patterns=["**/*.tmp", "!keep.tmp"],
+        )
+        assert matcher.is_file_included(PurePath("keep.tmp"))
+        assert not matcher.is_file_included(PurePath("scratch.tmp"))
+
+    def test_negated_exclude_keeps_exception_directory_traversable(self) -> None:
+        matcher = PatternFilePathMatcher(
+            included_patterns=["**/*.yml", "**/*.yaml"],
+            excluded_patterns=["**/.*", "!**/.github/**"],
+        )
+        assert matcher.is_dir_included(PurePath(".github"))
+        assert matcher.is_dir_included(PurePath(".github/workflows"))
+        assert matcher.is_file_included(PurePath(".github/workflows/ci.yml"))
+        assert not matcher.is_dir_included(PurePath(".git"))
+        assert not matcher.is_dir_included(PurePath(".vscode"))
+
 
 class TestPatternFilePathMatcherEdgeCases:
     def test_invalid_pattern_raises(self) -> None:

--- a/rust/ops_text/src/pattern_matcher.rs
+++ b/rust/ops_text/src/pattern_matcher.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
 
 /// Builds a GlobSet from a vector of pattern strings
 fn build_glob_set(patterns: Vec<String>) -> Result<GlobSet> {
@@ -10,6 +10,76 @@ fn build_glob_set(patterns: Vec<String>) -> Result<GlobSet> {
     Ok(builder.build()?)
 }
 
+#[derive(Debug)]
+struct ExcludeRule {
+    matcher: GlobMatcher,
+    excludes: bool,
+    literal_components: Vec<String>,
+}
+
+fn literal_components(pattern: &str) -> Vec<String> {
+    pattern
+        .split('/')
+        .filter(|component| {
+            !component.is_empty()
+                && *component != "**"
+                && !component
+                    .chars()
+                    .any(|ch| matches!(ch, '*' | '?' | '[' | ']' | '{' | '}'))
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn path_components(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|component| !component.is_empty())
+        .collect()
+}
+
+impl ExcludeRule {
+    fn new(pattern: String) -> Result<Self> {
+        let (excludes, glob_pattern) = if let Some(negated) = pattern.strip_prefix('!') {
+            (false, negated)
+        } else {
+            (true, pattern.as_str())
+        };
+        let matcher = Glob::new(glob_pattern)?.compile_matcher();
+        Ok(Self {
+            matcher,
+            excludes,
+            literal_components: literal_components(glob_pattern),
+        })
+    }
+
+    fn could_match_descendant(&self, path: &str) -> bool {
+        if self.excludes {
+            return false;
+        }
+        // Keep an excluded parent traversable when a later negated pattern can
+        // re-include one of its descendants, e.g. **/.* then !**/.github/**.
+        if self.matcher.is_match(path) || self.matcher.is_match(format!("{path}/")) {
+            return true;
+        }
+        if self.literal_components.is_empty() {
+            return true;
+        }
+
+        let components = path_components(path);
+        let max_overlap = components.len().min(self.literal_components.len());
+        (1..=max_overlap).any(|overlap| {
+            components[components.len() - overlap..]
+                .iter()
+                .zip(&self.literal_components[..overlap])
+                .all(|(path_component, pattern_component)| path_component == pattern_component)
+        })
+    }
+}
+
+fn build_exclude_rules(patterns: Vec<String>) -> Result<Vec<ExcludeRule>> {
+    patterns.into_iter().map(ExcludeRule::new).collect()
+}
+
 /// Pattern matcher that handles include and exclude patterns for files
 #[derive(Debug)]
 pub struct PatternMatcher {
@@ -17,7 +87,7 @@ pub struct PatternMatcher {
     included_glob_set: Option<GlobSet>,
     /// Patterns matching full path of files and directories to be excluded.
     /// If a directory is excluded, all files and subdirectories within it are also excluded.
-    excluded_glob_set: Option<GlobSet>,
+    excluded_rules: Option<Vec<ExcludeRule>>,
 }
 
 impl PatternMatcher {
@@ -27,26 +97,37 @@ impl PatternMatcher {
         excluded_patterns: Option<Vec<String>>,
     ) -> Result<Self> {
         let included_glob_set = included_patterns.map(build_glob_set).transpose()?;
-        let excluded_glob_set = excluded_patterns.map(build_glob_set).transpose()?;
+        let excluded_rules = excluded_patterns.map(build_exclude_rules).transpose()?;
 
         Ok(Self {
             included_glob_set,
-            excluded_glob_set,
+            excluded_rules,
         })
     }
 
     /// Check if a file or directory is excluded by the exclude patterns
     /// Can be called on directories to prune traversal on excluded directories.
     pub fn is_excluded(&self, path: &str) -> bool {
-        self.excluded_glob_set
-            .as_ref()
-            .is_some_and(|glob_set| glob_set.is_match(path))
+        self.excluded_rules.as_ref().is_some_and(|rules| {
+            let mut excluded = false;
+            for rule in rules {
+                if rule.matcher.is_match(path) {
+                    excluded = rule.excludes;
+                }
+            }
+            excluded
+        })
     }
 
     /// Check if a directory should be included (traversed) based on the exclude patterns.
     /// Directories are included unless they match an exclude pattern.
     pub fn is_dir_included(&self, path: &str) -> bool {
-        !self.is_excluded(path)
+        if !self.is_excluded(path) {
+            return true;
+        }
+        self.excluded_rules
+            .as_ref()
+            .is_some_and(|rules| rules.iter().any(|rule| rule.could_match_descendant(path)))
     }
 
     /// Check if a file should be included based on both include and exclude patterns
@@ -106,6 +187,18 @@ mod tests {
     }
 
     #[test]
+    fn test_pattern_matcher_exclude_negation_reincludes_file() {
+        let matcher = PatternMatcher::new(
+            Some(vec!["**/*.tmp".to_string()]),
+            Some(vec!["**/*.tmp".to_string(), "!keep.tmp".to_string()]),
+        )
+        .unwrap();
+
+        assert!(matcher.is_file_included("keep.tmp"));
+        assert!(!matcher.is_file_included("scratch.tmp"));
+    }
+
+    #[test]
     fn test_is_dir_included_no_patterns() {
         let matcher = PatternMatcher::new(None, None).unwrap();
         assert!(matcher.is_dir_included("any_dir"));
@@ -119,6 +212,19 @@ mod tests {
         assert!(!matcher.is_dir_included("src/.hidden"));
         assert!(matcher.is_dir_included("src"));
         assert!(matcher.is_dir_included("node_modules"));
+    }
+
+    #[test]
+    fn test_is_dir_included_for_negated_descendant_pattern() {
+        let matcher = PatternMatcher::new(
+            None,
+            Some(vec!["**/.*".to_string(), "!**/.github/**".to_string()]),
+        )
+        .unwrap();
+
+        assert!(matcher.is_dir_included(".github"));
+        assert!(matcher.is_dir_included(".github/workflows"));
+        assert!(!matcher.is_dir_included(".git"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Support leading `!` rules in `PatternFilePathMatcher.excluded_patterns` to re-include paths after broader exclude rules.
- Preserve directory traversal when a negated descendant pattern can re-include files inside an otherwise excluded directory.
- Add Rust and Python tests for file re-inclusion and the `.github/workflows` exception use case.
- Document the ordered, last-match-wins behavior for excluded patterns.

## Motivation and context

Users currently cannot express common filtering rules such as excluding all dot-directories while keeping `.github/workflows` for CI/CD analysis. This change makes `excluded_patterns` behave more like `.gitignore` by allowing later negated rules to override earlier broader excludes.

## Breaking changes

None.

## Related issues

Closes #1778.

## Test Plan

- `cargo fmt --check`
- `cargo test -p cocoindex_ops_text pattern_matcher`
- `cargo test -p cocoindex_ops_text`
- `/usr/bin/env -u CONDA_PREFIX uv run pytest python/tests/resources/test_file_path_matcher.py -q`
- `/usr/bin/env -u CONDA_PREFIX uv run pytest python/tests/resources -q`
- `/usr/bin/env -u CONDA_PREFIX uv run ruff check python/cocoindex/resources/file.py python/tests/resources/test_file_path_matcher.py`
- `npm run build` from `docs`
