### PR TITLE
test(resources): add unit tests for chunk and schema modules

### DIFF
--- a/python/tests/resources/test_chunk.py
+++ b/python/tests/resources/test_chunk.py
@@ -1,0 +1,85 @@
+"""Tests for Chunk and TextPosition dataclasses."""
+
+import pytest
+
+from cocoindex.resources.chunk import Chunk, TextPosition
+
+
+class TestTextPosition:
+    def test_construction(self) -> None:
+        pos = TextPosition(byte_offset=0, char_offset=0, line=1, column=1)
+        assert pos.byte_offset == 0
+        assert pos.char_offset == 0
+        assert pos.line == 1
+        assert pos.column == 1
+
+    def test_non_zero_offsets(self) -> None:
+        pos = TextPosition(byte_offset=10, char_offset=8, line=3, column=5)
+        assert pos.byte_offset == 10
+        assert pos.char_offset == 8
+        assert pos.line == 3
+        assert pos.column == 5
+
+    def test_frozen_immutability(self) -> None:
+        pos = TextPosition(byte_offset=0, char_offset=0, line=1, column=1)
+        with pytest.raises((AttributeError, TypeError)):
+            pos.byte_offset = 99  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        pos1 = TextPosition(byte_offset=5, char_offset=5, line=2, column=3)
+        pos2 = TextPosition(byte_offset=5, char_offset=5, line=2, column=3)
+        assert pos1 == pos2
+
+    def test_inequality(self) -> None:
+        pos1 = TextPosition(byte_offset=0, char_offset=0, line=1, column=1)
+        pos2 = TextPosition(byte_offset=1, char_offset=1, line=1, column=2)
+        assert pos1 != pos2
+
+
+class TestChunk:
+    def _make_pos(self, byte: int, char: int, line: int, col: int) -> TextPosition:
+        return TextPosition(byte_offset=byte, char_offset=char, line=line, column=col)
+
+    def test_construction(self) -> None:
+        start = self._make_pos(0, 0, 1, 1)
+        end = self._make_pos(5, 5, 1, 6)
+        chunk = Chunk(text="hello", start=start, end=end)
+        assert chunk.text == "hello"
+        assert chunk.start == start
+        assert chunk.end == end
+
+    def test_empty_text(self) -> None:
+        pos = self._make_pos(0, 0, 1, 1)
+        chunk = Chunk(text="", start=pos, end=pos)
+        assert chunk.text == ""
+        assert chunk.start is pos
+        assert chunk.end is pos
+
+    def test_multiline_text(self) -> None:
+        start = self._make_pos(0, 0, 1, 1)
+        end = self._make_pos(11, 11, 2, 6)
+        chunk = Chunk(text="hello\nworld", start=start, end=end)
+        assert chunk.text == "hello\nworld"
+        assert chunk.start.line == 1
+        assert chunk.end.line == 2
+
+    def test_frozen_immutability(self) -> None:
+        start = self._make_pos(0, 0, 1, 1)
+        end = self._make_pos(5, 5, 1, 6)
+        chunk = Chunk(text="hello", start=start, end=end)
+        with pytest.raises((AttributeError, TypeError)):
+            chunk.text = "other"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        start = self._make_pos(0, 0, 1, 1)
+        end = self._make_pos(5, 5, 1, 6)
+        chunk1 = Chunk(text="hello", start=start, end=end)
+        chunk2 = Chunk(text="hello", start=start, end=end)
+        assert chunk1 == chunk2
+
+    def test_inequality_by_text(self) -> None:
+        start = self._make_pos(0, 0, 1, 1)
+        end = self._make_pos(5, 5, 1, 6)
+        chunk1 = Chunk(text="hello", start=start, end=end)
+        chunk2 = Chunk(text="world", start=start, end=end)
+        assert chunk1 != chunk2

