### PR TITLE
feat(rust-sdk): move provide to the Environment (env-level resources)

### DIFF
--- a/benchmarks/file_summarization/rust/src/main.rs
+++ b/benchmarks/file_summarization/rust/src/main.rs
@@ -233,16 +233,18 @@ async fn main() -> cocoindex::Result<()> {
     let profile = Arc::new(args.profile.clone());
     let sync_stats = Arc::new(Mutex::new(None::<OutputSyncStats>));
 
-    let app = Environment::builder(),
-        args.profile.as_str()
-    ))
-    .db_path(&args.state)
-    .provide(metrics.clone())
-    .provide(profile.clone())
-    .build()
-    .await?.app(&format!(
-        "benchmark_{}_{}",
-        args.scenario.as_str().await?;
+    let app = Environment::builder()
+        .db_path(&args.state)
+        .provide(metrics.clone())
+        .provide(profile.clone())
+        .build()
+        .await?
+        .app(&format!(
+            "benchmark_{}_{}",
+            args.scenario.as_str(),
+            args.profile.as_str()
+        ))
+        .await?;
 
     let dataset = args.dataset.clone();
     let output = args.output.clone();

--- a/benchmarks/file_summarization/rust/src/main.rs
+++ b/benchmarks/file_summarization/rust/src/main.rs
@@ -233,16 +233,16 @@ async fn main() -> cocoindex::Result<()> {
     let profile = Arc::new(args.profile.clone());
     let sync_stats = Arc::new(Mutex::new(None::<OutputSyncStats>));
 
-    let app = App::builder(&format!(
-        "benchmark_{}_{}",
-        args.scenario.as_str(),
+    let app = Environment::builder(),
         args.profile.as_str()
     ))
     .db_path(&args.state)
     .provide(metrics.clone())
     .provide(profile.clone())
     .build()
-    .await?;
+    .await?.app(&format!(
+        "benchmark_{}_{}",
+        args.scenario.as_str().await?;
 
     let dataset = args.dataset.clone();
     let output = args.output.clone();

--- a/examples/rust/amazon_s3_embedding/src/main.rs
+++ b/examples/rust/amazon_s3_embedding/src/main.rs
@@ -236,12 +236,14 @@ async fn main() -> Result<()> {
             let db = postgres::Database::connect(&database_url()).await?;
             let s3 = S3Client::connect().await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("AmazonS3EmbeddingRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&S3, s3)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("AmazonS3EmbeddingRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, bucket, prefix)).await?;
             println!("{stats}");

--- a/examples/rust/audio_to_text/src/main.rs
+++ b/examples/rust/audio_to_text/src/main.rs
@@ -138,10 +138,12 @@ async fn main() -> Result<()> {
     .unwrap_or_else(default_sourcedir);
 
     let db = postgres::Database::connect(&database_url()).await?;
-    let app = App::builder("AudioToText")
+    let app = Environment::builder()
         .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
         .provide_key(&DB, db)
         .build()
+        .await?
+        .app("AudioToText")
         .await?;
 
     let stats = app.run(move |ctx| app_main(ctx, dir)).await?;

--- a/examples/rust/code_embedding/src/main.rs
+++ b/examples/rust/code_embedding/src/main.rs
@@ -276,11 +276,13 @@ async fn main() -> Result<()> {
 
             let db = connect_target_db().await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("CodeEmbeddingRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("CodeEmbeddingRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/code_embedding_lancedb/src/main.rs
+++ b/examples/rust/code_embedding_lancedb/src/main.rs
@@ -201,11 +201,13 @@ async fn main() -> Result<()> {
 
             let db = LanceDatabase::connect(&lancedb_uri()).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("CodeEmbeddingLanceDBRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("CodeEmbeddingLanceDBRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/conversation_to_knowledge/src/main.rs
+++ b/examples/rust/conversation_to_knowledge/src/main.rs
@@ -175,13 +175,15 @@ async fn main() -> Result<()> {
         .map_err(|e| Error::engine(format!("embedder load panicked: {e}")))??;
 
     let graph_for_report = graph.clone();
-    let app = App::builder("ConversationToKnowledge")
+    let app = Environment::builder()
         .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
         .provide_key(&clients::GRAPH, graph)
         .provide_key(&clients::LLM, llm)
         .provide_key(&clients::RESOLVER_LLM, resolver_llm)
         .provide_key(&clients::EMBEDDER, embedder)
         .build()
+        .await?
+        .app("ConversationToKnowledge")
         .await?;
 
     let stats = app.run(move |ctx| app_main(ctx, input_dir)).await?;

--- a/examples/rust/files_to_sqlite/src/main.rs
+++ b/examples/rust/files_to_sqlite/src/main.rs
@@ -71,10 +71,12 @@ async fn process_file(ctx: &Ctx, file: FileEntry, table: sqlite::TableTarget) ->
 
 async fn index(source_dir: PathBuf, db_path: String) -> Result<()> {
     let db = sqlite::Database::connect(&db_path).await?;
-    let app = cocoindex::App::builder("FilesToSqlite")
+    let app = cocoindex::Environment::builder()
         .db_path(".cocoindex_db")
         .provide_key(&DB, db)
         .build()
+        .await?
+        .app("FilesToSqlite")
         .await?;
 
     let stats = app

--- a/examples/rust/gdrive_text_embedding/src/main.rs
+++ b/examples/rust/gdrive_text_embedding/src/main.rs
@@ -248,12 +248,14 @@ async fn main() -> Result<()> {
             let embedder = load_embedder().await?;
             let gdrive = load_gdrive_client()?;
             let root_folder_ids = root_folder_ids()?;
-            let app = App::builder("GoogleDriveTextEmbeddingRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .provide_key(&GDRIVE, gdrive)
                 .build()
+                .await?
+                .app("GoogleDriveTextEmbeddingRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, root_folder_ids)).await?;
             println!("{stats}");

--- a/examples/rust/hn_trending_topics/src/main.rs
+++ b/examples/rust/hn_trending_topics/src/main.rs
@@ -496,11 +496,13 @@ async fn main() -> Result<()> {
             let llm = LlmClient::new(
                 std::env::var("LLM_MODEL").unwrap_or_else(|_| "gpt-4o-mini".into()),
             )?;
-            let app = App::builder("HNTrendingTopics")
+            let app = Environment::builder()
                 .db_path(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&PG, db)
                 .provide_key(&LLM, llm)
                 .build()
+                .await?
+                .app("HNTrendingTopics")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, max_threads)).await?;
             println!("{stats}");

--- a/examples/rust/image_search/src/main.rs
+++ b/examples/rust/image_search/src/main.rs
@@ -160,11 +160,13 @@ async fn main() -> Result<()> {
 
             let conn = QdrantConnection::connect(&qdrant_url()).await?;
             let embedder = ImageEmbedder::load(IMAGE_MODEL).await?;
-            let app = App::builder("ImageSearchRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, conn)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("ImageSearchRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/image_search_colpali/src/main.rs
+++ b/examples/rust/image_search_colpali/src/main.rs
@@ -212,11 +212,13 @@ async fn main() -> Result<()> {
 
             let conn = QdrantConnection::connect(&qdrant_url()).await?;
             let colpali = ColpaliClient::new(colpali_url());
-            let app = App::builder("ImageSearchColpaliRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, conn)
                 .provide_key(&COLPALI, colpali)
                 .build()
+                .await?
+                .app("ImageSearchColpaliRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/oci_object_storage_embedding/src/main.rs
+++ b/examples/rust/oci_object_storage_embedding/src/main.rs
@@ -240,12 +240,14 @@ async fn main() -> Result<()> {
             let db = postgres::Database::connect(&database_url()).await?;
             let oci = OciClient::connect().await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("OciObjectStorageEmbeddingRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&OCI, oci)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("OciObjectStorageEmbeddingRust")
                 .await?;
             let stats = app
                 .run(move |ctx| app_main(ctx, namespace, bucket, prefix))

--- a/examples/rust/paper_metadata/src/main.rs
+++ b/examples/rust/paper_metadata/src/main.rs
@@ -522,12 +522,14 @@ async fn main() -> Result<()> {
             let db = postgres::Database::connect(&database_url()?).await?;
             let llm = LlmClient::new(LLM_MODEL.to_string())?;
             let embedder = load_embedder().await?;
-            let app = App::builder("PaperMetadataV1")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&LLM, llm)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("PaperMetadataV1")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/pdf_embedding/src/main.rs
+++ b/examples/rust/pdf_embedding/src/main.rs
@@ -230,11 +230,13 @@ async fn main() -> Result<()> {
 
             let db = postgres::Database::connect(&database_url()?).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("PdfEmbeddingV1")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("PdfEmbeddingV1")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/postgres_source/src/main.rs
+++ b/examples/rust/postgres_source/src/main.rs
@@ -233,12 +233,14 @@ async fn main() -> Result<()> {
             let db = postgres::Database::connect(&database_url()).await?;
             let source_db = postgres::Database::connect(&source_database_url()).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("PostgresSourceRust")
+            let app = Environment::builder()
                 .db_path(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&SOURCE_DB, source_db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("PostgresSourceRust")
                 .await?;
             let stats = app.run(app_main).await?;
             println!("{stats}");

--- a/examples/rust/text_embedding/src/main.rs
+++ b/examples/rust/text_embedding/src/main.rs
@@ -223,11 +223,13 @@ async fn main() -> Result<()> {
 
             let db = postgres::Database::connect(&database_url()).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("TextEmbeddingRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("TextEmbeddingRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/text_embedding_lancedb/src/main.rs
+++ b/examples/rust/text_embedding_lancedb/src/main.rs
@@ -186,11 +186,13 @@ async fn main() -> Result<()> {
 
             let db = LanceDatabase::connect(&lancedb_uri()).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("TextEmbeddingLanceDBRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, db)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("TextEmbeddingLanceDBRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/text_embedding_qdrant/src/main.rs
+++ b/examples/rust/text_embedding_qdrant/src/main.rs
@@ -192,11 +192,13 @@ async fn main() -> Result<()> {
 
             let conn = QdrantConnection::connect(&qdrant_url()).await?;
             let embedder = load_embedder().await?;
-            let app = App::builder("TextEmbeddingQdrantRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, conn)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("TextEmbeddingQdrantRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir)).await?;
             println!("{stats}");

--- a/examples/rust/text_embedding_turbopuffer/src/main.rs
+++ b/examples/rust/text_embedding_turbopuffer/src/main.rs
@@ -203,11 +203,13 @@ async fn main() -> Result<()> {
             let conn = connect()?;
             let embedder = load_embedder().await?;
             let ns = namespace();
-            let app = App::builder("TextEmbeddingTurbopufferRust")
+            let app = Environment::builder()
                 .db_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cocoindex_db"))
                 .provide_key(&DB, conn)
                 .provide_key(&EMBEDDER, embedder)
                 .build()
+                .await?
+                .app("TextEmbeddingTurbopufferRust")
                 .await?;
             let stats = app.run(move |ctx| app_main(ctx, dir, ns)).await?;
             println!("{stats}");

--- a/rust/sdk/cocoindex/src/app.rs
+++ b/rust/sdk/cocoindex/src/app.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use cocoindex_core::engine::app::{App as CoreApp, AppOpHandle, AppUpdateOptions};
-use cocoindex_core::engine::environment::{Environment, EnvironmentSettings};
+use cocoindex_core::engine::environment::{Environment as CoreEnvironment, EnvironmentSettings};
 use cocoindex_core::engine::progress_display::{ProgressDisplayOptions, show_progress};
 use cocoindex_core::engine::stats::{ProcessingStats, TERMINATED_VERSION};
 use cocoindex_core::engine::target_state::TargetStateProviderRegistry;
@@ -21,11 +21,84 @@ use crate::stats::RunStats;
 use crate::typemap::TypeMap;
 
 // ---------------------------------------------------------------------------
-// AppBuilder
+// Environment — the home for provided resources + LMDB settings
 // ---------------------------------------------------------------------------
 
-pub struct AppBuilder {
-    name: String,
+/// A CocoIndex environment: the LMDB store plus the resources shared with every
+/// app (and target sink) built from it. Build one with [`Environment::builder`],
+/// then create apps with [`Environment::app`]. Multiple environments (separate
+/// `db_path`s) can coexist for multi-tenancy or test isolation.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use cocoindex::Environment;
+/// # async fn run() -> cocoindex::error::Result<()> {
+/// let env = Environment::builder()
+///     .db_path("./.cocoindex")
+///     .provide(String::from("shared resource"))
+///     .build()
+///     .await?;
+/// let app = env.app("MyApp").await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Environment {
+    inner: Arc<EnvironmentInner>,
+}
+
+pub(crate) struct EnvironmentInner {
+    core_env: CoreEnvironment<RustProfile>,
+    state: Arc<TypeMap>,
+    context: Arc<ContextStore>,
+    max_inflight_components: Option<usize>,
+}
+
+impl Environment {
+    /// Start building an environment.
+    pub fn builder() -> EnvironmentBuilder {
+        EnvironmentBuilder::new()
+    }
+
+    /// Create an app in this environment. Multiple apps may share one
+    /// environment — each `name` is its own LMDB namespace and they share the
+    /// environment's provided resources.
+    ///
+    /// # Errors
+    /// Returns an error if the app's state store cannot be created.
+    pub async fn app(&self, name: &str) -> Result<App> {
+        let core_app = CoreApp::new(
+            name,
+            self.inner.core_env.clone(),
+            self.inner.max_inflight_components,
+        )
+        .await
+        .map_err(|e| Error::engine(format!("failed to create app: {e}")))?;
+
+        Ok(App {
+            inner: Arc::new(AppInner {
+                name: name.to_owned(),
+                core_app,
+                state: self.inner.state.clone(),
+                context: self.inner.context.clone(),
+            }),
+        })
+    }
+
+    /// Create an app in this environment (blocking). Convenience for sync
+    /// callers — creates a tokio runtime internally and awaits [`Self::app`].
+    pub fn app_blocking(&self, name: &str) -> Result<App> {
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| Error::engine(format!("failed to create tokio runtime: {e}")))?;
+        rt.block_on(self.app(name))
+    }
+}
+
+/// Builder for [`Environment`]. Provided resources, the LMDB `db_path`, and
+/// other engine settings live here — apps are created from a built environment
+/// via [`Environment::app`].
+pub struct EnvironmentBuilder {
     db_path: Option<PathBuf>,
     lmdb_max_dbs: u32,
     lmdb_map_size: usize,
@@ -34,8 +107,19 @@ pub struct AppBuilder {
     context: ContextStore,
 }
 
-impl AppBuilder {
-    /// Set the LMDB database directory. Default: `./coco_state/{name}/`.
+impl EnvironmentBuilder {
+    fn new() -> Self {
+        Self {
+            db_path: None,
+            lmdb_max_dbs: 1024,
+            lmdb_map_size: 0x1_0000_0000,
+            max_inflight_components: None,
+            state: TypeMap::new(),
+            context: ContextStore::default(),
+        }
+    }
+
+    /// Set the LMDB database directory. Default: `./coco_state`.
     pub fn db_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.db_path = Some(path.into());
         self
@@ -53,7 +137,7 @@ impl AppBuilder {
         self
     }
 
-    /// Limit the number of concurrently processing components.
+    /// Limit the number of concurrently processing components (per app).
     pub fn max_inflight_components(mut self, value: usize) -> Self {
         self.max_inflight_components = Some(value);
         self
@@ -63,11 +147,11 @@ impl AppBuilder {
     /// The type IS the key — each type can only be provided once.
     ///
     /// # Panics
-    /// Panics if a value of type `T` has already been provided for this app.
+    /// Panics if a value of type `T` has already been provided.
     pub fn provide<T: Send + Sync + 'static>(mut self, value: T) -> Self {
         if self.state.contains::<T>() {
             panic!(
-                "AppBuilder::provide: type `{}` has already been provided",
+                "Environment::provide: type `{}` has already been provided",
                 std::any::type_name::<T>()
             );
         }
@@ -77,24 +161,25 @@ impl AppBuilder {
 
     /// Inject a shared resource by named [`ContextKey`].
     ///
-    /// Named keys are useful when multiple resources share the same Rust type.
+    /// Named keys are useful when multiple resources share the same Rust type
+    /// and carry change-tracking.
     ///
     /// # Panics
     /// Panics if a change-tracked key cannot fingerprint the provided value.
     pub fn provide_key<T: Send + Sync + 'static>(mut self, key: &ContextKey<T>, value: T) -> Self {
         self.context
             .provide(key, value)
-            .unwrap_or_else(|e| panic!("AppBuilder::provide_key({}): {e}", key.name()));
+            .unwrap_or_else(|e| panic!("Environment::provide_key({}): {e}", key.name()));
         self
     }
 
-    /// Build the app. Opens (or creates) the LMDB database.
+    /// Build the environment, opening (or creating) the LMDB database.
     ///
     /// # Errors
     ///
     /// Returns an error if the LMDB database environment fails to initialize
     /// (e.g., due to permissions, disk space, or a corrupted state directory).
-    pub async fn build(self) -> Result<App> {
+    pub async fn build(self) -> Result<Environment> {
         // Register every `#[coco::function]`'s logic fingerprint into the engine's
         // logic set, so memo entries that depend on them validate correctly
         // (see `crate::logic`). Idempotent across builds.
@@ -102,7 +187,7 @@ impl AppBuilder {
 
         let db_path = self
             .db_path
-            .unwrap_or_else(|| PathBuf::from(format!("./coco_state/{}/", self.name)));
+            .unwrap_or_else(|| PathBuf::from("./coco_state"));
 
         let settings = EnvironmentSettings {
             db_path,
@@ -112,26 +197,77 @@ impl AppBuilder {
         let providers = Arc::new(std::sync::Mutex::new(TargetStateProviderRegistry::new(
             Default::default(),
         )));
-        let env = Environment::<RustProfile>::new(settings, providers, ())
+        let core_env = CoreEnvironment::<RustProfile>::new(settings, providers, ())
             .await
             .map_err(|e| Error::engine(format!("failed to open LMDB: {e}")))?;
-        self.context.register_logic(&env);
-        let core_app = CoreApp::new(&self.name, env, self.max_inflight_components)
-            .await
-            .map_err(|e| Error::engine(format!("failed to create app: {e}")))?;
+        self.context.register_logic(&core_env);
 
-        Ok(App {
-            inner: Arc::new(AppInner {
-                name: self.name,
-                core_app,
-                state: self.state,
-                context: self.context,
+        Ok(Environment {
+            inner: Arc::new(EnvironmentInner {
+                core_env,
+                state: Arc::new(self.state),
+                context: Arc::new(self.context),
+                max_inflight_components: self.max_inflight_components,
             }),
         })
     }
 
-    /// Build the app (blocking). Convenience for sync callers — creates a
-    /// tokio runtime internally and awaits [`Self::build`].
+    /// Build the environment (blocking). Convenience for sync callers.
+    pub fn build_blocking(self) -> Result<Environment> {
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| Error::engine(format!("failed to create tokio runtime: {e}")))?;
+        rt.block_on(self.build())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AppBuilder — single-app convenience (no provided resources). To provide
+// shared resources, use `Environment::builder().provide(…).build()` then
+// `env.app(name)`.
+// ---------------------------------------------------------------------------
+
+pub struct AppBuilder {
+    name: String,
+    env: EnvironmentBuilder,
+}
+
+impl AppBuilder {
+    /// Set the LMDB database directory. Default: `./coco_state`.
+    pub fn db_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.env = self.env.db_path(path);
+        self
+    }
+
+    /// Set the LMDB maximum number of named databases.
+    pub fn lmdb_max_dbs(mut self, value: u32) -> Self {
+        self.env = self.env.lmdb_max_dbs(value);
+        self
+    }
+
+    /// Set the LMDB map size in bytes.
+    pub fn lmdb_map_size(mut self, value: usize) -> Self {
+        self.env = self.env.lmdb_map_size(value);
+        self
+    }
+
+    /// Limit the number of concurrently processing components.
+    pub fn max_inflight_components(mut self, value: usize) -> Self {
+        self.env = self.env.max_inflight_components(value);
+        self
+    }
+
+    /// Build the app. Creates a single-app environment with no provided
+    /// resources, then the app. To provide resources, use
+    /// [`Environment::builder`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the LMDB database environment fails to initialize.
+    pub async fn build(self) -> Result<App> {
+        self.env.build().await?.app(&self.name).await
+    }
+
+    /// Build the app (blocking). Convenience for sync callers.
     pub fn build_blocking(self) -> Result<App> {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| Error::engine(format!("failed to create tokio runtime: {e}")))?;
@@ -146,7 +282,7 @@ mod tests {
     #[test]
     fn provide_panics_on_duplicate_type() {
         let result = std::panic::catch_unwind(|| {
-            let _ = App::builder("test").provide(1u32).provide(2u32);
+            let _ = Environment::builder().provide(1u32).provide(2u32);
         });
         assert!(result.is_err());
     }
@@ -159,8 +295,8 @@ mod tests {
 pub(crate) struct AppInner {
     pub(crate) name: String,
     pub(crate) core_app: CoreApp<RustProfile>,
-    pub(crate) state: TypeMap,
-    pub(crate) context: ContextStore,
+    pub(crate) state: Arc<TypeMap>,
+    pub(crate) context: Arc<ContextStore>,
 }
 
 #[derive(Clone)]
@@ -195,30 +331,23 @@ impl App {
         App::builder(name).db_path(db_path).build_blocking()
     }
 
-    /// Start building an app. Name determines the LMDB database namespace.
+    /// Start building a single-app environment. Name determines the LMDB
+    /// database namespace. To provide shared resources, use
+    /// [`Environment::builder`] then [`Environment::app`] instead.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use cocoindex::app::App;
     /// # async fn run() -> cocoindex::error::Result<()> {
-    /// let app = App::builder("my_app")
-    ///     .db_path("./data")
-    ///     .provide(String::from("shared resource"))
-    ///     .build()
-    ///     .await?;
+    /// let app = App::builder("my_app").db_path("./data").build().await?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn builder(name: &str) -> AppBuilder {
         AppBuilder {
             name: name.to_owned(),
-            db_path: None,
-            lmdb_max_dbs: 1024,
-            lmdb_map_size: 0x1_0000_0000,
-            max_inflight_components: None,
-            state: TypeMap::new(),
-            context: ContextStore::default(),
+            env: EnvironmentBuilder::new(),
         }
     }
 

--- a/rust/sdk/cocoindex/src/error.rs
+++ b/rust/sdk/cocoindex/src/error.rs
@@ -21,7 +21,9 @@ pub enum Error {
     Engine(String),
 
     /// Requested type or key not found in context.
-    #[error("context: `{0}` not provided — call App::builder().provide() or provide_key() first")]
+    #[error(
+        "context: `{0}` not provided — call Environment::builder().provide() or provide_key() first"
+    )]
     MissingContext(String),
 
     /// User-provided closure returned an error.

--- a/rust/sdk/cocoindex/src/falkordb.rs
+++ b/rust/sdk/cocoindex/src/falkordb.rs
@@ -129,7 +129,7 @@ mod tests {
     use serde::Serialize;
 
     use super::*;
-    use crate::{App, ContextKey};
+    use crate::{App, ContextKey, Environment};
 
     static GRAPH: LazyLock<ContextKey<Graph>> = LazyLock::new(|| ContextKey::new("falkordb_graph"));
 
@@ -241,10 +241,12 @@ mod tests {
         let person_label = format!("Person_{nonce}");
         let relation_label = format!("KNOWS_{nonce}");
         let dir = tempfile::tempdir().unwrap();
-        let app = App::builder("FalkorDBTargetE2ETest")
+        let app = Environment::builder()
             .db_path(dir.path().join(".cocoindex_db"))
             .provide_key(&GRAPH, graph.clone())
             .build()
+            .await?
+            .app("FalkorDBTargetE2ETest")
             .await?;
 
         run_people_graph(&app, person_label.clone(), relation_label.clone(), true).await?;

--- a/rust/sdk/cocoindex/src/lib.rs
+++ b/rust/sdk/cocoindex/src/lib.rs
@@ -55,8 +55,8 @@ mod typemap;
 
 // Flat re-exports — the public API surface
 pub use app::{
-    App, AppBuilder, DropHandle, PreviewAction, PreviewValue, Progress, StatsGroupHandle,
-    StatsGroupOptions, UpdateHandle, UpdateOptions,
+    App, AppBuilder, DropHandle, Environment, EnvironmentBuilder, PreviewAction, PreviewValue,
+    Progress, StatsGroupHandle, StatsGroupOptions, UpdateHandle, UpdateOptions,
 };
 pub use batched::Batched;
 pub use ctx::{ContextKey, Ctx};

--- a/rust/sdk/cocoindex/src/neo4j.rs
+++ b/rust/sdk/cocoindex/src/neo4j.rs
@@ -141,7 +141,7 @@ mod tests {
     use serde::Serialize;
 
     use super::*;
-    use crate::{App, ContextKey};
+    use crate::{App, ContextKey, Environment};
 
     static GRAPH: LazyLock<ContextKey<Graph>> = LazyLock::new(|| ContextKey::new("neo4j_graph"));
 
@@ -269,10 +269,12 @@ mod tests {
             .ok();
 
         let dir = tempfile::tempdir().unwrap();
-        let app = App::builder("Neo4jTargetE2ETest")
+        let app = Environment::builder()
             .db_path(dir.path().join(".cocoindex_db"))
             .provide_key(&GRAPH, graph.clone())
             .build()
+            .await?
+            .app("Neo4jTargetE2ETest")
             .await?;
 
         run_people_graph(&app, person_label.clone(), relation_label.clone(), true).await?;

--- a/rust/sdk/cocoindex/src/prelude.rs
+++ b/rust/sdk/cocoindex/src/prelude.rs
@@ -41,8 +41,8 @@ pub use crate::target_state::{
     register_root_target_states_provider,
 };
 pub use crate::{
-    App, ContextKey, DropHandle, PreviewAction, PreviewValue, Progress, StatsGroupHandle,
-    StatsGroupOptions, UpdateHandle, UpdateOptions,
+    App, ContextKey, DropHandle, Environment, EnvironmentBuilder, PreviewAction, PreviewValue,
+    Progress, StatsGroupHandle, StatsGroupOptions, UpdateHandle, UpdateOptions,
 };
 
 pub use crate::{function, mount_each, use_mount};

--- a/rust/sdk/cocoindex/tests/amazon_s3_source.rs
+++ b/rust/sdk/cocoindex/tests/amazon_s3_source.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use cocoindex::amazon_s3::aws_sdk_s3::primitives::ByteStream;
 use cocoindex::amazon_s3::{self, ListOptions, S3Client, S3File};
 use cocoindex::file::PatternFilePathMatcher;
-use cocoindex::{App, FileLike, Result};
+use cocoindex::{App, Environment, FileLike, Result};
 
 /// Build a client against MinIO, or `None` to skip when `AWS_ENDPOINT_URL` is unset.
 async fn try_client() -> Option<S3Client> {
@@ -240,10 +240,12 @@ async fn s3_source_mount_each_pipeline_when_available() -> Result<()> {
     }
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("S3PipelineTest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&S3, client.clone())
         .build()
+        .await?
+        .app("S3PipelineTest")
         .await?;
 
     let bucket_for_run = bucket.clone();

--- a/rust/sdk/cocoindex/tests/graph_vector_index.rs
+++ b/rust/sdk/cocoindex/tests/graph_vector_index.rs
@@ -25,7 +25,7 @@ fn nonce() -> u128 {
 #[tokio::test]
 async fn neo4j_vector_index_create_then_drop_when_available() {
     use cocoindex::neo4j::{self, ColumnDef, TableSchema, VectorMetric};
-    use cocoindex::{App, ContextKey, Result};
+    use cocoindex::{App, ContextKey, Environment, Result};
     use std::sync::LazyLock;
 
     static G: LazyLock<ContextKey<neo4j::Graph>> =
@@ -42,10 +42,13 @@ async fn neo4j_vector_index_create_then_drop_when_available() {
 
     let label = format!("VecDoc{}", nonce());
     let tmp = tempfile::tempdir().unwrap();
-    let app = App::builder("Neo4jVectorIndex")
+    let app = Environment::builder()
         .db_path(tmp.path().join("db"))
         .provide_key(&G, graph)
         .build()
+        .await
+        .unwrap()
+        .app("Neo4jVectorIndex")
         .await
         .unwrap();
 
@@ -107,7 +110,7 @@ async fn neo4j_vector_index_create_then_drop_when_available() {
 #[tokio::test]
 async fn falkordb_vector_index_create_then_drop_when_available() {
     use cocoindex::falkordb::{self, ColumnDef, TableSchema, VectorMetric};
-    use cocoindex::{App, ContextKey, Result};
+    use cocoindex::{App, ContextKey, Environment, Result};
     use std::sync::LazyLock;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -129,10 +132,13 @@ async fn falkordb_vector_index_create_then_drop_when_available() {
     };
 
     let tmp = tempfile::tempdir().unwrap();
-    let app = App::builder("FalkorDbVectorIndex")
+    let app = Environment::builder()
         .db_path(tmp.path().join("db"))
         .provide_key(&G, graph)
         .build()
+        .await
+        .unwrap()
+        .app("FalkorDbVectorIndex")
         .await
         .unwrap();
 

--- a/rust/sdk/cocoindex/tests/lancedb_target.rs
+++ b/rust/sdk/cocoindex/tests/lancedb_target.rs
@@ -9,7 +9,7 @@
 #![cfg(feature = "lancedb")]
 
 use cocoindex::lancedb::{self, ColumnDef, ColumnType, LanceDatabase, TableSchema};
-use cocoindex::{App, ContextKey, ManagedTargetOptions, Result};
+use cocoindex::{App, ContextKey, Environment, ManagedTargetOptions, Result};
 use serde::Serialize;
 use std::sync::LazyLock;
 
@@ -119,10 +119,13 @@ async fn lancedb_target_creates_upserts_searches_and_reconciles() -> Result<()> 
         let db = db.clone();
         let coco_db_path = coco_db_path.clone();
         async move {
-            let app = App::builder("LanceTargetTest")
+            let app = Environment::builder()
                 .db_path(&coco_db_path)
                 .provide_key(&DB, db)
                 .build()
+                .await
+                .unwrap()
+                .app("LanceTargetTest")
                 .await
                 .unwrap();
             app.run(move |ctx| {
@@ -207,10 +210,13 @@ async fn lancedb_target_creates_upserts_searches_and_reconciles() -> Result<()> 
         mk_v2(1, "alpha-updated", "first", [1.0, 0.0, 0.0]),
         mk_v2(2, "beta", "second", [0.0, 1.0, 0.0]),
     ];
-    let app = App::builder("LanceTargetTest")
+    let app = Environment::builder()
         .db_path(&coco_db_path_for_v2)
         .provide_key(&DB, db_for_v2)
         .build()
+        .await
+        .unwrap()
+        .app("LanceTargetTest")
         .await
         .unwrap();
     app.run(move |ctx| {
@@ -254,10 +260,12 @@ async fn lancedb_replays_unchanged_rows_after_destructive_schema_change() -> Res
         let coco_db_path = coco_db_path.clone();
         let rows = rows.clone();
         async move {
-            let app = App::builder("LanceTargetReplayRowsTest")
+            let app = Environment::builder()
                 .db_path(&coco_db_path)
                 .provide_key(&DB, db)
                 .build()
+                .await?
+                .app("LanceTargetReplayRowsTest")
                 .await?;
             app.run(move |ctx| {
                 let rows = rows.clone();
@@ -300,10 +308,12 @@ async fn lancedb_replaces_table_on_destructive_schema_change() -> Result<()> {
         let db = db.clone();
         let coco_db_path = coco_db_path.clone();
         async move {
-            let app = App::builder("LanceTargetReplaceTest")
+            let app = Environment::builder()
                 .db_path(&coco_db_path)
                 .provide_key(&DB, db)
                 .build()
+                .await?
+                .app("LanceTargetReplaceTest")
                 .await?;
             app.run(move |ctx| {
                 let rows = rows.clone();
@@ -364,10 +374,12 @@ async fn lancedb_user_managed_target_does_not_create_table() -> Result<()> {
     let tempdir = tempfile::tempdir().unwrap();
     let uri = tempdir.path().join("lancedb_data");
     let db = LanceDatabase::connect(uri.to_str().unwrap()).await?;
-    let app = App::builder("LanceUserManagedTargetTest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&DB, db.clone())
         .build()
+        .await?
+        .app("LanceUserManagedTargetTest")
         .await?;
 
     app.run(move |ctx| async move {
@@ -426,10 +438,12 @@ async fn lancedb_adds_vector_column_additively() -> Result<()> {
 
     // v1: single vector column.
     {
-        let app = App::builder("LanceAddVecTest")
+        let app = Environment::builder()
             .db_path(&coco_db_path)
             .provide_key(&DB, db.clone())
             .build()
+            .await?
+            .app("LanceAddVecTest")
             .await?;
         app.run(move |ctx| async move {
             let db = ctx.get_key(&DB)?;
@@ -458,10 +472,12 @@ async fn lancedb_adds_vector_column_additively() -> Result<()> {
 
     // v2: add a second (nullable) vector column. Additive evolution.
     {
-        let app = App::builder("LanceAddVecTest")
+        let app = Environment::builder()
             .db_path(&coco_db_path)
             .provide_key(&DB, db.clone())
             .build()
+            .await?
+            .app("LanceAddVecTest")
             .await?;
         app.run(move |ctx| async move {
             let db = ctx.get_key(&DB)?;

--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -1,6 +1,8 @@
 //! Integration tests for the pipeline: App::update, memo::cached, sync API.
 
-use cocoindex::{App, ContextKey, IdGenerator, UuidGenerator, generate_id, generate_uuid};
+use cocoindex::{
+    App, ContextKey, Environment, IdGenerator, UuidGenerator, generate_id, generate_uuid,
+};
 use tokio::time::{Duration, sleep};
 
 /// Helper: create an App with a temp LMDB directory (async tests).
@@ -66,10 +68,12 @@ fn update_blocking_provide_and_get() {
     }
 
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder("sync_provide")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide(Config { value: 42 })
         .build_blocking()
+        .unwrap()
+        .app_blocking("sync_provide")
         .unwrap();
 
     app.update_blocking(|ctx| async move {
@@ -443,10 +447,13 @@ async fn named_context_key_accepts_non_serializable_resource() {
 
     let key = ContextKey::<Resource>::new("pipeline/non_serializable_resource");
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder("named_context_resource")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, Resource { value: 123 })
         .build()
+        .await
+        .unwrap()
+        .app("named_context_resource")
         .await
         .unwrap();
 
@@ -491,10 +498,13 @@ async fn detect_change_context_key_invalidates_memo() {
     let dir = tempfile::tempdir().unwrap();
     let call_count = Arc::new(AtomicUsize::new(0));
 
-    let app = App::builder("context_change_invalidates_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v1".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_change_invalidates_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -516,10 +526,13 @@ async fn detect_change_context_key_invalidates_memo() {
     .unwrap();
     drop(app);
 
-    let app = App::builder("context_change_invalidates_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v2".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_change_invalidates_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -552,10 +565,13 @@ async fn detect_change_context_key_read_outside_memo_invalidates_component() {
     let dir = tempfile::tempdir().unwrap();
     let call_count = Arc::new(AtomicUsize::new(0));
 
-    let app = App::builder("context_change_component")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v1".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_change_component")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -570,10 +586,13 @@ async fn detect_change_context_key_read_outside_memo_invalidates_component() {
     .unwrap();
     drop(app);
 
-    let app = App::builder("context_change_component")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v2".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_change_component")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -599,10 +618,13 @@ async fn no_detect_change_context_key_does_not_invalidate_memo() {
     let dir = tempfile::tempdir().unwrap();
     let call_count = Arc::new(AtomicUsize::new(0));
 
-    let app = App::builder("context_no_change_does_not_invalidate_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v1".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_no_change_does_not_invalidate_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -624,10 +646,13 @@ async fn no_detect_change_context_key_does_not_invalidate_memo() {
     .unwrap();
     drop(app);
 
-    let app = App::builder("context_no_change_does_not_invalidate_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v2".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("context_no_change_does_not_invalidate_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -682,10 +707,13 @@ async fn state_fn_context_key_invalidates_on_state_change_only() {
         tag: &'static str,
         call_count: std::sync::Arc<AtomicUsize>,
     ) -> u64 {
-        let app = App::builder("state_fn_context_key")
+        let app = Environment::builder()
             .db_path(path)
             .provide_key(&key, Resource { version, _tag: tag })
             .build()
+            .await
+            .unwrap()
+            .app("state_fn_context_key")
             .await
             .unwrap();
         let count = call_count.clone();
@@ -766,11 +794,14 @@ async fn concurrent_detect_change_keys_invalidate_independently() {
         a_calls: Arc<AtomicUsize>,
         b_calls: Arc<AtomicUsize>,
     ) -> String {
-        let app = App::builder("concurrent_detect_change")
+        let app = Environment::builder()
             .db_path(path)
             .provide_key(&key_a, a_val.to_string())
             .provide_key(&key_b, b_val.to_string())
             .build()
+            .await
+            .unwrap()
+            .app("concurrent_detect_change")
             .await
             .unwrap();
         app.update(move |ctx| async move {
@@ -1433,10 +1464,13 @@ async fn bare_function_context_key_invalidates_manual_memo_callers() {
     let dir = tempfile::tempdir().unwrap();
     let call_count = Arc::new(AtomicUsize::new(0));
 
-    let app = App::builder("bare_context_key_invalidates_manual_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v1".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("bare_context_key_invalidates_manual_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -1458,10 +1492,13 @@ async fn bare_function_context_key_invalidates_manual_memo_callers() {
     .unwrap();
     drop(app);
 
-    let app = App::builder("bare_context_key_invalidates_manual_memo")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&key, "v2".to_string())
         .build()
+        .await
+        .unwrap()
+        .app("bare_context_key_invalidates_manual_memo")
         .await
         .unwrap();
     let count = call_count.clone();
@@ -1787,10 +1824,13 @@ mod memo_test_file_state {
 
         let calls = Arc::new(AtomicUsize::new(0));
         let dir = tempfile::tempdir().unwrap();
-        let app = App::builder("file_memo_state_reuses_same_content")
+        let app = Environment::builder()
             .db_path(dir.path().join("lmdb"))
             .provide_key(calls_key(), calls.clone())
             .build()
+            .await
+            .unwrap()
+            .app("file_memo_state_reuses_same_content")
             .await
             .unwrap();
 
@@ -1888,10 +1928,13 @@ mod function_macro_identity_tests {
     async fn identical_body_functions_do_not_share_memo_entries() {
         let dir = tempfile::tempdir().unwrap();
         let calls = Arc::new(AtomicUsize::new(0));
-        let app = cocoindex::App::builder("function_identity_memo")
+        let app = cocoindex::Environment::builder()
             .db_path(dir.path().join("lmdb"))
             .provide_key(calls_key(), calls.clone())
             .build()
+            .await
+            .unwrap()
+            .app("function_identity_memo")
             .await
             .unwrap();
 
@@ -1940,10 +1983,13 @@ mod function_macro_memo_key_tests {
     async fn memo_key_transform_and_skip_for_function_macro() {
         let dir = tempfile::tempdir().unwrap();
         let calls = Arc::new(AtomicUsize::new(0));
-        let app = cocoindex::App::builder("function_macro_memo_key")
+        let app = cocoindex::Environment::builder()
             .db_path(dir.path().join("lmdb"))
             .provide_key(calls_key(), calls.clone())
             .build()
+            .await
+            .unwrap()
+            .app("function_macro_memo_key")
             .await
             .unwrap();
 
@@ -2597,10 +2643,13 @@ mod mock_bare {
     async fn bare_calls_api_every_time() {
         let api = MockApi::new();
         let dir = tempfile::tempdir().unwrap();
-        let app = cocoindex::App::builder("mock_bare")
+        let app = cocoindex::Environment::builder()
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
+            .unwrap()
+            .app("mock_bare")
             .await
             .unwrap();
 
@@ -2653,10 +2702,13 @@ mod mock_memo {
     async fn memo_caches_on_second_run() {
         let api = MockApi::new();
         let dir = tempfile::tempdir().unwrap();
-        let app = cocoindex::App::builder("mock_memo")
+        let app = cocoindex::Environment::builder()
             .db_path(dir.path().join("lmdb"))
             .provide(api.clone())
             .build()
+            .await
+            .unwrap()
+            .app("mock_memo")
             .await
             .unwrap();
 

--- a/rust/sdk/cocoindex/tests/postgres_source.rs
+++ b/rust/sdk/cocoindex/tests/postgres_source.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cocoindex::{App, ContextKey, Ctx, Result, postgres};
+use cocoindex::{App, ContextKey, Ctx, Environment, Result, postgres};
 use serde::{Deserialize, Serialize};
 
 static DB: LazyLock<ContextKey<postgres::Database>> = LazyLock::new(|| {
@@ -218,10 +218,13 @@ async fn postgres_source_reads_processes_and_reconciles_when_available() -> Resu
             let out_schema_name = out_schema_name.clone();
             let db_path = db_path.clone();
             async move {
-                let app = App::builder("PgSourceTest")
+                let app = Environment::builder()
                     .db_path(&db_path)
                     .provide_key(&DB, db.clone())
                     .build()
+                    .await
+                    .unwrap()
+                    .app("PgSourceTest")
                     .await
                     .unwrap();
                 app.run(move |ctx| {

--- a/rust/sdk/cocoindex/tests/postgres_target.rs
+++ b/rust/sdk/cocoindex/tests/postgres_target.rs
@@ -3,7 +3,7 @@
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cocoindex::{App, ContextKey, Ctx, Result, postgres};
+use cocoindex::{App, ContextKey, Ctx, Environment, Result, postgres};
 use serde::{Deserialize, Serialize};
 use sqlx::Row as _;
 
@@ -169,10 +169,12 @@ async fn postgres_table_target_reconciles_rows_when_available() -> Result<()> {
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresTargetE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresTargetE2ETest")
         .await?;
 
     app.run({
@@ -280,10 +282,12 @@ async fn postgres_sql_command_attachment_runs_setup_and_teardown_when_available(
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresSqlCommandE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresSqlCommandE2ETest")
         .await?;
 
     // Declare the attachment → setup SQL creates the index.
@@ -387,10 +391,12 @@ async fn postgres_vector_index_target_reconciles_when_available() -> Result<()> 
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresVectorIndexE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresVectorIndexE2ETest")
         .await?;
 
     app.run({
@@ -437,10 +443,12 @@ async fn postgres_strips_nul_from_text_when_available() -> Result<()> {
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresNulE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresNulE2ETest")
         .await?;
 
     // A label containing a U+0000 NUL — Postgres `text` cannot store it, so it
@@ -541,10 +549,12 @@ async fn postgres_adds_and_drops_columns_when_available() -> Result<()> {
         .await
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresEvolveE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresEvolveE2ETest")
         .await?;
 
     // v1: (id, label)
@@ -623,10 +633,12 @@ async fn postgres_column_drop_retries_after_failed_attempt_when_available() -> R
         .await
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresDropRetryE2ETest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresDropRetryE2ETest")
         .await?;
 
     // v1: table with (id, label, extra).
@@ -749,10 +761,12 @@ async fn postgres_bytea_round_trips_byte_arrays_when_available() -> Result<()> {
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresByteaTest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresByteaTest")
         .await?;
 
     app.run({
@@ -859,10 +873,12 @@ async fn postgres_schema_evolution_retype_and_pk_change_when_available() -> Resu
         .map_err(|e| cocoindex::Error::engine(format!("postgres cleanup: {e}")))?;
 
     let tempdir = tempfile::tempdir().unwrap();
-    let app = App::builder("PostgresEvoTest")
+    let app = Environment::builder()
         .db_path(tempdir.path().join(".cocoindex_db"))
         .provide_key(&PG, db.clone())
         .build()
+        .await?
+        .app("PostgresEvoTest")
         .await?;
 
     // v1: score is bigint.

--- a/rust/sdk/cocoindex/tests/qdrant_target.rs
+++ b/rust/sdk/cocoindex/tests/qdrant_target.rs
@@ -13,7 +13,7 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cocoindex::qdrant::{self, CollectionSchema, Distance, QdrantConnection};
-use cocoindex::{App, ContextKey, Result};
+use cocoindex::{App, ContextKey, Environment, Result};
 use serde_json::json;
 
 static DB: LazyLock<ContextKey<QdrantConnection>> = LazyLock::new(|| {
@@ -52,10 +52,13 @@ async fn qdrant_target_creates_upserts_searches_and_reconciles() -> Result<()> {
         let collection = collection.clone();
         let coco_db = coco_db.clone();
         async move {
-            let app = App::builder("QdrantTargetTest")
+            let app = Environment::builder()
                 .db_path(&coco_db)
                 .provide_key(&DB, conn)
                 .build()
+                .await
+                .unwrap()
+                .app("QdrantTargetTest")
                 .await
                 .unwrap();
             app.run(move |ctx| {
@@ -177,10 +180,13 @@ async fn qdrant_target_supports_uuid_point_ids() -> Result<()> {
         let collection = collection.clone();
         let coco_db = coco_db.clone();
         async move {
-            let app = App::builder("QdrantUuidTest")
+            let app = Environment::builder()
                 .db_path(&coco_db)
                 .provide_key(&DB, conn)
                 .build()
+                .await
+                .unwrap()
+                .app("QdrantUuidTest")
                 .await
                 .unwrap();
             app.run(move |ctx| {

--- a/rust/sdk/cocoindex/tests/sqlite_target.rs
+++ b/rust/sdk/cocoindex/tests/sqlite_target.rs
@@ -8,7 +8,7 @@
 
 use std::sync::LazyLock;
 
-use cocoindex::{App, ContextKey, Ctx, Result, sqlite};
+use cocoindex::{App, ContextKey, Ctx, Environment, Result, sqlite};
 use serde::Serialize;
 use serde_json::json;
 use sqlx::Row as _;
@@ -54,10 +54,13 @@ async fn temp_db() -> (sqlite::Database, tempfile::TempDir) {
 
 async fn build_app(db: &sqlite::Database) -> (App, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder("SqliteTargetTest")
+    let app = Environment::builder()
         .db_path(dir.path().join(".cocoindex_db"))
         .provide_key(&DB, db.clone())
         .build()
+        .await
+        .unwrap()
+        .app("SqliteTargetTest")
         .await
         .unwrap();
     (app, dir)

--- a/rust/sdk/cocoindex/tests/surrealdb_target.rs
+++ b/rust/sdk/cocoindex/tests/surrealdb_target.rs
@@ -29,10 +29,13 @@ async fn surrealdb_targets_reconcile_records_and_relations_when_available() {
     };
 
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder("surrealdb_target_smoke")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&GRAPH, graph.clone())
         .build()
+        .await
+        .unwrap()
+        .app("surrealdb_target_smoke")
         .await
         .unwrap();
 
@@ -58,10 +61,13 @@ async fn surrealdb_targets_e2e_conversation_graph_write_when_available() {
     };
 
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder("surrealdb_target_e2e")
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&GRAPH, graph.clone())
         .build()
+        .await
+        .unwrap()
+        .app("surrealdb_target_e2e")
         .await
         .unwrap();
 
@@ -248,10 +254,13 @@ async fn surrealdb_declare_row_derives_id_from_row_when_available() {
 
 async fn temp_app(graph: &Graph, name: &str) -> (App, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let app = App::builder(name)
+    let app = Environment::builder()
         .db_path(dir.path().join("lmdb"))
         .provide_key(&GRAPH, graph.clone())
         .build()
+        .await
+        .unwrap()
+        .app(name)
         .await
         .unwrap();
     (app, dir)

--- a/rust/sdk/cocoindex/tests/turbopuffer_target.rs
+++ b/rust/sdk/cocoindex/tests/turbopuffer_target.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cocoindex::turbopuffer::{self, DistanceMetric, NamespaceSchema, TurbopufferConnection};
-use cocoindex::{App, ContextKey, Result};
+use cocoindex::{App, ContextKey, Environment, Result};
 use serde_json::json;
 
 static DB: LazyLock<ContextKey<TurbopufferConnection>> = LazyLock::new(|| {
@@ -49,10 +49,13 @@ async fn turbopuffer_target_upserts_searches_and_reconciles() -> Result<()> {
         let namespace = namespace.clone();
         let coco_db = coco_db.clone();
         async move {
-            let app = App::builder("TurbopufferTargetTest")
+            let app = Environment::builder()
                 .db_path(&coco_db)
                 .provide_key(&DB, conn)
                 .build()
+                .await
+                .unwrap()
+                .app("TurbopufferTargetTest")
                 .await
                 .unwrap();
             app.run(move |ctx| {


### PR DESCRIPTION
## Summary
- Move resource provisioning from the app to the **environment** (design §10/§14): `Environment::builder().db_path(p).provide_key(&DB, pool).build().await?` then `let app = env.app("MyApp").await?`. Matches Python's lifespan / `EnvironmentBuilder` and enables multiple apps/environments sharing provided resources.
- Add `Environment` (Clone, Arc-wrapped) + `EnvironmentBuilder`; the env owns the DI stores (`Arc<TypeMap>` / `Arc<ContextStore>`) and the core `Environment`, so multiple `env.app(name)` apps share them. `app_blocking` for sync callers.
- Remove `provide`/`provide_key` from `AppBuilder`. `App::builder(name)` (db_path/lmdb settings only) and `App::open(name, db_path)` remain as single-app sugar over a default no-resource environment — so the many no-provide call sites are untouched; only the `provide` sites migrate.
- Migrate every `provide` site: 18 examples + the `file_summarization` benchmark + `pipeline.rs` + `neo4j`/`falkordb` + the feature-gated target/source tests.

## Test plan
- `cargo test -p cocoindex` — 78 tests pass (incl. the migrated env-provide tests + the dup-provide panic test on `Environment::builder`).
- postgres+sqlite feature tests compile; `files_to_sqlite` + `postgres_source` examples compile; `cargo fmt --check` + no-pyo3 clean.
- CI (`build-test` + `cargo-test-rust-externs`) covers the feature-gated tests (qdrant/lancedb/surreal/turbopuffer/s3/neo4j/falkordb/graph) and the ONNX/cloud examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
