### PR TITLE
test(splitter): add tree-sitter splitting tests for python, rust, go, java, typescript, json

### DIFF
--- a/python/tests/ops/test_text.py
+++ b/python/tests/ops/test_text.py
@@ -356,3 +356,150 @@ def test_recursive_splitter_with_hcl() -> None:
 
     assert len(chunks) >= 1
     assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_python() -> None:
+    """Test RecursiveSplitter with Python syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "import os\n\n\n"
+        "def read_file(path: str) -> str:\n"
+        "    with open(path) as f:\n"
+        "        return f.read()\n\n\n"
+        "class FileProcessor:\n"
+        "    def __init__(self, root: str) -> None:\n"
+        "        self.root = root\n\n"
+        "    def process(self) -> list[str]:\n"
+        "        return [read_file(p) for p in os.listdir(self.root)]\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="python")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_rust() -> None:
+    """Test RecursiveSplitter with Rust syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "use std::collections::HashMap;\n\n"
+        "pub struct Counter {\n"
+        "    counts: HashMap<String, usize>,\n"
+        "}\n\n"
+        "impl Counter {\n"
+        "    pub fn new() -> Self {\n"
+        "        Self { counts: HashMap::new() }\n"
+        "    }\n\n"
+        "    pub fn add(&mut self, key: &str) {\n"
+        "        *self.counts.entry(key.to_string()).or_insert(0) += 1;\n"
+        "    }\n"
+        "}\n\n"
+        "fn main() {\n"
+        "    let mut c = Counter::new();\n"
+        '    c.add("hello");\n'
+        "}\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="rust")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_go() -> None:
+    """Test RecursiveSplitter with Go syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "package main\n\n"
+        'import "fmt"\n\n'
+        "type Greeter struct {\n"
+        "    Name string\n"
+        "}\n\n"
+        "func (g Greeter) Greet() string {\n"
+        '    return fmt.Sprintf("Hello, %s!", g.Name)\n'
+        "}\n\n"
+        "func main() {\n"
+        '    g := Greeter{Name: "World"}\n'
+        "    fmt.Println(g.Greet())\n"
+        "}\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="go")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_java() -> None:
+    """Test RecursiveSplitter with Java syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "import java.util.List;\n\n"
+        "public class DataProcessor {\n"
+        "    private final List<String> items;\n\n"
+        "    public DataProcessor(List<String> items) {\n"
+        "        this.items = items;\n"
+        "    }\n\n"
+        "    public int count() {\n"
+        "        return items.size();\n"
+        "    }\n\n"
+        "    public static void main(String[] args) {\n"
+        '        DataProcessor p = new DataProcessor(List.of("a", "b"));\n'
+        "        System.out.println(p.count());\n"
+        "    }\n"
+        "}\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="java")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_typescript() -> None:
+    """Test RecursiveSplitter with TypeScript syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "interface User {\n"
+        "  id: number;\n"
+        "  name: string;\n"
+        "}\n\n"
+        "function greet(user: User): string {\n"
+        "  return `Hello, ${user.name}!`;\n"
+        "}\n\n"
+        "class UserService {\n"
+        "  private users: User[] = [];\n\n"
+        "  add(user: User): void {\n"
+        "    this.users.push(user);\n"
+        "  }\n\n"
+        "  getAll(): User[] {\n"
+        "    return this.users;\n"
+        "  }\n"
+        "}\n"
+    )
+    chunks = splitter.split(
+        code, chunk_size=80, min_chunk_size=20, language="typescript"
+    )
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_json() -> None:
+    """Test RecursiveSplitter with JSON syntax-aware splitting."""
+    splitter = RecursiveSplitter()
+    code = (
+        "{\n"
+        '  "name": "cocoindex",\n'
+        '  "version": "1.0.0",\n'
+        '  "dependencies": {\n'
+        '    "numpy": ">=1.24",\n'
+        '    "pydantic": ">=2.0"\n'
+        "  },\n"
+        '  "scripts": {\n'
+        '    "test": "pytest",\n'
+        '    "build": "maturin develop"\n'
+        "  }\n"
+        "}\n"
+    )
+    chunks = splitter.split(code, chunk_size=80, min_chunk_size=20, language="json")
+
+    assert len(chunks) >= 1
+    assert all(isinstance(c, Chunk) for c in chunks)


### PR DESCRIPTION
## Summary
- Extends `test_text.py` with six dedicated `RecursiveSplitter` tests for tree-sitter-backed languages that were not previously covered: `python`, `rust`, `go`, `java`, `typescript`, and `json`
- Each test uses a realistic multi-block code snippet and follows the same pattern established by the existing `bash`, `cmake`, and `hcl` tests
- All 30 tests pass (`pytest python/tests/ops/test_text.py`)

## Test plan
- `uv run maturin develop`
- `uv run pytest python/tests/ops/test_text.py`
- `uv run ruff format --check python/tests/ops/test_text.py`
- `uv run ruff check python/tests/ops/test_text.py`