### PR TITLE
fix(ops): retry transient LiteLLM embedding errors

### DIFF
--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -15,7 +15,12 @@ __all__ = [
 
 import asyncio as _asyncio
 import io as _io
+import logging as _logging
+import time as _time
+from collections.abc import Awaitable as _Awaitable
+from collections.abc import Callable as _Callable
 from typing import Any as _Any
+from typing import TypeVar as _TypeVar
 
 import litellm as litellm
 import numpy as _np
@@ -24,6 +29,133 @@ from numpy.typing import NDArray as _NDArray
 import cocoindex as coco
 from cocoindex.resources import file as _file
 from cocoindex.resources import schema as _schema
+
+_logger = _logging.getLogger(__name__)
+
+_T = _TypeVar("_T")
+_EMBEDDING_RETRY_TIMEOUT_SECONDS = 10 * 60
+_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
+_EMBEDDING_RETRY_MAX_BACKOFF_SECONDS = 30.0
+_RETRYABLE_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+_RETRYABLE_TRANSPORT_ERROR_CLASS_NAMES = frozenset(
+    {
+        "ClientConnectorError",
+        "ConnectError",
+        "ConnectTimeout",
+        "PoolTimeout",
+        "ReadError",
+        "ReadTimeout",
+        "RemoteProtocolError",
+        "ServerDisconnectedError",
+        "WriteError",
+        "WriteTimeout",
+    }
+)
+
+
+def _message_indicates_non_retryable_credentials_error(message: str) -> bool:
+    normalized = message.lower()
+    if any(
+        fragment in normalized
+        for fragment in (
+            "missing credentials",
+            "no api key",
+            "invalid api key",
+            "unauthorized",
+        )
+    ):
+        return True
+    if "api key" not in normalized and "api_key" not in normalized:
+        return False
+    return any(
+        fragment in normalized
+        for fragment in ("missing", "must be set", "not set", "required", "invalid")
+    )
+
+
+def _litellm_exception_classes(*names: str) -> tuple[type[BaseException], ...]:
+    classes: list[type[BaseException]] = []
+    for name in names:
+        obj = getattr(litellm, name, None)
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            classes.append(obj)
+    return tuple(classes)
+
+
+_RETRYABLE_LITELLM_EXCEPTION_CLASSES = _litellm_exception_classes(
+    "APIConnectionError",
+    "BadGatewayError",
+    "InternalServerError",
+    "RateLimitError",
+    "ServiceUnavailableError",
+    "Timeout",
+)
+
+
+def _http_status_code(error: BaseException) -> int | None:
+    for attr in ("status_code", "exception_status_code"):
+        value = getattr(error, attr, None)
+        if isinstance(value, int):
+            return value
+    response = getattr(error, "response", None)
+    value = getattr(response, "status_code", None)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _is_transport_error(error: BaseException) -> bool:
+    if isinstance(error, (TimeoutError, ConnectionError)):
+        return True
+    error_type = type(error)
+    module = error_type.__module__
+    return (
+        module.startswith(("aiohttp.", "httpcore.", "httpx."))
+        and error_type.__name__ in _RETRYABLE_TRANSPORT_ERROR_CLASS_NAMES
+    )
+
+
+def _is_retryable_litellm_error(error: BaseException) -> bool:
+    if _message_indicates_non_retryable_credentials_error(str(error)):
+        return False
+    status_code = _http_status_code(error)
+    if status_code is not None:
+        return status_code in _RETRYABLE_HTTP_STATUS_CODES or 500 <= status_code < 600
+    return isinstance(
+        error, _RETRYABLE_LITELLM_EXCEPTION_CLASSES
+    ) or _is_transport_error(error)
+
+
+async def _retry_litellm_call(
+    operation: _Callable[[], _Awaitable[_T]],
+    operation_name: str,
+) -> _T:
+    deadline = _time.monotonic() + _EMBEDDING_RETRY_TIMEOUT_SECONDS
+    backoff = _EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS
+    attempt = 1
+    while True:
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"{operation_name} did not succeed within 10 minutes")
+        try:
+            return await _asyncio.wait_for(operation(), timeout=remaining)
+        except Exception as e:
+            if not _is_retryable_litellm_error(e):
+                raise
+            remaining = deadline - _time.monotonic()
+            if remaining <= 0:
+                raise
+            delay = min(backoff, remaining)
+            _logger.warning(
+                "%s failed with transient error on attempt %d; retrying in %.1fs: %s",
+                operation_name,
+                attempt,
+                delay,
+                e,
+            )
+            await _asyncio.sleep(delay)
+            backoff = min(backoff * 2, _EMBEDDING_RETRY_MAX_BACKOFF_SECONDS)
+            attempt += 1
 
 
 class LiteLLMEmbedder(_schema.VectorSchemaProvider):
@@ -77,6 +209,16 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
             kwargs.setdefault("drop_params", True)
         return kwargs
 
