### PR TITLE
docs(examples): add missing READMEs for pdf_to_markdown and files_transform

### DIFF
--- a/examples/files_transform/README.md
+++ b/examples/files_transform/README.md
@@ -1,0 +1,34 @@
+# Files Transform
+
+This example watches a directory of local Markdown files, converts each one to HTML using [markdown-it-py](https://github.com/executablebooks/markdown-it-py), and writes the resulting `.html` files to an output folder. It runs in live mode, so it continues watching for file changes after the initial sync.
+
+## Prerequisites
+
+- Python 3.11+
+- No external services required.
+
+## Run
+
+Install deps:
+
+```sh
+pip install -e .
+```
+
+Place the Markdown files you want to transform in a `data/` directory (sample files are already included).
+
+Build/update the index (converts Markdown and writes HTML to `output_html/`). Pick one of the two modes:
+
+- **Catch-up run** — scan sources, sync changes, exit:
+
+  ```sh
+  cocoindex update main
+  ```
+
+- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+
+  ```sh
+  cocoindex update -L main
+  ```
+
+The converted `.html` files will appear in `./output_html/`, with each file named after the path parts of the original Markdown file joined by `__` (e.g. `subdir__file.html`).

--- a/examples/pdf_to_markdown/README.md
+++ b/examples/pdf_to_markdown/README.md
@@ -1,0 +1,26 @@
+# PDF to Markdown
+
+This example walks a directory of local PDF files, converts each one to Markdown using [docling](https://github.com/DS4SD/docling), and writes the resulting `.md` files to an output folder.
+
+## Prerequisites
+
+- Python 3.11+
+- No external services required — all processing runs locally on CPU.
+
+## Run
+
+Install deps:
+
+```sh
+pip install -e .
+```
+
+Place the PDF files you want to convert in a `pdf_files/` directory (a sample PDF — the "Attention Is All You Need" paper — is already included).
+
+Build/update the index (converts PDFs and writes Markdown to `out/`):
+
+```sh
+cocoindex update main
+```
+
+The converted `.md` files will appear in `./out/`, with each file named after the original PDF (e.g. `1706.03762v7.md`).


### PR DESCRIPTION
## Summary
- Add `README.md` to `examples/pdf_to_markdown/`
- Add `README.md` to `examples/files_transform/`
- Follows the pattern of other example READMEs in the repo

## Test Plan
- [ ] README renders correctly on GitHub
- [ ] Setup and run instructions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)