### PR TITLE
feat(rust-sdk): register #[function] logic fingerprints (transitive change detection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "globset",
  "iggy",
  "lancedb",
+ "linkme",
  "neo4rs",
  "notify",
  "qdrant-client",
@@ -6925,6 +6926,26 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/benchmarks/file_summarization/rust/Cargo.lock
+++ b/benchmarks/file_summarization/rust/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1183,6 +1184,26 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/amazon_s3_embedding/Cargo.lock
+++ b/examples/rust/amazon_s3_embedding/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2842,6 +2843,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/audio_to_text/Cargo.lock
+++ b/examples/rust/audio_to_text/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "reqwest",
  "rmp-serde",
  "rustc-hash",
@@ -1468,6 +1469,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding/Cargo.lock
+++ b/examples/rust/code_embedding/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2074,6 +2075,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding_lancedb/Cargo.lock
+++ b/examples/rust/code_embedding_lancedb/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "futures",
  "globset",
  "lancedb",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -4135,6 +4136,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/examples/rust/conversation_to_knowledge/Cargo.lock
+++ b/examples/rust/conversation_to_knowledge/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -3000,6 +3001,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/examples/rust/csv_to_iggy/Cargo.lock
+++ b/examples/rust/csv_to_iggy/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "futures",
  "globset",
  "iggy",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2538,6 +2539,26 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/rust/csv_to_kafka/Cargo.lock
+++ b/examples/rust/csv_to_kafka/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rskafka",
  "rustc-hash",
@@ -1257,6 +1258,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/files_to_sqlite/Cargo.lock
+++ b/examples/rust/files_to_sqlite/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1382,6 +1383,26 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/files_transform/Cargo.lock
+++ b/examples/rust/files_transform/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1191,6 +1192,26 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/gdrive_text_embedding/Cargo.lock
+++ b/examples/rust/gdrive_text_embedding/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "reqwest",
  "rmp-serde",
  "rsa",
@@ -2078,6 +2079,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/hn_trending_topics/Cargo.lock
+++ b/examples/rust/hn_trending_topics/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1470,6 +1471,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/image_search/Cargo.lock
+++ b/examples/rust/image_search/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "qdrant-client",
  "rmp-serde",
  "rustc-hash",
@@ -1944,6 +1945,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/image_search_colpali/Cargo.lock
+++ b/examples/rust/image_search_colpali/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "qdrant-client",
  "rmp-serde",
  "rustc-hash",
@@ -1460,6 +1461,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/rust/kafka_consume/Cargo.lock
+++ b/examples/rust/kafka_consume/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rskafka",
  "rustc-hash",
@@ -1232,6 +1233,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "redis",
  "rmp-serde",
  "rustc-hash",
@@ -1204,6 +1205,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "neo4rs",
  "rmp-serde",
  "rustc-hash",
@@ -1284,6 +1285,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/multi_codebase_summarization/Cargo.lock
+++ b/examples/rust/multi_codebase_summarization/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1268,6 +1269,26 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/rust/oci_object_storage_embedding/Cargo.lock
+++ b/examples/rust/oci_object_storage_embedding/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "reqwest",
  "rmp-serde",
  "rsa",
@@ -2067,6 +2068,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/paper_metadata/Cargo.lock
+++ b/examples/rust/paper_metadata/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2165,6 +2166,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/pdf_embedding/Cargo.lock
+++ b/examples/rust/pdf_embedding/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2165,6 +2166,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/pdf_to_markdown/Cargo.lock
+++ b/examples/rust/pdf_to_markdown/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -1337,6 +1338,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "litemap"

--- a/examples/rust/postgres_source/Cargo.lock
+++ b/examples/rust/postgres_source/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2016,6 +2017,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding/Cargo.lock
+++ b/examples/rust/text_embedding/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2063,6 +2064,26 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_lancedb/Cargo.lock
+++ b/examples/rust/text_embedding_lancedb/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "futures",
  "globset",
  "lancedb",
+ "linkme",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -4125,6 +4126,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_qdrant/Cargo.lock
+++ b/examples/rust/text_embedding_qdrant/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "qdrant-client",
  "rmp-serde",
  "rustc-hash",
