### PR TITLE
refactor(engine): prefetch fn-memos and user-states in one read txn

### DIFF
--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -947,13 +947,13 @@ impl<Prof: EngineProfile> Component<Prof> {
                         eager_existence_upsert(processor_context).await?;
                     }
 
-                    // Eagerly load all function-memo entries for this component
-                    // into the per-build cache, so every subsequent fn-call probe
-                    // serves from memory. Skipped under `full_reprocess` and in
-                    // delete mode (no `ComponentBuildingState`); see the cache
-                    // flush logic for how those cases are handled at commit time.
-                    processor_context.prefetch_fn_memos().await?;
-                    processor_context.prefetch_user_states().await?;
+                    // Eagerly load all function-memo and user-state entries for
+                    // this component into the per-build cache (one read txn), so
+                    // every subsequent fn-call probe and `use_state` serves from
+                    // memory. Skipped under `full_reprocess` and in delete mode
+                    // (no `ComponentBuildingState`); see the cache flush logic
+                    // for how those cases are handled at commit time.
+                    processor_context.prefetch_states().await?;
 
                     if memo_fp_to_store.is_some() {
                         *self.inner.last_memo_fp.lock().unwrap() = memo_fp_to_store;

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -261,7 +261,7 @@ impl<Prof: EngineProfile> FnMemoCache<Prof> {
 
     /// Insert prefetched rows from the database into the cache and mark it
     /// fully loaded. The async I/O lives at the context layer
-    /// ([`ComponentProcessorContext::prefetch_fn_memos`]); this is the sync
+    /// ([`ComponentProcessorContext::prefetch_states`]); this is the sync
     /// half that runs under the building-state mutex.
     pub(crate) fn populate(&mut self, rows: Vec<(Fingerprint, Vec<u8>)>) {
         for (fp, bytes) in rows {
@@ -752,69 +752,46 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         self.inner.component.stable_path()
     }
 
-    /// Eagerly load every function-memo entry for this component from
-    /// storage into the per-build cache. Called at the start of build mode
-    /// before any function calls run; skipped under `full_reprocess` so
-    /// the cache stays empty and `into_flush_plan` produces a clear-all
-    /// plan followed by writes of newly-computed entries.
-    pub(crate) async fn prefetch_fn_memos(&self) -> Result<()> {
+    /// Eagerly load every function-memo and user-state entry for this
+    /// component from storage into the per-build cache. Called at the start
+    /// of build mode before any function calls run, so every subsequent
+    /// fn-call probe and `use_state` serves from memory. Skipped under
+    /// `full_reprocess` so both caches stay empty and `into_flush_plan`
+    /// produces a clear-all plan followed by writes of newly-computed entries.
+    ///
+    /// Both ranges are read under a single LMDB read transaction: under
+    /// `MDB_NOTLS` every read-txn begin takes the reader-table mutex, so
+    /// one snapshot instead of two halves that cost — most visibly during
+    /// `mount_each` fan-out, where many child components prefetch at once
+    /// (it also halves concurrent reader-slot occupancy against LMDB's
+    /// `MDB_READERS_FULL` limit).
+    pub(crate) async fn prefetch_states(&self) -> Result<()> {
         if self.full_reprocess() {
             return Ok(());
         }
-        // Cheap check: skip if already loaded (re-entry, etc.).
+        // Cheap check: skip if already loaded (re-entry, etc.). The two
+        // caches are always prefetched together, so they load as a pair.
         let already_loaded = match &self.inner.processing_action {
             ComponentProcessingAction::Build(build_ctx) => {
                 let guard = build_ctx.state.lock().unwrap();
                 let Some(state) = guard.as_ref() else {
                     return Ok(());
                 };
-                state.fn_memos.is_fully_loaded()
+                state.fn_memos.is_fully_loaded() && state.user_states.is_loaded()
             }
             ComponentProcessingAction::Delete { .. } => return Ok(()),
         };
         if already_loaded {
             return Ok(());
         }
-        let app_store = self.app_ctx().app_store();
-        let path = self.stable_path();
-        let rows = app_store.list_fn_memos(path).await?;
-        self.update_building_state(|s| {
-            s.fn_memos.populate(rows);
-            Ok(())
-        })
-    }
-
-    /// Eagerly load every user-state entry for this component from storage
-    /// into the per-build cache. Mirrors `prefetch_fn_memos`; skipped under
-    /// `full_reprocess` so `into_flush_plan` produces a clear-all plan
-    /// followed by writes of the newly-declared entries.
-    pub(crate) async fn prefetch_user_states(&self) -> Result<()> {
-        if self.full_reprocess() {
-            return Ok(());
-        }
-
-        // Cheap check: skip if already loaded (re-entry, etc.).
-        let already_loaded = match &self.inner.processing_action {
-            ComponentProcessingAction::Build(build_ctx) => {
-                let guard = build_ctx.state.lock().unwrap();
-                let Some(state) = guard.as_ref() else {
-                    return Ok(());
-                };
-                state.user_states.is_loaded()
-            }
-            ComponentProcessingAction::Delete { .. } => return Ok(()),
-        };
-        if already_loaded {
-            return Ok(());
-        }
-
-        let rows = self
+        let (fn_memo_rows, user_state_rows) = self
             .app_ctx()
             .app_store()
-            .list_user_states(self.stable_path(), db_schema::StateKind::Regular)
+            .prefetch_fn_processing_states(self.stable_path())
             .await?;
         self.update_building_state(|s| {
-            s.user_states.populate(rows);
+            s.fn_memos.populate(fn_memo_rows);
+            s.user_states.populate(user_state_rows);
             Ok(())
         })
     }
@@ -1141,6 +1118,13 @@ mod tests {
         pairs.into_iter().collect()
     }
 
+    /// Read back a component's Regular user states through the production
+    /// prefetch path (`prefetch_fn_processing_states`), so these tests assert
+    /// against the same read code the engine runs.
+    async fn read_regular_states(store: &AppStore, p: &StablePath) -> HashMap<StableKey, Vec<u8>> {
+        to_map(store.prefetch_fn_processing_states(p).await.unwrap().1)
+    }
+
     // --- use_state -----------------------------------------------------------
 
     #[test]
@@ -1257,12 +1241,7 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 2);
         assert!(entries.contains_key(&sym("a")));
         assert!(entries.contains_key(&sym("b")));
@@ -1288,12 +1267,7 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 1);
         assert!(!entries.contains_key(&sym("old")));
         assert_eq!(entries[&sym("new_k")], b("new_val"));
@@ -1319,12 +1293,7 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[&sym("a")], b("a_val"));
         assert_eq!(entries[&sym("b")], b("b_new"));
@@ -1350,12 +1319,7 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries[&sym("k")], b("new"));
     }
 
