### PR TITLE
fix(py_utils): use Display instead of Debug for runtime errors crossing into Python

### DIFF
--- a/rust/py_utils/src/error.rs
+++ b/rust/py_utils/src/error.rs
@@ -120,7 +120,7 @@ fn cerror_to_pyerr(err: CError) -> PyErr {
     if let CError::Client { .. } = inner {
         return PyValueError::new_err(format!("{}", err));
     }
-    PyRuntimeError::new_err(format!("{:?}", err))
+    PyRuntimeError::new_err(format!("{}", err))
 }
 
 pub trait FromPyResult<T> {


### PR DESCRIPTION
## Summary
- In `cerror_to_pyerr` (`rust/py_utils/src/error.rs`), the final fallback for non-HostLang, non-Client errors was using `format!("{:?}", err)` (Debug) to construct the `PyRuntimeError` message
- `Debug` for `Error::Internal` delegates to `anyhow::Error`'s debug output, which can include noisy backtrace representation and omits the human-readable context chain in some cases
- `Display` for `Error` already walks and formats the full context chain (via `format_context`) and then prints the inner error with its own `Display`
- This change makes the Python-facing error message consistent with the `Client` variant (which already used `format!("{}", err)`) and surfaces the context chain that Rust callers attach via `.context("...")`

Before (example from issue #1060):
```
Exception: version 1213486160 is not supported
```

After, when the error is wrapped with context:
```
RuntimeError:
Context:
  1: while loading flow state
  2: while reading stored version
version 1213486160 is not supported
```

## Test plan
- `cargo test` (all 184 existing tests pass, no new failures)
- `uv run maturin develop && uv run pytest python/`

Closes #1060