+    async def _aembedding_with_retry(self, texts: list[str], **extra: _Any) -> _Any:
+        async def _call() -> _Any:
+            return await litellm.aembedding(
+                model=self._model,
+                input=texts,
+                **self._build_call_kwargs(**extra),
+            )
+
+        return await _retry_litellm_call(_call, "litellm.aembedding")
+
     async def _get_dim(self) -> int:
         """Get embedding dimension, caching the result.
 
@@ -88,11 +230,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         async with self._get_lock():
             if self._dim is not None:
                 return self._dim
-            response = await litellm.aembedding(
-                model=self._model,
-                input=["hello"],
-                **self._build_call_kwargs(),
-            )
+            response = await self._aembedding_with_retry(["hello"])
             embedding = response.data[0]["embedding"]
             self._dim = len(embedding)
             return self._dim
@@ -119,11 +257,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         extra: dict[str, _Any] = {}
         if input_type is not None:
             extra["input_type"] = input_type
-        response = await litellm.aembedding(
-            model=self._model,
-            input=texts,
-            **self._build_call_kwargs(**extra),
-        )
+        response = await self._aembedding_with_retry(texts, **extra)
         return [
             _np.array(item["embedding"], dtype=_np.float32) for item in response.data
         ]

--- a/python/tests/ops/test_embedder_refactor.py
+++ b/python/tests/ops/test_embedder_refactor.py
@@ -8,7 +8,7 @@ single ``NDArray[np.float32]`` rather than a ``list[NDArray]``.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import numpy as np
 import pytest
@@ -17,6 +17,12 @@ pytest.importorskip("litellm", reason="litellm not installed")
 
 from cocoindex.ops.litellm import LiteLLMEmbedder  # noqa: E402
 from cocoindex.resources.embedder import Embedder  # noqa: E402
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code: int, message: str | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message or f"HTTP {status_code}")
 
 
 @pytest.mark.asyncio
@@ -84,3 +90,70 @@ async def test_litellm_encoding_format_gated_by_provider(
     else:
         assert "encoding_format" not in call_kwargs
         assert "drop_params" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_retries_transient_embedding_errors() -> None:
+    fake_response = type(
+        "R",
+        (),
+        {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4]}]},
+    )()
+    embedder = LiteLLMEmbedder("fake-model")
+    mocked_embedding = AsyncMock(
+        side_effect=[
+            _FakeHTTPError(429),
+            _FakeHTTPError(503),
+            fake_response,
+        ]
+    )
+
+    with (
+        patch("cocoindex.ops.litellm.litellm.aembedding", new=mocked_embedding),
+        patch("cocoindex.ops.litellm._asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        vec = await embedder.embed("hello")
+
+    assert vec.tolist() == pytest.approx([0.1, 0.2, 0.3, 0.4])
+    assert mocked_embedding.call_count == 3
+    sleep.assert_has_awaits([call(1.0), call(2.0)])
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_does_not_retry_non_transient_embedding_errors() -> None:
+    embedder = LiteLLMEmbedder("fake-model")
+    mocked_embedding = AsyncMock(side_effect=_FakeHTTPError(400))
+
+    with (
+        patch("cocoindex.ops.litellm.litellm.aembedding", new=mocked_embedding),
+        patch("cocoindex.ops.litellm._asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        with pytest.raises(_FakeHTTPError):
+            await embedder.embed("hello")
+
+    mocked_embedding.assert_awaited_once()
+    sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_does_not_retry_missing_credentials_server_error() -> (
+    None
+):
+    embedder = LiteLLMEmbedder("fake-model")
+    missing_credentials_error = _FakeHTTPError(
+        500,
+        "litellm.InternalServerError: OpenAIException - Missing credentials. "
+        "Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set "
+        "the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.",
+    )
+    mocked_embedding = AsyncMock(side_effect=missing_credentials_error)
+
+    with (
+        patch("cocoindex.ops.litellm.litellm.aembedding", new=mocked_embedding),
+        patch("cocoindex.ops.litellm._asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        with pytest.raises(_FakeHTTPError):
+            await embedder.embed("hello")
+
+    mocked_embedding.assert_awaited_once()
+    sleep.assert_not_called()


### PR DESCRIPTION
## Summary
- Add bounded exponential retry handling around LiteLLM embedding calls for transient provider/transport failures.
- Keep credential/configuration failures such as missing API keys non-retryable, even when LiteLLM wraps them as server errors.
- Add regression coverage for transient retries and missing-credentials no-retry behavior.

## Note
This uses a local 10-minute retry deadline for now. Once #2054 provides the unified timeout/deadline mechanism, this retry loop should use that shared deadline model instead.

## Test plan
- `uv run ruff check python/cocoindex/ops/litellm.py python/tests/ops/test_embedder_refactor.py`
- `uv run --extra litellm pytest python/tests/ops/test_embedder_refactor.py`
- `uv run mypy`
- commit hook: `ruff format`, `mypy`, `maturin develop`, `pytest`
