### PR TITLE
feat(py): add LiveMap in-memory intermediate collection

### DIFF
--- a/docs/src/content/docs/common_resources/live_map.mdx
+++ b/docs/src/content/docs/common_resources/live_map.mdx
@@ -1,0 +1,82 @@
+---
+title: In-memory *LiveMap*
+description: >
+  LiveMap is an in-memory keyed collection that bridges live producing and consuming
+  logic — declare (key, value) entries as target states on one side, consume it as a
+  LiveMapView with mount_each on the other.
+---
+`LiveMap[K, V]` (`cocoindex.resources.live_map`) is an in-memory, keyed collection that sits **between** a producing part of your pipeline and a consuming part. The producing side **declares** `(key, value)` entries; the consuming side reads the map as a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) via `coco.mount_each`, getting one processing component per entry that stays in sync as entries appear, change, and disappear.
+
+Think of it as a connector whose "external system" is an in-process `dict`: entries are declared as [target states](../programming_guide/target_state) — so they participate in CocoIndex's declarative change detection and ownership — and that same `dict` is simultaneously exposed as a live source for downstream components. It lets you split a pipeline into a producer half and a consumer half that are decoupled through one shared, incrementally-maintained collection.
+
+It is designed for [live mode](../programming_guide/live_mode): the producer and consumer run concurrently, and the consumer reacts as the producer updates the map.
+
+## Example
+
+```python
+import cocoindex as coco
+from cocoindex.resources.live_map import LiveMap
+
+
+@coco.fn
+async def produce_entries(lm: LiveMap[str, str]) -> None:
+    # Any component can declare entries — often a live component reading a stream.
+    for key, text in fetch_items():
+        lm.declare_entry(key, text)
+
+
+@coco.fn
+async def process_entry(value: str) -> None:
+    ...  # build something from each entry's value
+
+
+@coco.fn
+async def app_main() -> None:
+    lm: LiveMap[str, str] = await LiveMap.create()
+
+    await coco.mount(produce_entries, lm)        # producing side
+    await coco.mount_each(process_entry, lm)     # consuming side: one component per entry
+```
+
+## Creating a LiveMap
+
+```python
+lm: LiveMap[str, str] = await LiveMap.create()
+```
+
+`create()` is an async factory and must be called from **inside the app's component tree** (it mounts a backing target). `K` must be a [stable key](../programming_guide/processing_component#component-path); `V` is any value comparable with `==` — no hashability, serialization, or fingerprinting is required, so arbitrary objects (lists, dataclasses, …) work.
+
+## Producing entries
+
+```python
+lm.declare_entry(key, value)
+```
+
+Call `declare_entry` from inside any component. The entry is a target state **owned by the declaring component**, which gives it normal declarative semantics:
+
+- Declaring a key makes it present, or updates its value.
+- The consumer is notified **only when the value actually changes** (compared with `==`) — re-declaring the same value is a no-op for downstream.
+- An entry is removed when the component that declared it **stops declaring it** (on a re-run) or disappears. There is no explicit delete verb; deletion follows target-state ownership, exactly like other CocoIndex targets.
+
+Multiple components may declare into the same map, as long as each key has a single owner (two components declaring the same key is a conflict, the same as for any target).
+
+## Consuming entries
+
+A `LiveMap` is a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview), so pass it straight to `coco.mount_each` — it behaves just like a live source:
+
+```python
+await coco.mount_each(process_entry, lm)
+```
+
+`mount_each` mounts one processing component per entry (keyed by the entry key), scans the current entries first, then reacts to incremental changes — re-mounting a component when its value changes and removing it when its entry is deleted. The processor receives the entry **value**.
+
+A LiveMap supports **one active consumer** (`mount_each`) at a time.
+
+## Semantics
+
+- **Live-mode first.** LiveMap is built for [`app.update(live=True)`](../programming_guide/live_mode): the consumer subscribes and reacts as producers update the map. In catch-up mode (plain `app.update()`), the consumer scans whatever entries happen to exist when it runs, which can race producers running concurrently in the same session — so for predictable one-shot results, order the producer ahead of the consumer (await the producer's `handle.ready()` before consuming).
+- **In-memory and per-session.** The map lives in process memory and is rebuilt from its producers each time the app starts; its contents do not persist across restarts.
+
+## When to use it
+
+Reach for a LiveMap when you want to decouple a producing stage from a consuming stage through a shared, incrementally-maintained collection. For example: one part of your pipeline watches a stream, extracts entities, and declares them into a map keyed by entity ID; another part builds an index or enrichment for each entity, reacting automatically as entities are added, updated, or removed.

--- a/docs/src/content/docs/programming_guide/live_mode.mdx
+++ b/docs/src/content/docs/programming_guide/live_mode.mdx
@@ -93,6 +93,10 @@ app.update_blocking(live=True)
 
 **Handling deletes:** each cycle's declarations are reconciled against the previous run. If a row disappears from the source table between polls, `sync_users` simply doesn't declare it that cycle — CocoIndex automatically deletes the corresponding target. You don't need to track deletions yourself.
 
+### Decoupling stages with an in-memory `LiveMap`
+
+When one part of your pipeline produces keyed data and another consumes it — without going through an external system — put an in-memory [`LiveMap`](../common_resources/live_map) between them. Producers declare `(key, value)` entries; the consumer reads it as a `LiveMapView` via `mount_each`, reacting to adds, updates, and deletes just like a live source.
+
 ## Examples
 
 ### `localfs` — file watching with `LiveMapView`

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -52,6 +52,7 @@ export const sidebar: SidebarItem[] = [
       { type: 'doc', slug: 'common_resources/data_types', label: 'Data types' },
       { type: 'doc', slug: 'common_resources/vector_schema', label: 'Vector schema' },
       { type: 'doc', slug: 'common_resources/id_generation', label: 'ID generation' },
+      { type: 'doc', slug: 'common_resources/live_map', label: 'LiveMap' },
     ],
   },
   {

--- a/python/cocoindex/resources/live_map.py
+++ b/python/cocoindex/resources/live_map.py
@@ -1,0 +1,291 @@
+"""In-memory live key-value map.
+
+``LiveMap[K, V]`` bridges live data-*producing* logic and live data-*consuming* logic within a
+single CocoIndex session. The producing side declares ``(key, value)`` entries as **target
+states** via :meth:`LiveMap.declare_entry`; the consuming side reads it as a
+``coco.LiveMapView`` via ``coco.mount_each``. All data is held in an in-process ``dict`` that
+the engine keeps in sync through normal target-state ownership, and that same ``dict`` is
+exposed as a live source for downstream components.
+
+Designed for live mode (``app.update(live=True)``). See ``specs/live_map`` for the full design.
+
+Example::
+
+    lm: LiveMap[str, str] = await LiveMap.create()   # inside the app's component tree
+    lm.declare_entry(key, value)                      # producer: inside any component
+    await coco.mount_each(process_entry, lm)          # consumer: one component per entry
+"""
+
+from __future__ import annotations
+
+import asyncio as _asyncio
+import uuid as _uuid
+import weakref as _weakref
+from collections.abc import AsyncIterator as _AsyncIterator
+from collections.abc import Collection as _Collection
+from collections.abc import Sequence as _Sequence
+from dataclasses import dataclass as _dataclass
+from typing import Any as _Any
+from typing import Generic as _Generic
+from typing import NamedTuple as _NamedTuple
+from typing import TypeVar as _TypeVar
+
+import msgspec as _msgspec
+
+import cocoindex as _coco
+
+__all__ = ["LiveMap"]
+
+# K becomes both the entry target-state key and the consumer's per-entry component subpath,
+# so it must be a StableKey. V is any `==`-comparable value (no hashability required).
+_K = _TypeVar("_K", bound="_coco.StableKey")
+_V = _TypeVar("_V")
+
+# Sentinel distinguishing "key absent" from "present with value None" in the == gate.
+_MISSING: _Any = object()
+
+# Maps a LiveMap's UUID to its live instance so the shared, stateless container sink can
+# recover the Python object during apply. Weak so instances aren't retained past their
+# container's teardown; a bound `_EntryHandler` holds a strong ref, keeping an in-use map
+# alive (see specs/live_map/design.md).
+_REGISTRY: "_weakref.WeakValueDictionary[_uuid.UUID, LiveMap[_Any, _Any]]" = (
+    _weakref.WeakValueDictionary()
+)
+
+
+# ============================================================================
+# Private target-state types
+# ============================================================================
+
+
+@_dataclass(frozen=True, slots=True)
+class _ContainerSpec:
+    """Marker value for the per-map container target state (keyed by the map's UUID)."""
+
+
+class _ContainerRecord(_msgspec.Struct, frozen=True):
+    """Minimal existence marker persisted for the container target state."""
+
+
+class _EntryRecord(_msgspec.Struct, frozen=True):
+    """Minimal existence marker persisted for an entry target state.
+
+    Never read — its only job is to be a non-``NON_EXISTENCE`` value so the engine records
+    "this key exists", which lets a later run drive a delete when the producer stops declaring
+    it. Change detection for the consumer is done by ``==`` in the sink, not from this record.
+    """
+
+
+class _ContainerAction(_NamedTuple):
+    live_map: "LiveMap[_Any, _Any] | None"
+    deleted: bool
+
+
+class _EntryAction(_NamedTuple):
+    live_map: "LiveMap[_Any, _Any]"
+    key: _coco.StableKey
+    value: _Any
+    deleted: bool
+
+
+class _Change(_NamedTuple):
+    key: _Any
+    value: _Any
+    deleted: bool
+
+
+# ============================================================================
+# Handlers and sinks (producer side)
+# ============================================================================
+
+
+class _EntryHandler:
+    """Per-instance target handler for entries; closes over one ``LiveMap``.
+
+    Constructed by the container sink (bound to the instance recovered from the registry) and
+    reused for every entry declared into that map.
+    """
+
+    __slots__ = ("_live_map",)
+
+    def __init__(self, live_map: "LiveMap[_Any, _Any]") -> None:
+        self._live_map = live_map
+
+    def reconcile(
+        self,
+        key: _coco.StableKey,
+        desired_state: _Any | _coco.NonExistenceType,
+        prev_possible_records: _Collection[_EntryRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> "_coco.TargetReconcileOutput[_EntryAction, _EntryRecord] | None":
+        # Never skip: applying to an in-memory dict is cheap, and the `==` gate in the sink
+        # decides whether to notify the consumer. `prev_possible_records` is intentionally
+        # unused (no fingerprint compare).
+        if _coco.is_non_existence(desired_state):
+            return _coco.TargetReconcileOutput(
+                action=_EntryAction(self._live_map, key, None, True),
+                sink=_ENTRY_SINK,
+                tracking_record=_coco.NON_EXISTENCE,
+            )
+        return _coco.TargetReconcileOutput(
+            action=_EntryAction(self._live_map, key, desired_state, False),
+            sink=_ENTRY_SINK,
+            tracking_record=_EntryRecord(),
+        )
+
+
+class _ContainerHandler:
+    """Root handler: binds a per-instance ``_EntryHandler`` via the UUID→instance registry."""
+
+    def reconcile(
+        self,
+        key: _coco.StableKey,
+        desired_state: "_ContainerSpec | _coco.NonExistenceType",
+        prev_possible_records: _Collection[_ContainerRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> "_coco.TargetReconcileOutput[_ContainerAction, _ContainerRecord, _EntryHandler] | None":
+        if _coco.is_non_existence(desired_state):
+            return _coco.TargetReconcileOutput(
+                action=_ContainerAction(None, True),
+                sink=_CONTAINER_SINK,
+                tracking_record=_coco.NON_EXISTENCE,
+            )
+        assert isinstance(key, _uuid.UUID)
+        return _coco.TargetReconcileOutput(
+            action=_ContainerAction(_REGISTRY.get(key), False),
+            sink=_CONTAINER_SINK,
+            tracking_record=_ContainerRecord(),
+        )
+
+
+async def _apply_entry_actions(
+    context_provider: _coco.ContextProvider,
+    actions: _Sequence[_EntryAction],
+    /,
+) -> None:
+    # Runs on the app event loop (async sink), so it mutates `_entries` and notifies the
+    # watcher queue directly — no locks, no cross-thread marshalling.
+    for action in actions:
+        live_map = action.live_map
+        if action.deleted:
+            if action.key in live_map._entries:
+                del live_map._entries[action.key]
+                live_map._emit(_Change(action.key, None, True))
+        else:
+            prev = live_map._entries.get(action.key, _MISSING)
+            if prev is _MISSING or prev != action.value:
+                live_map._entries[action.key] = action.value
+                live_map._emit(_Change(action.key, action.value, False))
+
+
+async def _apply_container_actions(
+    context_provider: _coco.ContextProvider,
+    actions: _Sequence[_ContainerAction],
+    /,
+) -> "list[_coco.ChildTargetDef[_EntryHandler] | None]":
+    out: "list[_coco.ChildTargetDef[_EntryHandler] | None]" = []
+    for action in actions:
+        if action.deleted or action.live_map is None:
+            out.append(None)
+        else:
+            out.append(_coco.ChildTargetDef(handler=_EntryHandler(action.live_map)))
+    return out
+
+
+_ENTRY_SINK: _coco.TargetActionSink[_EntryAction, None] = (
+    _coco.TargetActionSink.from_async_fn(_apply_entry_actions)
+)
+_CONTAINER_SINK: _coco.TargetActionSink[_ContainerAction, _EntryHandler] = (
+    _coco.TargetActionSink.from_async_fn(_apply_container_actions)
+)
+_CONTAINER_PROVIDER = _coco.register_root_target_states_provider(
+    "cocoindex/livemap", _ContainerHandler()
+)
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+
+class LiveMap(_Generic[_K, _V]):
+    """An in-memory, keyed collection that is both a target and a ``coco.LiveMapView``.
+
+    Create with ``await LiveMap.create()`` from inside the app's component tree. Producers add
+    entries with :meth:`declare_entry` from inside any component; consumers pass the map to
+    ``coco.mount_each`` to process one component per entry, kept in sync as entries appear,
+    change, and disappear. An entry exists as long as some live component declares it; when its
+    declaring component stops declaring it (or disappears), the entry is removed.
+
+    Single active ``watch()`` at a time. ``K`` must be a ``coco.StableKey``; ``V`` is any
+    ``==``-comparable value (no hashability required).
+    """
+
+    __slots__ = (
+        "_uuid",
+        "_entries",
+        "_entry_provider",
+        "_watcher_queue",
+        "__weakref__",
+    )
+
+    _uuid: _uuid.UUID
+    _entries: dict[_K, _V]
+    _entry_provider: "_coco.TargetStateProvider[_Any, None]"
+    _watcher_queue: "_asyncio.Queue[_Change] | None"
+
+    def __init__(self) -> None:
+        # Only sets up in-memory state — `create()` mounts the container and sets
+        # `_entry_provider`; the map isn't usable until then.
+        self._uuid = _uuid.uuid4()
+        self._entries = {}
+        self._watcher_queue = None
+
+    @classmethod
+    async def create(cls) -> "LiveMap[_K, _V]":
+        """Create a LiveMap and mount its backing target. Call inside a component context."""
+        self = cls()
+        _REGISTRY[self._uuid] = self
+        container = _CONTAINER_PROVIDER.target_state(self._uuid, _ContainerSpec())
+        self._entry_provider = await _coco.mount_target(container)
+        return self
+
+    def declare_entry(self, key: _K, value: _V) -> None:
+        """Declare an entry, owned by the calling component. Call inside a component context."""
+        _coco.declare_target_state(self._entry_provider.target_state(key, value))
+
+    def __aiter__(self) -> _AsyncIterator[tuple[_K, _V]]:
+        return self._scan()
+
+    async def _scan(self) -> _AsyncIterator[tuple[_K, _V]]:
+        # Snapshot synchronously so a sink firing between yields can't mutate mid-iteration.
+        for item in list(self._entries.items()):
+            yield item
+
+    async def watch(self, subscriber: "_coco.LiveMapSubscriber[_K, _V]") -> None:
+        """Deliver an initial snapshot then incremental changes. Drives one consumer."""
+        if self._watcher_queue is not None:
+            raise RuntimeError("LiveMap supports a single active watch() at a time.")
+        queue: _asyncio.Queue[_Change] = _asyncio.Queue()
+        self._watcher_queue = (
+            queue  # arm before the scan so concurrent changes aren't lost
+        )
+        try:
+            await subscriber.update_all()
+            await subscriber.mark_ready()
+            while True:
+                change = await queue.get()
+                if change.deleted:
+                    handle = await subscriber.delete(change.key)
+                else:
+                    handle = await subscriber.update(change.key, change.value)
+                await handle.ready()
+        finally:
+            self._watcher_queue = None
+
+    def _emit(self, change: _Change) -> None:
+        queue = self._watcher_queue
+        if queue is not None:
+            queue.put_nowait(change)

--- a/python/tests/resources/test_live_map.py
+++ b/python/tests/resources/test_live_map.py
@@ -217,31 +217,41 @@ def test_aiter_snapshot() -> None:
     assert collected == {"a": "1", "b": "2"}
 
 
+# Desired entries for the restart test below; varied between updates of the same app.
+_restart_desired: dict[str, Any] = {}
+
+
 def test_restart_refill_and_cross_run_delete() -> None:
     GlobalDictTarget.store.clear()
     _call_counts.clear()
     env = common.create_test_env(__file__, suffix="restart")
 
-    def run(desired: dict[str, Any]) -> None:
-        @coco.fn
-        async def app_main() -> None:
-            lm: LiveMap[str, Val] = await LiveMap.create()
-            handle = await coco.mount(produce, lm, desired)
-            await handle.ready()
-            await coco.mount_each(process_entry, lm)
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        handle = await coco.mount(produce, lm, dict(_restart_desired))
+        await handle.ready()
+        await coco.mount_each(process_entry, lm)
 
-        app = coco.App(
-            coco.AppConfig(name="test_live_map_restart", environment=env), app_main
-        )
-        app.update_blocking()
+    # One app, re-run via repeated update_blocking() — the supported multi-run pattern. (A
+    # fresh Environment/App per run at the same db_path is not supported by LMDB; see
+    # tests/core/test_context_tracked_state_validation.py.) Each update re-runs app_main,
+    # creating a fresh LiveMap (new UUID, empty dict) against the persisted state.
+    app = coco.App(
+        coco.AppConfig(name="test_live_map_restart", environment=env), app_main
+    )
 
     # Run 1.
-    run({"a": "1", "b": "2"})
+    _restart_desired.clear()
+    _restart_desired.update({"a": "1", "b": "2"})
+    app.update_blocking()
     assert _data() == {"a": "1", "b": "2"}
 
-    # Run 2 (same env + app name = restart): fresh LiveMap (new UUID) refills the empty dict;
-    # `a` unchanged still reappears, `b` dropped is removed, `c` added.
-    run({"a": "1", "c": "3"})
+    # Run 2 = restart: fresh LiveMap (new UUID) refills the empty dict; `a` unchanged still
+    # reappears, `b` dropped is removed, `c` added.
+    _restart_desired.clear()
+    _restart_desired.update({"a": "1", "c": "3"})
+    app.update_blocking()
     assert _data() == {"a": "1", "c": "3"}
 
 
@@ -253,22 +263,20 @@ def test_restart_same_inputs_refill() -> None:
     GlobalDictTarget.store.clear()
     env = common.create_test_env(__file__, suffix="restart_same")
 
-    def run() -> None:
-        @coco.fn
-        async def app_main() -> None:
-            lm: LiveMap[str, Val] = await LiveMap.create()
-            handle = await coco.mount(produce, lm, {"a": "1", "b": "2"})
-            await handle.ready()
-            await coco.mount_each(process_entry, lm)
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        handle = await coco.mount(produce, lm, {"a": "1", "b": "2"})
+        await handle.ready()
+        await coco.mount_each(process_entry, lm)
 
-        app = coco.App(
-            coco.AppConfig(name="test_live_map_restart_same", environment=env), app_main
-        )
-        app.update_blocking()
-
-    run()
+    # One app, re-run via repeated update_blocking() (the supported multi-run pattern).
+    app = coco.App(
+        coco.AppConfig(name="test_live_map_restart_same", environment=env), app_main
+    )
+    app.update_blocking()
     assert _data() == {"a": "1", "b": "2"}
-    run()  # same inputs, fresh LiveMap: must still refill, not empty out.
+    app.update_blocking()  # same inputs, fresh LiveMap: must still refill, not empty out.
     assert _data() == {"a": "1", "b": "2"}
 
 

--- a/python/tests/resources/test_live_map.py
+++ b/python/tests/resources/test_live_map.py
@@ -1,0 +1,413 @@
+"""End-to-end tests for LiveMap (producer target + LiveMapView consumer bridge)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import cocoindex as coco
+from cocoindex.resources.live_map import LiveMap
+
+from tests import common
+from tests.common.target_states import AsyncGlobalDictTarget, GlobalDictTarget
+
+
+# A value that carries its own key, so the consumer (which only receives the value from
+# mount_each) can key the output target. Intentionally an unhashable, non-frozen dataclass:
+# LiveMap requires only `==` on V, never hashing/fingerprinting.
+@dataclass
+class Val:
+    key: str
+    payload: Any
+
+
+# How many times each entry was processed by the consumer (isolates LiveMap's `==` gate).
+_call_counts: dict[str, int] = {}
+
+
+@coco.fn
+async def process_entry(v: Val) -> None:
+    _call_counts[v.key] = _call_counts.get(v.key, 0) + 1
+    coco.declare_target_state(GlobalDictTarget.target_state(v.key, v.payload))
+
+
+@coco.fn
+async def process_entry_b(v: Val) -> None:
+    coco.declare_target_state(AsyncGlobalDictTarget.target_state(v.key, v.payload))
+
+
+@coco.fn
+async def produce(lm: LiveMap[str, Val], desired: dict[str, Any]) -> None:
+    """One-shot producer: declare the given entries (owned by this component)."""
+    for k, payload in desired.items():
+        lm.declare_entry(k, Val(k, payload))
+
+
+# --- Live producer driven by module-level control (so no unpicklable args are passed) ---
+
+_live_desired: dict[str, dict[str, Any]] = {}
+_live_signals: dict[str, asyncio.Queue[None]] = {}
+
+
+class MapProducer:
+    """A live producer: each `update_full` re-declares the current desired set into the map."""
+
+    def __init__(self, lm: LiveMap[str, Val], name: str) -> None:
+        self._lm = lm
+        self._name = name
+
+    async def process(self) -> None:
+        for k, payload in list(_live_desired[self._name].items()):
+            self._lm.declare_entry(k, Val(k, payload))
+
+    async def process_live(self, operator: Any) -> None:
+        await operator.update_full()
+        await operator.mark_ready()
+        signal = _live_signals[self._name]
+        while True:
+            await signal.get()
+            await operator.update_full()
+
+
+# --- Polling helpers (modeled on test_localfs_live.py) ---
+
+
+async def _wait_for_target_keys(
+    expected_keys: set[str], *, timeout: float = 20.0, poll_interval: float = 0.05
+) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if set(GlobalDictTarget.store.data.keys()) == expected_keys:
+            return
+        await asyncio.sleep(poll_interval)
+    raise AssertionError(
+        f"Timed out. Expected {expected_keys}, got {set(GlobalDictTarget.store.data.keys())}"
+    )
+
+
+async def _wait_for_value(
+    key: str, expected: Any, *, timeout: float = 20.0, poll_interval: float = 0.05
+) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        entry = GlobalDictTarget.store.data.get(key)
+        if entry is not None and entry.data == expected:
+            return
+        await asyncio.sleep(poll_interval)
+    raise AssertionError(
+        f"Timed out waiting for {key!r}=={expected!r}; got {GlobalDictTarget.store.data.get(key)}"
+    )
+
+
+def _data() -> dict[str, Any]:
+    return {k: v.data for k, v in GlobalDictTarget.store.data.items()}
+
+
+# ============================================================================
+# One-shot, ordered (deterministic)
+# ============================================================================
+
+
+def _run_oneshot(name: str, app_main: Any) -> None:
+    env = common.create_test_env(__file__, suffix=name)
+    app = coco.App(
+        coco.AppConfig(name=f"test_live_map_{name}", environment=env), app_main
+    )
+    app.update_blocking()
+
+
+def test_basic_produce_consume() -> None:
+    GlobalDictTarget.store.clear()
+    _call_counts.clear()
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        handle = await coco.mount(produce, lm, {"a": "1", "b": "2", "c": "3"})
+        await handle.ready()
+        await coco.mount_each(process_entry, lm)
+
+    _run_oneshot("basic", app_main)
+    assert _data() == {"a": "1", "b": "2", "c": "3"}
+    assert _call_counts == {"a": 1, "b": 1, "c": 1}
+
+
+def test_multiple_producers_one_map() -> None:
+    GlobalDictTarget.store.clear()
+    _call_counts.clear()
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        h1 = await coco.mount(
+            coco.component_subpath("p1"), produce, lm, {"a": "1", "b": "2"}
+        )
+        h2 = await coco.mount(
+            coco.component_subpath("p2"), produce, lm, {"c": "3", "d": "4"}
+        )
+        await h1.ready()
+        await h2.ready()
+        await coco.mount_each(process_entry, lm)
+
+    _run_oneshot("multi_producer", app_main)
+    assert _data() == {"a": "1", "b": "2", "c": "3", "d": "4"}
+
+
+def test_multiple_livemaps_isolated() -> None:
+    GlobalDictTarget.store.clear()
+    AsyncGlobalDictTarget.store.clear()
+
+    @coco.fn
+    async def app_main() -> None:
+        lm1: LiveMap[str, Val] = await LiveMap.create()
+        lm2: LiveMap[str, Val] = await LiveMap.create()
+        h1 = await coco.mount(
+            coco.component_subpath("p1"), produce, lm1, {"a": "1", "b": "2"}
+        )
+        h2 = await coco.mount(
+            coco.component_subpath("p2"), produce, lm2, {"c": "3", "d": "4"}
+        )
+        await h1.ready()
+        await h2.ready()
+        await coco.mount_each(coco.component_subpath("c1"), process_entry, lm1)
+        await coco.mount_each(coco.component_subpath("c2"), process_entry_b, lm2)
+
+    _run_oneshot("isolation", app_main)
+    assert {k: v.data for k, v in GlobalDictTarget.store.data.items()} == {
+        "a": "1",
+        "b": "2",
+    }
+    assert {k: v.data for k, v in AsyncGlobalDictTarget.store.data.items()} == {
+        "c": "3",
+        "d": "4",
+    }
+
+
+def test_unhashable_value() -> None:
+    GlobalDictTarget.store.clear()
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        # payloads are unhashable lists — proves no hashability/fingerprintability needed.
+        handle = await coco.mount(produce, lm, {"a": [1, 2], "b": [3]})
+        await handle.ready()
+        await coco.mount_each(process_entry, lm)
+
+    _run_oneshot("unhashable", app_main)
+    assert _data() == {"a": [1, 2], "b": [3]}
+
+
+def test_aiter_snapshot() -> None:
+    GlobalDictTarget.store.clear()
+    collected: dict[str, Any] = {}
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        handle = await coco.mount(produce, lm, {"a": "1", "b": "2"})
+        await handle.ready()
+        async for key, value in lm:
+            collected[key] = value.payload
+
+    _run_oneshot("aiter", app_main)
+    assert collected == {"a": "1", "b": "2"}
+
+
+def test_restart_refill_and_cross_run_delete() -> None:
+    GlobalDictTarget.store.clear()
+    _call_counts.clear()
+    env = common.create_test_env(__file__, suffix="restart")
+
+    def run(desired: dict[str, Any]) -> None:
+        @coco.fn
+        async def app_main() -> None:
+            lm: LiveMap[str, Val] = await LiveMap.create()
+            handle = await coco.mount(produce, lm, desired)
+            await handle.ready()
+            await coco.mount_each(process_entry, lm)
+
+        app = coco.App(
+            coco.AppConfig(name="test_live_map_restart", environment=env), app_main
+        )
+        app.update_blocking()
+
+    # Run 1.
+    run({"a": "1", "b": "2"})
+    assert _data() == {"a": "1", "b": "2"}
+
+    # Run 2 (same env + app name = restart): fresh LiveMap (new UUID) refills the empty dict;
+    # `a` unchanged still reappears, `b` dropped is removed, `c` added.
+    run({"a": "1", "c": "3"})
+    assert _data() == {"a": "1", "c": "3"}
+
+
+def test_restart_same_inputs_refill() -> None:
+    # The hard case: identical producer inputs across a restart. The in-memory dict is gone, so
+    # the producer MUST re-run to refill it — even though its inputs are unchanged. If it were
+    # allowed to memoize and skip, the fresh map would stay empty and the consumer would tear
+    # down its (now-unbacked) entries.
+    GlobalDictTarget.store.clear()
+    env = common.create_test_env(__file__, suffix="restart_same")
+
+    def run() -> None:
+        @coco.fn
+        async def app_main() -> None:
+            lm: LiveMap[str, Val] = await LiveMap.create()
+            handle = await coco.mount(produce, lm, {"a": "1", "b": "2"})
+            await handle.ready()
+            await coco.mount_each(process_entry, lm)
+
+        app = coco.App(
+            coco.AppConfig(name="test_live_map_restart_same", environment=env), app_main
+        )
+        app.update_blocking()
+
+    run()
+    assert _data() == {"a": "1", "b": "2"}
+    run()  # same inputs, fresh LiveMap: must still refill, not empty out.
+    assert _data() == {"a": "1", "b": "2"}
+
+
+def test_single_watcher_raises() -> None:
+    env = common.create_test_env(__file__, suffix="single_watcher")
+    result: list[bool] = []
+
+    class _FakeSub:
+        async def update_all(self) -> None: ...
+        async def mark_ready(self) -> None: ...
+        async def update(self, key: Any, value: Any) -> Any:
+            raise AssertionError("unreached")
+
+        async def delete(self, key: Any) -> Any:
+            raise AssertionError("unreached")
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        task = asyncio.create_task(lm.watch(_FakeSub()))  # type: ignore[arg-type]
+        await asyncio.sleep(0)  # let the first watch arm its queue
+        try:
+            await lm.watch(_FakeSub())  # type: ignore[arg-type]
+            result.append(False)
+        except RuntimeError:
+            result.append(True)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    app = coco.App(
+        coco.AppConfig(name="test_live_map_single_watcher", environment=env), app_main
+    )
+    app.update_blocking()
+    assert result == [True]
+
+
+# ============================================================================
+# Live mode
+# ============================================================================
+
+
+def _make_live_app(name: str) -> coco.App[[], None]:
+    env = common.create_test_env(__file__, suffix=name)
+
+    @coco.fn
+    async def app_main() -> None:
+        lm: LiveMap[str, Val] = await LiveMap.create()
+        await coco.mount_each(process_entry, lm)
+        await coco.mount(coco.component_subpath("producer"), MapProducer, lm, name)
+
+    return coco.App(
+        coco.AppConfig(name=f"test_live_map_{name}", environment=env), app_main
+    )
+
+
+async def _run_live(name: str, body: Any) -> None:
+    GlobalDictTarget.store.clear()
+    _call_counts.clear()
+    _live_signals[name] = asyncio.Queue()
+    app = _make_live_app(name)
+    handle = app.update(live=True)
+    task = asyncio.create_task(handle.result())
+    await asyncio.sleep(0.3)
+    try:
+        await body()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_live_initial_scan_then_add() -> None:
+    name = "live_add"
+    _live_desired[name] = {"a": "1", "b": "2"}
+
+    async def body() -> None:
+        await _wait_for_target_keys({"a", "b"})
+        _live_desired[name]["c"] = "3"
+        _live_signals[name].put_nowait(None)
+        await _wait_for_target_keys({"a", "b", "c"})
+        assert GlobalDictTarget.store.data["c"].data == "3"
+
+    await _run_live(name, body)
+
+
+@pytest.mark.asyncio
+async def test_live_update_value() -> None:
+    name = "live_update"
+    _live_desired[name] = {"a": "1"}
+
+    async def body() -> None:
+        await _wait_for_value("a", "1")
+        assert _call_counts.get("a") == 1
+        _live_desired[name]["a"] = "2"
+        _live_signals[name].put_nowait(None)
+        await _wait_for_value("a", "2")
+        assert _call_counts.get("a") == 2
+
+    await _run_live(name, body)
+
+
+@pytest.mark.asyncio
+async def test_live_change_gating() -> None:
+    name = "live_gating"
+    _live_desired[name] = {"a": "1"}
+
+    async def body() -> None:
+        await _wait_for_value("a", "1")
+        assert _call_counts.get("a") == 1
+        # Re-declare the SAME value: the == gate must suppress the emit (no re-trigger).
+        _live_signals[name].put_nowait(None)
+        await asyncio.sleep(0.4)
+        assert _call_counts.get("a") == 1
+        # Change the value: must re-trigger.
+        _live_desired[name]["a"] = "2"
+        _live_signals[name].put_nowait(None)
+        await _wait_for_value("a", "2")
+        assert _call_counts.get("a") == 2
+
+    await _run_live(name, body)
+
+
+@pytest.mark.asyncio
+async def test_live_delete_via_ownership() -> None:
+    name = "live_delete"
+    _live_desired[name] = {"a": "1", "b": "2"}
+
+    async def body() -> None:
+        await _wait_for_target_keys({"a", "b"})
+        _live_desired[name] = {"a": "1"}  # drop b
+        _live_signals[name].put_nowait(None)
+        await _wait_for_target_keys({"a"})
+        assert "b" not in GlobalDictTarget.store.data
+
+    await _run_live(name, body)


### PR DESCRIPTION
## Summary
- Add `LiveMap[K, V]` (`cocoindex.resources.live_map`): an in-memory keyed collection that bridges live data-producing and data-consuming logic within a session. Producers declare `(key, value)` entries as target states; consumers read it as a `LiveMapView` via `coco.mount_each` — one processing component per entry, kept in sync as entries appear, change, and disappear.
- Built entirely on the public `coco.*` API as a two-level container→entry target (per-instance UUID key, weak registry binds the per-instance entry handler). Ownership-based deletion, `==`-gated downstream change events, async sinks that run on the app event loop.
- Docs: new `common_resources/live_map` page + sidebar entry + cross-link from the live-mode guide.

## Test plan
- `python/tests/resources/test_live_map.py` — E2E: one-shot (basic, multi-producer, map isolation, unhashable value, `__aiter__`, restart/refill incl. identical-inputs, single-watcher guard) and live mode (initial-scan-then-add, value update, `==`-gating, delete-via-ownership). 12 tests, all passing.
- CI: ruff, mypy, pytest, docs build.