@@ -1382,13 +1346,7 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        assert!(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap()
-                .is_empty()
-        );
+        assert!(read_regular_states(&store, &p).await.is_empty());
     }
 
     #[tokio::test]
@@ -1409,12 +1367,6 @@ mod tests {
 
         apply_plan_via_commit(&store, &p, cache).await;
 
-        assert!(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap()
-                .is_empty()
-        );
+        assert!(read_regular_states(&store, &p).await.is_empty());
     }
 }

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -660,8 +660,8 @@ mod tests {
     }
 
     /// Prefix for path A must not match entries under path B.
-    /// Guards the scoping guarantee: `list_user_states(path_a)` never
-    /// returns entries that belong to path_b.
+    /// Guards the scoping guarantee: a user-state prefix scan for path_a
+    /// never returns entries that belong to path_b.
     #[test]
     fn user_state_prefix_does_not_cross_paths() {
         let path_a = StablePath(Arc::from(vec![StableKey::Str(Arc::from("file_a.md"))]));

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -469,21 +469,6 @@ impl AppStore {
 // --- Function memoization ------------------------------------------------
 
 impl AppStore {
-    /// List every function memo under `path` from a fresh snapshot. Used
-    /// by the per-component `fn_memos` loader outside `run_txn`.
-    pub async fn list_fn_memos(&self, path: &StablePath) -> Result<Vec<(Fingerprint, Vec<u8>)>> {
-        let rtxn = self.read_txn().await?;
-        let prefix = key_fn_memo_prefix(path)?;
-        let db = self.db();
-        let mut out = Vec::new();
-        for entry in db.prefix_iter(&rtxn, &prefix)? {
-            let (raw_key, raw_val) = entry?;
-            let fp: Fingerprint = storekey::decode(raw_key[prefix.len()..].as_ref())?;
-            out.push((fp, raw_val.to_vec()));
-        }
-        Ok(out)
-    }
-
     pub async fn write_fn_memo(
         &self,
         txn: &mut WriteTxn<'_>,
@@ -825,25 +810,6 @@ impl AppStore {
 // --- User state ----------------------------------------------------------
 
 impl AppStore {
-    /// List all user-state entries of `kind` under `path` from a fresh
-    /// snapshot. Returns `(user_key, value_bytes)` pairs in on-disk key order.
-    pub async fn list_user_states(
-        &self,
-        path: &StablePath,
-        kind: StateKind,
-    ) -> Result<Vec<(StableKey, Vec<u8>)>> {
-        let rtxn = self.read_txn().await?;
-        let prefix = key_user_state_prefix(path, kind)?;
-        let db = self.db();
-        let mut out = Vec::new();
-        for entry in db.prefix_iter(&rtxn, &prefix)? {
-            let (raw_key, raw_val) = entry?;
-            let user_key: StableKey = storekey::decode(raw_key[prefix.len()..].as_ref())?;
-            out.push((user_key, raw_val.to_vec()));
-        }
-        Ok(out)
-    }
-
     /// Point-read the single `kind` entry under `(path, user_key)` from a
     /// fresh snapshot, or `None` if absent. Used by `read_committed_state`
     /// to fetch one [`StateKind::Live`] key without scanning the prefix.
@@ -931,6 +897,48 @@ impl AppStore {
     }
 }
 
+// --- Combined prefetch read ----------------------------------------------
+
+impl AppStore {
+    /// List every function-memo and user-state entry under `path` from a
+    /// single read snapshot. Used by the per-component prefetch
+    /// ([`crate::engine::context::ComponentProcessorContext::prefetch_states`]).
+    ///
+    /// Both ranges are read under one `RoTxn` rather than two. Under
+    /// `MDB_NOTLS` each read-txn begin takes the reader-table mutex, so a
+    /// single snapshot halves that cost — most visibly when many child
+    /// components prefetch concurrently during `mount_each` fan-out — and
+    /// halves concurrent reader-slot occupancy against the
+    /// `MDB_READERS_FULL` limit.
+    pub async fn prefetch_fn_processing_states(
+        &self,
+        path: &StablePath,
+    ) -> Result<(Vec<(Fingerprint, Vec<u8>)>, Vec<(StableKey, Vec<u8>)>)> {
+        let rtxn = self.read_txn().await?;
+        let db = self.db();
+
+        // Function memos, keyed by fingerprint.
+        let fp_prefix = key_fn_memo_prefix(path)?;
+        let mut memos = Vec::new();
+        for entry in db.prefix_iter(&rtxn, &fp_prefix)? {
+            let (raw_key, raw_val) = entry?;
+            let fp: Fingerprint = storekey::decode(raw_key[fp_prefix.len()..].as_ref())?;
+            memos.push((fp, raw_val.to_vec()));
+        }
+
+        // User states, keyed by stable key.
+        let us_prefix = key_user_state_prefix(path, StateKind::Regular)?;
+        let mut states = Vec::new();
+        for entry in db.prefix_iter(&rtxn, &us_prefix)? {
+            let (raw_key, raw_val) = entry?;
+            let user_key: StableKey = storekey::decode(raw_key[us_prefix.len()..].as_ref())?;
+            states.push((user_key, raw_val.to_vec()));
+        }
+
+        Ok((memos, states))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::AppStore;
@@ -975,15 +983,20 @@ mod tests {
         pairs.into_iter().collect()
     }
 
-    // --- list_user_states --------------------------------------------------
+    /// Read back a component's Regular user states through the production
+    /// prefetch path (`prefetch_fn_processing_states`), so these tests assert
+    /// against the same read code the engine runs. The fn-memo half of the
+    /// result is unused here (these tests write no memos).
+    async fn read_regular_states(store: &AppStore, p: &StablePath) -> HashMap<StableKey, Vec<u8>> {
+        to_map(store.prefetch_fn_processing_states(p).await.unwrap().1)
+    }
+
+    // --- user state read-back (via prefetch) -------------------------------
 
     #[tokio::test]
-    async fn list_user_states_empty_on_fresh_path() {
+    async fn user_states_empty_on_fresh_path() {
         let (store, _dir) = make_test_store().await;
-        let result = store
-            .list_user_states(&comp_path("comp"), StateKind::Regular)
-            .await
-            .unwrap();
+        let result = read_regular_states(&store, &comp_path("comp")).await;
         assert!(result.is_empty());
     }
 
@@ -1009,12 +1022,7 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[&sym("count")], b"42");
         assert_eq!(entries[&sym("name")], b"hello");
@@ -1040,12 +1048,7 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[&sym("k")], b"v2");
     }
@@ -1086,12 +1089,7 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[&sym("a")], b"new_a");
         assert!(!entries.contains_key(&sym("b")));
@@ -1138,12 +1136,7 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        let entries = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let entries = read_regular_states(&store, &p).await;
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[&sym("a")], b"new_a");
         assert!(!entries.contains_key(&sym("b")));
@@ -1170,18 +1163,8 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        let r1 = to_map(
-            store
-                .list_user_states(&p1, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
-        let r2 = to_map(
-            store
-                .list_user_states(&p2, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
+        let r1 = read_regular_states(&store, &p1).await;
+        let r2 = read_regular_states(&store, &p2).await;
         assert_eq!(r1.len(), 1);
         assert_eq!(r2.len(), 1);
         assert_eq!(r1[&sym("k")], b"from_a");
@@ -1193,8 +1176,9 @@ mod tests {
     #[tokio::test]
     async fn user_states_isolated_by_kind() {
         // Regular and Live share the component path and even the same user
-        // key, but never collide: per-kind list/read see only their own
-        // entries, and a Regular bulk-delete leaves Live intact.
+        // key, but never collide: the Regular bulk read excludes Live, point
+        // reads resolve per kind, and a Regular bulk-delete leaves Live intact.
+        // (Live has no bulk reader by design — production point-reads it.)
         let (store, _dir) = make_test_store().await;
         let p = comp_path("comp");
 
@@ -1209,20 +1193,13 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        // Per-kind list sees only its own keyspace, even for the same key.
-        let reg = to_map(
-            store
-                .list_user_states(&p, StateKind::Regular)
-                .await
-                .unwrap(),
-        );
-        let live = to_map(store.list_user_states(&p, StateKind::Live).await.unwrap());
+        // The Regular bulk read sees only the Regular entry, never the Live
+        // one written under the same key.
+        let reg = read_regular_states(&store, &p).await;
         assert_eq!(reg.len(), 1);
-        assert_eq!(live.len(), 1);
         assert_eq!(reg[&sym("k")], b"reg");
-        assert_eq!(live[&sym("k")], b"live");
 
-        // Point-read resolves per kind.
+        // Point-read resolves per kind for the shared key, and misses absent.
         assert_eq!(
             store
                 .read_user_state(&p, StateKind::Regular, &sym("k"))
@@ -1256,16 +1233,15 @@ mod tests {
             .unwrap();
         wtxn.into_inner().commit().unwrap();
 
-        assert!(
+        assert!(read_regular_states(&store, &p).await.is_empty());
+        assert_eq!(
             store
-                .list_user_states(&p, StateKind::Regular)
+                .read_user_state(&p, StateKind::Live, &sym("k"))
                 .await
                 .unwrap()
-                .is_empty()
+                .as_deref(),
+            Some(&b"live"[..])
         );
-        let live = to_map(store.list_user_states(&p, StateKind::Live).await.unwrap());
-        assert_eq!(live.len(), 1);
-        assert_eq!(live[&sym("k")], b"live");
 
         // Clearing Live too leaves the component with no user state.
         let mut wtxn = WriteTxn::new(store.env.write_txn().unwrap());
@@ -1276,10 +1252,10 @@ mod tests {
         wtxn.into_inner().commit().unwrap();
         assert!(
             store
-                .list_user_states(&p, StateKind::Live)
+                .read_user_state(&p, StateKind::Live, &sym("k"))
                 .await
                 .unwrap()
-                .is_empty()
+                .is_none()
         );
     }
 }


### PR DESCRIPTION
## What

Combine the two separate prefetch calls (`prefetch_fn_memos` + `prefetch_user_states`) into a single `prefetch_states` that loads both the function-memo and user-state ranges for a component under **one** LMDB read transaction, via a new `AppStore::prefetch_fn_processing_states`.

The two caches were always loaded back-to-back at the start of build mode, each opening its own read snapshot. Combining them into one read transaction removes a redundant read-txn begin per component.

## When this helps

Under `MDB_NOTLS`, every read-txn begin takes the reader-table mutex. The benefit shows up under `mount_each` fan-out, where many child components prefetch concurrently — this halves reader-table-mutex acquisitions and reader-slot occupancy against LMDB's `MDB_READERS_FULL` limit, allowing for greater concurrency during component building.

No benchmark is included for that reason — the justification is mechanistic (2 read-txn begins → 1 read-txn begin per component prefetch).

## Test consolidation

With the prefetch unified, `AppStore::list_user_states` has no production caller left, it is only used in tests. This PR migrates every user-state test read-back onto the production path via a `read_regular_states` helper that calls `prefetch_fn_processing_states(p).1`, so tests exercise the same read code the engine runs instead of a parallel, test-only reader.

The `user_states_isolated_by_kind` test keeps its Live-state assertions via `read_user_state` point-reads — the unified prefetch loads only `Regular` states (`Live` is point-read in production), so no test-only bulk reader is needed. With the last caller gone, `list_user_states` is deleted.

## Behavior

No behavior change to production reads: the two caches are still populated together, and the `full_reprocess` / already-loaded / delete-mode skip paths are preserved.

