### PR TITLE
feat(rust-sdk): grouped-call mount macros with component-memo fast-path

### DIFF
--- a/examples/rust/amazon_s3_embedding/src/main.rs
+++ b/examples/rust/amazon_s3_embedding/src/main.rs
@@ -51,8 +51,8 @@ struct DocEmbeddingRow {
     embedding: Vec<f32>,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &S3File) -> Result<Vec<DocEmbeddingRow>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: S3File) -> Result<Vec<DocEmbeddingRow>> {
     let text = ctx.get_key(&S3)?.read_text(&file).await?;
     let splitter = RecursiveSplitter::new()?;
     let chunks = splitter.split_with(
@@ -117,15 +117,16 @@ async fn app_main(ctx: Ctx, bucket: String, prefix: String) -> Result<()> {
     )
     .list()
     .await?;
-    println!("indexing {} markdown file(s) from s3://{bucket}", files.len());
+    println!(
+        "indexing {} markdown file(s) from s3://{bucket}",
+        files.len()
+    );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(
+        files.into_iter().map(|f| (f.key(), f)),
+        |file| process_file(ctx, file)
+    )
+    .await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {
@@ -138,7 +139,11 @@ async fn app_main(ctx: Ctx, bucket: String, prefix: String) -> Result<()> {
     Ok(())
 }
 
-async fn query_once(pool: &PgPool, embedder: &SentenceTransformerEmbedder, query: &str) -> Result<()> {
+async fn query_once(
+    pool: &PgPool,
+    embedder: &SentenceTransformerEmbedder,
+    query: &str,
+) -> Result<()> {
     let query_vec = vector_param(&embedder.embed(query).await?);
     let rows = sqlx::query(&format!(
         "SELECT filename, text, embedding <=> $1::vector AS distance \

--- a/examples/rust/audio_to_text/src/main.rs
+++ b/examples/rust/audio_to_text/src/main.rs
@@ -20,7 +20,6 @@ use std::sync::LazyLock;
 use cocoindex::ops::api::ApiTranscriber;
 use cocoindex::postgres;
 use cocoindex::prelude::*;
-use cocoindex::walk;
 
 const TABLE: &str = "audio_transcriptions";
 const PG_SCHEMA: &str = "coco_examples";
@@ -63,7 +62,7 @@ fn transcription_schema() -> Result<postgres::TableSchema> {
 /// Transcribe one audio file with OpenAI Whisper via the SDK's
 /// `ApiTranscriber`. Memoized so the expensive API call only runs when the
 /// file's content changes (or is first seen).
-#[cocoindex::function(memo)]
+#[cocoindex::function]
 async fn transcribe(_ctx: &Ctx, file: &FileEntry) -> Result<String> {
     let bytes = file.content()?;
     // Whisper sniffs the container from the upload filename's extension, so
@@ -83,37 +82,37 @@ async fn transcribe(_ctx: &Ctx, file: &FileEntry) -> Result<String> {
     transcriber.transcribe_bytes(bytes, name).await
 }
 
+/// Process one audio file: transcribe it and declare the output row. Mounted as
+/// a per-file processing component — the component-memo fast-path skips files
+/// whose content and this logic are unchanged, so the Whisper call is not
+/// repeated.
+#[cocoindex::function]
+async fn process_audio(ctx: &Ctx, file: FileEntry, table: postgres::TableTarget) -> Result<()> {
+    let text = transcribe(ctx, &file).await?;
+    table.declare_row(
+        ctx,
+        &AudioTranscription {
+            filename: file.key(),
+            text,
+        },
+    )?;
+    Ok(())
+}
+
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
     let table =
         postgres::mount_table_target(&ctx, db, TABLE, transcription_schema()?, Some(PG_SCHEMA))
             .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, AUDIO_PATTERNS)?;
+    let files = walk_items(&sourcedir, AUDIO_PATTERNS)?;
     println!(
         "transcribing {} audio file(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    ctx.mount_each(files, |f| f.key(), {
-        let table = table.clone();
-        move |child, file| {
-            let table = table.clone();
-            async move {
-                let text = transcribe(&child, &file).await?;
-                table.declare_row(
-                    &child,
-                    &AudioTranscription {
-                        filename: file.key(),
-                        text,
-                    },
-                )?;
-                Ok(())
-            }
-        }
-    })
-    .await?;
+    mount_each!(files, |file| process_audio(ctx, file, table)).await?;
 
     Ok(())
 }

--- a/examples/rust/code_embedding/src/main.rs
+++ b/examples/rust/code_embedding/src/main.rs
@@ -19,9 +19,8 @@ use std::sync::LazyLock;
 
 use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter, detect_code_language};
-use cocoindex::prelude::*;
 use cocoindex::postgres;
-use cocoindex::walk;
+use cocoindex::prelude::*;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -67,8 +66,8 @@ struct CodeEmbeddingRow {
 /// Process one file into desired embedding rows. Memoized by the file's
 /// fingerprint, while target row declarations still happen in the active
 /// pipeline.
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<CodeEmbeddingRow>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<CodeEmbeddingRow>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -112,14 +111,9 @@ async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<CodeEmbeddingRo
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
-    let table = postgres::mount_table_target(
-        &ctx,
-        db,
-        TABLE,
-        code_embedding_schema()?,
-        Some(PG_SCHEMA),
-    )
-    .await?;
+    let table =
+        postgres::mount_table_target(&ctx, db, TABLE, code_embedding_schema()?, Some(PG_SCHEMA))
+            .await?;
     table.declare_vector_index(
         &ctx,
         "embedding",
@@ -130,9 +124,9 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
         },
     )?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, INCLUDE_PATTERNS)?
+    let files: Vec<(String, FileEntry)> = walk_items(&sourcedir, INCLUDE_PATTERNS)?
         .into_iter()
-        .filter(|f| !is_excluded(&f.key()))
+        .filter(|(_, f)| !is_excluded(&f.key()))
         .collect();
     println!(
         "indexing {} files from {}",
@@ -140,13 +134,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
         sourcedir.display()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {
@@ -164,7 +152,11 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
 // Query
 // ---------------------------------------------------------------------------
 
-async fn query_once(pool: &PgPool, embedder: &SentenceTransformerEmbedder, query: &str) -> Result<()> {
+async fn query_once(
+    pool: &PgPool,
+    embedder: &SentenceTransformerEmbedder,
+    query: &str,
+) -> Result<()> {
     let query_vec = vector_param(&embedder.embed(query).await?);
 
     let rows = sqlx::query(&format!(

--- a/examples/rust/code_embedding_lancedb/src/main.rs
+++ b/examples/rust/code_embedding_lancedb/src/main.rs
@@ -17,7 +17,6 @@ use cocoindex::lancedb::{self, ColumnDef, ColumnType, LanceDatabase, TableSchema
 use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter, detect_code_language};
 use cocoindex::prelude::*;
-use cocoindex::walk;
 
 const EMBED_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
 const EMBED_DIM: usize = 384;
@@ -47,8 +46,8 @@ struct CodeEmbedding {
     end_line: i64,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<CodeEmbedding>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<CodeEmbedding>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -111,9 +110,9 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
     let table = lancedb::mount_table_target(&ctx, db, TABLE, code_embedding_schema()?).await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, INCLUDE_PATTERNS)?
+    let files: Vec<(String, FileEntry)> = walk_items(&sourcedir, INCLUDE_PATTERNS)?
         .into_iter()
-        .filter(|f| !is_excluded(&f.key()))
+        .filter(|(_, f)| !is_excluded(&f.key()))
         .collect();
     println!(
         "indexing {} file(s) from {}",
@@ -121,13 +120,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
         sourcedir.display()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/examples/rust/conversation_to_knowledge/src/clients.rs
+++ b/examples/rust/conversation_to_knowledge/src/clients.rs
@@ -34,8 +34,9 @@ pub static EMBEDDER: LazyLock<ContextKey<Embedder>> =
 
 /// SurrealDB connection. State-tracked on the target endpoint so changing the
 /// external graph database invalidates local target-state reconciliation.
-pub static GRAPH: LazyLock<ContextKey<Graph>> =
-    LazyLock::new(|| ContextKey::new_with_state("surreal_db", |g: &Graph| g.state_id().to_string()));
+pub static GRAPH: LazyLock<ContextKey<Graph>> = LazyLock::new(|| {
+    ContextKey::new_with_state("surreal_db", |g: &Graph| g.state_id().to_string())
+});
 
 // ---------------------------------------------------------------------------
 // LLM client (OpenAI-compatible, JSON mode)

--- a/examples/rust/conversation_to_knowledge/src/main.rs
+++ b/examples/rust/conversation_to_knowledge/src/main.rs
@@ -33,7 +33,7 @@ use serde::Deserialize;
 
 use clients::{Embedder, Graph, LlmClient};
 use models::*;
-use pipeline::{collect_raw, create_knowledge_base, process_session, resolve_entities};
+use pipeline::{collect_raw, create_knowledge_base, resolve_entities};
 
 const INCLUDE: &[&str] = &["**/*.txt", "**/*.json"];
 
@@ -119,12 +119,10 @@ async fn app_main(ctx: Ctx, input_dir: PathBuf) -> Result<()> {
     );
 
     // Phase 1: per-session fetch + extract (memoized, concurrent).
-    let processed: Vec<ProcessedSession> = ctx
-        .mount_each(
-            sources,
-            |s| s.key(),
-            |child, source| async move { process_session(&child, &source).await },
-        )
+    let processed: Vec<ProcessedSession> =
+        mount_each!(sources.into_iter().map(|s| (s.key(), s)), |source| {
+            pipeline::process_session(ctx, source)
+        })
         .await?;
 
     // Phase 2: entity resolution per type.

--- a/examples/rust/conversation_to_knowledge/src/pipeline.rs
+++ b/examples/rust/conversation_to_knowledge/src/pipeline.rs
@@ -109,8 +109,8 @@ pub fn format_transcript(
 /// Process one session end-to-end (fetch -> 2-pass extract -> assign ids).
 /// Memoized by source: unchanged sessions skip all fetch/LLM work. Graph writes
 /// happen later in `create_knowledge_base` through target-state declarations.
-#[cocoindex::function(memo)]
-pub async fn process_session(ctx: &Ctx, source: &SessionSource) -> Result<ProcessedSession> {
+#[cocoindex::function]
+pub async fn process_session(ctx: &Ctx, source: SessionSource) -> Result<ProcessedSession> {
     let transcript = fetch_transcript(&ctx, &source).await?;
 
     // Step 1: format with no known names, extract metadata + speaker map.

--- a/examples/rust/csv_to_iggy/src/main.rs
+++ b/examples/rust/csv_to_iggy/src/main.rs
@@ -44,8 +44,8 @@ fn topic_name() -> String {
 
 /// Parse one CSV file into `(message_key, json_value)` pairs. Memoized: a file
 /// whose content is unchanged since the last run is not re-parsed.
-#[cocoindex::function(memo)]
-async fn process_csv(_ctx: &Ctx, file: &FileEntry) -> Result<Vec<(String, String)>> {
+#[cocoindex::function]
+async fn process_csv(_ctx: &Ctx, file: FileEntry) -> Result<Vec<(String, String)>> {
     let text = file.content_str()?;
     let mut reader = csv::Reader::from_reader(text.as_bytes());
     let headers = reader
@@ -117,18 +117,13 @@ async fn index(producer: IggyProducer, stream: String, topic: String) -> Result<
                         format!("{{\"_deleted\":\"{key}\"}}").into_bytes()
                     })),
                 };
-                let target = iggy::mount_iggy_topic_target(&ctx, &producer, stream, topic, options)?;
+                let target =
+                    iggy::mount_iggy_topic_target(&ctx, &producer, stream, topic, options)?;
 
-                let files = cocoindex::fs::walk("./data", &["**/*.csv"])?;
+                let files = cocoindex::fs::walk_items("./data", &["**/*.csv"])?;
                 println!("found {} CSV file(s)", files.len());
 
-                let per_file = ctx
-                    .mount_each(
-                        files,
-                        |f| f.key(),
-                        |child, file| async move { process_csv(&child, &file).await },
-                    )
-                    .await?;
+                let per_file = mount_each!(files, |file| process_csv(ctx, file)).await?;
 
                 let mut declared = 0;
                 for messages in &per_file {
@@ -149,8 +144,8 @@ async fn index(producer: IggyProducer, stream: String, topic: String) -> Result<
 async fn consume(producer: &IggyProducer, stream: &str, topic: &str) -> Result<()> {
     let stream_id = Identifier::from_str_value(stream)
         .map_err(|e| Error::engine(format!("iggy stream id: {e}")))?;
-    let topic_id =
-        Identifier::from_str_value(topic).map_err(|e| Error::engine(format!("iggy topic id: {e}")))?;
+    let topic_id = Identifier::from_str_value(topic)
+        .map_err(|e| Error::engine(format!("iggy topic id: {e}")))?;
     let consumer = Consumer::new(
         Identifier::numeric(1).map_err(|e| Error::engine(format!("iggy consumer id: {e}")))?,
     );

--- a/examples/rust/csv_to_kafka/src/main.rs
+++ b/examples/rust/csv_to_kafka/src/main.rs
@@ -38,8 +38,8 @@ fn topic_name() -> String {
 
 /// Parse one CSV file into `(message_key, json_value)` pairs. Memoized: a file
 /// whose content is unchanged since the last run is not re-parsed.
-#[cocoindex::function(memo)]
-async fn process_csv(_ctx: &Ctx, file: &FileEntry) -> Result<Vec<(String, String)>> {
+#[cocoindex::function]
+async fn process_csv(_ctx: &Ctx, file: FileEntry) -> Result<Vec<(String, String)>> {
     let text = file.content_str()?;
     let mut reader = csv::Reader::from_reader(text.as_bytes());
     let headers = reader
@@ -90,16 +90,10 @@ async fn index(producer: KafkaProducer, topic: String) -> Result<()> {
                     kafka::KafkaTopicOptions::default(),
                 )?;
 
-                let files = cocoindex::fs::walk("./data", &["**/*.csv"])?;
+                let files = cocoindex::fs::walk_items("./data", &["**/*.csv"])?;
                 println!("found {} CSV file(s)", files.len());
 
-                let per_file = ctx
-                    .mount_each(
-                        files,
-                        |f| f.key(),
-                        |child, file| async move { process_csv(&child, &file).await },
-                    )
-                    .await?;
+                let per_file = mount_each!(files, |file| process_csv(ctx, file)).await?;
 
                 let mut declared = 0;
                 for messages in &per_file {

--- a/examples/rust/files_to_sqlite/src/main.rs
+++ b/examples/rust/files_to_sqlite/src/main.rs
@@ -47,8 +47,8 @@ fn files_schema() -> Result<sqlite::TableSchema> {
     )
 }
 
-/// Summarize one file. Memoized: unchanged files are skipped on re-runs.
-#[cocoindex::function(memo)]
+/// Summarize one file. Logic-tracked, so editing it invalidates cached files.
+#[cocoindex::function]
 async fn summarize(_ctx: &Ctx, file: &FileEntry) -> Result<FileRow> {
     let text = file.content_str()?;
     let word_count = text.split_whitespace().count() as i64;
@@ -58,6 +58,15 @@ async fn summarize(_ctx: &Ctx, file: &FileEntry) -> Result<FileRow> {
         word_count,
         first_line,
     })
+}
+
+/// Summarize one file and declare its row. Mounted as a per-file processing
+/// component — the component-memo fast-path skips unchanged files on re-runs.
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry, table: sqlite::TableTarget) -> Result<()> {
+    let row = summarize(ctx, &file).await?;
+    table.declare_row(ctx, &row)?;
+    Ok(())
 }
 
 async fn index(source_dir: PathBuf, db_path: String) -> Result<()> {
@@ -75,19 +84,8 @@ async fn index(source_dir: PathBuf, db_path: String) -> Result<()> {
                 let db = ctx.get_key(&DB)?;
                 let table = sqlite::mount_table_target(&ctx, db, TABLE, files_schema()?).await?;
 
-                let files = cocoindex::fs::walk(&source_dir, &["**/*.md", "**/*.txt"])?;
-                ctx.mount_each(files, |file| file.key(), {
-                    let table = table.clone();
-                    move |file_ctx, file| {
-                        let table = table.clone();
-                        async move {
-                            let row = summarize(&file_ctx, &file).await?;
-                            table.declare_row(&file_ctx, &row)?;
-                            Ok(())
-                        }
-                    }
-                })
-                .await?;
+                let files = cocoindex::fs::walk_items(&source_dir, &["**/*.md", "**/*.txt"])?;
+                mount_each!(files, |file| process_file(ctx, file, table)).await?;
                 Ok(())
             }
         })
@@ -127,15 +125,18 @@ async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match args.first().map(String::as_str) {
         Some("query") => {
-            let db_path = args.get(1).cloned().unwrap_or_else(|| "./files.db".to_string());
+            let db_path = args
+                .get(1)
+                .cloned()
+                .unwrap_or_else(|| "./files.db".to_string());
             query(db_path).await
         }
         _ => {
-            let source_dir = args
-                .get(1)
-                .map(PathBuf::from)
-                .unwrap_or_else(data_dir);
-            let db_path = args.get(2).cloned().unwrap_or_else(|| "./files.db".to_string());
+            let source_dir = args.get(1).map(PathBuf::from).unwrap_or_else(data_dir);
+            let db_path = args
+                .get(2)
+                .cloned()
+                .unwrap_or_else(|| "./files.db".to_string());
             index(source_dir, db_path).await
         }
     }

--- a/examples/rust/files_transform/src/main.rs
+++ b/examples/rust/files_transform/src/main.rs
@@ -10,7 +10,7 @@ use cocoindex::prelude::*;
 use pulldown_cmark::{Options, Parser, html};
 use std::path::PathBuf;
 
-#[cocoindex::function(memo)]
+#[cocoindex::function]
 async fn render_markdown(_ctx: &Ctx, file: &FileEntry) -> Result<String> {
     let markdown = file.content_str()?;
     // GFM-leaning options, to track the Python example's MarkdownIt("gfm-like").
@@ -28,6 +28,21 @@ async fn render_markdown(_ctx: &Ctx, file: &FileEntry) -> Result<String> {
     let mut html_out = String::new();
     html::push_html(&mut html_out, parser);
     Ok(html_out)
+}
+
+/// Process one markdown file: render it and declare the HTML output.
+///
+/// Mounted as a processing component per file via `mount_each!`. As a component
+/// entry it carries the component-memo fast-path — when this logic and the
+/// file's content (and the target) are unchanged, the engine skips the whole
+/// component and replays the previous output, so unchanged files aren't
+/// re-rendered or re-written. `render_markdown` is logic-tracked, so editing it
+/// invalidates the cache.
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry, target: DirTarget) -> Result<()> {
+    let html = render_markdown(ctx, &file).await?;
+    target.declare_file(ctx, &output_name_for(&file), html.as_bytes())?;
+    Ok(())
 }
 
 fn output_name_for(file: &FileEntry) -> String {
@@ -66,27 +81,16 @@ async fn main() -> Result<()> {
                 // the previous run and deletes outputs whose source disappeared.
                 let target = DirTarget::mount(&ctx, &output_dir)?;
                 // Recursive `**/*.md`, matching the Python example's
-                // `PatternFilePathMatcher(included_patterns=["**/*.md"])`.
-                // (Output names join the relative-path components with `__`, so
-                // nested files don't collide — see `output_name_for`.)
-                let files = cocoindex::fs::walk(&source_dir, &["**/*.md"])?;
+                // `PatternFilePathMatcher(included_patterns=["**/*.md"])`, as
+                // `(key, file)` pairs for `mount_each!`. (Output names join the
+                // relative-path components with `__`, so nested files don't
+                // collide — see `output_name_for`.)
+                let files = cocoindex::fs::walk_items(&source_dir, &["**/*.md"])?;
 
-                ctx.mount_each(files, |file| file.key(), {
-                    let target = target.clone();
-                    move |file_ctx, file| {
-                        let target = target.clone();
-                        async move {
-                            let html = render_markdown(&file_ctx, &file).await?;
-                            target.declare_file(
-                                &file_ctx,
-                                &output_name_for(&file),
-                                html.as_bytes(),
-                            )?;
-                            Ok(())
-                        }
-                    }
-                })
-                .await?;
+                // One processing component per file. `ctx` is the parent; the
+                // macro substitutes each child scope's `&Ctx`, and fingerprints
+                // `(file, target)` for the per-file component-memo fast-path.
+                mount_each!(files, |file| process_file(ctx, file, target)).await?;
 
                 Ok(())
             }

--- a/examples/rust/gdrive_text_embedding/src/main.rs
+++ b/examples/rust/gdrive_text_embedding/src/main.rs
@@ -48,8 +48,8 @@ struct DocEmbeddingRow {
     embedding: Vec<f32>,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &DriveFile) -> Result<Vec<DocEmbeddingRow>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: DriveFile) -> Result<Vec<DocEmbeddingRow>> {
     let client = ctx.get_key(&GDRIVE)?;
     let text = client.read_text(&file).await?;
     let splitter = RecursiveSplitter::new()?;
@@ -89,7 +89,8 @@ async fn process_file(ctx: &Ctx, file: &DriveFile) -> Result<Vec<DocEmbeddingRow
 async fn app_main(ctx: Ctx, root_folder_ids: Vec<String>) -> Result<()> {
     let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA)).await?;
+        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+            .await?;
     table.declare_vector_index(
         &ctx,
         "embedding",
@@ -104,13 +105,10 @@ async fn app_main(ctx: Ctx, root_folder_ids: Vec<String>) -> Result<()> {
     let files = source.list_files().await?;
     println!("indexing {} Google Drive files", files.len());
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |file| file.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files.into_iter().map(|file| (file.key(), file)), |file| {
+        process_file(ctx, file)
+    })
+    .await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/examples/rust/hn_trending_topics/src/main.rs
+++ b/examples/rust/hn_trending_topics/src/main.rs
@@ -19,8 +19,8 @@
 
 use std::sync::LazyLock;
 
-use cocoindex::prelude::*;
 use cocoindex::postgres;
+use cocoindex::prelude::*;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -32,8 +32,9 @@ const MAX_TEXT: usize = 4000;
 static HTTP: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 /// Shared Postgres target database.
-static PG: LazyLock<ContextKey<postgres::Database>> =
-    LazyLock::new(|| ContextKey::new_with_state("hn_db", |db: &postgres::Database| db.state_id().to_string()));
+static PG: LazyLock<ContextKey<postgres::Database>> = LazyLock::new(|| {
+    ContextKey::new_with_state("hn_db", |db: &postgres::Database| db.state_id().to_string())
+});
 /// LLM client; state-tracked on the model so changing it invalidates memos.
 static LLM: LazyLock<ContextKey<LlmClient>> =
     LazyLock::new(|| ContextKey::new_with_state("llm_model", |c: &LlmClient| c.model.clone()));
@@ -267,8 +268,8 @@ fn max_comments() -> usize {
 /// Fetch one thread and extract topics for every message.
 /// Memoized by thread id: re-runs skip already-processed threads, while target
 /// row declarations still happen in the active pipeline.
-#[cocoindex::function(memo)]
-async fn process_thread(ctx: &Ctx, thread_id: &String) -> Result<ProcessedThread> {
+#[cocoindex::function]
+async fn process_thread(ctx: &Ctx, thread_id: String) -> Result<ProcessedThread> {
     let llm = ctx.get_key(&LLM)?;
     let thread = fetch_thread(&thread_id, max_comments()).await?;
     let mut messages = Vec::with_capacity(thread.messages.len());
@@ -326,13 +327,10 @@ async fn app_main(ctx: Ctx, max_threads: usize) -> Result<()> {
     let thread_ids = fetch_thread_ids(max_threads).await?;
     println!("fetched {} threads from HackerNews", thread_ids.len());
 
-    let processed = ctx
-        .mount_each(
-            thread_ids.clone(),
-            |id| id.clone(),
-            |child, id| async move { process_thread(&child, &id).await },
-        )
-        .await?;
+    let processed = mount_each!(thread_ids.into_iter().map(|id| (id.clone(), id)), |id| {
+        process_thread(ctx, id)
+    })
+    .await?;
 
     let mut count = 0usize;
     for thread in &processed {

--- a/examples/rust/image_search/src/main.rs
+++ b/examples/rust/image_search/src/main.rs
@@ -25,7 +25,6 @@ use cocoindex::ops::image::ImageEmbedder;
 use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::prelude::*;
 use cocoindex::qdrant::{self, CollectionSchema, Distance, QdrantConnection};
-use cocoindex::walk;
 use serde_json::json;
 
 /// CLIP ViT-B/32 vision tower (images) and text tower (queries). Both output
@@ -64,8 +63,8 @@ struct PointData {
     filename: String,
 }
 
-#[cocoindex::function(memo)]
-async fn process_image(ctx: &Ctx, file: &FileEntry) -> Result<PointData> {
+#[cocoindex::function]
+async fn process_image(ctx: &Ctx, file: FileEntry) -> Result<PointData> {
     let filename = file.key();
     let bytes = file.content()?;
     let vector = ctx.get_key(&EMBEDDER)?.embed(bytes).await?;
@@ -88,20 +87,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     )
     .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, IMAGE_GLOBS)?;
+    let files = walk_items(&sourcedir, IMAGE_GLOBS)?;
     println!(
         "indexing {} image(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let points = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_image(&child, &file).await },
-        )
-        .await?;
+    let points = mount_each!(files, |file| process_image(ctx, file)).await?;
 
     for p in &points {
         let payload = json!({ "filename": p.filename })

--- a/examples/rust/image_search_colpali/src/main.rs
+++ b/examples/rust/image_search_colpali/src/main.rs
@@ -28,7 +28,6 @@ use std::sync::LazyLock;
 
 use cocoindex::prelude::*;
 use cocoindex::qdrant::{self, CollectionSchema, Distance, QdrantConnection};
-use cocoindex::walk;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -51,9 +50,8 @@ static DB: LazyLock<ContextKey<QdrantConnection>> = LazyLock::new(|| {
         c.state_id().to_string()
     })
 });
-static COLPALI: LazyLock<ContextKey<ColpaliClient>> = LazyLock::new(|| {
-    ContextKey::new_with_state("colpali", |c: &ColpaliClient| c.url.clone())
-});
+static COLPALI: LazyLock<ContextKey<ColpaliClient>> =
+    LazyLock::new(|| ContextKey::new_with_state("colpali", |c: &ColpaliClient| c.url.clone()));
 
 /// HTTP client for an external ColPali inference service (see module docs).
 #[derive(Clone)]
@@ -118,8 +116,8 @@ struct PointData {
     filename: String,
 }
 
-#[cocoindex::function(memo)]
-async fn process_image(ctx: &Ctx, file: &FileEntry) -> Result<PointData> {
+#[cocoindex::function]
+async fn process_image(ctx: &Ctx, file: FileEntry) -> Result<PointData> {
     let filename = file.key();
     let bytes = file.content()?;
     let vectors = ctx.get_key(&COLPALI)?.embed_image(bytes).await?;
@@ -142,20 +140,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     )
     .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, IMAGE_GLOBS)?;
+    let files = walk_items(&sourcedir, IMAGE_GLOBS)?;
     println!(
         "indexing {} image(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let points = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_image(&child, &file).await },
-        )
-        .await?;
+    let points = mount_each!(files, |file| process_image(ctx, file)).await?;
 
     for p in &points {
         let payload = json!({ "filename": p.filename })

--- a/examples/rust/multi_codebase_summarization/src/main.rs
+++ b/examples/rust/multi_codebase_summarization/src/main.rs
@@ -8,11 +8,13 @@
 //! Aggregates per-file extractions into a project summary and outputs
 //! markdown documentation.
 //!
-//! Demonstrates full macro usage:
-//! - `#[cocoindex::function(memo)]` — per-file LLM extraction cached by fingerprint
-//! - `#[cocoindex::function(memo)]` — project aggregation cached by project fingerprint
-//! - `#[cocoindex::function]` — markdown generation
-//! - `ctx.mount_each(...)` — concurrent per-file processing
+//! Demonstrates the mount macros and memoization layering:
+//! - `use_mount!(key, process_project(ctx, …))` — one component per project,
+//!   skipped wholesale on the component-memo fast-path when unchanged
+//! - `mount_each!(files, |file| extract_file_info(ctx, file))` — concurrent
+//!   per-file extraction, each its own component (unchanged files skip the LLM)
+//! - `#[cocoindex::function(memo)]` — project aggregation cached by project
+//!   fingerprint (function-memo nested inside the project component)
 //! - `DirTarget` — declarative output file sync
 //!
 //! ## Usage
@@ -125,8 +127,8 @@ fn should_skip_python_file(file: &FileEntry) -> bool {
 
 /// Extract structured info from a single Python file via LLM.
 /// `memo` caches results by file fingerprint — unchanged files are skipped.
-#[cocoindex::function(memo)]
-async fn extract_file_info(_ctx: &Ctx, file: &FileEntry) -> Result<CodebaseInfo> {
+#[cocoindex::function]
+async fn extract_file_info(_ctx: &Ctx, file: FileEntry) -> Result<CodebaseInfo> {
     let content = file.content_str()?;
     let file_path = file.key();
 
@@ -307,6 +309,38 @@ async fn generate_markdown(
 }
 
 // ---------------------------------------------------------------------------
+// Per-project processing component
+// ---------------------------------------------------------------------------
+
+/// Process one project: extract per-file info (one child component per file),
+/// aggregate into a project summary, and write the markdown. Mounted as a
+/// per-project processing component — the component-memo fast-path skips
+/// projects whose files and this logic are unchanged.
+#[cocoindex::function]
+async fn process_project(
+    ctx: &Ctx,
+    project_name: String,
+    files: Vec<FileEntry>,
+    target: DirTarget,
+) -> Result<()> {
+    // Extract per-file info — one child component per file (unchanged files skip).
+    let file_infos: Vec<CodebaseInfo> =
+        mount_each!(files.into_iter().map(|f| (f.key(), f)), |file| {
+            extract_file_info(ctx, file)
+        })
+        .await?;
+
+    // Aggregate into a project summary (memoized — unchanged projects skip the LLM).
+    let project_info =
+        aggregate_project_info(ctx, project_name.clone(), file_infos.clone()).await?;
+
+    // Generate and write the markdown.
+    let markdown = generate_markdown(ctx, project_name.clone(), project_info, file_infos).await?;
+    target.declare_file(ctx, &format!("{project_name}.md"), markdown.as_bytes())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -358,46 +392,10 @@ async fn main() -> Result<()> {
 
                 println!("Processing project: {project_name} ({} files)", files.len());
 
-                ctx.scope(&format!("project/{project_name}"), {
-                    let project_name = project_name.clone();
-                    let target = target.clone();
-                    move |project_ctx| async move {
-                        // Extract per-file info (memoized — unchanged files skip LLM)
-                        let file_infos: Vec<CodebaseInfo> = project_ctx
-                            .mount_each(
-                                files,
-                                |f| f.key(),
-                                |child_ctx, file| async move {
-                                    extract_file_info(&child_ctx, &file).await
-                                },
-                            )
-                            .await?;
-
-                        // Aggregate into project summary (memoized — unchanged projects skip LLM)
-                        let project_info = aggregate_project_info(
-                            &project_ctx,
-                            project_name.clone(),
-                            file_infos.clone(),
-                        )
-                        .await?;
-
-                        // Generate and write markdown
-                        let markdown = generate_markdown(
-                            &project_ctx,
-                            project_name.clone(),
-                            project_info,
-                            file_infos,
-                        )
-                        .await?;
-
-                        target.declare_file(
-                            &project_ctx,
-                            &format!("{project_name}.md"),
-                            markdown.as_bytes(),
-                        )?;
-                        Ok(())
-                    }
-                })
+                use_mount!(
+                    format!("project/{project_name}"),
+                    process_project(ctx, project_name.clone(), files, target.clone())
+                )
                 .await?;
                 println!("  Wrote {}/{project_name}.md", output_dir.display());
             }

--- a/examples/rust/oci_object_storage_embedding/src/main.rs
+++ b/examples/rust/oci_object_storage_embedding/src/main.rs
@@ -52,8 +52,8 @@ struct DocEmbeddingRow {
     embedding: Vec<f32>,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &OciFile) -> Result<Vec<DocEmbeddingRow>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: OciFile) -> Result<Vec<DocEmbeddingRow>> {
     let text = ctx.get_key(&OCI)?.read_text(&file).await?;
     let splitter = RecursiveSplitter::new()?;
     let chunks = splitter.split_with(
@@ -124,13 +124,11 @@ async fn app_main(ctx: Ctx, namespace: String, bucket: String, prefix: String) -
         files.len()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(
+        files.into_iter().map(|f| (f.key(), f)),
+        |file| process_file(ctx, file)
+    )
+    .await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/examples/rust/paper_metadata/src/main.rs
+++ b/examples/rust/paper_metadata/src/main.rs
@@ -33,7 +33,6 @@ use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{CustomLanguageConfig, RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::postgres;
 use cocoindex::prelude::*;
-use cocoindex::walk;
 use serde::de::DeserializeOwned;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -230,7 +229,7 @@ async fn extract_metadata(llm: &LlmClient, first_page_text: &str) -> Result<Pape
     llm.json(system, &user).await
 }
 
-#[cocoindex::function(memo)]
+#[cocoindex::function]
 async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<ProcessedPaper> {
     let filename = file.key();
     let content = file.content()?;
@@ -292,7 +291,10 @@ async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<ProcessedPaper> {
     if !chunk_texts.is_empty() {
         let vecs = embedder.embed_batch(chunk_texts.clone()).await?;
         for (text, embedding) in chunk_texts.into_iter().zip(vecs) {
-            let id = uuid_gen.next_uuid(&ctx, &("abstract", &text)).await?.to_string();
+            let id = uuid_gen
+                .next_uuid(&ctx, &("abstract", &text))
+                .await?
+                .to_string();
             embeddings.push(MetadataEmbeddingRow {
                 id,
                 filename: filename.clone(),
@@ -363,11 +365,38 @@ fn embedding_schema() -> Result<postgres::TableSchema> {
 // Indexing
 // ---------------------------------------------------------------------------
 
+/// Process one paper and declare its metadata, author, and embedding rows.
+/// Mounted as a per-file processing component — the component-memo fast-path
+/// skips unchanged papers on re-runs.
+#[cocoindex::function]
+async fn index_paper(
+    ctx: &Ctx,
+    file: FileEntry,
+    metadata_table: postgres::TableTarget,
+    author_table: postgres::TableTarget,
+    embedding_table: postgres::TableTarget,
+) -> Result<()> {
+    let processed = process_file(ctx, &file).await?;
+    metadata_table.declare_row(ctx, &processed.metadata)?;
+    for row in &processed.authors {
+        author_table.declare_row(ctx, row)?;
+    }
+    for row in &processed.embeddings {
+        embedding_table.declare_row(ctx, row)?;
+    }
+    Ok(())
+}
+
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
-    let metadata_table =
-        postgres::mount_table_target(&ctx, db, TABLE_METADATA, metadata_schema()?, Some(PG_SCHEMA))
-            .await?;
+    let metadata_table = postgres::mount_table_target(
+        &ctx,
+        db,
+        TABLE_METADATA,
+        metadata_schema()?,
+        Some(PG_SCHEMA),
+    )
+    .await?;
     let author_table = postgres::mount_table_target(
         &ctx,
         db,
@@ -385,34 +414,20 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     )
     .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.pdf"])?;
+    let files = walk_items(&sourcedir, &["**/*.pdf"])?;
     println!(
         "indexing {} PDF(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    ctx.mount_each(files, |f| f.key(), {
-        let metadata_table = metadata_table.clone();
-        let author_table = author_table.clone();
-        let embedding_table = embedding_table.clone();
-        move |child, file| {
-            let metadata_table = metadata_table.clone();
-            let author_table = author_table.clone();
-            let embedding_table = embedding_table.clone();
-            async move {
-                let processed = process_file(&child, &file).await?;
-                metadata_table.declare_row(&child, &processed.metadata)?;
-                for row in &processed.authors {
-                    author_table.declare_row(&child, row)?;
-                }
-                for row in &processed.embeddings {
-                    embedding_table.declare_row(&child, row)?;
-                }
-                Ok(())
-            }
-        }
-    })
+    mount_each!(files, |file| index_paper(
+        ctx,
+        file,
+        metadata_table,
+        author_table,
+        embedding_table
+    ))
     .await?;
 
     Ok(())
@@ -422,7 +437,11 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
 // Query demo (no vector index — sequential cosine scan, like Python)
 // ---------------------------------------------------------------------------
 
-async fn query_once(pool: &PgPool, embedder: &SentenceTransformerEmbedder, query: &str) -> Result<()> {
+async fn query_once(
+    pool: &PgPool,
+    embedder: &SentenceTransformerEmbedder,
+    query: &str,
+) -> Result<()> {
     let query_vec = vector_param(&embedder.embed(query).await?);
     let rows = sqlx::query(&format!(
         "SELECT filename, location, text, embedding <=> $1::vector AS distance \

--- a/examples/rust/pdf_embedding/src/main.rs
+++ b/examples/rust/pdf_embedding/src/main.rs
@@ -20,7 +20,6 @@ use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::postgres;
 use cocoindex::prelude::*;
-use cocoindex::walk;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
@@ -65,8 +64,8 @@ fn pdf_to_text(content: &[u8]) -> Result<String> {
         .map_err(|e| Error::engine(format!("failed to extract PDF text: {e}")))
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<PdfEmbedding>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<PdfEmbedding>> {
     let filename = file.key();
     let content = file.content()?;
     let text = tokio::task::spawn_blocking(move || pdf_to_text(&content))
@@ -131,16 +130,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
         postgres::mount_table_target(&ctx, db, TABLE, pdf_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.pdf"])?;
-    println!("indexing {} PDF(s) from {}", files.len(), sourcedir.display());
+    let files = walk_items(&sourcedir, &["**/*.pdf"])?;
+    println!(
+        "indexing {} PDF(s) from {}",
+        files.len(),
+        sourcedir.display()
+    );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/examples/rust/pdf_to_markdown/src/main.rs
+++ b/examples/rust/pdf_to_markdown/src/main.rs
@@ -30,7 +30,7 @@ fn pdf_to_text(content: &[u8]) -> Result<String> {
         .map_err(|e| Error::engine(format!("failed to extract PDF text: {e}")))
 }
 
-#[cocoindex::function(memo)]
+#[cocoindex::function]
 async fn convert_pdf(_ctx: &Ctx, file: &FileEntry) -> Result<String> {
     let content = file.content()?;
     tokio::task::spawn_blocking(move || pdf_to_text(&content))
@@ -51,6 +51,16 @@ fn parse_args() -> (PathBuf, PathBuf) {
     (source_dir, output_dir)
 }
 
+/// Convert one PDF and declare its Markdown output. Mounted as a per-file
+/// processing component — the component-memo fast-path skips unchanged PDFs.
+#[cocoindex::function]
+async fn process_pdf(ctx: &Ctx, file: FileEntry, target: DirTarget) -> Result<()> {
+    let markdown = convert_pdf(ctx, &file).await?;
+    let outname = format!("{}.md", file.stem());
+    target.declare_file(ctx, &outname, markdown.as_bytes())?;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let (source_dir, output_dir) = parse_args();
@@ -65,26 +75,14 @@ async fn main() -> Result<()> {
             let output_dir = output_dir.clone();
             async move {
                 let target = DirTarget::mount(&ctx, &output_dir)?;
-                let files = cocoindex::fs::walk(&source_dir, &["**/*.pdf"])?;
+                let files = cocoindex::fs::walk_items(&source_dir, &["**/*.pdf"])?;
                 println!(
                     "converting {} PDF(s) from {}",
                     files.len(),
                     source_dir.display()
                 );
 
-                ctx.mount_each(files, |file| file.key(), {
-                    let target = target.clone();
-                    move |file_ctx, file| {
-                        let target = target.clone();
-                        async move {
-                            let markdown = convert_pdf(&file_ctx, &file).await?;
-                            let outname = format!("{}.md", file.stem());
-                            target.declare_file(&file_ctx, &outname, markdown.as_bytes())?;
-                            Ok(())
-                        }
-                    }
-                })
-                .await?;
+                mount_each!(files, |file| process_pdf(ctx, file, target)).await?;
                 Ok(())
             }
         })

--- a/examples/rust/postgres_source/src/main.rs
+++ b/examples/rust/postgres_source/src/main.rs
@@ -82,8 +82,8 @@ struct OutputProduct {
 
 /// Compute the derived fields + embedding for one source row. Memoized by the
 /// row content, so unchanged rows skip the embedding work on re-runs.
-#[cocoindex::function(memo)]
-async fn process_product(ctx: &Ctx, product: &SourceProduct) -> Result<OutputProduct> {
+#[cocoindex::function]
+async fn process_product(ctx: &Ctx, product: SourceProduct) -> Result<OutputProduct> {
     let full_description = format!(
         "Category: {}\nName: {}\n\n{}",
         product.product_category, product.product_name, product.description
@@ -121,7 +121,8 @@ fn output_schema() -> Result<postgres::TableSchema> {
 
 async fn app_main(ctx: Ctx) -> Result<()> {
     let db = ctx.get_key(&DB)?;
-    let target = postgres::mount_table_target(&ctx, db, TABLE, output_schema()?, Some(PG_SCHEMA)).await?;
+    let target =
+        postgres::mount_table_target(&ctx, db, TABLE, output_schema()?, Some(PG_SCHEMA)).await?;
     target.declare_vector_index(
         &ctx,
         "embedding",
@@ -135,13 +136,13 @@ async fn app_main(ctx: Ctx) -> Result<()> {
     let products: Vec<SourceProduct> = postgres::read_table(source_db, "source_products").await?;
     println!("read {} source product(s)", products.len());
 
-    let outputs = ctx
-        .mount_each(
-            products,
-            |p| format!("{}|{}", p.product_category, p.product_name),
-            |child, product| async move { process_product(&child, &product).await },
-        )
-        .await?;
+    let outputs = mount_each!(
+        products
+            .into_iter()
+            .map(|p| (format!("{}|{}", p.product_category, p.product_name), p)),
+        |product| process_product(ctx, product)
+    )
+    .await?;
 
     for output in &outputs {
         target.declare_row(&ctx, output)?;

--- a/examples/rust/text_embedding/src/main.rs
+++ b/examples/rust/text_embedding/src/main.rs
@@ -19,7 +19,6 @@ use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::postgres;
 use cocoindex::prelude::*;
-use cocoindex::walk;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
@@ -52,8 +51,8 @@ struct DocEmbedding {
     embedding: Vec<f32>,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<DocEmbedding>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<DocEmbedding>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -112,7 +111,8 @@ fn doc_embedding_schema() -> Result<postgres::TableSchema> {
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA)).await?;
+        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+            .await?;
     table.declare_vector_index(
         &ctx,
         "embedding",
@@ -122,20 +122,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
         },
     )?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.md"])?;
+    let files = walk_items(&sourcedir, &["**/*.md"])?;
     println!(
         "indexing {} markdown file(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {
@@ -148,7 +142,11 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     Ok(())
 }
 
-async fn query_once(pool: &PgPool, embedder: &SentenceTransformerEmbedder, query: &str) -> Result<()> {
+async fn query_once(
+    pool: &PgPool,
+    embedder: &SentenceTransformerEmbedder,
+    query: &str,
+) -> Result<()> {
     let query_vec = vector_param(&embedder.embed(query).await?);
     let rows = sqlx::query(&format!(
         "SELECT filename, text, embedding <=> $1::vector AS distance \

--- a/examples/rust/text_embedding_lancedb/src/main.rs
+++ b/examples/rust/text_embedding_lancedb/src/main.rs
@@ -17,7 +17,6 @@ use cocoindex::lancedb::{self, ColumnDef, ColumnType, LanceDatabase, TableSchema
 use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::prelude::*;
-use cocoindex::walk;
 
 const EMBED_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
 const EMBED_DIM: usize = 384;
@@ -47,8 +46,8 @@ struct DocEmbedding {
     embedding: Vec<f32>,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<DocEmbedding>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<DocEmbedding>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -105,20 +104,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
     let table = lancedb::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?).await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.md"])?;
+    let files = walk_items(&sourcedir, &["**/*.md"])?;
     println!(
         "indexing {} markdown file(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/examples/rust/text_embedding_qdrant/src/main.rs
+++ b/examples/rust/text_embedding_qdrant/src/main.rs
@@ -20,7 +20,6 @@ use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::prelude::*;
 use cocoindex::qdrant::{self, CollectionSchema, Distance, QdrantConnection};
-use cocoindex::walk;
 use serde_json::json;
 
 const EMBED_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
@@ -52,8 +51,8 @@ struct PointData {
     text: String,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<PointData>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<PointData>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -100,20 +99,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     )
     .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.md"])?;
+    let files = walk_items(&sourcedir, &["**/*.md"])?;
     println!(
         "indexing {} markdown file(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let points_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let points_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for points in &points_by_file {

--- a/examples/rust/text_embedding_turbopuffer/src/main.rs
+++ b/examples/rust/text_embedding_turbopuffer/src/main.rs
@@ -23,7 +23,6 @@ use cocoindex::ops::sentence_transformers::SentenceTransformerEmbedder;
 use cocoindex::ops::text::{RecursiveChunkConfig, RecursiveSplitter};
 use cocoindex::prelude::*;
 use cocoindex::turbopuffer::{self, DistanceMetric, NamespaceSchema, TurbopufferConnection};
-use cocoindex::walk;
 use serde_json::json;
 
 const EMBED_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
@@ -54,8 +53,8 @@ struct RowData {
     text: String,
 }
 
-#[cocoindex::function(memo)]
-async fn process_file(ctx: &Ctx, file: &FileEntry) -> Result<Vec<RowData>> {
+#[cocoindex::function]
+async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<RowData>> {
     let filename = file.key();
     let text = file.content_str()?;
 
@@ -102,20 +101,14 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf, namespace: String) -> Result<()>
     )
     .await?;
 
-    let files: Vec<FileEntry> = walk(&sourcedir, &["**/*.md"])?;
+    let files = walk_items(&sourcedir, &["**/*.md"])?;
     println!(
         "indexing {} markdown file(s) from {}",
         files.len(),
         sourcedir.display()
     );
 
-    let rows_by_file = ctx
-        .mount_each(
-            files,
-            |f| f.key(),
-            |child, file| async move { process_file(&child, &file).await },
-        )
-        .await?;
+    let rows_by_file = mount_each!(files, |file| process_file(ctx, file)).await?;
 
     let mut count = 0usize;
     for rows in &rows_by_file {

--- a/rust/sdk/cocoindex/src/ctx.rs
+++ b/rust/sdk/cocoindex/src/ctx.rs
@@ -713,14 +713,35 @@ impl Ctx {
         F: FnOnce(Ctx) -> Fut + Send + 'static,
         Fut: Future<Output = Result<T>> + Send + 'static,
     {
+        self.__use_mount_fp(key.to_string(), None, f).await
+    }
+
+    /// Foreground mount with an explicit component-memo fingerprint. The
+    /// `mount!` / `use_mount!` / `mount_each!` macros call this; `scope` is the
+    /// `memo_fp = None` (always-run) case kept for direct use and tests.
+    ///
+    /// When `memo_fp` is `Some`, the engine checks it before running the child
+    /// and skips the whole component on an unchanged hit (see
+    /// [`crate::mount::component_memo_fp`]).
+    #[doc(hidden)]
+    pub async fn __use_mount_fp<T, F, Fut>(
+        &self,
+        key: String,
+        memo_fp: Option<Fingerprint>,
+        f: F,
+    ) -> Result<T>
+    where
+        T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+        F: FnOnce(Ctx) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T>> + Send + 'static,
+    {
         let Some(comp_ctx) = &self.comp_ctx else {
             // No pipeline context — just run the closure directly.
             let child_ctx = self.child(None);
             return f(child_ctx).await;
         };
 
-        let key_str = key.to_string();
-        let child_stable_key = StableKey::Str(Arc::from(key_str.as_str()));
+        let child_stable_key = StableKey::Str(Arc::from(key.as_str()));
         let child_path = comp_ctx.stable_path().concat_part(child_stable_key);
 
         let fn_ctx = Arc::new(FnCallContext::default());
@@ -749,8 +770,8 @@ impl Ctx {
                     Value::from_serializable(&result)
                 })
             },
-            None,
-            format!("scope:{key_str}"),
+            memo_fp,
+            format!("mount:{key}"),
         );
 
         let handle = match child_component.use_mount(comp_ctx, processor).await {
@@ -773,6 +794,58 @@ impl Ctx {
             }
         };
         Ok(result)
+    }
+
+    /// Per-item foreground mounts with component-memo fingerprints, the runtime
+    /// behind `mount_each!`. Each `(key, value)` pair becomes a child component
+    /// at `prefix/key` (or `key` when `prefix` is `None`); `memo_of` computes
+    /// the value's component-memo fingerprint and `body` runs the entry
+    /// function under the child scope. All children run concurrently.
+    #[doc(hidden)]
+    pub async fn __mount_each_fp<K, V, M, B, Fut, T>(
+        &self,
+        items: impl IntoIterator<Item = (K, V)>,
+        prefix: Option<&str>,
+        memo_of: M,
+        body: B,
+    ) -> Result<Vec<T>>
+    where
+        K: Display,
+        V: Send + 'static,
+        T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+        M: Fn(&V) -> Result<Option<Fingerprint>>,
+        B: Fn(Ctx, V) -> Fut + Clone + Send + 'static,
+        Fut: Future<Output = Result<T>> + Send + 'static,
+    {
+        let mut keys = rustc_hash::FxHashSet::default();
+        let mut keyed = Vec::new();
+        for (key, value) in items {
+            let key = key.to_string();
+            if !keys.insert(key.clone()) {
+                return Err(Error::engine(format!(
+                    "duplicate key `{key}` in mount_each batch"
+                )));
+            }
+            let memo_fp = memo_of(&value)?;
+            let subpath = match prefix {
+                Some(prefix) => format!("{prefix}/{key}"),
+                None => key,
+            };
+            keyed.push((subpath, memo_fp, value));
+        }
+
+        let futs: Vec<_> = keyed
+            .into_iter()
+            .map(|(subpath, memo_fp, value)| {
+                let body = body.clone();
+                async move {
+                    self.__use_mount_fp(subpath, memo_fp, move |child| body(child, value))
+                        .await
+                }
+            })
+            .collect();
+
+        futures::future::try_join_all(futs).await
     }
 
     /// Cached computation. If `key` hasn't changed since the last run,

--- a/rust/sdk/cocoindex/src/fs.rs
+++ b/rust/sdk/cocoindex/src/fs.rs
@@ -278,6 +278,16 @@ pub fn walk(dir: impl AsRef<Path>, patterns: &[&str]) -> Result<Vec<FileEntry>> 
     walk_internal(&FilePath::new(dir.as_ref()), true, &matcher)
 }
 
+/// Like [`walk`], but yields `(stable key, file)` pairs ready to feed to
+/// `mount_each!`, which expects `(key, value)` items (each file's
+/// [`FileEntry::key`] is its relative path).
+pub fn walk_items(dir: impl AsRef<Path>, patterns: &[&str]) -> Result<Vec<(String, FileEntry)>> {
+    Ok(walk(dir, patterns)?
+        .into_iter()
+        .map(|file| (file.key(), file))
+        .collect())
+}
+
 fn walk_internal(
     root: &FilePath,
     recursive: bool,
@@ -369,8 +379,12 @@ fn relative_path(root: &Path, canonical_root: &Path, path: &Path) -> Result<Path
 /// * unchanged files are skipped (no rewrite),
 /// * files declared in a previous run but **not** this run (e.g. their source
 ///   was deleted) are removed from disk.
-#[derive(Clone)]
+/// A directory target handle. As a `mount_each!` / `use_mount!` argument it
+/// fingerprints by its `dir` (its stable key) — the `provider` is a runtime
+/// handle, not part of the component-memo identity.
+#[derive(Clone, Serialize)]
 pub struct DirTarget {
+    #[serde(skip)]
     provider: TargetStateProvider<Vec<u8>>,
     dir: PathBuf,
 }

--- a/rust/sdk/cocoindex/src/lib.rs
+++ b/rust/sdk/cocoindex/src/lib.rs
@@ -26,6 +26,7 @@ pub mod live_component;
 #[doc(hidden)]
 pub mod logic;
 pub mod memo;
+pub mod mount;
 #[cfg(feature = "neo4j")]
 pub mod neo4j;
 #[cfg(feature = "oci_object_storage")]
@@ -71,7 +72,7 @@ pub use file::{
 };
 pub use fs::{
     DirTarget, DirTargetState, DirWalker, FileEntry, declare_dir_target, dir_target,
-    mount_dir_target, walk, walk_dir,
+    mount_dir_target, walk, walk_dir, walk_items,
 };
 pub use id::{
     IdGenerator, UuidGenerator, generate_id, generate_id_default, generate_uuid,
@@ -106,7 +107,7 @@ pub use target_state::{
 };
 
 // Re-export proc macros
-pub use cocoindex_macros::{SchemaFields, function};
+pub use cocoindex_macros::{SchemaFields, function, mount_each, use_mount};
 pub use row_schema::{LogicalType, SchemaField, SchemaFields};
 
 // Re-exported so users can implement the async `LiveComponent` / `LiveMapFeed`

--- a/rust/sdk/cocoindex/src/mount.rs
+++ b/rust/sdk/cocoindex/src/mount.rs
@@ -1,0 +1,40 @@
+//! Support for the `mount!` / `use_mount!` / `mount_each!` macros.
+//!
+//! These helpers are called from the generated macro code; they are not meant
+//! to be used directly. The macros live in `cocoindex_macros`; see `design.md`
+//! §7.2 for the grouped-call shape and the component-level memo fast-path they
+//! enable.
+
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::memo::{finish_key_fingerprinter, new_key_fingerprinter, write_key_fingerprint_part};
+use cocoindex_utils::fingerprint::Fingerprint;
+
+/// Compute a processing component's memo fingerprint from the entry function's
+/// logic identity (`module`, `name`, `code_hash`) and the fingerprint of its
+/// non-`ctx` arguments.
+///
+/// The engine checks this fingerprint *before* running the component
+/// (`Component::execute_once` → `memo_key_fingerprint`), so on an unchanged hit
+/// the whole component — including child mounts and target-state declaration —
+/// is skipped and the previous run is replayed.
+///
+/// Targets passed as mount arguments fingerprint by their stable key (e.g.
+/// `DirTarget` by its directory), so pointing a component at a different output
+/// invalidates it while reusing the same output is a hit.
+#[doc(hidden)]
+pub fn component_memo_fp<A: Serialize + ?Sized>(
+    module: &str,
+    name: &str,
+    code_hash: u64,
+    args: &A,
+) -> Result<Fingerprint> {
+    let mut fp = new_key_fingerprinter();
+    write_key_fingerprint_part(&mut fp, &"cocoindex_component")?;
+    write_key_fingerprint_part(&mut fp, &module)?;
+    write_key_fingerprint_part(&mut fp, &name)?;
+    write_key_fingerprint_part(&mut fp, &code_hash)?;
+    write_key_fingerprint_part(&mut fp, args)?;
+    Ok(finish_key_fingerprinter(fp))
+}

--- a/rust/sdk/cocoindex/src/postgres.rs
+++ b/rust/sdk/cocoindex/src/postgres.rs
@@ -183,13 +183,21 @@ fn postgres_column_def(field: &crate::row_schema::SchemaField) -> ColumnDef {
 
 /// A declarative Postgres table target — a handle to declare rows (and a vector
 /// index) on. See the [module docs](self).
-#[derive(Clone)]
+///
+/// As a `mount_each!` / `use_mount!` argument it fingerprints by its qualified
+/// table name (its stable key); the schema, managed-by flag, and runtime
+/// providers are not part of the component-memo identity.
+#[derive(Clone, Serialize)]
 pub struct TableTarget {
     pg_schema_name: Option<Arc<str>>,
     table_name: Arc<str>,
+    #[serde(skip)]
     table_schema: TableSchema,
+    #[serde(skip)]
     managed_by: ManagedBy,
+    #[serde(skip)]
     table_provider: TargetStateProvider<TableSpec>,
+    #[serde(skip)]
     rows: TargetStateProvider<RowState>,
 }
 

--- a/rust/sdk/cocoindex/src/prelude.rs
+++ b/rust/sdk/cocoindex/src/prelude.rs
@@ -13,7 +13,7 @@ pub use crate::file::{
 };
 pub use crate::fs::{
     DirTarget, DirTargetState, DirWalker, FileEntry, declare_dir_target, dir_target,
-    mount_dir_target, walk_dir,
+    mount_dir_target, walk, walk_dir, walk_items,
 };
 pub use crate::id::{
     IdGenerator, UuidGenerator, generate_id, generate_id_default, generate_uuid,
@@ -44,5 +44,7 @@ pub use crate::{
     App, ContextKey, DropHandle, PreviewAction, PreviewValue, Progress, StatsGroupHandle,
     StatsGroupOptions, UpdateHandle, UpdateOptions,
 };
+
+pub use crate::{function, mount_each, use_mount};
 
 pub use serde::{Deserialize, Serialize};

--- a/rust/sdk/cocoindex/src/sqlite.rs
+++ b/rust/sdk/cocoindex/src/sqlite.rs
@@ -211,10 +211,16 @@ pub struct SqliteTableOptions {
 // ---------------------------------------------------------------------------
 
 /// A declarative SQLite table target — a handle to declare rows on.
-#[derive(Clone)]
+///
+/// As a `mount_each!` / `use_mount!` argument it fingerprints by its table name
+/// (its stable key); the schema and runtime provider are not part of the
+/// component-memo identity.
+#[derive(Clone, Serialize)]
 pub struct TableTarget {
     table_name: Arc<str>,
+    #[serde(skip)]
     table_schema: TableSchema,
+    #[serde(skip)]
     rows: TargetStateProvider<RowState>,
 }
 

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -2972,4 +2972,28 @@ mod mount_macros {
         assert_eq!(run(&app).await, 21);
         assert_eq!(ONCE_CALLS.load(Ordering::SeqCst), 1);
     }
+
+    #[cocoindex::function]
+    async fn block_id(_ctx: &Ctx, n: u32) -> Result<u32> {
+        Ok(n)
+    }
+
+    #[tokio::test]
+    async fn mount_each_accepts_block_form_closure() {
+        // rustfmt may rewrite `|n| block_id(ctx, n)` into block form
+        // `|n| { block_id(ctx, n) }`; the macro must parse both identically.
+        let (app, _dir) = temp_app("mount_each_block").await;
+        let items = vec![("a".to_string(), 5u32), ("b".to_string(), 6u32)];
+        let out: Vec<u32> = app
+            .update(move |ctx| async move {
+                // `#[rustfmt::skip]` keeps the block braces so this test keeps
+                // exercising the block-form closure body the macro must accept.
+                #[rustfmt::skip]
+                let out = cocoindex::mount_each!(items, |n| { block_id(ctx, n) }).await?;
+                Ok(out)
+            })
+            .await
+            .unwrap();
+        assert_eq!(out, vec![5, 6]);
+    }
 }

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -2870,3 +2870,106 @@ async fn dir_target_deletes_file_when_source_disappears_via_mount_each() {
         "output for a removed source must be deleted"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Grouped-call mount macros: `mount_each!` / `use_mount!` component-memo
+// fast-path (design.md §7.2). Each test uses its own entry fn + static counter
+// so concurrently-running tests don't share state.
+// ---------------------------------------------------------------------------
+
+mod mount_macros {
+    use super::temp_app;
+    use cocoindex::prelude::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static EACH_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[cocoindex::function]
+    async fn each_double(_ctx: &Ctx, n: u32) -> Result<u32> {
+        EACH_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(n * 2)
+    }
+
+    async fn run_each(app: &cocoindex::App, items: Vec<(String, u32)>) -> Vec<u32> {
+        app.update(move |ctx| async move {
+            let out = cocoindex::mount_each!(items, |n| each_double(ctx, n)).await?;
+            Ok(out)
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn mount_each_skips_unchanged_components_across_runs() {
+        let (app, _dir) = temp_app("mount_each_skip").await;
+        let items = vec![("a".to_string(), 1u32), ("b".to_string(), 2u32)];
+
+        let first = run_each(&app, items.clone()).await;
+        assert_eq!(first, vec![2, 4]);
+        assert_eq!(EACH_CALLS.load(Ordering::SeqCst), 2);
+
+        // Same items: both components hit the component-memo fast-path and are
+        // skipped — the cached values are replayed and the fn is not re-run.
+        let second = run_each(&app, items).await;
+        assert_eq!(second, vec![2, 4]);
+        assert_eq!(EACH_CALLS.load(Ordering::SeqCst), 2);
+    }
+
+    static SEL_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[cocoindex::function]
+    async fn sel_double(_ctx: &Ctx, n: u32) -> Result<u32> {
+        SEL_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(n * 2)
+    }
+
+    #[tokio::test]
+    async fn mount_each_reprocesses_only_changed_item() {
+        let (app, _dir) = temp_app("mount_each_changed").await;
+
+        async fn run(app: &cocoindex::App, items: Vec<(String, u32)>) {
+            app.update(move |ctx| async move {
+                cocoindex::mount_each!(items, |n| sel_double(ctx, n)).await?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        }
+
+        run(&app, vec![("a".to_string(), 1), ("b".to_string(), 2)]).await;
+        assert_eq!(SEL_CALLS.load(Ordering::SeqCst), 2);
+
+        // `b`'s value changes (1→3 for key b), `a` is identical: only `b` re-runs.
+        run(&app, vec![("a".to_string(), 1), ("b".to_string(), 3)]).await;
+        assert_eq!(SEL_CALLS.load(Ordering::SeqCst), 3);
+    }
+
+    static ONCE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[cocoindex::function]
+    async fn once_triple(_ctx: &Ctx, n: u32) -> Result<u32> {
+        ONCE_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(n * 3)
+    }
+
+    #[tokio::test]
+    async fn use_mount_skips_unchanged_component_across_runs() {
+        let (app, _dir) = temp_app("use_mount_skip").await;
+
+        async fn run(app: &cocoindex::App) -> u32 {
+            app.update(|ctx| async move {
+                let out = cocoindex::use_mount!(once_triple(ctx, 7u32)).await?;
+                Ok(out)
+            })
+            .await
+            .unwrap()
+        }
+
+        assert_eq!(run(&app).await, 21);
+        assert_eq!(ONCE_CALLS.load(Ordering::SeqCst), 1);
+
+        // Same argument: component-memo hit, fn not re-run, cached value replayed.
+        assert_eq!(run(&app).await, 21);
+        assert_eq!(ONCE_CALLS.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rust/sdk/cocoindex_macros/src/lib.rs
+++ b/rust/sdk/cocoindex_macros/src/lib.rs
@@ -1,13 +1,14 @@
 //! Proc macros for cocoindex: `#[function]`.
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{
-    Error as SynError, Expr, FnArg, Ident, ItemFn, LitInt, PatType, Token, Type, TypeReference,
-    parenthesized,
+    Error as SynError, Expr, FnArg, Ident, ItemFn, LitInt, Pat, PatType, Path, Token, Type,
+    TypeReference, parenthesized,
     parse::{Parse, ParseStream},
     parse_macro_input,
+    punctuated::Punctuated,
 };
 
 /// Information about a non-ctx parameter.
@@ -511,6 +512,236 @@ pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         expanded.into()
     }
+}
+
+// ===========================================================================
+// mount!/use_mount!/mount_each! — grouped-call mount macros (design.md §7.2)
+//
+// These read like the real call — `use_mount!(my_fn(ctx, a, b))` — and turn it
+// into a child processing component whose component-memo fingerprint is
+// `entry-fn logic ⊕ fingerprint(non-ctx args)`. The engine checks that
+// fingerprint *before* running, so an unchanged component (and its whole
+// subtree) is skipped. The macro relies on the `&Ctx`-is-always-first
+// convention: the call's first argument is the parent ctx, which the macro
+// replaces with the freshly-mounted child scope.
+// ===========================================================================
+
+/// Derive the `__COCO_FN_HASH_<NAME>` const path from a function path,
+/// preserving the module prefix (`a::b::my_fn` → `a::b::__COCO_FN_HASH_MY_FN`).
+fn hash_const_path(func_path: &Path) -> Path {
+    let mut path = func_path.clone();
+    if let Some(last) = path.segments.last_mut() {
+        last.ident = format_ident!("__COCO_FN_HASH_{}", last.ident.to_string().to_uppercase());
+        last.arguments = syn::PathArguments::None;
+    }
+    path
+}
+
+/// Destructure a grouped call `my_fn(ctx, a, b)` into its path and arguments.
+fn parse_grouped_call(expr: &Expr) -> syn::Result<(Path, Vec<Expr>)> {
+    let Expr::Call(call) = expr else {
+        return Err(SynError::new_spanned(
+            expr,
+            "expected a function call like `my_fn(ctx, args...)`",
+        ));
+    };
+    let Expr::Path(path) = call.func.as_ref() else {
+        return Err(SynError::new_spanned(
+            &call.func,
+            "expected a plain function path",
+        ));
+    };
+    let args: Vec<Expr> = call.args.iter().cloned().collect();
+    if args.is_empty() {
+        return Err(SynError::new_spanned(
+            expr,
+            "the call's first argument must be the `&Ctx`",
+        ));
+    }
+    Ok((path.path.clone(), args))
+}
+
+/// `use_mount!(my_fn(ctx, a, b))` or `use_mount!(key, my_fn(ctx, a, b))`.
+///
+/// Foreground mount: creates a child component, runs `my_fn` under it with the
+/// child `&Ctx` substituted for the first argument, and returns its value.
+/// `(a, b)` are fingerprinted for the component-memo fast-path. The subpath is
+/// `key` if given, else the function's name.
+#[proc_macro]
+pub fn use_mount(input: TokenStream) -> TokenStream {
+    let parsed = parse_macro_input!(input with Punctuated::<Expr, Token![,]>::parse_terminated);
+    let elems: Vec<Expr> = parsed.into_iter().collect();
+    let (key_expr, call) = match elems.as_slice() {
+        [call] => (None, call),
+        [key, call] => (Some(key), call),
+        _ => {
+            return SynError::new(
+                Span::call_site(),
+                "use_mount! takes `my_fn(ctx, args...)` or `key, my_fn(ctx, args...)`",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let (path, args) = match parse_grouped_call(call) {
+        Ok(v) => v,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let fn_ident = path.segments.last().unwrap().ident.clone();
+    let hash_path = hash_const_path(&path);
+    let ctx_arg = &args[0];
+    let data_args = &args[1..];
+
+    let arg_idents: Vec<Ident> = (0..data_args.len())
+        .map(|i| format_ident!("__coco_arg{i}"))
+        .collect();
+    let arg_binds = arg_idents
+        .iter()
+        .zip(data_args)
+        .map(|(id, expr)| quote! { let #id = #expr; });
+    let fp_refs = arg_idents.iter().map(|id| quote! { & #id });
+    let key_tokens = match key_expr {
+        Some(key) => quote! { ::std::string::ToString::to_string(&(#key)) },
+        None => quote! { ::std::string::ToString::to_string(::core::stringify!(#fn_ident)) },
+    };
+
+    quote! {{
+        let __coco_parent = &(#ctx_arg);
+        #(#arg_binds)*
+        let __coco_memo_fp = ::cocoindex::mount::component_memo_fp(
+            ::core::module_path!(),
+            ::core::stringify!(#fn_ident),
+            #hash_path,
+            &( #(#fp_refs,)* ),
+        )?;
+        let __coco_key: ::std::string::String = #key_tokens;
+        __coco_parent.__use_mount_fp(
+            __coco_key,
+            ::core::option::Option::Some(__coco_memo_fp),
+            move |__coco_child| async move {
+                #path(&__coco_child, #(#arg_idents),*).await
+            },
+        )
+    }}
+    .into()
+}
+
+/// `mount_each!(items, |item| my_fn(ctx, item, a, b))` or
+/// `mount_each!(prefix, items, |item| my_fn(ctx, item, a, b))`.
+///
+/// One child component per `(key, value)` item (subpath `prefix/key`, prefix
+/// defaulting to the function name). The closure binds the item's **value**;
+/// inside the call, `ctx` → child scope, the bound `item` → that value, and any
+/// other arguments are captured extras that are fingerprinted (with the value)
+/// for each item's component-memo key.
+#[proc_macro]
+pub fn mount_each(input: TokenStream) -> TokenStream {
+    let parsed = parse_macro_input!(input with Punctuated::<Expr, Token![,]>::parse_terminated);
+    let elems: Vec<Expr> = parsed.into_iter().collect();
+    let (prefix_expr, items_expr, closure) = match elems.as_slice() {
+        [items, closure] => (None, items, closure),
+        [prefix, items, closure] => (Some(prefix), items, closure),
+        _ => {
+            return SynError::new(
+                Span::call_site(),
+                "mount_each! takes `items, |item| my_fn(ctx, item, ...)` \
+                 or `prefix, items, |item| my_fn(ctx, item, ...)`",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let Expr::Closure(closure) = closure else {
+        return SynError::new_spanned(closure, "expected a closure `|item| my_fn(ctx, item, ...)`")
+            .to_compile_error()
+            .into();
+    };
+    if closure.inputs.len() != 1 {
+        return SynError::new_spanned(closure, "the closure must take exactly one item parameter")
+            .to_compile_error()
+            .into();
+    }
+    let item_ident = match &closure.inputs[0] {
+        Pat::Ident(pat) => pat.ident.clone(),
+        other => {
+            return SynError::new_spanned(other, "the closure parameter must be an identifier")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let (path, args) = match parse_grouped_call(&closure.body) {
+        Ok(v) => v,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let fn_ident = path.segments.last().unwrap().ident.clone();
+    let hash_path = hash_const_path(&path);
+    let ctx_arg = &args[0];
+
+    // Classify each call argument: position 0 is the ctx; the argument equal to
+    // the closure's item ident is the per-item value; everything else is a
+    // captured extra (bound once, cloned per item).
+    let mut extra_binds = Vec::new();
+    let mut extra_idents = Vec::new();
+    let mut fp_elems = Vec::new(); // non-ctx args, in order, for the memo fingerprint
+    let mut body_args = Vec::new(); // all args, in order, for the body call
+    for (i, arg) in args.iter().enumerate() {
+        if i == 0 {
+            body_args.push(quote! { &__coco_child });
+            continue;
+        }
+        if expr_is_ident(arg, &item_ident) {
+            fp_elems.push(quote! { __coco_value });
+            body_args.push(quote! { __coco_value });
+        } else {
+            let id = format_ident!("__coco_extra{}", extra_idents.len());
+            extra_binds.push(quote! { let #id = #arg; });
+            fp_elems.push(quote! { & #id });
+            body_args.push(quote! { #id });
+            extra_idents.push(id);
+        }
+    }
+
+    let prefix_tokens = match prefix_expr {
+        Some(prefix) => quote! { ::core::option::Option::Some(#prefix) },
+        None => quote! { ::core::option::Option::Some(::core::stringify!(#fn_ident)) },
+    };
+
+    quote! {{
+        #(#extra_binds)*
+        let __coco_memo_of = {
+            #( let #extra_idents = ::core::clone::Clone::clone(&#extra_idents); )*
+            move |__coco_value: &_| ::cocoindex::mount::component_memo_fp(
+                ::core::module_path!(),
+                ::core::stringify!(#fn_ident),
+                #hash_path,
+                &( #(#fp_elems,)* ),
+            )
+            .map(::core::option::Option::Some)
+        };
+        let __coco_body = {
+            #( let #extra_idents = ::core::clone::Clone::clone(&#extra_idents); )*
+            move |__coco_child: ::cocoindex::Ctx, __coco_value| {
+                #( let #extra_idents = ::core::clone::Clone::clone(&#extra_idents); )*
+                async move { #path(#(#body_args),*).await }
+            }
+        };
+        (#ctx_arg).__mount_each_fp(#items_expr, #prefix_tokens, __coco_memo_of, __coco_body)
+    }}
+    .into()
+}
+
+/// Whether `expr` is exactly the identifier `ident` (a bare path with one
+/// segment), used to spot the `mount_each!` item-value argument.
+fn expr_is_ident(expr: &Expr, ident: &Ident) -> bool {
+    if let Expr::Path(path) = expr {
+        if path.qself.is_none() {
+            return path.path.is_ident(ident);
+        }
+    }
+    false
 }
 
 // ===========================================================================

--- a/rust/sdk/cocoindex_macros/src/lib.rs
+++ b/rust/sdk/cocoindex_macros/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{
-    Error as SynError, Expr, FnArg, Ident, ItemFn, LitInt, Pat, PatType, Path, Token, Type,
+    Error as SynError, Expr, FnArg, Ident, ItemFn, LitInt, Pat, PatType, Path, Stmt, Token, Type,
     TypeReference, parenthesized,
     parse::{Parse, ParseStream},
     parse_macro_input,
@@ -537,8 +537,23 @@ fn hash_const_path(func_path: &Path) -> Path {
     path
 }
 
+/// Unwrap a single tail-expression block (`{ expr }`) to `expr`. rustfmt may
+/// rewrite a closure body `|x| call(...)` into block form `|x| { call(...) }`,
+/// and users may write the block form by hand — both must still parse as a
+/// grouped call.
+fn unwrap_block_expr(expr: &Expr) -> &Expr {
+    if let Expr::Block(block) = expr
+        && block.block.stmts.len() == 1
+        && let Stmt::Expr(inner, None) = &block.block.stmts[0]
+    {
+        return inner;
+    }
+    expr
+}
+
 /// Destructure a grouped call `my_fn(ctx, a, b)` into its path and arguments.
 fn parse_grouped_call(expr: &Expr) -> syn::Result<(Path, Vec<Expr>)> {
+    let expr = unwrap_block_expr(expr);
     let Expr::Call(call) = expr else {
         return Err(SynError::new_spanned(
             expr,


### PR DESCRIPTION
## Summary
- Add grouped-call mount macros `mount_each!` / `use_mount!` to the Rust SDK, replacing the
  method-based `ctx.mount_each(items, key_fn, closure)` in all examples. The macro reads like the
  real call (`mount_each!(items, |item| my_fn(ctx, item, extra))`), substitutes each child scope's
  `&Ctx` for the first argument, and fingerprints the non-ctx args into a **component-level memo**
  key — so the engine skips a whole unchanged component (and its subtree) before running it
  (design §7.2).
- SDK: `mount.rs::component_memo_fp` (entry-fn logic ⊕ args fp); `ctx.rs` `__use_mount_fp` /
  `__mount_each_fp` runtimes (`scope` delegates with no memo fp); `fs::walk_items` for `(key,value)`
  pairs. Targets fingerprint by their stable key — `DirTarget`, `postgres`/`sqlite::TableTarget`
  gain `Serialize` (providers skipped). Public `scope`/`mount_each` methods retained for explicit
  non-memo mounting (the `file_summarization` benchmark relies on it).
- Examples: all 22 mount sites converted; entry bodies lifted to named `#[cocoindex::function]` fns
  with owned value params; `(key,value)` item sources.
- Background `mount!` (→ handle) is intentionally deferred until a use appears (minimize surface).

## Test plan
- New SDK tests (`tests/pipeline.rs::mount_macros`): `mount_each!` skips unchanged components,
  reprocesses only the changed item, and `use_mount!` skips an unchanged component. All 77 pipeline
  tests pass; `files_transform` verified end-to-end (warm run skips unchanged files).
- SDK builds with `--features postgres,sqlite` (TableTarget `Serialize` derives); `cargo fmt`
  + no-pyo3 gates pass. A representative subset of converted examples checked locally with the
  shared externs target (files_transform, multi_codebase, files_to_sqlite, pdf_to_markdown,
  hn_trending_topics, conversation_to_knowledge, pdf_embedding).
- CI `cargo-test-rust-externs` covers full `cargo check` of all examples + benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