@@ -1980,6 +1981,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_turbopuffer/Cargo.lock
+++ b/examples/rust/text_embedding_turbopuffer/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "fastembed",
  "futures",
  "globset",
+ "linkme",
  "reqwest",
  "rmp-serde",
  "rustc-hash",
@@ -1898,6 +1899,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/sdk/cocoindex/Cargo.toml
+++ b/rust/sdk/cocoindex/Cargo.toml
@@ -73,6 +73,9 @@ async-trait = "0.1"
 # Filesystem watcher for live LocalFS sources (feature `fs_live`).
 notify = { version = "8", optional = true }
 rustc-hash = "2.1.1"
+# Link-time registry of `#[coco::function]` logic fingerprints, registered into
+# the engine's logic set at startup so transitive logic-change detection works.
+linkme = "0.3"
 uuid = { workspace = true }
 serde_json = { version = "1", optional = true }
 sqlx = { version = "0.8", default-features = false, optional = true, features = [

--- a/rust/sdk/cocoindex/src/app.rs
+++ b/rust/sdk/cocoindex/src/app.rs
@@ -95,6 +95,11 @@ impl AppBuilder {
     /// Returns an error if the LMDB database environment fails to initialize
     /// (e.g., due to permissions, disk space, or a corrupted state directory).
     pub async fn build(self) -> Result<App> {
+        // Register every `#[coco::function]`'s logic fingerprint into the engine's
+        // logic set, so memo entries that depend on them validate correctly
+        // (see `crate::logic`). Idempotent across builds.
+        crate::logic::register_all_fn_logic();
+
         let db_path = self
             .db_path
             .unwrap_or_else(|| PathBuf::from(format!("./coco_state/{}/", self.name)));

--- a/rust/sdk/cocoindex/src/lib.rs
+++ b/rust/sdk/cocoindex/src/lib.rs
@@ -22,6 +22,8 @@ pub mod kafka;
 #[cfg(feature = "lancedb")]
 pub mod lancedb;
 pub mod live_component;
+#[doc(hidden)]
+pub mod logic;
 pub mod memo;
 #[cfg(feature = "neo4j")]
 pub mod neo4j;
@@ -73,10 +75,16 @@ pub use id::{
     IdGenerator, UuidGenerator, generate_id, generate_id_default, generate_uuid,
     generate_uuid_default,
 };
+// Re-exported so `#[cocoindex::function]` output can register each function's
+// logic fingerprint without the user crate needing a direct `linkme` dependency.
+#[doc(hidden)]
+pub use linkme;
 pub use live_component::{
     ExceptionContext, ExceptionHandler, LiveComponent, LiveComponentOperator, LiveMapFeed,
     LiveMapSubscriber, LiveMapView, MountKind,
 };
+#[doc(hidden)]
+pub use logic::{COCO_FN_LOGIC, FnLogicEntry};
 pub use resources::chunk::{Chunk, TextPosition};
 pub use resources::embedder::Embedder;
 pub use resources::schema::{

--- a/rust/sdk/cocoindex/src/logic.rs
+++ b/rust/sdk/cocoindex/src/logic.rs
@@ -1,0 +1,49 @@
+//! Link-time registry of `#[coco::function]` logic fingerprints.
+//!
+//! Each `#[cocoindex::function]` adds one [`FnLogicEntry`] to the [`COCO_FN_LOGIC`]
+//! distributed slice (collected across crates at link time). At app/environment
+//! startup, [`register_all_fn_logic`] computes each function's logic fingerprint
+//! and registers it into the engine's logic set.
+//!
+//! Why this matters: a memoized caller's entry stores the logic fingerprints of
+//! every `#[coco::function]` it transitively called (its `logic_deps`). On lookup
+//! the engine validates them via `all_contained_with_env`. Without registration,
+//! those fingerprints are never "contained", so any memo that calls a tracked
+//! function would be perpetually invalid (it would re-run every time). Registering
+//! the *current* fingerprints makes unchanged calls cache, while an edited
+//! function (whose fingerprint changes on recompile) leaves the old, now-absent
+//! fingerprint in a stale entry — correctly invalidating it.
+
+use cocoindex_core::engine::logic_registry;
+use cocoindex_utils::fingerprint::Fingerprint;
+
+/// One `#[coco::function]`'s logic identity, collected at link time.
+///
+/// The fingerprint computed from these fields must match the one
+/// `#[cocoindex::function]` records at call time (see `Ctx::__coco_tracked_fn`):
+/// `Fingerprint::from(&("cocoindex_fn", module, name, code_hash))`.
+pub struct FnLogicEntry {
+    pub module: &'static str,
+    pub name: &'static str,
+    pub code_hash: u64,
+}
+
+#[linkme::distributed_slice]
+pub static COCO_FN_LOGIC: [FnLogicEntry] = [..];
+
+/// The logic fingerprint for one registered function — kept in sync with
+/// `Ctx::__coco_tracked_fn`.
+fn entry_fingerprint(e: &FnLogicEntry) -> Option<Fingerprint> {
+    Fingerprint::from(&("cocoindex_fn", e.module, e.name, e.code_hash)).ok()
+}
+
+/// Register every `#[coco::function]`'s logic fingerprint into the engine's
+/// logic set. Idempotent (the set is a `HashSet`), so it is safe to call on
+/// every app/environment build.
+pub(crate) fn register_all_fn_logic() {
+    for entry in COCO_FN_LOGIC {
+        if let Some(fp) = entry_fingerprint(entry) {
+            logic_registry::register(fp);
+        }
+    }
+}

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -1486,8 +1486,15 @@ async fn bare_function_context_key_invalidates_manual_memo_callers() {
 }
 
 #[tokio::test]
-async fn bare_function_logic_invalidates_manual_memo_callers() {
-    let (app, _dir) = temp_app("bare_logic_invalidates_manual_memo").await;
+async fn manual_memo_closure_body_is_not_logic_tracked() {
+    // The closure passed to `ctx.memo` is NOT logic-tracked — only the memo key
+    // and the `#[coco::function]`s it *calls* are. Calling a different helper the
+    // second time (same key "stable") therefore re-uses the cached result: the
+    // first run recorded `bare_logic_v1`'s fingerprint as a dep, that fingerprint
+    // is still registered (its code is unchanged), so the entry stays valid and
+    // the body (which now calls `bare_logic_v2`) does not run. To invalidate on
+    // such a change, include `__COCO_FN_HASH_*` in the memo key.
+    let (app, _dir) = temp_app("manual_memo_untracked_closure").await;
 
     app.update(|ctx| async move {
         let result: i32 = ctx
@@ -1504,13 +1511,53 @@ async fn bare_function_logic_invalidates_manual_memo_callers() {
             .memo(&"stable", |ctx| async move { bare_logic_v2(&ctx).await })
             .await?;
         assert_eq!(
-            result, 2,
-            "bare #[function] helper logic did not invalidate its memoized caller"
+            result, 1,
+            "manual ctx.memo should cache: the closure body is not logic-tracked, \
+             and bare_logic_v1's unchanged logic keeps the entry valid"
         );
         Ok(())
     })
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn memo_with_function_dep_caches_when_unchanged() {
+    // A memoized caller whose body calls a bare `#[function]` should CACHE on an
+    // unchanged rerun — the called function's logic fingerprint, accumulated into
+    // the memo entry's logic_deps, must validate against the registered logic set.
+    // (Regression: without startup fingerprint registration, the stored dep is
+    // never "contained", so the memo is perpetually invalid and re-runs.)
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let (app, _dir) = temp_app("memo_fn_dep_caches").await;
+    let call_count = Arc::new(AtomicUsize::new(0));
+
+    for _ in 0..2 {
+        let count = call_count.clone();
+        app.update(move |ctx| async move {
+            let result: i32 = ctx
+                .memo(&"stable", move |ctx| {
+                    let count = count.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bare_logic_v1(&ctx).await
+                    }
+                })
+                .await?;
+            assert_eq!(result, 1);
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        call_count.load(Ordering::SeqCst),
+        1,
+        "memo body calling a #[function] should cache on unchanged rerun (ran twice)"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/sdk/cocoindex_macros/src/lib.rs
+++ b/rust/sdk/cocoindex_macros/src/lib.rs
@@ -395,6 +395,26 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
     let fn_name = &func.sig.ident;
     let hash_const_name = format_ident!("__COCO_FN_HASH_{}", fn_name.to_string().to_uppercase());
 
+    // Register this function's logic fingerprint into a link-time slice. At
+    // app/environment startup the SDK drains the slice into the engine's logic
+    // set, so a memoized caller's stored `logic_deps` (which include the
+    // fingerprints of transitively-called `#[coco::function]`s) validate via
+    // `all_contained` instead of being perpetually treated as stale. The
+    // (module, name, code_hash) tuple must match `Ctx::__coco_tracked_fn`'s
+    // fingerprint computation. `linkme` is reached through the re-export so the
+    // user crate needs no direct dependency.
+    let logic_slice_name = format_ident!("__COCO_FN_LOGIC_{}", fn_name.to_string().to_uppercase());
+    let logic_registration = quote! {
+        #[::cocoindex::linkme::distributed_slice(::cocoindex::COCO_FN_LOGIC)]
+        #[linkme(crate = ::cocoindex::linkme)]
+        #[doc(hidden)]
+        static #logic_slice_name: ::cocoindex::FnLogicEntry = ::cocoindex::FnLogicEntry {
+            module: ::core::module_path!(),
+            name: ::core::stringify!(#fn_name),
+            code_hash: #code_hash,
+        };
+    };
+
     if !args.memo && !args.memo_key.is_empty() {
         return TokenStream::from(
             SynError::new(
@@ -473,6 +493,7 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
         let expanded = quote! {
             #[doc(hidden)]
             pub const #hash_const_name: u64 = #code_hash;
+            #logic_registration
 
             #(#attrs)*
             #vis #sig {
@@ -548,6 +569,7 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
         let expanded = quote! {
             #[doc(hidden)]
             pub const #hash_const_name: u64 = #code_hash;
+            #logic_registration
 
             #(#attrs)*
             #vis #sig {
@@ -593,6 +615,7 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
         let expanded = quote! {
             #[doc(hidden)]
             pub const #hash_const_name: u64 = #code_hash;
+            #logic_registration
 
             #(#attrs)*
             #vis #sig {


### PR DESCRIPTION
## Summary
- Register every `#[cocoindex::function]`'s logic fingerprint into the engine's logic set at startup, so transitive logic-change detection actually works.
- **Bug fixed:** a memoized caller records the fingerprints of the `#[function]`s it transitively calls (`logic_deps`), validated by `all_contained_with_env`. Those fingerprints were never registered, so the check always failed — any memo that called a tracked function was perpetually invalid and re-ran every time.
- New `src/logic.rs`: a `linkme` distributed slice (`COCO_FN_LOGIC`) of `FnLogicEntry`, drained into `logic_registry` in `AppBuilder::build`. The `#[cocoindex::function]` macro emits one slice entry per function; `linkme` is re-exported so user/example crates need no direct dependency.
- New regression test `memo_with_function_dep_caches_when_unchanged` (failed before this change).
- Reworked the pre-existing `bare_function_logic_invalidates_manual_memo_callers` test into `manual_memo_closure_body_is_not_logic_tracked`: manual `ctx.memo` closures are intentionally *not* logic-tracked, and the old assertion only passed because of the missing-registration bug.

Part of the ongoing Rust SDK convergence with the reconciled design (§4 transitive logic tracking). A follow-up (memo→memo fingerprint propagation through memo boundaries) is tracked separately.

## Test plan
- `cargo test -p cocoindex` — pipeline 90, lib 53, entity_resolution 8, live_component 9, memo_batch_regressions 3, all green.
- `cargo test -p cocoindex_macros` — 19 pass.
- `cargo fmt --check`, SDK-no-pyo3 check — pass.
- CI: cargo test + `cargo check` on all examples (verifies the new macro output compiles everywhere).
