### PR TITLE
refactor(state_store): make commit existence-reconciler re-runnable

### DIFF
--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -389,7 +389,13 @@ impl<Prof: EngineProfile> Committer<Prof> {
         let app_store = self.app_store.clone();
         let component_path = self.component_path.clone();
         let cps = child_path_set;
+        // `Fn` (not `FnOnce`) so a backend that re-runs its commit txn can
+        // re-invoke it — clone the (cheap, `Arc`/owned) captures per call
+        // rather than moving them into the future.
         let reconciler: ExistenceReconciler = Box::new(move |wtxn| {
+            let app_store = app_store.clone();
+            let component_path = component_path.clone();
+            let cps = cps.clone();
             Box::pin(async move {
                 reconcile_child_existence(wtxn, &app_store, &component_path, cps.as_deref()).await
             })

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -351,8 +351,13 @@ pub struct CommitPlan {
 /// `&'a mut WriteTxn<'env>` borrow is bounded by the callback's await
 /// suspension scope. The body's future is `'a`-tied so it can't outlive
 /// the borrow.
+///
+/// `Fn` (not `FnOnce`) so a backend that re-runs its commit txn can
+/// invoke the reconciler more than once; it therefore clones or
+/// `Arc`-shares its captures rather than moving them in. The LMDB
+/// AppStore invokes it exactly once.
 pub type ExistenceReconciler =
-    Box<dyn for<'a, 'env> FnOnce(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<()>> + Send>;
+    Box<dyn for<'a, 'env> Fn(&'a mut WriteTxn<'env>) -> BoxFuture<'a, Result<()>> + Send + Sync>;
 
 // ---------------------------------------------------------------------------
 // AppStore methods — Phase 2 driver + Phase 4 commit / cleanup


### PR DESCRIPTION
## Summary
- Relax `ExistenceReconciler` (the child-existence-diff callback the AppStore runs inside its commit txn) from `FnOnce` to `Fn`, so a backend that re-runs its commit transaction (e.g. to replay it after a transient conflict aborts the txn) can invoke the reconciler more than once.
- The engine now clones the closure's (cheap, `Arc`/owned) captures per call instead of moving them in.

Behaviorally a no-op for the LMDB AppStore, which invokes the reconciler exactly once — this only widens the bound so re-running becomes possible.

## Test plan
- CI. `cargo build -p cocoindex_core` + `cargo test -p cocoindex_core` pass locally.