--- a/python/tests/resources/test_schema.py
+++ b/python/tests/resources/test_schema.py
@@ -1,0 +1,107 @@
+"""Tests for VectorSchema and MultiVectorSchema concrete implementations."""
+
+import asyncio
+
+import numpy as np
+
+from cocoindex.resources.schema import (
+    MultiVectorSchema,
+    MultiVectorSchemaProvider,
+    VectorSchema,
+    VectorSchemaProvider,
+    get_multi_vector_schema,
+    get_vector_schema,
+)
+
+
+class TestVectorSchema:
+    def test_construction(self) -> None:
+        schema = VectorSchema(dtype=np.dtype("float32"), size=128)
+        assert schema.dtype == np.dtype("float32")
+        assert schema.size == 128
+
+    def test_different_dtypes(self) -> None:
+        schema_f32 = VectorSchema(dtype=np.dtype("float32"), size=64)
+        schema_f64 = VectorSchema(dtype=np.dtype("float64"), size=64)
+        assert schema_f32.dtype == np.dtype("float32")
+        assert schema_f64.dtype == np.dtype("float64")
+
+    def test_equality(self) -> None:
+        schema1 = VectorSchema(dtype=np.dtype("float32"), size=256)
+        schema2 = VectorSchema(dtype=np.dtype("float32"), size=256)
+        assert schema1 == schema2
+
+    def test_inequality_by_size(self) -> None:
+        schema1 = VectorSchema(dtype=np.dtype("float32"), size=128)
+        schema2 = VectorSchema(dtype=np.dtype("float32"), size=256)
+        assert schema1 != schema2
+
+    def test_coco_vector_schema_returns_self(self) -> None:
+        schema = VectorSchema(dtype=np.dtype("float32"), size=128)
+        result = asyncio.run(schema.__coco_vector_schema__())
+        assert result is schema
+
+    def test_is_vector_schema_provider(self) -> None:
+        schema = VectorSchema(dtype=np.dtype("float32"), size=128)
+        assert isinstance(schema, VectorSchemaProvider)
+
+
+class TestMultiVectorSchema:
+    def test_construction(self) -> None:
+        vs = VectorSchema(dtype=np.dtype("float32"), size=128)
+        mvs = MultiVectorSchema(vector_schema=vs)
+        assert mvs.vector_schema == vs
+
+    def test_coco_multi_vector_schema_returns_self(self) -> None:
+        vs = VectorSchema(dtype=np.dtype("float32"), size=64)
+        mvs = MultiVectorSchema(vector_schema=vs)
+        result = asyncio.run(mvs.__coco_multi_vector_schema__())
+        assert result is mvs
+
+    def test_is_multi_vector_schema_provider(self) -> None:
+        vs = VectorSchema(dtype=np.dtype("float32"), size=64)
+        mvs = MultiVectorSchema(vector_schema=vs)
+        assert isinstance(mvs, MultiVectorSchemaProvider)
+
+    def test_equality(self) -> None:
+        vs = VectorSchema(dtype=np.dtype("float32"), size=32)
+        mvs1 = MultiVectorSchema(vector_schema=vs)
+        mvs2 = MultiVectorSchema(vector_schema=vs)
+        assert mvs1 == mvs2
+
+
+class TestGetVectorSchema:
+    def test_returns_schema_for_provider(self) -> None:
+        schema = VectorSchema(dtype=np.dtype("float32"), size=128)
+        result = asyncio.run(get_vector_schema(schema))
+        assert result == schema
+
+    def test_returns_none_for_non_provider(self) -> None:
+        result = asyncio.run(get_vector_schema("not a provider"))
+        assert result is None
+
+    def test_returns_none_for_none(self) -> None:
+        result = asyncio.run(get_vector_schema(None))
+        assert result is None
+
+    def test_returns_none_for_plain_object(self) -> None:
+        result = asyncio.run(get_vector_schema(object()))
+        assert result is None
+
+
+class TestGetMultiVectorSchema:
+    def test_returns_schema_for_provider(self) -> None:
+        vs = VectorSchema(dtype=np.dtype("float32"), size=64)
+        mvs = MultiVectorSchema(vector_schema=vs)
+        result = asyncio.run(get_multi_vector_schema(mvs))
+        assert result == mvs
+
+    def test_returns_none_for_non_provider(self) -> None:
+        result = asyncio.run(get_multi_vector_schema("not a provider"))
+        assert result is None
+
+    def test_returns_none_for_plain_vector_schema(self) -> None:
+        """VectorSchema is not a MultiVectorSchemaProvider."""
+        vs = VectorSchema(dtype=np.dtype("float32"), size=128)
+        result = asyncio.run(get_multi_vector_schema(vs))
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `test_chunk.py` with unit tests for `TextPosition` and `Chunk` frozen dataclasses (construction, immutability, equality)
- Add `test_schema.py` with unit tests for `VectorSchema`, `MultiVectorSchema`, and the `get_vector_schema`/`get_multi_vector_schema` helper functions
- Pure Python tests; no external dependencies or CocoIndex app/environment required

## Test Plan
- [ ] `uv run pytest python/tests/resources/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)