### PR TITLE
refactor(rust-sdk): drop untracked Ctx::write_file

### DIFF
--- a/rust/sdk/cocoindex/src/ctx.rs
+++ b/rust/sdk/cocoindex/src/ctx.rs
@@ -1,11 +1,10 @@
-//! Pipeline context: scope, memo, write_file.
+//! Pipeline context: scope, memo.
 
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::future::Future;
 use std::marker::PhantomData;
-use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -952,30 +951,6 @@ impl Ctx {
     {
         let futs: Vec<_> = items.into_iter().map(f).collect();
         futures::future::try_join_all(futs).await
-    }
-
-    /// Declare a file output. Writes content to the given path.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use cocoindex::ctx::Ctx;
-    /// # async fn doc(ctx: &Ctx) -> cocoindex::error::Result<()> {
-    /// ctx.write_file("output.txt", b"hello world")?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Error::Io`] if the parent directory cannot be created or
-    /// if the file cannot be written to disk.
-    pub fn write_file(&self, path: impl AsRef<Path>, content: &[u8]) -> Result<()> {
-        let path = path.as_ref();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(Error::Io)?;
-        }
-        std::fs::write(path, content).map_err(Error::Io)
     }
 }
 

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -1380,48 +1380,6 @@ async fn ctx_scope_runs_child() {
 }
 
 // ---------------------------------------------------------------------------
-// ctx.write_file() method
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn ctx_write_file_creates_file() {
-    let (app, dir) = temp_app("ctx_write").await;
-    let output_dir = dir.path().join("output");
-
-    let out = output_dir.clone();
-    app.update(|ctx| async move {
-        ctx.write_file(out.join("hello.txt"), b"world")?;
-        Ok(())
-    })
-    .await
-    .unwrap();
-
-    let content = std::fs::read_to_string(output_dir.join("hello.txt")).unwrap();
-    assert_eq!(content, "world");
-}
-
-#[tokio::test]
-async fn ctx_write_file_creates_nested_dirs_and_overwrites() {
-    let (app, dir) = temp_app("ctx_write_nested").await;
-    let output_dir = dir.path().join("output");
-    let nested = output_dir.join("sub/hello.txt");
-
-    std::fs::create_dir_all(nested.parent().unwrap()).unwrap();
-    std::fs::write(&nested, "old").unwrap();
-
-    let out = nested.clone();
-    app.update(|ctx| async move {
-        ctx.write_file(&out, b"new")?;
-        Ok(())
-    })
-    .await
-    .unwrap();
-
-    let content = std::fs::read_to_string(&nested).unwrap();
-    assert_eq!(content, "new");
-}
-
-// ---------------------------------------------------------------------------
 // #[cocoindex::function] macro — bare (L0, no memo)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove the untracked `Ctx::write_file` method from the Rust SDK. Writing a file is a localfs target action (`DirTarget::declare_file`), reconciled and GC'd by the engine — it does not belong on the generic `Ctx`.
- Drop its now-unused `std::path::Path` import and the two dedicated `tests/pipeline.rs` tests (tracked file writing is covered by the localfs `DirTarget` path).
- No example used `write_file`.

Part of the ongoing Rust SDK convergence with the reconciled design.

## Test plan
- `cargo test -p cocoindex --test pipeline` — 89 tests pass.
- CI: cargo fmt / cargo test / cargo check (examples) / SDK-no-pyo3.
