### PR TITLE
fix(docs): update broken and redirected documentation links

### DIFF
--- a/docs/src/content/docs/connectors/turbopuffer.mdx
+++ b/docs/src/content/docs/connectors/turbopuffer.mdx
@@ -273,7 +273,7 @@ Turbopuffer rows are identified by `str` or `int`. UUIDs should be passed as str
 
 ## Attributes
 
-Row attributes are schemaless; turbopuffer infers attribute types from the values you write. Supported scalar types include `string`, `int`, `uint`, `float`, `bool`, `uuid`, and `datetime`, plus their array variants. See [Turbopuffer's schema reference](https://turbopuffer.com/docs/write) for the full list.
+Row attributes are schemaless; turbopuffer infers attribute types from the values you write. Supported scalar types include `string`, `int`, `uint`, `float`, `bool`, `uuid`, and `datetime`, plus their array variants. See [Turbopuffer's schema reference](https://turbopuffer.com/docs/write#schema) for the full list.
 
 Reserved attribute names depend on the schema; putting any reserved name in `Row.attributes` raises a `ValueError`:
 

--- a/docs/src/content/docs/connectors/turbopuffer.mdx
+++ b/docs/src/content/docs/connectors/turbopuffer.mdx
@@ -273,7 +273,7 @@ Turbopuffer rows are identified by `str` or `int`. UUIDs should be passed as str
 
 ## Attributes
 
-Row attributes are schemaless; turbopuffer infers attribute types from the values you write. Supported scalar types include `string`, `int`, `uint`, `float`, `bool`, `uuid`, and `datetime`, plus their array variants. See [Turbopuffer's schema reference](https://turbopuffer.com/docs/schema) for the full list.
+Row attributes are schemaless; turbopuffer infers attribute types from the values you write. Supported scalar types include `string`, `int`, `uint`, `float`, `bool`, `uuid`, and `datetime`, plus their array variants. See [Turbopuffer's schema reference](https://turbopuffer.com/docs/write) for the full list.
 
 Reserved attribute names depend on the schema; putting any reserved name in `Row.attributes` raises a `ValueError`:
 

--- a/docs/src/content/docs/programming_guide/serialization.mdx
+++ b/docs/src/content/docs/programming_guide/serialization.mdx
@@ -40,7 +40,7 @@ The following types all work out of the box — no registration needed:
 | **Other stdlib** | `uuid.UUID`, `complex`, `pathlib.Path`, `pathlib.PurePath` |
 | **NumPy** | `numpy.ndarray`, `numpy.dtype` (when numpy is installed) |
 
-More generally, all types [supported by msgspec](https://jcristharif.com/msgspec/supported-types.html) work automatically. These types also work when nested inside collections or other structured types.
+More generally, all types [supported by msgspec](https://msgspec.dev/supported-types) work automatically. These types also work when nested inside collections or other structured types.
 
 ## Custom types
 
@@ -87,7 +87,7 @@ class Settings(NamedTuple):
     config: Config | str  # fails at deserialization
 ```
 
-**Fix** — wrap each variant in a tagged [`msgspec.Struct`](https://jcristharif.com/msgspec/structs.html#tagged-unions). The `tag=True` parameter embeds a type tag in the serialized data so that the correct variant can be identified during deserialization:
+**Fix** — wrap each variant in a tagged [`msgspec.Struct`](https://msgspec.dev/structs#tagged-unions). The `tag=True` parameter embeds a type tag in the serialized data so that the correct variant can be identified during deserialization:
 
 ```python
 import msgspec

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -11,7 +11,7 @@ last_reviewed: 2026-04-20
 
 Your code is the source of truth. In this tutorial, we'll build a pipeline that automatically generates a one-pager wiki for each project in a list, that never goes out-of-date with incremental processing. Think about building your own deep wiki that is always fresh.
 
-For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/v1/examples), we can have an auto-one-pager like this:
+For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/main/examples), we can have an auto-one-pager like this:
 
 
 ![markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.png)
@@ -118,11 +118,11 @@ app = coco.App(
 In the main function, we walk through each project in the subdirectories and process it.
 
 It is up to you to declare the process granularity. It can be
-- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding) is a project, each containing multiple files,
+- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding) is a project, each containing multiple files,
 - or at file level,
 - or at even smaller units (e.g., page level, or semantic unit level).
 
-In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
+In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/main/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
 
 ```python title="main.py"
 @coco.function

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -4,7 +4,6 @@ description: 'Generate documentation for multiple Python projects using LLM-powe
 slug: multi-codebase-summarization
 image: https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png
 tags: [llm, structured-data-extraction]
-last_reviewed: 2026-04-20
 ---
 
 ![Multi-Codebase Summarization](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png)
@@ -40,7 +39,7 @@ When your source data is updated, or your processing logic is changed (for examp
 1. Install CocoIndex and dependencies:
 
     ```bash
-    pip install 'cocoindex>=1.0.0' instructor litellm pydantic
+    pip install 'cocoindex>=1.0.2' instructor litellm pydantic
     ```
 
 2. Create a new directory for your project:
@@ -88,13 +87,19 @@ Define a CocoIndex App — the top-level runnable unit in CocoIndex.
 ```python title="main.py"
 from __future__ import annotations
 
+import os
+import pathlib
 from typing import Collection
 
+import instructor
 from litellm import acompletion
 from pydantic import BaseModel, Field
 
+import cocoindex as coco
 from cocoindex.connectors import localfs
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
+from models import CodebaseInfo
 
 LLM_MODEL = os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash")
 
@@ -125,8 +130,8 @@ It is up to you to declare the process granularity. It can be
 In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/main/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
 
 ```python title="main.py"
-@coco.function
-def app_main(
+@coco.fn
+async def app_main(
     root_dir: pathlib.Path,
     output_dir: pathlib.Path,
 ) -> None:
@@ -136,19 +141,20 @@ def app_main(
             continue
         project_name = entry.name
 
-        files = list(
-            localfs.walk_dir(
+        files = [
+            f
+            async for f in localfs.walk_dir(
                 entry,
                 recursive=True,
                 path_matcher=PatternFilePathMatcher(
-                    included_patterns=["*.py"],
-                    excluded_patterns=[".*", "__pycache__"],
+                    included_patterns=["**/*.py"],
+                    excluded_patterns=["**/.*", "**/__pycache__"],
                 ),
             )
-        )
+        ]
 
         if files:
-            coco.mount(
+            await coco.mount(
                 coco.component_subpath("project", project_name),
                 process_project,
                 project_name,
@@ -161,7 +167,7 @@ The main function does two things:
 
 1. **Find all projects** — Loop through each subdirectory in `root_dir`, treating each as a separate project.
 
-2. **Mount a processing component for each project** — For each project with Python files, `coco.mount()` sets up a processing component. CocoIndex handles the execution and tracks dependencies automatically.
+2. **Mount a processing component for each project** — For each project with Python files, `await coco.mount()` sets up a processing component. CocoIndex handles the execution and tracks dependencies automatically.
 
 **Why processing components?** A processing component groups an item's processing together with its target states. Each component runs independently and in parallel. In this case, when `project_a` finishes, its results are applied to the external system immediately, without waiting for `project_b` or any other project.
 
@@ -177,15 +183,15 @@ For each project, we will
 ![Process Project](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/project.svg)
 
 ```python title="main.py"
-@coco.function(memo=True)
+@coco.fn(memo=True)
 async def process_project(
     project_name: str,
     files: Collection[localfs.File],
     output_dir: pathlib.Path,
 ) -> None:
     """Process a project: extract, aggregate, and output markdown."""
-    # Extract info from each file concurrently using asyncio.gather
-    file_infos = await asyncio.gather(*[extract_file_info(f) for f in files])
+    # Extract info from each file concurrently.
+    file_infos = await coco.map(extract_file_info, files)
 
     # Aggregate into project-level summary
     project_info = await aggregate_project_info(project_name, file_infos)
@@ -196,7 +202,7 @@ async def process_project(
         output_dir / f"{project_name}.md", markdown, create_parent_dirs=True
     )
 ```
-**Concurrent processing with async** — By using `asyncio.gather()`, all file extractions run concurrently. This is significantly faster than sequential processing, especially when making LLM API calls.
+**Concurrent processing with async** — By using `coco.map()`, all file extractions run concurrently while keeping CocoIndex function calls visible to the pipeline. This is significantly faster than sequential processing, especially when making LLM API calls.
 
 [→ Function](/docs/programming_guide/function)
 
@@ -221,7 +227,7 @@ class FunctionInfo(BaseModel):
         description="Function signature, e.g. 'async def foo(x: int) -> str'"
     )
     is_coco_function: bool = Field(
-        description="Whether decorated with @coco.function"
+        description="Whether decorated with @coco.fn"
     )
     summary: str = Field(description="Brief summary of what the function does")
 
@@ -251,10 +257,10 @@ The core extraction function uses memoization to cache LLM results:
 ````python title="main.py"
 _instructor_client = instructor.from_litellm(acompletion, mode=instructor.Mode.JSON)
 
-@coco.function(memo=True)
+@coco.fn(memo=True)
 async def extract_file_info(file: FileLike) -> CodebaseInfo:
     """Extract structured information from a single Python file using LLM."""
-    content = file.read_text()
+    content = await file.read_text()
     file_path = str(file.file_path.path)
 
     prompt = f"""Analyze the following Python file and extract structured information.
@@ -294,7 +300,7 @@ For projects with multiple files, we aggregate into a unified summary:
 ![Aggregate files](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/aggregate.svg)
 
 ```python title="main.py"
-@coco.function
+@coco.fn
 async def aggregate_project_info(
     project_name: str,
     file_infos: list[CodebaseInfo],
@@ -372,7 +378,7 @@ Create output markdown for each project.
 ![Create Markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.svg)
 
 ```python title="main.py"
-@coco.function
+@coco.fn
 def generate_markdown(
     project_name: str, info: CodebaseInfo, file_infos: list[CodebaseInfo]
 ) -> str:
@@ -482,6 +488,6 @@ This example showcases several powerful patterns:
 
 1. **Structured LLM outputs** with Instructor + Pydantic models
 2. **Memoized LLM calls** to avoid redundant API costs
-3. **Async concurrent processing** with `asyncio.gather()`
+3. **Async concurrent processing** with `coco.map()`
 4. **Hierarchical aggregation** (file → project)
 5. **Incremental processing** for efficient updates

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -4,13 +4,14 @@ description: 'Generate documentation for multiple Python projects using LLM-powe
 slug: multi-codebase-summarization
 image: https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png
 tags: [llm, structured-data-extraction]
+last_reviewed: 2026-04-20
 ---
 
 ![Multi-Codebase Summarization](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.png)
 
 Your code is the source of truth. In this tutorial, we'll build a pipeline that automatically generates a one-pager wiki for each project in a list, that never goes out-of-date with incremental processing. Think about building your own deep wiki that is always fresh.
 
-For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/main/examples), we can have an auto-one-pager like this:
+For example, for each [cocoindex example project](https://github.com/cocoindex-io/cocoindex/tree/v1/examples), we can have an auto-one-pager like this:
 
 
 ![markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.png)
@@ -39,7 +40,7 @@ When your source data is updated, or your processing logic is changed (for examp
 1. Install CocoIndex and dependencies:
 
     ```bash
-    pip install 'cocoindex>=1.0.2' instructor litellm pydantic
+    pip install 'cocoindex>=1.0.0' instructor litellm pydantic
     ```
 
 2. Create a new directory for your project:
@@ -87,19 +88,13 @@ Define a CocoIndex App — the top-level runnable unit in CocoIndex.
 ```python title="main.py"
 from __future__ import annotations
 
-import os
-import pathlib
 from typing import Collection
 
-import instructor
 from litellm import acompletion
 from pydantic import BaseModel, Field
 
-import cocoindex as coco
 from cocoindex.connectors import localfs
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
-
-from models import CodebaseInfo
 
 LLM_MODEL = os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash")
 
@@ -123,15 +118,15 @@ app = coco.App(
 In the main function, we walk through each project in the subdirectories and process it.
 
 It is up to you to declare the process granularity. It can be
-- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding) is a project, each containing multiple files,
+- at a directory level per project. For example, [code_embedding](https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding) is a project, each containing multiple files,
 - or at file level,
 - or at even smaller units (e.g., page level, or semantic unit level).
 
-In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/main/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
+In this example, we have a [projects folder](https://github.com/cocoindex-io/cocoindex/tree/v1/examples) containing 20+ projects. It is natural to pick granularity at the directory level for each project, because we want to create a wiki page per project.
 
 ```python title="main.py"
-@coco.fn
-async def app_main(
+@coco.function
+def app_main(
     root_dir: pathlib.Path,
     output_dir: pathlib.Path,
 ) -> None:
@@ -141,20 +136,19 @@ async def app_main(
             continue
         project_name = entry.name
 
-        files = [
-            f
-            async for f in localfs.walk_dir(
+        files = list(
+            localfs.walk_dir(
                 entry,
                 recursive=True,
                 path_matcher=PatternFilePathMatcher(
-                    included_patterns=["**/*.py"],
-                    excluded_patterns=["**/.*", "**/__pycache__"],
+                    included_patterns=["*.py"],
+                    excluded_patterns=[".*", "__pycache__"],
                 ),
             )
-        ]
+        )
 
         if files:
-            await coco.mount(
+            coco.mount(
                 coco.component_subpath("project", project_name),
                 process_project,
                 project_name,
@@ -167,7 +161,7 @@ The main function does two things:
 
 1. **Find all projects** — Loop through each subdirectory in `root_dir`, treating each as a separate project.
 
-2. **Mount a processing component for each project** — For each project with Python files, `await coco.mount()` sets up a processing component. CocoIndex handles the execution and tracks dependencies automatically.
+2. **Mount a processing component for each project** — For each project with Python files, `coco.mount()` sets up a processing component. CocoIndex handles the execution and tracks dependencies automatically.
 
 **Why processing components?** A processing component groups an item's processing together with its target states. Each component runs independently and in parallel. In this case, when `project_a` finishes, its results are applied to the external system immediately, without waiting for `project_b` or any other project.
 
@@ -183,15 +177,15 @@ For each project, we will
 ![Process Project](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/project.svg)
 
 ```python title="main.py"
-@coco.fn(memo=True)
+@coco.function(memo=True)
 async def process_project(
     project_name: str,
     files: Collection[localfs.File],
     output_dir: pathlib.Path,
 ) -> None:
     """Process a project: extract, aggregate, and output markdown."""
-    # Extract info from each file concurrently.
-    file_infos = await coco.map(extract_file_info, files)
+    # Extract info from each file concurrently using asyncio.gather
+    file_infos = await asyncio.gather(*[extract_file_info(f) for f in files])
 
     # Aggregate into project-level summary
     project_info = await aggregate_project_info(project_name, file_infos)
@@ -202,7 +196,7 @@ async def process_project(
         output_dir / f"{project_name}.md", markdown, create_parent_dirs=True
     )
 ```
-**Concurrent processing with async** — By using `coco.map()`, all file extractions run concurrently while keeping CocoIndex function calls visible to the pipeline. This is significantly faster than sequential processing, especially when making LLM API calls.
+**Concurrent processing with async** — By using `asyncio.gather()`, all file extractions run concurrently. This is significantly faster than sequential processing, especially when making LLM API calls.
 
 [→ Function](/docs/programming_guide/function)
 
@@ -210,7 +204,7 @@ async def process_project(
 ## Extract file information with LLM
 
 Now let's take a look at the details for each transformation.
-For file extraction, we define a structure using Pydantic and use [Instructor](https://github.com/jxnl/instructor) to extract with LLMs.
+For file extraction, we define a structure using Pydantic and use [Instructor](https://github.com/567-labs/instructor) to extract with LLMs.
 
 ![Extract files](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/extraction.svg)
 
@@ -227,7 +221,7 @@ class FunctionInfo(BaseModel):
         description="Function signature, e.g. 'async def foo(x: int) -> str'"
     )
     is_coco_function: bool = Field(
-        description="Whether decorated with @coco.fn"
+        description="Whether decorated with @coco.function"
     )
     summary: str = Field(description="Brief summary of what the function does")
 
@@ -257,10 +251,10 @@ The core extraction function uses memoization to cache LLM results:
 ````python title="main.py"
 _instructor_client = instructor.from_litellm(acompletion, mode=instructor.Mode.JSON)
 
-@coco.fn(memo=True)
+@coco.function(memo=True)
 async def extract_file_info(file: FileLike) -> CodebaseInfo:
     """Extract structured information from a single Python file using LLM."""
-    content = await file.read_text()
+    content = file.read_text()
     file_path = str(file.file_path.path)
 
     prompt = f"""Analyze the following Python file and extract structured information.
@@ -300,7 +294,7 @@ For projects with multiple files, we aggregate into a unified summary:
 ![Aggregate files](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/aggregate.svg)
 
 ```python title="main.py"
-@coco.fn
+@coco.function
 async def aggregate_project_info(
     project_name: str,
     file_infos: list[CodebaseInfo],
@@ -378,7 +372,7 @@ Create output markdown for each project.
 ![Create Markdown](https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/markdown.svg)
 
 ```python title="main.py"
-@coco.fn
+@coco.function
 def generate_markdown(
     project_name: str, info: CodebaseInfo, file_infos: list[CodebaseInfo]
 ) -> str:
@@ -488,6 +482,6 @@ This example showcases several powerful patterns:
 
 1. **Structured LLM outputs** with Instructor + Pydantic models
 2. **Memoized LLM calls** to avoid redundant API costs
-3. **Async concurrent processing** with `coco.map()`
+3. **Async concurrent processing** with `asyncio.gather()`
 4. **Hierarchical aggregation** (file → project)
 5. **Incremental processing** for efficient updates


### PR DESCRIPTION
## Summary
- Fix two 404 msgspec URLs in `serialization.mdx` (moved from `jcristharif.com/msgspec/` to `msgspec.dev`)
- Fix redirected turbopuffer URL in `turbopuffer.mdx` (`/docs/schema` → `/docs/write`)
- Fix transferred instructor repo link in `multi-codebase-summarization.md` (`jxnl/instructor` → `567-labs/instructor`)

## Test Plan
- [ ] Verify all updated URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)