### PR TITLE
feat(ratelimit): add a token-bucket RateLimiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ dependencies = [
  "blake2",
  "encoding_rs",
  "futures",
+ "governor",
  "hashlink 0.11.0",
  "hex",
  "indexmap 2.14.0",
@@ -1319,6 +1320,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1374,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2076,6 +2100,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3253,6 +3283,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ encoding_rs = "0.8.35"
 env_logger = "0.11.8"
 futures = "0.3.31"
 globset = "0.4.18"
+governor = { version = "0.10.1", default-features = false, features = [
+    "std",
+    "jitter",
+] }
 hashlink = "0.11"
 hex = "0.4.3"
 indexmap = { version = "2.12.1", features = ["serde"] }

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -530,3 +530,22 @@ class Batcher(Generic[T, R_co]):
         async_ctx: AsyncContext,
     ) -> "Batcher[T, R_co]": ...
     def run(self, input: T) -> Coroutine[Any, Any, R_co]: ...
+
+########################################################
+# Rate limiting
+########################################################
+
+# --- RateLimiter ---
+class RateLimiter:
+    """Token-bucket rate limiter (governor-based).
+
+    ``acquire(n)`` waits until ``n`` tokens are available; concurrent
+    callers are served in FIFO order. ``burst_window_secs`` sets how many
+    seconds' worth of tokens (``max_rows_per_second * burst_window_secs``)
+    may accumulate while idle.
+    """
+
+    def __new__(
+        cls, max_rows_per_second: float, burst_window_secs: float = 1.0
+    ) -> "RateLimiter": ...
+    def acquire(self, n: int = 1) -> Coroutine[Any, Any, None]: ...

--- a/python/cocoindex/resources/rate_limit.py
+++ b/python/cocoindex/resources/rate_limit.py
@@ -1,0 +1,13 @@
+"""Rate limiting.
+
+A token-bucket :class:`RateLimiter` for throttling outbound work — e.g.
+API calls in a source/target connector. The implementation is the
+``governor``-backed limiter in the Rust core; this module is the public
+Python surface.
+"""
+
+from cocoindex._internal import core as _core
+
+RateLimiter = _core.RateLimiter
+
+__all__ = ["RateLimiter"]

--- a/rust/py/src/lib.rs
+++ b/rust/py/src/lib.rs
@@ -12,6 +12,7 @@ mod memo_fingerprint;
 mod ops;
 mod prelude;
 mod profile;
+mod ratelimit;
 mod runtime;
 mod rwlock;
 mod stable_path;
@@ -124,6 +125,9 @@ fn core_module(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()>
     m.add_class::<batching::PyBatchingOptions>()?;
     m.add_class::<batching::PyBatchQueue>()?;
     m.add_class::<batching::PyBatcher>()?;
+
+    // Rate limiting
+    m.add_class::<ratelimit::PyRateLimiter>()?;
 
     Ok(())
 }

--- a/rust/py/src/ratelimit.rs
+++ b/rust/py/src/ratelimit.rs
@@ -1,0 +1,49 @@
+//! Token-bucket rate limiter exposed to Python.
+//!
+//! Thin wrapper over the `governor`-based limiter in `cocoindex_utils`.
+//! Lets a pipeline throttle outbound work (e.g. API calls in a source /
+//! target connector) to stay within an external service's rate limit.
+
+use crate::prelude::*;
+use pyo3::exceptions::{PyException, PyValueError};
+use std::time::Duration;
+use utils::ratelimit::{RateLimit, RateLimiter};
+
+/// A token-bucket rate limiter.
+///
+/// `acquire(n)` asynchronously waits until `n` tokens are available.
+/// Concurrent callers are served in FIFO order.
+#[pyclass(name = "RateLimiter")]
+pub struct PyRateLimiter {
+    inner: Arc<RateLimiter>,
+}
+
+#[pymethods]
+impl PyRateLimiter {
+    #[new]
+    #[pyo3(signature = (max_rows_per_second, burst_window_secs=1.0))]
+    fn new(max_rows_per_second: f64, burst_window_secs: f64) -> PyResult<Self> {
+        let rate_limit = RateLimit {
+            max_rows_per_second,
+            burst_window: Duration::from_secs_f64(burst_window_secs.max(0.0)),
+        };
+        let limiter =
+            RateLimiter::new(&rate_limit).map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        Ok(Self {
+            inner: Arc::new(limiter),
+        })
+    }
+
+    /// Wait until `n` tokens are available (default 1). Returns an awaitable.
+    #[pyo3(signature = (n=1))]
+    fn acquire<'py>(&self, py: Python<'py>, n: u32) -> PyResult<Bound<'py, PyAny>> {
+        let limiter = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            limiter
+                .until_ready_n(n)
+                .await
+                .map_err(|e| PyException::new_err(format!("{e}")))?;
+            Ok(())
+        })
+    }
+}

