### PR TITLE
feat(rust-sdk): HostCtx = ContextProvider; postgres/sqlite resolve at apply

### DIFF
--- a/examples/rust/amazon_s3_embedding/src/main.rs
+++ b/examples/rust/amazon_s3_embedding/src/main.rs
@@ -89,9 +89,8 @@ async fn process_file(ctx: &Ctx, file: S3File) -> Result<Vec<DocEmbeddingRow>> {
 }
 
 async fn app_main(ctx: Ctx, bucket: String, prefix: String) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
     table.declare_vector_index(
         &ctx,

--- a/examples/rust/audio_to_text/src/main.rs
+++ b/examples/rust/audio_to_text/src/main.rs
@@ -100,9 +100,8 @@ async fn process_audio(ctx: &Ctx, file: FileEntry, table: postgres::TableTarget)
 }
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, transcription_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, transcription_schema()?, Some(PG_SCHEMA))
             .await?;
 
     let files = walk_items(&sourcedir, AUDIO_PATTERNS)?;

--- a/examples/rust/code_embedding/src/main.rs
+++ b/examples/rust/code_embedding/src/main.rs
@@ -110,9 +110,8 @@ async fn process_file(ctx: &Ctx, file: FileEntry) -> Result<Vec<CodeEmbeddingRow
 }
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, code_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, code_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
     table.declare_vector_index(
         &ctx,

--- a/examples/rust/files_to_sqlite/src/main.rs
+++ b/examples/rust/files_to_sqlite/src/main.rs
@@ -83,8 +83,7 @@ async fn index(source_dir: PathBuf, db_path: String) -> Result<()> {
         .run(move |ctx| {
             let source_dir = source_dir.clone();
             async move {
-                let db = ctx.get_key(&DB)?;
-                let table = sqlite::mount_table_target(&ctx, db, TABLE, files_schema()?).await?;
+                let table = sqlite::mount_table_target(&ctx, &DB, TABLE, files_schema()?).await?;
 
                 let files = cocoindex::fs::walk_items(&source_dir, &["**/*.md", "**/*.txt"])?;
                 mount_each!(files, |file| process_file(ctx, file, table)).await?;

--- a/examples/rust/gdrive_text_embedding/src/main.rs
+++ b/examples/rust/gdrive_text_embedding/src/main.rs
@@ -87,9 +87,8 @@ async fn process_file(ctx: &Ctx, file: DriveFile) -> Result<Vec<DocEmbeddingRow>
 }
 
 async fn app_main(ctx: Ctx, root_folder_ids: Vec<String>) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
     table.declare_vector_index(
         &ctx,

--- a/examples/rust/hn_trending_topics/src/main.rs
+++ b/examples/rust/hn_trending_topics/src/main.rs
@@ -306,10 +306,9 @@ async fn process_thread(ctx: &Ctx, thread_id: String) -> Result<ProcessedThread>
 }
 
 async fn app_main(ctx: Ctx, max_threads: usize) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let messages = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "hn_messages",
         message_schema()?,
         Some("coco_examples"),
@@ -317,7 +316,7 @@ async fn app_main(ctx: Ctx, max_threads: usize) -> Result<()> {
     .await?;
     let topics = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "hn_topics",
         topic_schema()?,
         Some("coco_examples"),

--- a/examples/rust/oci_object_storage_embedding/src/main.rs
+++ b/examples/rust/oci_object_storage_embedding/src/main.rs
@@ -90,9 +90,8 @@ async fn process_file(ctx: &Ctx, file: OciFile) -> Result<Vec<DocEmbeddingRow>> 
 }
 
 async fn app_main(ctx: Ctx, namespace: String, bucket: String, prefix: String) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
     table.declare_vector_index(
         &ctx,

--- a/examples/rust/paper_metadata/src/main.rs
+++ b/examples/rust/paper_metadata/src/main.rs
@@ -388,10 +388,9 @@ async fn index_paper(
 }
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let metadata_table = postgres::mount_table_target(
         &ctx,
-        db,
+        &DB,
         TABLE_METADATA,
         metadata_schema()?,
         Some(PG_SCHEMA),
@@ -399,7 +398,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     .await?;
     let author_table = postgres::mount_table_target(
         &ctx,
-        db,
+        &DB,
         TABLE_AUTHOR_PAPERS,
         author_schema()?,
         Some(PG_SCHEMA),
@@ -407,7 +406,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     .await?;
     let embedding_table = postgres::mount_table_target(
         &ctx,
-        db,
+        &DB,
         TABLE_EMBEDDINGS,
         embedding_schema()?,
         Some(PG_SCHEMA),

--- a/examples/rust/pdf_embedding/src/main.rs
+++ b/examples/rust/pdf_embedding/src/main.rs
@@ -125,9 +125,8 @@ fn pdf_embedding_schema() -> Result<postgres::TableSchema> {
 }
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, pdf_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, pdf_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
 
     let files = walk_items(&sourcedir, &["**/*.pdf"])?;

--- a/examples/rust/postgres_source/src/main.rs
+++ b/examples/rust/postgres_source/src/main.rs
@@ -120,9 +120,8 @@ fn output_schema() -> Result<postgres::TableSchema> {
 }
 
 async fn app_main(ctx: Ctx) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let target =
-        postgres::mount_table_target(&ctx, db, TABLE, output_schema()?, Some(PG_SCHEMA)).await?;
+        postgres::mount_table_target(&ctx, &DB, TABLE, output_schema()?, Some(PG_SCHEMA)).await?;
     target.declare_vector_index(
         &ctx,
         "embedding",

--- a/examples/rust/text_embedding/src/main.rs
+++ b/examples/rust/text_embedding/src/main.rs
@@ -109,9 +109,8 @@ fn doc_embedding_schema() -> Result<postgres::TableSchema> {
 }
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
     let table =
-        postgres::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
+        postgres::mount_table_target(&ctx, &DB, TABLE, doc_embedding_schema()?, Some(PG_SCHEMA))
             .await?;
     table.declare_vector_index(
         &ctx,

--- a/rust/sdk/cocoindex/src/app.rs
+++ b/rust/sdk/cocoindex/src/app.rs
@@ -537,7 +537,12 @@ impl App {
         let (core, preview_collector) = self
             .inner
             .core_app
-            .update(processor, core_options, Arc::new(()), preview_collector)
+            .update(
+                processor,
+                core_options,
+                self.inner.context.clone(),
+                preview_collector,
+            )
             .map_err(|e| Error::engine(format!("{e}")))?;
         Ok(UpdateHandle {
             core,
@@ -592,7 +597,7 @@ impl App {
         let core = self
             .inner
             .core_app
-            .drop_app(Arc::new(()))
+            .drop_app(self.inner.context.clone())
             .map_err(|e| Error::engine(format!("{e}")))?;
         Ok(DropHandle { core })
     }

--- a/rust/sdk/cocoindex/src/ctx.rs
+++ b/rust/sdk/cocoindex/src/ctx.rs
@@ -132,7 +132,7 @@ impl<T> ContextKey<T> {
 
 static USED_CONTEXT_KEYS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct ContextStore {
     values: HashMap<Arc<str>, Arc<dyn Any + Send + Sync>>,
     fingerprints: HashMap<Arc<str>, Fingerprint>,
@@ -162,6 +162,19 @@ impl ContextStore {
         self.values
             .get(&key.name)
             .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    /// Resolve a provided resource by its `ContextKey` name (the stable
+    /// `db_key`), returning a shared handle. Target sinks call this at apply
+    /// time via `HostCtx` (the environment's [`ContextStore`]) so connection
+    /// identity in target keys stays a stable key while the live pool/client is
+    /// resolved only when the sink runs (see `design_connectors.md` §5.5).
+    // Used only by feature-gated connectors (postgres/sqlite today).
+    #[allow(dead_code)]
+    pub(crate) fn resolve<T: Send + Sync + 'static>(&self, db_key: &str) -> Option<Arc<T>> {
+        self.values
+            .get(db_key)
+            .and_then(|value| value.clone().downcast::<T>().ok())
     }
 
     fn fingerprint<T>(&self, key: &ContextKey<T>) -> Option<Fingerprint> {

--- a/rust/sdk/cocoindex/src/postgres.rs
+++ b/rust/sdk/cocoindex/src/postgres.rs
@@ -19,7 +19,7 @@ use serde_json::{Map, Value as JsonValue};
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::statediff::{
     ManagedBy, ManagedTargetOptions, MutualTrackingRecord, resolve_system_transition,
@@ -207,7 +207,7 @@ pub struct TableTarget {
 /// [`declare_target_state_with_child`]/[`mount_target`].
 pub fn table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     pg_schema_name: Option<&str>,
@@ -225,7 +225,7 @@ pub fn table_target(
 /// [`table_target`] with explicit [`ManagedTargetOptions`] (`managed_by`).
 pub fn table_target_with_options(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     pg_schema_name: Option<&str>,
@@ -238,13 +238,17 @@ pub fn table_target_with_options(
     }
     let provider = register_root_target_states_provider(
         ctx,
+        // Stable connection identity = the ContextKey's name (`db_key`); the pool
+        // is resolved at apply time from the host context (design_connectors §5.5).
         format!(
             "cocoindex/postgres/table/{}/{}/{}",
-            db.state_id(),
+            db.name(),
             pg_schema_name.unwrap_or("public"),
             table_name
         ),
-        TableHandler { db: db.clone() },
+        TableHandler {
+            db_key: db.name().to_string(),
+        },
     )?;
     Ok(provider.target_state(
         "default",
@@ -262,7 +266,7 @@ pub fn table_target_with_options(
 /// use [`mount_table_target`] when rows must be declared immediately.
 pub fn declare_table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     pg_schema_name: Option<&str>,
@@ -278,7 +282,7 @@ pub fn declare_table_target(
 /// immediately) and return a handle. System-managed.
 pub async fn mount_table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     pg_schema_name: Option<&str>,
@@ -297,7 +301,7 @@ pub async fn mount_table_target(
 /// [`mount_table_target`] with explicit [`ManagedTargetOptions`] (`managed_by`).
 pub async fn mount_table_target_with_options(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     pg_schema_name: Option<&str>,
@@ -518,7 +522,7 @@ pub struct VectorIndexSpec {
 // ---------------------------------------------------------------------------
 
 struct TableHandler {
-    db: Database,
+    db_key: String,
 }
 
 impl TargetHandler<TableSpec> for TableHandler {
@@ -632,13 +636,13 @@ impl TargetHandler<TableSpec> for TableHandler {
             (
                 "vector_index".to_string(),
                 ChildTargetDef::new::<VectorIndexSpec, _>(VectorIndexHandler {
-                    db: self.db.clone(),
+                    db_key: self.db_key.clone(),
                 }),
             ),
             (
                 "sql_command_attachment".to_string(),
                 ChildTargetDef::new::<SqlCommandSpec, _>(SqlCommandHandler {
-                    db: self.db.clone(),
+                    db_key: self.db_key.clone(),
                 }),
             ),
         ])
@@ -647,11 +651,12 @@ impl TargetHandler<TableSpec> for TableHandler {
 
 impl TableHandler {
     fn table_sink(&self) -> TargetActionSink<TableAction> {
-        let db = self.db.clone();
-        TargetActionSink::from_async_fn_with_children(
-            move |actions: Vec<TargetAction<TableAction>>| {
-                let db = db.clone();
+        let db_key = self.db_key.clone();
+        TargetActionSink::from_async_fn_with_children_ctx(
+            move |host_ctx, actions: Vec<TargetAction<TableAction>>| {
+                let db_key = db_key.clone();
                 async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
                     let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                     for action in actions {
                         match action {
@@ -675,7 +680,7 @@ impl TableHandler {
                                     apply_retypes(&db, &spec, &a.retype_cols).await?;
                                 }
                                 out.push(Some(ChildTargetDef::new::<RowState, _>(RowHandler {
-                                    db: db.clone(),
+                                    db_key: db_key.clone(),
                                     spec,
                                 })));
                             }
@@ -700,7 +705,7 @@ impl TableHandler {
 // ---------------------------------------------------------------------------
 
 struct RowHandler {
-    db: Database,
+    db_key: String,
     spec: TableSpec,
 }
 
@@ -740,26 +745,40 @@ impl TargetHandler<RowState> for RowHandler {
     }
 }
 
+/// Resolve the live Postgres [`Database`] from the host context by its stable
+/// `db_key` (the `ContextKey` name it was provided under).
+fn resolve_db(host_ctx: &Arc<ContextStore>, db_key: &str) -> Result<Arc<Database>> {
+    host_ctx.resolve::<Database>(db_key).ok_or_else(|| {
+        Error::engine(format!(
+            "postgres target: database `{db_key}` was not provided in the environment \
+             (call Environment::builder().provide_key(&KEY, db))"
+        ))
+    })
+}
+
 impl RowHandler {
     fn row_sink(&self) -> TargetActionSink<RowAction> {
-        let db = self.db.clone();
+        let db_key = self.db_key.clone();
         let spec = self.spec.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RowAction>>| {
-            let db = db.clone();
-            let spec = spec.clone();
-            async move {
-                let mut mutations = Vec::with_capacity(actions.len());
-                for action in actions {
-                    let row = match action {
-                        TargetAction::Create(r)
-                        | TargetAction::Update(r)
-                        | TargetAction::Delete(r) => r,
-                    };
-                    mutations.push((row.pk, row.state));
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<RowAction>>| {
+                let db_key = db_key.clone();
+                let spec = spec.clone();
+                async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
+                    let mut mutations = Vec::with_capacity(actions.len());
+                    for action in actions {
+                        let row = match action {
+                            TargetAction::Create(r)
+                            | TargetAction::Update(r)
+                            | TargetAction::Delete(r) => r,
+                        };
+                        mutations.push((row.pk, row.state));
+                    }
+                    apply_rows(&db, &spec, mutations).await
                 }
-                apply_rows(&db, &spec, mutations).await
-            }
-        })
+            },
+        )
     }
 }
 
@@ -768,7 +787,7 @@ impl RowHandler {
 // ---------------------------------------------------------------------------
 
 struct VectorIndexHandler {
-    db: Database,
+    db_key: String,
 }
 
 impl TargetHandler<VectorIndexSpec> for VectorIndexHandler {
@@ -814,34 +833,37 @@ impl TargetHandler<VectorIndexSpec> for VectorIndexHandler {
 
 impl VectorIndexHandler {
     fn vector_index_sink(&self) -> TargetActionSink<VectorIndexAction> {
-        let db = self.db.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<VectorIndexAction>>| {
-            let db = db.clone();
-            async move {
-                for action in actions {
-                    let (is_delete, spec) = match action {
-                        TargetAction::Delete(a) => (true, a.spec),
-                        TargetAction::Create(a) | TargetAction::Update(a) => (false, a.spec),
-                    };
-                    if is_delete {
-                        drop_vector_index(&db, &spec).await?;
-                    } else {
-                        define_table(
-                            &db,
-                            &TableSpec {
-                                pg_schema_name: spec.pg_schema_name.clone(),
-                                table_name: spec.table_name.clone(),
-                                table_schema: spec.table_schema.clone(),
-                                managed_by: spec.managed_by,
-                            },
-                        )
-                        .await?;
-                        recreate_vector_index(&db, &spec).await?;
+        let db_key = self.db_key.clone();
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<VectorIndexAction>>| {
+                let db_key = db_key.clone();
+                async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
+                    for action in actions {
+                        let (is_delete, spec) = match action {
+                            TargetAction::Delete(a) => (true, a.spec),
+                            TargetAction::Create(a) | TargetAction::Update(a) => (false, a.spec),
+                        };
+                        if is_delete {
+                            drop_vector_index(&db, &spec).await?;
+                        } else {
+                            define_table(
+                                &db,
+                                &TableSpec {
+                                    pg_schema_name: spec.pg_schema_name.clone(),
+                                    table_name: spec.table_name.clone(),
+                                    table_schema: spec.table_schema.clone(),
+                                    managed_by: spec.managed_by,
+                                },
+                            )
+                            .await?;
+                            recreate_vector_index(&db, &spec).await?;
+                        }
                     }
+                    Ok(())
                 }
-                Ok(())
-            }
-        })
+            },
+        )
     }
 }
 
@@ -871,7 +893,7 @@ fn collect_teardown_sql(prev: &[SqlCommandSpec]) -> Option<String> {
 }
 
 struct SqlCommandHandler {
-    db: Database,
+    db_key: String,
 }
 
 impl TargetHandler<SqlCommandSpec> for SqlCommandHandler {
@@ -923,33 +945,36 @@ impl TargetHandler<SqlCommandSpec> for SqlCommandHandler {
 
 impl SqlCommandHandler {
     fn sql_command_sink(&self) -> TargetActionSink<SqlCommandAction> {
-        let db = self.db.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<SqlCommandAction>>| {
-            let db = db.clone();
-            async move {
-                for action in actions {
-                    let action = match action {
-                        TargetAction::Create(a)
-                        | TargetAction::Update(a)
-                        | TargetAction::Delete(a) => a,
-                    };
-                    // Run previous teardown first (on change or removal), then setup.
-                    if let Some(teardown) = action.prev_teardown_sql {
-                        sqlx::query(&teardown)
-                            .execute(db.pool())
-                            .await
-                            .map_err(pg_err)?;
+        let db_key = self.db_key.clone();
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<SqlCommandAction>>| {
+                let db_key = db_key.clone();
+                async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
+                    for action in actions {
+                        let action = match action {
+                            TargetAction::Create(a)
+                            | TargetAction::Update(a)
+                            | TargetAction::Delete(a) => a,
+                        };
+                        // Run previous teardown first (on change or removal), then setup.
+                        if let Some(teardown) = action.prev_teardown_sql {
+                            sqlx::query(&teardown)
+                                .execute(db.pool())
+                                .await
+                                .map_err(pg_err)?;
+                        }
+                        if let Some(spec) = action.spec {
+                            sqlx::query(&spec.setup_sql)
+                                .execute(db.pool())
+                                .await
+                                .map_err(pg_err)?;
+                        }
                     }
-                    if let Some(spec) = action.spec {
-                        sqlx::query(&spec.setup_sql)
-                            .execute(db.pool())
-                            .await
-                            .map_err(pg_err)?;
-                    }
+                    Ok(())
                 }
-                Ok(())
-            }
-        })
+            },
+        )
     }
 }
 

--- a/rust/sdk/cocoindex/src/profile.rs
+++ b/rust/sdk/cocoindex/src/profile.rs
@@ -16,6 +16,7 @@ use cocoindex_core::state::stable_path::StableKey;
 use cocoindex_utils::fingerprint::Fingerprint;
 use serde::{Deserialize, Serialize};
 
+use crate::ctx::ContextStore;
 use crate::error::Result;
 
 // ---------------------------------------------------------------------------
@@ -27,7 +28,9 @@ pub(crate) struct RustProfile;
 
 impl EngineProfile for RustProfile {
     type HostRuntimeCtx = ();
-    type HostCtx = ();
+    /// The environment's context store, so target sinks can resolve provided
+    /// resources (pools/clients) by their stable key at apply time (§10/§11).
+    type HostCtx = ContextStore;
     type ComponentProc = BoxedProcessor;
     type FunctionData = Value;
 
@@ -236,20 +239,21 @@ impl TargetHandler<RustProfile> for BoxedHandler {
 // BoxedSink — Type-erased action sink for batched target state application.
 // ---------------------------------------------------------------------------
 
-type SinkFn = Arc<
-    dyn Fn(
-            Vec<Action>,
-        ) -> Pin<
-            Box<
-                dyn Future<
-                        Output = cocoindex_utils::error::Result<
-                            Option<Vec<Option<ChildTargetDef<RustProfile>>>>,
-                        >,
-                    > + Send,
-            >,
-        > + Send
-        + Sync,
+type SinkFuture = Pin<
+    Box<
+        dyn Future<
+                Output = cocoindex_utils::error::Result<
+                    Option<Vec<Option<ChildTargetDef<RustProfile>>>>,
+                >,
+            > + Send,
+    >,
 >;
+
+// The sink receives the host context (the environment's `ContextStore`) so it
+// can resolve provided resources (pools/clients) by their stable key at apply
+// time. `BoxedSink::new` adapts host-ctx-free closures (the common case);
+// `new_with_ctx` is for connectors that resolve a connection at apply.
+type SinkFn = Arc<dyn Fn(Arc<ContextStore>, Vec<Action>) -> SinkFuture + Send + Sync>;
 
 #[derive(Clone)]
 pub(crate) struct BoxedSink {
@@ -258,20 +262,12 @@ pub(crate) struct BoxedSink {
 }
 
 impl BoxedSink {
-    pub(crate) fn new(
-        f: impl Fn(
-            Vec<Action>,
-        ) -> Pin<
-            Box<
-                dyn Future<
-                        Output = cocoindex_utils::error::Result<
-                            Option<Vec<Option<ChildTargetDef<RustProfile>>>>,
-                        >,
-                    > + Send,
-            >,
-        > + Send
-        + Sync
-        + 'static,
+    pub(crate) fn new(f: impl Fn(Vec<Action>) -> SinkFuture + Send + Sync + 'static) -> Self {
+        Self::new_with_ctx(move |_host_ctx, actions| f(actions))
+    }
+
+    pub(crate) fn new_with_ctx(
+        f: impl Fn(Arc<ContextStore>, Vec<Action>) -> SinkFuture + Send + Sync + 'static,
     ) -> Self {
         let arc: SinkFn = Arc::new(f);
         // Cast through a thin pointer to get a stable address for equality.
@@ -299,10 +295,10 @@ impl TargetActionSink<RustProfile> for BoxedSink {
     async fn apply(
         &self,
         _host_runtime_ctx: &(),
-        _host_ctx: Arc<()>,
+        host_ctx: Arc<ContextStore>,
         actions: Vec<Action>,
     ) -> cocoindex_utils::error::Result<Option<Vec<Option<ChildTargetDef<RustProfile>>>>> {
-        (self.apply_fn)(actions).await
+        (self.apply_fn)(host_ctx, actions).await
     }
 }
 

--- a/rust/sdk/cocoindex/src/sqlite.rs
+++ b/rust/sdk/cocoindex/src/sqlite.rs
@@ -21,7 +21,7 @@ use serde_json::{Map, Value as JsonValue};
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, Ctx};
 use crate::error::{Error, Result};
 use crate::sql_ident::validate_ident;
 use crate::statediff::{
@@ -228,7 +228,7 @@ pub struct TableTarget {
 /// constructor). System-managed regular table.
 pub fn table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TargetState<TableSpec>> {
@@ -245,7 +245,7 @@ pub fn table_target(
 /// `virtual_table_def`).
 pub fn table_target_with_options(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: SqliteTableOptions,
@@ -257,8 +257,13 @@ pub fn table_target_with_options(
     }
     let provider = register_root_target_states_provider(
         ctx,
-        format!("cocoindex/sqlite/table/{}/{}", db.state_id(), table_name),
-        TableHandler { db: db.clone() },
+        // Stable connection identity = the ContextKey's name (`db_key`), never
+        // live connection details; the pool is resolved at apply time from the
+        // host context (see `design_connectors.md` §5.5).
+        format!("cocoindex/sqlite/table/{}/{}", db.name(), table_name),
+        TableHandler {
+            db_key: db.name().to_string(),
+        },
     )?;
     Ok(provider.target_state(
         "default",
@@ -275,7 +280,7 @@ pub fn table_target_with_options(
 /// provider resolves at this component's commit) and return a handle.
 pub fn declare_table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TableTarget> {
@@ -291,7 +296,7 @@ pub fn declare_table_target(
 /// [`declare_table_target`] with explicit [`SqliteTableOptions`].
 pub fn declare_table_target_with_options(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: SqliteTableOptions,
@@ -306,7 +311,7 @@ pub fn declare_table_target_with_options(
 /// immediately) and return a handle. System-managed regular table.
 pub async fn mount_table_target(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TableTarget> {
@@ -323,7 +328,7 @@ pub async fn mount_table_target(
 /// [`mount_table_target`] with explicit [`SqliteTableOptions`].
 pub async fn mount_table_target_with_options(
     ctx: &Ctx,
-    db: &Database,
+    db: &ContextKey<Database>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: SqliteTableOptions,
@@ -479,7 +484,9 @@ struct RowAction {
 // ---------------------------------------------------------------------------
 
 struct TableHandler {
-    db: Database,
+    /// Stable connection identity (the `ContextKey` name); the live pool is
+    /// resolved from the host context at apply time.
+    db_key: String,
 }
 
 impl TargetHandler<TableSpec> for TableHandler {
@@ -566,11 +573,12 @@ impl TargetHandler<TableSpec> for TableHandler {
 
 impl TableHandler {
     fn table_sink(&self) -> TargetActionSink<TableAction> {
-        let db = self.db.clone();
-        TargetActionSink::from_async_fn_with_children(
-            move |actions: Vec<TargetAction<TableAction>>| {
-                let db = db.clone();
+        let db_key = self.db_key.clone();
+        TargetActionSink::from_async_fn_with_children_ctx(
+            move |host_ctx, actions: Vec<TargetAction<TableAction>>| {
+                let db_key = db_key.clone();
                 async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
                     let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                     for action in actions {
                         let a = match action {
@@ -578,7 +586,7 @@ impl TableHandler {
                             | TargetAction::Update(a)
                             | TargetAction::Delete(a) => a,
                         };
-                        out.push(apply_table_action(&db, a).await?);
+                        out.push(apply_table_action(&db, &db_key, a).await?);
                     }
                     Ok(out)
                 }
@@ -587,9 +595,27 @@ impl TableHandler {
     }
 }
 
+/// Resolve the live SQLite [`Database`] from the host context by its stable
+/// `db_key` (the `ContextKey` name it was provided under).
+fn resolve_db(
+    host_ctx: &std::sync::Arc<crate::ctx::ContextStore>,
+    db_key: &str,
+) -> Result<std::sync::Arc<Database>> {
+    host_ctx.resolve::<Database>(db_key).ok_or_else(|| {
+        Error::engine(format!(
+            "sqlite target: database `{db_key}` was not provided in the environment \
+             (call Environment::builder().provide_key(&KEY, db))"
+        ))
+    })
+}
+
 /// Apply one resolved table action and return the row child provider (or
 /// `None` for a drop). Mirrors Python's `_apply_table_actions` decision tree.
-async fn apply_table_action(db: &Database, action: TableAction) -> Result<Option<ChildTargetDef>> {
+async fn apply_table_action(
+    db: &Database,
+    db_key: &str,
+    action: TableAction,
+) -> Result<Option<ChildTargetDef>> {
     let TableAction {
         spec,
         drop,
@@ -639,7 +665,7 @@ async fn apply_table_action(db: &Database, action: TableAction) -> Result<Option
     }
 
     Ok(Some(ChildTargetDef::new::<RowState, _>(RowHandler {
-        db: db.clone(),
+        db_key: db_key.to_string(),
         spec,
     })))
 }
@@ -649,7 +675,7 @@ async fn apply_table_action(db: &Database, action: TableAction) -> Result<Option
 // ---------------------------------------------------------------------------
 
 struct RowHandler {
-    db: Database,
+    db_key: String,
     spec: TableSpec,
 }
 
@@ -689,24 +715,27 @@ impl TargetHandler<RowState> for RowHandler {
 
 impl RowHandler {
     fn row_sink(&self) -> TargetActionSink<RowAction> {
-        let db = self.db.clone();
+        let db_key = self.db_key.clone();
         let spec = self.spec.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RowAction>>| {
-            let db = db.clone();
-            let spec = spec.clone();
-            async move {
-                let mut mutations = Vec::with_capacity(actions.len());
-                for action in actions {
-                    let row = match action {
-                        TargetAction::Create(r)
-                        | TargetAction::Update(r)
-                        | TargetAction::Delete(r) => r,
-                    };
-                    mutations.push((row.pk, row.state));
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<RowAction>>| {
+                let db_key = db_key.clone();
+                let spec = spec.clone();
+                async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
+                    let mut mutations = Vec::with_capacity(actions.len());
+                    for action in actions {
+                        let row = match action {
+                            TargetAction::Create(r)
+                            | TargetAction::Update(r)
+                            | TargetAction::Delete(r) => r,
+                        };
+                        mutations.push((row.pk, row.state));
+                    }
+                    apply_rows(&db, &spec, mutations).await
                 }
-                apply_rows(&db, &spec, mutations).await
-            }
-        })
+            },
+        )
     }
 }
 

--- a/rust/sdk/cocoindex/src/target_state.rs
+++ b/rust/sdk/cocoindex/src/target_state.rs
@@ -9,7 +9,7 @@ use cocoindex_core::engine::target_state::ChildInvalidation;
 pub use cocoindex_core::state::stable_path::StableKey;
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextStore, Ctx};
 use crate::error::Result;
 use crate::profile::{Action, BoxedHandler, BoxedSink, RustProfile, Value};
 
@@ -238,6 +238,79 @@ where
                 .collect::<Result<Vec<_>>>();
             let fut = match decoded {
                 Ok(actions) => Box::pin(f(actions))
+                    as Pin<Box<dyn Future<Output = Result<Vec<Option<ChildTargetDef>>>> + Send>>,
+                Err(err) => Box::pin(async move { Err(err) }),
+            };
+            Box::pin(async move {
+                let defs = fut
+                    .await
+                    .map_err(|e| cocoindex_utils::error::Error::internal_msg(e.to_string()))?;
+                let mapped = defs
+                    .into_iter()
+                    .map(|d| {
+                        d.map(|d| cocoindex_core::engine::target_state::ChildTargetDef {
+                            handler: d.handler,
+                        })
+                    })
+                    .collect();
+                Ok(Some(mapped))
+            })
+        });
+        Self {
+            inner,
+            _action: PhantomData,
+        }
+    }
+
+    /// Like [`Self::from_async_fn`], but the apply closure also receives the
+    /// host context (the environment's [`ContextStore`]) so it can resolve a
+    /// provided connection by its stable key at apply time (`design_connectors.md`
+    /// §5.5). Used by connectors that resolve pools/clients in `apply`.
+    // Used only by feature-gated connectors (postgres/sqlite today); harmless
+    // dead code in builds without any such connector enabled.
+    #[allow(dead_code)]
+    pub(crate) fn from_async_fn_with_ctx<F, Fut>(f: F) -> Self
+    where
+        F: Fn(Arc<ContextStore>, Vec<TargetAction<A>>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let inner = BoxedSink::new_with_ctx(move |host_ctx, actions| {
+            let decoded = actions
+                .into_iter()
+                .map(decode_action::<A>)
+                .collect::<Result<Vec<_>>>();
+            let fut = match decoded {
+                Ok(actions) => Box::pin(f(host_ctx, actions))
+                    as Pin<Box<dyn Future<Output = Result<()>> + Send>>,
+                Err(err) => Box::pin(async move { Err(err) }),
+            };
+            Box::pin(async move {
+                fut.await
+                    .map_err(|e| cocoindex_utils::error::Error::internal_msg(e.to_string()))?;
+                Ok(None)
+            })
+        });
+        Self {
+            inner,
+            _action: PhantomData,
+        }
+    }
+
+    /// Like [`Self::from_async_fn_with_children`], but the apply closure also
+    /// receives the host context for apply-time connection resolution.
+    #[allow(dead_code)]
+    pub(crate) fn from_async_fn_with_children_ctx<F, Fut>(f: F) -> Self
+    where
+        F: Fn(Arc<ContextStore>, Vec<TargetAction<A>>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<Option<ChildTargetDef>>>> + Send + 'static,
+    {
+        let inner = BoxedSink::new_with_ctx(move |host_ctx, actions| {
+            let decoded = actions
+                .into_iter()
+                .map(decode_action::<A>)
+                .collect::<Result<Vec<_>>>();
+            let fut = match decoded {
+                Ok(actions) => Box::pin(f(host_ctx, actions))
                     as Pin<Box<dyn Future<Output = Result<Vec<Option<ChildTargetDef>>>> + Send>>,
                 Err(err) => Box::pin(async move { Err(err) }),
             };

--- a/rust/sdk/cocoindex/tests/postgres_source.rs
+++ b/rust/sdk/cocoindex/tests/postgres_source.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cocoindex::{App, ContextKey, Ctx, Environment, Result, postgres};
+use cocoindex::{ContextKey, Ctx, Environment, Result, postgres};
 use serde::{Deserialize, Serialize};
 
 static DB: LazyLock<ContextKey<postgres::Database>> = LazyLock::new(|| {
@@ -234,7 +234,7 @@ async fn postgres_source_reads_processes_and_reconciles_when_available() -> Resu
                         let db = ctx.get_key(&DB)?;
                         let target = postgres::mount_table_target(
                             &ctx,
-                            db,
+                            &DB,
                             "output",
                             out_schema(),
                             Some(&out_schema_name),

--- a/rust/sdk/cocoindex/tests/postgres_target.rs
+++ b/rust/sdk/cocoindex/tests/postgres_target.rs
@@ -3,7 +3,7 @@
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cocoindex::{App, ContextKey, Ctx, Environment, Result, postgres};
+use cocoindex::{ContextKey, Ctx, Environment, Result, postgres};
 use serde::{Deserialize, Serialize};
 use sqlx::Row as _;
 
@@ -26,10 +26,9 @@ struct EmbeddingRow {
 }
 
 async fn declare_rows(ctx: Ctx, schema: String, rows: Vec<TestRow>) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "rows",
         postgres::TableSchema::new(
             [
@@ -48,10 +47,9 @@ async fn declare_rows(ctx: Ctx, schema: String, rows: Vec<TestRow>) -> Result<()
 }
 
 async fn declare_vector_table(ctx: Ctx, schema: String, with_index: bool) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "vectors",
         postgres::TableSchema::new(
             [
@@ -88,10 +86,9 @@ async fn declare_rows_with_sql_command(
     schema: String,
     with_attachment: bool,
 ) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "rows",
         postgres::TableSchema::new(
             [
@@ -489,14 +486,13 @@ async fn declare_cols(
     columns: Vec<(String, String)>,
     row: serde_json::Value,
 ) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let cols: Vec<(String, postgres::ColumnDef)> = columns
         .into_iter()
         .map(|(n, t)| (n, postgres::ColumnDef::new(t)))
         .collect();
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "rows",
         postgres::TableSchema::new(cols, ["id"])?,
         Some(&schema_ns),
@@ -722,10 +718,9 @@ struct BlobRow {
 }
 
 async fn declare_blobs(ctx: Ctx, schema: String, rows: Vec<BlobRow>) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "blobs",
         postgres::TableSchema::new(
             [
@@ -824,10 +819,9 @@ async fn declare_evo_table(
     pk: Vec<&'static str>,
     rows: Vec<serde_json::Value>,
 ) -> Result<()> {
-    let db = ctx.get_key(&PG)?;
     let table = postgres::mount_table_target(
         &ctx,
-        db,
+        &PG,
         "evo",
         postgres::TableSchema::new(
             cols.into_iter()

--- a/rust/sdk/cocoindex/tests/schema_from_row.rs
+++ b/rust/sdk/cocoindex/tests/schema_from_row.rs
@@ -120,7 +120,7 @@ fn postgres_from_row_matches_explicit_schema() {
 #[tokio::test]
 async fn sqlite_from_row_round_trips_a_row() -> cocoindex::Result<()> {
     use cocoindex::sqlite::{self, Database, TableSchema};
-    use cocoindex::{App, SchemaFields};
+    use cocoindex::{ContextKey, Environment, SchemaFields};
     use sqlx::Row as _;
 
     #[derive(serde::Serialize, SchemaFields, Clone)]
@@ -147,17 +147,18 @@ async fn sqlite_from_row_round_trips_a_row() -> cocoindex::Result<()> {
         },
     ];
 
-    let app = App::builder("SqliteFromRow")
+    let db_key = ContextKey::<Database>::new("sqlite_from_row_db");
+    let env = Environment::builder()
         .db_path(tmp.path().join("coco_db"))
+        .provide_key(&db_key, db.clone())
         .build()
         .await?;
-    let db2 = db.clone();
+    let app = env.app("SqliteFromRow").await?;
     app.run(move |ctx| {
-        let db = db2.clone();
         let rows = rows.clone();
         async move {
             let schema = TableSchema::from_row::<Item>(["id"])?;
-            let table = sqlite::mount_table_target(&ctx, &db, "items", schema).await?;
+            let table = sqlite::mount_table_target(&ctx, &db_key, "items", schema).await?;
             for row in &rows {
                 table.declare_row(&ctx, row)?;
             }

--- a/rust/sdk/cocoindex/tests/sqlite_target.rs
+++ b/rust/sdk/cocoindex/tests/sqlite_target.rs
@@ -77,8 +77,7 @@ async fn fetch(db: &sqlite::Database, table: &str) -> Vec<(i64, String)> {
 }
 
 async fn declare_items(ctx: Ctx, items: Vec<Item>) -> Result<()> {
-    let db = ctx.get_key(&DB)?;
-    let table = sqlite::mount_table_target(&ctx, db, "items", item_schema()).await?;
+    let table = sqlite::mount_table_target(&ctx, &DB, "items", item_schema()).await?;
     for it in &items {
         table.declare_row(&ctx, it)?;
     }
@@ -137,8 +136,7 @@ async fn sqlite_table_dropped_when_no_longer_declared() {
     // Re-register the table provider but declare nothing → the orphaned table
     // is dropped (handler present, table state absent).
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
-        let _ = sqlite::table_target(&ctx, db, "items", item_schema())?;
+        let _ = sqlite::table_target(&ctx, &DB, "items", item_schema())?;
         Ok(())
     })
     .await
@@ -163,10 +161,9 @@ async fn sqlite_user_managed_table_keeps_table_manages_rows() {
     let (app, _appdir) = build_app(&db).await;
 
     async fn declare_user(ctx: Ctx, items: Vec<Item>) -> Result<()> {
-        let db = ctx.get_key(&DB)?;
         let table = sqlite::mount_table_target_with_options(
             &ctx,
-            db,
+            &DB,
             "items",
             item_schema(),
             sqlite::SqliteTableOptions {
@@ -204,10 +201,9 @@ async fn sqlite_multiple_tables_in_one_run() {
     let (app, _appdir) = build_app(&db).await;
 
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let users = sqlite::mount_table_target(
             &ctx,
-            db,
+            &DB,
             "users",
             sqlite::TableSchema::new(
                 [
@@ -220,7 +216,7 @@ async fn sqlite_multiple_tables_in_one_run() {
         .await?;
         let products = sqlite::mount_table_target(
             &ctx,
-            db,
+            &DB,
             "products",
             sqlite::TableSchema::new(
                 [
@@ -273,9 +269,8 @@ async fn sqlite_add_column_preserves_rows() {
 
     // v1: (id, label)
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s = sqlite::TableSchema::new([("id", col("INTEGER")), ("label", col("TEXT"))], ["id"])?;
-        let t = sqlite::mount_table_target(&ctx, db, "items", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "items", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "label": "one"}))?;
         t.declare_row(&ctx, &json!({"id": 2, "label": "two"}))?;
         Ok(())
@@ -285,7 +280,6 @@ async fn sqlite_add_column_preserves_rows() {
 
     // v2: add nullable `extra` column; same PK → incremental ALTER TABLE ADD COLUMN.
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s = sqlite::TableSchema::new(
             [
                 ("id", col("INTEGER")),
@@ -294,7 +288,7 @@ async fn sqlite_add_column_preserves_rows() {
             ],
             ["id"],
         )?;
-        let t = sqlite::mount_table_target(&ctx, db, "items", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "items", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "label": "one", "extra": "x1"}))?;
         t.declare_row(&ctx, &json!({"id": 2, "label": "two"}))?; // extra → NULL
         Ok(())
@@ -326,7 +320,6 @@ async fn sqlite_drop_column_preserves_rows() {
 
     // v1: (id, label, extra)
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s = sqlite::TableSchema::new(
             [
                 ("id", col("INTEGER")),
@@ -335,7 +328,7 @@ async fn sqlite_drop_column_preserves_rows() {
             ],
             ["id"],
         )?;
-        let t = sqlite::mount_table_target(&ctx, db, "items", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "items", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "label": "one", "extra": "x1"}))?;
         Ok(())
     })
@@ -344,9 +337,8 @@ async fn sqlite_drop_column_preserves_rows() {
 
     // v2: drop `extra`; same PK → incremental ALTER TABLE DROP COLUMN.
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s = sqlite::TableSchema::new([("id", col("INTEGER")), ("label", col("TEXT"))], ["id"])?;
-        let t = sqlite::mount_table_target(&ctx, db, "items", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "items", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "label": "one"}))?;
         Ok(())
     })
@@ -368,9 +360,8 @@ async fn sqlite_change_column_type_recreates_column() {
 
     // v1: score TEXT
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s = sqlite::TableSchema::new([("id", col("INTEGER")), ("score", col("TEXT"))], ["id"])?;
-        let t = sqlite::mount_table_target(&ctx, db, "scores", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "scores", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "score": "10"}))?;
         Ok(())
     })
@@ -379,10 +370,9 @@ async fn sqlite_change_column_type_recreates_column() {
 
     // v2: score INTEGER; same PK → column type change (DROP + ADD COLUMN).
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let s =
             sqlite::TableSchema::new([("id", col("INTEGER")), ("score", col("INTEGER"))], ["id"])?;
-        let t = sqlite::mount_table_target(&ctx, db, "scores", s).await?;
+        let t = sqlite::mount_table_target(&ctx, &DB, "scores", s).await?;
         t.declare_row(&ctx, &json!({"id": 1, "score": 42}))?;
         Ok(())
     })
@@ -417,8 +407,7 @@ async fn sqlite_mount_each_per_item_rows() {
     // one row per item from `mount_each` sub-components (mirrors Python's
     // `await coco.mount_each(process, items, target)`).
     app.run(|ctx| async move {
-        let db = ctx.get_key(&DB)?;
-        let table = sqlite::mount_table_target(&ctx, db, "items", item_schema()).await?;
+        let table = sqlite::mount_table_target(&ctx, &DB, "items", item_schema()).await?;
         ctx.mount_each(
             vec![item(1, "one"), item(2, "two"), item(3, "three")],
             |it| it.id.to_string(),


### PR DESCRIPTION
## Summary
- Target sinks now resolve their connection from the **environment's context store at apply time**, keyed by a stable `db_key` (the `ContextKey` name) — decoupling target identity from live credentials and enabling apply-time resolution across environments (design §10/§11, design_connectors §5.5). **Staged: postgres + sqlite first**; remaining connectors (qdrant/lancedb/turbopuffer/neo4j/falkordb/surrealdb/doris) follow the same pattern next.
- **Foundation:** `RustProfile::HostCtx = ContextStore` (was `()`); SDK passes the env's `Arc<ContextStore>` as host_ctx on update/drop. `BoxedSink` threads host_ctx (`new` adapts host-ctx-free closures; `new_with_ctx` for resolving ones); `ContextStore::resolve::<T>(db_key)`; `TargetActionSink::from_async_fn_with_ctx` + `_with_children_ctx`. (`HostCtx` is fully generic in the engine — no core changes.)
- **postgres + sqlite:** handlers store `db_key: String` instead of a captured `Database`; sinks resolve the live pool at apply (`resolve_db(&host_ctx, &db_key)`); provider keys use the ContextKey name (stable). **Declare API takes `&ContextKey<Database>`** instead of a live `db`.
- Migrated the postgres/sqlite examples + the target/source tests (and `schema_from_row`, now via a `ContextKey` + `Environment`).

## Test plan
- `cargo test -p cocoindex` — 53 lib + 78 pipeline pass (host_ctx wiring doesn't change existing behavior).
- **`sqlite_target` live tests 8/8 pass** — proves resolve-at-apply end-to-end (tables created + rows reconciled through the host-ctx-resolved pool, no server needed).
- `cargo test -p cocoindex --features postgres,sqlite --no-run` compiles; `files_to_sqlite` example compiles; `cargo fmt --check` clean.
- CI (`build-test` + `cargo-test-rust-externs`) covers the postgres/ONNX examples and feature-gated tests; live postgres tests need a running DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
