### PR TITLE
feat(rust-sdk): add Batched (unified batching: single-value calls + memo + core batcher)

### DIFF
--- a/rust/sdk/cocoindex/src/batched.rs
+++ b/rust/sdk/cocoindex/src/batched.rs
@@ -1,0 +1,132 @@
+//! `Batched` — call a batch implementation on **single values**, with per-item
+//! memoization and automatic coalescing of concurrent cache-misses into one
+//! batch call (via the core batcher, `cocoindex_utils::batching`).
+//!
+//! This is the single batching mechanism, composable with memoization: each
+//! `call` memo-probes its own item; only misses execute, and concurrent misses
+//! (even across different components) are combined into one invocation of the
+//! batch implementation. You never assemble a list yourself.
+//!
+//! ```ignore
+//! #[cocoindex::function]                                   // ctx-free batch impl; emits a logic hash
+//! async fn embed_batch(texts: Vec<String>) -> coco::Result<Vec<Vec<f32>>> {
+//!     model.encode(&texts)
+//! }
+//!
+//! static EMBED: std::sync::LazyLock<coco::Batched<String, Vec<f32>>> =
+//!     std::sync::LazyLock::new(|| coco::Batched::new(embed_batch, __COCO_FN_HASH_EMBED_BATCH));
+//!
+//! // Call per single item (e.g. inside ctx.map over chunks):
+//! let emb = EMBED.call(&ctx, text).await?;
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::ctx::Ctx;
+use crate::error::{Error, Result};
+
+type BatchFuture<Out> =
+    Pin<Box<dyn Future<Output = cocoindex_utils::error::Result<Vec<Out>>> + Send>>;
+type BatchFn<In, Out> = Box<dyn Fn(Vec<In>) -> BatchFuture<Out> + Send + Sync>;
+
+/// Adapts a user closure `Vec<In> -> Result<Vec<Out>>` to the core batcher's `Runner`.
+struct FnRunner<In, Out> {
+    f: BatchFn<In, Out>,
+}
+
+#[async_trait]
+impl<In: Send + 'static, Out: Send + 'static> Runner for FnRunner<In, Out> {
+    type Input = In;
+    type Output = Out;
+
+    async fn run(
+        &self,
+        inputs: Vec<In>,
+    ) -> cocoindex_utils::error::Result<impl ExactSizeIterator<Item = Out>> {
+        let outputs = (self.f)(inputs).await?;
+        Ok(outputs.into_iter())
+    }
+}
+
+/// A batched, memoized function. See the [module docs](self).
+pub struct Batched<In, Out>
+where
+    In: Send + 'static,
+    Out: Send + 'static,
+{
+    batcher: Arc<Batcher<FnRunner<In, Out>>>,
+    code_hash: u64,
+}
+
+impl<In, Out> Batched<In, Out>
+where
+    In: Serialize + Send + 'static,
+    Out: Serialize + DeserializeOwned + Send + 'static,
+{
+    /// Build a `Batched` from a batch implementation `f: Vec<In> -> Result<Vec<Out>>`.
+    ///
+    /// `code_hash` is the batch function's logic fingerprint — the
+    /// `__COCO_FN_HASH_*` constant emitted by `#[cocoindex::function]`. It is
+    /// folded into each item's memo key, so editing the batch logic invalidates
+    /// cached results.
+    pub fn new<F, Fut>(f: F, code_hash: u64) -> Self
+    where
+        F: Fn(Vec<In>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<Out>>> + Send + 'static,
+    {
+        Self::with_options(f, code_hash, BatchingOptions::default())
+    }
+
+    /// Like [`Batched::new`], but caps how many items are processed per batch.
+    pub fn with_max_batch<F, Fut>(f: F, code_hash: u64, max_batch_size: usize) -> Self
+    where
+        F: Fn(Vec<In>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<Out>>> + Send + 'static,
+    {
+        Self::with_options(
+            f,
+            code_hash,
+            BatchingOptions {
+                max_batch_size: Some(max_batch_size),
+            },
+        )
+    }
+
+    fn with_options<F, Fut>(f: F, code_hash: u64, options: BatchingOptions) -> Self
+    where
+        F: Fn(Vec<In>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<Out>>> + Send + 'static,
+    {
+        let wrapped: BatchFn<In, Out> = Box::new(move |inputs| {
+            let fut = f(inputs);
+            Box::pin(async move {
+                fut.await
+                    .map_err(|e: Error| cocoindex_utils::error::Error::internal_msg(e.to_string()))
+            })
+        });
+        let runner = FnRunner { f: wrapped };
+        let queue = Arc::new(BatchQueue::new());
+        let batcher = Arc::new(Batcher::new(runner, queue, options));
+        Self { batcher, code_hash }
+    }
+
+    /// Process one item. On a memo hit the stored result is returned; on a miss
+    /// the item is handed to the core batcher (coalesced with other concurrent
+    /// misses) and the result is memoized.
+    pub async fn call(&self, ctx: &Ctx, item: In) -> Result<Out> {
+        let fp =
+            crate::memo::key_fingerprint_result(&("cocoindex_batched", self.code_hash, &item))?;
+        let batcher = self.batcher.clone();
+        crate::memo::cached_by_fingerprint(ctx, fp, move |_ctx| async move {
+            batcher.run(item).await.map_err(Error::from)
+        })
+        .await
+    }
+}

--- a/rust/sdk/cocoindex/src/lib.rs
+++ b/rust/sdk/cocoindex/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "amazon_s3")]
 pub mod amazon_s3;
 pub mod app;
+pub mod batched;
 pub mod ctx;
 #[cfg(any(feature = "neo4j", feature = "falkordb"))]
 mod cypher_graph;
@@ -56,6 +57,7 @@ pub use app::{
     App, AppBuilder, DropHandle, PreviewAction, PreviewValue, Progress, StatsGroupHandle,
     StatsGroupOptions, UpdateHandle, UpdateOptions,
 };
+pub use batched::Batched;
 pub use ctx::{ContextKey, Ctx};
 pub use entity_resolution::{
     CanonicalSide, EntityEmbedder, ExistingCanonicalPolicy, PairDecision, PairResolver,

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -1561,6 +1561,77 @@ async fn memo_with_function_dep_caches_when_unchanged() {
 }
 
 // ---------------------------------------------------------------------------
+// coco::Batched — single-value calls with per-item memoization + core batcher
+// ---------------------------------------------------------------------------
+
+mod batched_test {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static ITEMS_PROCESSED: AtomicUsize = AtomicUsize::new(0);
+
+    // A ctx-free `#[cocoindex::function]` batch impl: gets a logic-hash const and
+    // stays directly callable, but takes no `&Ctx`.
+    #[cocoindex::function]
+    async fn double_batch(items: Vec<i64>) -> cocoindex::Result<Vec<i64>> {
+        ITEMS_PROCESSED.fetch_add(items.len(), Ordering::SeqCst);
+        Ok(items.into_iter().map(|x| x * 2).collect())
+    }
+
+    // A second ctx-free batch impl, used only to assert ctx-free callability
+    // without touching `double_batch`'s shared counter (tests run concurrently).
+    #[cocoindex::function]
+    async fn triple_batch(items: Vec<i64>) -> cocoindex::Result<Vec<i64>> {
+        Ok(items.into_iter().map(|x| x * 3).collect())
+    }
+
+    #[tokio::test]
+    async fn batched_is_ctx_free_and_callable() {
+        assert_ne!(__COCO_FN_HASH_TRIPLE_BATCH, 0);
+        assert_eq!(triple_batch(vec![5]).await.unwrap(), vec![15]);
+    }
+
+    #[tokio::test]
+    async fn batched_memoizes_per_item() {
+        ITEMS_PROCESSED.store(0, Ordering::SeqCst);
+        let (app, _dir) = temp_app("batched_memoizes").await;
+        let batched = Arc::new(cocoindex::Batched::new(
+            double_batch,
+            __COCO_FN_HASH_DOUBLE_BATCH,
+        ));
+
+        // Run 1: items 1,2,3 are misses → processed by the batch impl.
+        let b = batched.clone();
+        app.update(move |ctx| async move {
+            for x in [1i64, 2, 3] {
+                assert_eq!(b.call(&ctx, x).await?, x * 2);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(ITEMS_PROCESSED.load(Ordering::SeqCst), 3);
+
+        // Run 2: same items → all memo hits, the batch impl must not reprocess.
+        let b = batched.clone();
+        app.update(move |ctx| async move {
+            for x in [1i64, 2, 3] {
+                assert_eq!(b.call(&ctx, x).await?, x * 2);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            ITEMS_PROCESSED.load(Ordering::SeqCst),
+            3,
+            "run 2 should be all cache hits; batch impl must not reprocess items"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // #[cocoindex::function(memo)] macro
 // ---------------------------------------------------------------------------
 

--- a/rust/sdk/cocoindex_macros/src/lib.rs
+++ b/rust/sdk/cocoindex_macros/src/lib.rs
@@ -17,8 +17,11 @@ struct ParamInfo {
     is_str_ref: bool,
 }
 
-/// Parse an async fn and extract the ctx parameter name + non-ctx parameter info.
-fn parse_fn_params(func: &ItemFn) -> syn::Result<(syn::Ident, Vec<ParamInfo>)> {
+/// Parse an async fn and extract the optional `&Ctx` parameter name + non-ctx
+/// parameter info. A `&Ctx` parameter is not required: a ctx-free function (e.g.
+/// a batch implementation for `coco::Batched`) still gets a logic-hash const and
+/// registration, just no dependency-tracking wrapper.
+fn parse_fn_params_opt(func: &ItemFn) -> syn::Result<(Option<syn::Ident>, Vec<ParamInfo>)> {
     let mut ctx_ident = None;
     let mut params = Vec::new();
 
@@ -52,6 +55,13 @@ fn parse_fn_params(func: &ItemFn) -> syn::Result<(syn::Ident, Vec<ParamInfo>)> {
         });
     }
 
+    Ok((ctx_ident, params))
+}
+
+/// Like [`parse_fn_params_opt`], but requires a `&Ctx` parameter (memoized and
+/// component-entry functions need one).
+fn parse_fn_params(func: &ItemFn) -> syn::Result<(syn::Ident, Vec<ParamInfo>)> {
+    let (ctx_ident, params) = parse_fn_params_opt(func)?;
     let ctx_ident = ctx_ident.ok_or_else(|| {
         SynError::new(
             func.sig.ident.span(),
@@ -600,10 +610,12 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         expanded.into()
     } else {
-        // L0: change tracking only. The body still runs every time, but its
-        // logic fingerprint and nested context deps propagate to memoized
-        // callers, matching Python's `@coco.fn` without `memo=True`.
-        let (ctx_ident, _) = match parse_fn_params(&func) {
+        // L0: change tracking only. With a `&Ctx`, the body runs every time but
+        // its logic fingerprint and nested context deps propagate to memoized
+        // callers (Python's `@coco.fn` without `memo=True`). Without a `&Ctx`,
+        // the function is a pure logic-tracked helper — e.g. a batch impl for
+        // `coco::Batched` — that gets a logic-hash const + registration only.
+        let (ctx_opt, _) = match parse_fn_params_opt(&func) {
             Ok(params) => params,
             Err(err) => return TokenStream::from(err.to_compile_error()),
         };
@@ -612,22 +624,33 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
         let attrs = &func.attrs;
         let body = &func.block;
 
-        let expanded = quote! {
-            #[doc(hidden)]
-            pub const #hash_const_name: u64 = #code_hash;
-            #logic_registration
+        let expanded = if let Some(ctx_ident) = ctx_opt {
+            quote! {
+                #[doc(hidden)]
+                pub const #hash_const_name: u64 = #code_hash;
+                #logic_registration
 
-            #(#attrs)*
-            #vis #sig {
-                #ctx_ident.__coco_tracked_fn(
-                    ::core::module_path!(),
-                    ::core::stringify!(#fn_name),
-                    #hash_const_name,
-                    move |__coco_scoped_ctx| async move {
-                        let #ctx_ident = &__coco_scoped_ctx;
-                        #body
-                    },
-                ).await
+                #(#attrs)*
+                #vis #sig {
+                    #ctx_ident.__coco_tracked_fn(
+                        ::core::module_path!(),
+                        ::core::stringify!(#fn_name),
+                        #hash_const_name,
+                        move |__coco_scoped_ctx| async move {
+                            let #ctx_ident = &__coco_scoped_ctx;
+                            #body
+                        },
+                    ).await
+                }
+            }
+        } else {
+            quote! {
+                #[doc(hidden)]
+                pub const #hash_const_name: u64 = #code_hash;
+                #logic_registration
+
+                #(#attrs)*
+                #vis #sig #body
             }
         };
 


### PR DESCRIPTION
## Summary
- Add `coco::Batched<In, Out>` — the unified batching mechanism from the reconciled design (§4.5, §13). You call it on **single values**; each call memo-probes its own item, and concurrent cache-misses are coalesced into one invocation of the batch implementation by the core batcher (`cocoindex_utils::batching`). Composes memo + batch in one primitive, like Python's `batching=True`.
- Relax `#[cocoindex::function]` to allow a **ctx-free** function (no `&Ctx`): it gets a logic-hash const + registration but no dependency wrapper. This lets a pure batch impl `async fn embed_batch(texts: Vec<In>) -> Result<Vec<Out>>` carry a logic fingerprint, which `Batched` folds into each item's memo key.
- Additive only: the existing collection-oriented `ctx.batch` / `#[function(memo, batching)]` remain; they are removed in a follow-up.

## Test plan
- New `batched_test` module: `batched_memoizes_per_item` (run 2 is all cache hits — the batch impl doesn't reprocess) and `batched_is_ctx_free_and_callable`.
- `cargo test -p cocoindex` (pipeline 92) + `cargo test -p cocoindex_macros` (19) green; fmt + no-pyo3 pass.
- CI: cargo test + `cargo check` on all examples (ctx-free relaxation doesn't affect existing example fns, which all take `&Ctx`).