--- a/rust/utils/Cargo.toml
+++ b/rust/utils/Cargo.toml
@@ -16,6 +16,7 @@ base64 = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 futures = { workspace = true }
+governor = { workspace = true }
 blake2 = { workspace = true }
 itertools = { workspace = true }
 indexmap = { workspace = true }

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod deser;
 pub mod error;
 pub mod fingerprint;
 pub mod immutable;
+pub mod ratelimit;
 pub mod retryable;
 pub mod slow_warn;
 

--- a/rust/utils/src/ratelimit.rs
+++ b/rust/utils/src/ratelimit.rs
@@ -1,0 +1,93 @@
+use governor::{Jitter, Quota};
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
+use tokio::sync::Semaphore;
+
+use crate::api_bail;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RateLimit {
+    pub max_rows_per_second: f64,
+    pub burst_window: std::time::Duration,
+}
+
+pub struct RateLimiter {
+    limiter: governor::RateLimiter<
+        governor::state::NotKeyed,
+        governor::state::InMemoryState,
+        governor::clock::DefaultClock,
+    >,
+    jitter: Option<governor::Jitter>,
+    semaphore: Semaphore,
+}
+
+impl RateLimiter {
+    pub fn new(rate_limit: &RateLimit) -> anyhow::Result<Self> {
+        if rate_limit.max_rows_per_second <= 0.0 {
+            api_bail!("`max_rows_per_second` must be positive");
+        }
+
+        // Prefer building a quota based on an exact period derived from the desired per-second rate.
+        // This supports fractional rates as well (e.g., 2.5 ops/s => period of 0.4s).
+        let period_secs = 1.0 / rate_limit.max_rows_per_second;
+        let period = std::time::Duration::from_secs_f64(period_secs);
+
+        let (quota, jitter) = if let Some(q) = Quota::with_period(period) {
+            (q, None)
+        } else {
+            // Fallback for extremely high rates where period cannot be represented.
+            let tokens_per_second = rate_limit
+                .max_rows_per_second
+                .floor()
+                .max(1.0)
+                .min(u32::MAX as f64) as u32;
+            (
+                Quota::per_second(NonZeroU32::new(tokens_per_second).unwrap()),
+                Some(Jitter::up_to(std::time::Duration::from_secs(1))),
+            )
+        };
+
+        // Configure burst capacity based on the burst window.
+        let quota = if rate_limit.burst_window.as_nanos() > 0 {
+            let burst_tokens = (rate_limit.max_rows_per_second
+                * rate_limit.burst_window.as_secs_f64())
+            .floor()
+            .max(1.0)
+            .min(u32::MAX as f64) as u32;
+            if let Some(nz) = NonZeroU32::new(burst_tokens) {
+                quota.allow_burst(nz)
+            } else {
+                quota
+            }
+        } else {
+            quota
+        };
+
+        Ok(Self {
+            limiter: governor::RateLimiter::direct(quota),
+            jitter,
+            semaphore: Semaphore::new(1),
+        })
+    }
+}
+
+impl RateLimiter {
+    /// Acquire `n` tokens, waiting as needed.
+    ///
+    /// Tokens are drawn one at a time, so this never fails on the quota's
+    /// burst capacity the way `governor`'s `until_n_ready` does — a caller
+    /// may request more tokens than the bucket can hold at once. The
+    /// internal semaphore is held for the whole acquisition, so concurrent
+    /// callers are served in FIFO order rather than racing token-by-token.
+    pub async fn until_ready_n(&self, n: u32) -> Result<(), crate::error::Error> {
+        let _permit = self.semaphore.acquire().await?;
+        for _ in 0..n {
+            if let Some(jitter) = self.jitter {
+                self.limiter.until_ready_with_jitter(jitter).await;
+            } else {
+                self.limiter.until_ready().await;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
Add a `governor`-backed token-bucket rate limiter for throttling outbound work (e.g. API calls in a source/target connector) so a pipeline stays within an external service's rate limit.

- `cocoindex_utils::ratelimit::{RateLimit, RateLimiter}` — the core limiter. `until_ready_n(n)` draws `n` tokens one at a time (so it never trips the quota's burst ceiling) and serializes concurrent callers FIFO via an internal semaphore.
- `core.RateLimiter` PyO3 binding with an async `acquire(n=1)`.
- `cocoindex.resources.rate_limit.RateLimiter` — the public Python surface.
- `governor` becomes a workspace dependency.

## Test plan
- CI. `cargo build -p cocoindex_utils` / `-p cocoindex_py` pass locally.
