### PR TITLE
`feat`: Add (initial) `zvec` target integration

### DIFF
--- a/docs/src/content/docs/connectors/zvec.mdx
+++ b/docs/src/content/docs/connectors/zvec.mdx
@@ -1,0 +1,273 @@
+---
+title: "*zvec* connector"
+toc_max_heading_level: 4
+description: >
+  Write documents to zvec, an embedded in-process vector database. Covers
+  collection setup, declaring documents with dense and sparse vectors plus
+  scalar fields, schema-from-class type mapping, and lifecycle management.
+---
+The `zvec` connector writes documents to [zvec](https://zvec.org), an embedded, in-process vector database. zvec runs inside your application — no server or daemon — and stores each collection in a directory on disk.
+
+```python
+from cocoindex.connectors import zvec
+```
+
+:::note[Installation]
+zvec is an optional dependency:
+
+```bash
+pip install cocoindex[zvec]
+```
+:::
+
+## Connection setup
+
+### connect
+
+`connect()` creates a `ManagedConnection` rooted at a base directory. Each collection lives in a subdirectory under it.
+
+```python
+def connect(base_path: str | Path, *, enable_mmap: bool = True) -> ManagedConnection
+```
+
+**Parameters:**
+
+- `base_path` — Directory under which collections are stored. Created if missing.
+- `enable_mmap` — Whether zvec uses memory-mapped I/O for data files.
+
+### ManagedConnection
+
+A handle to the base directory. zvec takes an exclusive write lock per open collection, so `ManagedConnection` caches open handles by collection name and reuses them.
+
+**Methods:**
+
+- `collection_path(name)` — Path to a collection's directory.
+- `close()` — Release all open collection handles (drops their write locks).
+
+For a lifespan, use `managed_connection()`, which closes handles on exit:
+
+```python
+def managed_connection(
+    base_path: str | Path, *, enable_mmap: bool = True
+) -> Iterator[ManagedConnection]
+```
+
+## As target
+
+The `zvec` connector tracks which documents should exist in a collection and automatically handles upserts and deletions. zvec's native upsert is used directly, and documents are removed by id when they are no longer declared.
+
+### Declaring target states
+
+#### Setting up a connection
+
+Create a `ContextKey[zvec.ManagedConnection]` to identify your connection, then provide it in your lifespan:
+
+:::note
+The key name is load-bearing across runs — it's the stable identity CocoIndex uses to track managed documents. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
+:::
+
+```python
+import cocoindex as coco
+
+ZVEC_DB = coco.ContextKey[zvec.ManagedConnection]("main_db")
+
+@coco.lifespan
+def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+    with zvec.managed_connection("./zvec_data") as conn:
+        builder.provide(ZVEC_DB, conn)
+        yield
+```
+
+#### Collections (parent state)
+
+Declares a collection as a target state. Returns a `CollectionTarget` for declaring documents.
+
+```python
+def declare_collection_target(
+    db: ContextKey[ManagedConnection],
+    collection_name: str,
+    schema: CollectionSchema[RowT],
+    *,
+    managed_by: Literal["system", "user"] = "system",
+) -> CollectionTarget[RowT, coco.PendingS]
+```
+
+**Parameters:**
+
+- `db` — A `ContextKey[ManagedConnection]` identifying the connection.
+- `collection_name` — Name of the collection (a subdirectory under the connection's base path).
+- `schema` — Schema definition (see [Collection schema](#collection-schema-from-python-class)).
+- `managed_by` — Whether CocoIndex manages the collection lifecycle (`"system"`, creating and destroying it) or assumes it already exists (`"user"`, documents only).
+
+**Returns:** A pending `CollectionTarget`. Use `await zvec.mount_collection_target(ZVEC_DB, collection_name, schema)` to resolve.
+
+#### Documents (child states)
+
+Once a `CollectionTarget` is resolved, declare documents to be upserted:
+
+```python
+def CollectionTarget.declare_row(self, *, row: RowT) -> None
+```
+
+The primary-key value becomes the document `id` (converted to `str`).
+
+### Collection schema: from Python class
+
+Define the collection structure using a Python class (dataclass, NamedTuple, or Pydantic model):
+
+```python
+@classmethod
+async def CollectionSchema.from_class(
+    cls,
+    record_type: type[RowT],
+    primary_key: list[str],
+    *,
+    column_overrides: dict[str, ZvecType | ZvecVectorDef | VectorSchemaProvider] | None = None,
+) -> CollectionSchema[RowT]
+```
+
+**Parameters:**
+
+- `record_type` — A record type whose fields define the document structure.
+- `primary_key` — Exactly one column name. Its value becomes the document `id`.
+- `column_overrides` — Optional per-column overrides for type mapping or vector configuration.
+
+:::note[Single primary key]
+zvec documents have a single string `id`, so `primary_key` must name exactly one column. Its value is converted to `str` to form the id. Composite primary keys are not supported.
+:::
+
+:::note[At least one vector field]
+zvec is a vector database: every collection must declare at least one vector field (dense or sparse).
+:::
+
+**Example:**
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+import numpy as np
+from numpy.typing import NDArray
+from cocoindex.resources.schema import VectorSchema
+
+@dataclass
+class Doc:
+    id: str
+    title: str
+    year: int
+    embedding: Annotated[NDArray[np.float32], VectorSchema(dtype=np.dtype(np.float32), size=384)]
+
+schema = await zvec.CollectionSchema.from_class(Doc, primary_key=["id"])
+```
+
+Scalar Python types map to zvec field types as follows:
+
+| Python Type | zvec `DataType` |
+|-------------|-----------------|
+| `bool` | `BOOL` |
+| `int` | `INT64` |
+| `float` | `DOUBLE` |
+| `str` | `STRING` |
+| `bytes` | `STRING` (base64) |
+| `uuid.UUID` | `STRING` |
+| `decimal.Decimal` | `STRING` |
+| `datetime.date` / `time` / `datetime` | `STRING` (ISO format) |
+| `datetime.timedelta` | `DOUBLE` (total seconds) |
+| `list[str]` / `list[int]` / `list[float]` / `list[bool]` | `ARRAY_STRING` / `ARRAY_INT64` / `ARRAY_DOUBLE` / `ARRAY_BOOL` |
+| other `list`, `dict`, nested structs | `STRING` (JSON) |
+| `NDArray` (with vector schema) | `VECTOR_FP32` / `FP16` / `FP64` / `INT8` (by dtype) |
+
+Scalar fields get an invert index by default so they can be used in query filters. The primary-key column maps to the document `id` and is not stored as a separate field.
+
+#### ZvecType
+
+Override the scalar type, encoder, or indexing for a field:
+
+```python
+from typing import Annotated
+import zvec
+from cocoindex.connectors.zvec import ZvecType
+
+@dataclass
+class MyRow:
+    id: str
+    # Store as INT32 instead of INT64, without a filter index.
+    count: Annotated[int, ZvecType(zvec.DataType.INT32, indexed=False)]
+    embedding: Annotated[NDArray[np.float32], VectorSchema(dtype=np.dtype(np.float32), size=384)]
+```
+
+### Vectors
+
+A collection can declare multiple named vector fields, dense and sparse, in one schema. zvec supports querying across them with reranking at read time.
+
+#### Dense vectors
+
+A NumPy `ndarray` field with a `VectorSchema` becomes a dense vector. The element dtype selects the zvec type (`float32` → `VECTOR_FP32`, `float16` → `VECTOR_FP16`, `float64` → `VECTOR_FP64`, `int8` → `VECTOR_INT8`). Tune the HNSW index with `ZvecVectorDef`:
+
+```python
+from cocoindex.connectors.zvec import ZvecVectorDef
+
+@dataclass
+class Doc:
+    id: str
+    embedding: Annotated[
+        NDArray[np.float32],
+        VectorSchema(dtype=np.dtype(np.float32), size=384),
+        ZvecVectorDef(metric="cosine", quantize="int8"),
+    ]
+```
+
+`ZvecVectorDef` options: `metric` (`"cosine"`, `"ip"`, `"l2"`) and `quantize` (`"none"`, `"fp16"`, `"int8"`, `"int4"`).
+
+#### Sparse vectors
+
+Mark a `dict[int, float]` field (mapping dimension → weight) as sparse with `ZvecVectorDef(sparse=True)`:
+
+```python
+@dataclass
+class Doc:
+    id: str
+    sparse: Annotated[dict[int, float], ZvecVectorDef(sparse=True)]
+```
+
+## Full example
+
+```python
+import pathlib
+from dataclasses import dataclass
+from typing import Annotated, Iterator
+
+import cocoindex as coco
+import numpy as np
+from numpy.typing import NDArray
+from cocoindex.connectors import zvec
+from cocoindex.resources.schema import VectorSchema
+
+ZVEC_DB = coco.ContextKey[zvec.ManagedConnection]("main_db")
+
+
+@dataclass
+class Doc:
+    id: str
+    title: str
+    embedding: Annotated[
+        NDArray[np.float32], VectorSchema(dtype=np.dtype(np.float32), size=384)
+    ]
+
+
+@coco.lifespan
+def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+    with zvec.managed_connection("./zvec_data") as conn:
+        builder.provide(ZVEC_DB, conn)
+        yield
+
+
+@coco.fn
+async def index_docs(docs: list[Doc]) -> None:
+    target = await zvec.mount_collection_target(
+        ZVEC_DB,
+        "docs",
+        await zvec.CollectionSchema.from_class(Doc, primary_key=["id"]),
+    )
+    for doc in docs:
+        target.declare_row(row=doc)
+```

--- a/docs/src/content/docs/connectors/zvec.mdx
+++ b/docs/src/content/docs/connectors/zvec.mdx
@@ -174,7 +174,7 @@ Scalar Python types map to zvec field types as follows:
 | `datetime.timedelta` | `DOUBLE` (total seconds) |
 | `list[str]` / `list[int]` / `list[float]` / `list[bool]` | `ARRAY_STRING` / `ARRAY_INT64` / `ARRAY_DOUBLE` / `ARRAY_BOOL` |
 | other `list`, `dict`, nested structs | `STRING` (JSON) |
-| `NDArray` (with vector schema) | `VECTOR_FP32` / `FP16` / `FP64` / `INT8` (by dtype) |
+| `NDArray` (with vector schema) | `VECTOR_FP32` (float32) or `VECTOR_FP16` (float16) |
 
 Scalar fields get an invert index by default so they can be used in query filters. The primary-key column maps to the document `id` and is not stored as a separate field.
 
@@ -201,7 +201,7 @@ A collection can declare multiple named vector fields, dense and sparse, in one 
 
 #### Dense vectors
 
-A NumPy `ndarray` field with a `VectorSchema` becomes a dense vector. The element dtype selects the zvec type (`float32` → `VECTOR_FP32`, `float16` → `VECTOR_FP16`, `float64` → `VECTOR_FP64`, `int8` → `VECTOR_INT8`). Tune the HNSW index with `ZvecVectorDef`:
+A NumPy `ndarray` field with a `VectorSchema` becomes a dense vector. The element dtype selects the zvec type: `float32` → `VECTOR_FP32`, `float16` → `VECTOR_FP16`. zvec's dense index only accepts these two; for smaller storage, keep a float32 vector and set `quantize`. Tune the HNSW index with `ZvecVectorDef`:
 
 ```python
 from cocoindex.connectors.zvec import ZvecVectorDef

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -73,6 +73,7 @@ export const sidebar: SidebarItem[] = [
       { type: 'doc', slug: 'connectors/sqlite', label: 'SQLite' },
       { type: 'doc', slug: 'connectors/surrealdb', label: 'SurrealDB' },
       { type: 'doc', slug: 'connectors/turbopuffer', label: 'Turbopuffer' },
+      { type: 'doc', slug: 'connectors/zvec', label: 'zvec' },
     ],
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ postgres = ["asyncpg>=0.31.0"]
 qdrant = ["qdrant-client>=1.6.0"]
 sqlite = ["sqlite-vec>=0.1.6"]
 surrealdb = ["surrealdb>=1.0.0"]
+zvec = ["zvec>=0.4.0"]
 turbopuffer = ["turbopuffer>=0.5.0"]
 google_drive = [
     "google-api-python-client>=2.0.0",
@@ -125,6 +126,7 @@ all = [
     "oci>=2.0",
     "faiss-cpu>=1.7",
     "instructor>=1.0",
+    "zvec>=0.4.0",
 ]
 
 
@@ -235,6 +237,8 @@ module = [
     "transformers.*",
     "testcontainers",
     "testcontainers.*",
+    "zvec",
+    "zvec.*",
 ]
 ignore_missing_imports = true
 

--- a/python/cocoindex/connectors/zvec/__init__.py
+++ b/python/cocoindex/connectors/zvec/__init__.py
@@ -1,0 +1,4 @@
+from . import _target
+from ._target import *
+
+__all__ = _target.__all__

--- a/python/cocoindex/connectors/zvec/_target.py
+++ b/python/cocoindex/connectors/zvec/_target.py
@@ -559,12 +559,12 @@ def _build_doc(value: _DocValue) -> Any:
 class _DocHandler(coco.TargetHandler[_DocValue, bytes]):
     """Handler for document-level target states within a collection."""
 
-    _conn: ManagedConnection
+    _db_key: str
     _collection_name: str
     _sink: coco.TargetActionSink[_DocAction, None]
 
-    def __init__(self, conn: ManagedConnection, collection_name: str) -> None:
-        self._conn = conn
+    def __init__(self, db_key: str, collection_name: str) -> None:
+        self._db_key = db_key
         self._collection_name = collection_name
         self._sink = coco.TargetActionSink[_DocAction, None].from_fn(
             self._apply_actions
@@ -575,7 +575,8 @@ class _DocHandler(coco.TargetHandler[_DocValue, bytes]):
     ) -> None:
         if not actions:
             return
-        col = self._conn.open_existing(self._collection_name)
+        conn = context_provider.get(self._db_key, ManagedConnection)
+        col = conn.open_existing(self._collection_name)
 
         upserts: list[Any] = []
         deletes: list[str] = []
@@ -715,7 +716,7 @@ def _apply_collection_actions(
 
             spec = action.spec
             outputs[i] = coco.ChildTargetDef(
-                handler=_DocHandler(conn, key.collection_name)
+                handler=_DocHandler(key.db_key, key.collection_name)
             )
 
             if action.main_action in ("insert", "upsert", "replace"):

--- a/python/cocoindex/connectors/zvec/_target.py
+++ b/python/cocoindex/connectors/zvec/_target.py
@@ -284,17 +284,16 @@ def _json_encoder(value: Any) -> str:
 
 
 def _dense_vector_data_type(dtype: np.dtype) -> Any:
+    # zvec's dense vector index only accepts FP32 and FP16. For smaller storage,
+    # keep an FP32 vector and set quantize on ZvecVectorDef (e.g. "int8").
     if dtype == np.float32:
         return _zvec.DataType.VECTOR_FP32
     if dtype == np.float16:
         return _zvec.DataType.VECTOR_FP16
-    if dtype == np.float64:
-        return _zvec.DataType.VECTOR_FP64
-    if dtype == np.int8:
-        return _zvec.DataType.VECTOR_INT8
     raise ValueError(
-        f"Unsupported dense vector dtype {dtype!r}; expected float32, float16, "
-        "float64, or int8."
+        f"Unsupported dense vector dtype {dtype!r}; zvec dense vectors must be "
+        "float32 or float16. For compressed storage, use a float32 vector with "
+        'ZvecVectorDef(quantize="int8").'
     )
 
 

--- a/python/cocoindex/connectors/zvec/_target.py
+++ b/python/cocoindex/connectors/zvec/_target.py
@@ -1,0 +1,944 @@
+"""
+zvec target for CocoIndex.
+
+zvec (https://zvec.org) is an embedded, in-process vector database. This module
+provides a two-level target state system:
+
+1. Collection level: creates/destroys collections on disk.
+2. Document level: upserts/deletes documents within a collection.
+
+zvec is path-based: a ``ManagedConnection`` owns a base directory and each
+collection lives in a subdirectory under it. Each document has a single string
+``id`` (the primary key), a set of named vector fields (dense or sparse), and a
+set of scalar fields used for filtering.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import decimal
+import json
+import re
+import threading
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Generic,
+    Iterator,
+    Literal,
+    NamedTuple,
+    Sequence,
+    cast,
+)
+
+import numpy as np
+from typing_extensions import TypeVar
+
+try:
+    import zvec as _zvec
+except ImportError as e:
+    raise ImportError(
+        "zvec is required to use the zvec connector. Please install cocoindex[zvec]."
+    ) from e
+
+import msgspec
+
+import cocoindex as coco
+from cocoindex.connectorkits import statediff, target
+from cocoindex.connectorkits.fingerprint import fingerprint_object
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+from cocoindex._internal.datatype import (
+    RecordType,
+    SequenceType,
+    TypeChecker,
+    analyze_type_info,
+    is_record_type,
+)
+from cocoindex.resources import schema as res_schema
+
+ValueEncoder = Callable[[Any], Any]
+
+# Document id is always a string in zvec.
+_DocId = str
+_DOC_ID_CHECKER: TypeChecker[str] = TypeChecker(str)
+_COLLECTION_KEY_CHECKER = TypeChecker(tuple[str, str])
+
+RowT = TypeVar("RowT", default=dict[str, Any])
+
+
+# zvec rejects names that don't match its internal rule. We guard with a
+# conservative identifier allow-list before handing the name to zvec, which
+# mirrors the input-safety guidance for other connectors and gives a clear error
+# early.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# zvec additionally rejects collection names shorter than 3 characters.
+_MIN_COLLECTION_NAME_LEN = 3
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> None:
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid {kind}: {name!r}")
+
+
+def _validate_collection_name(name: str) -> None:
+    _validate_identifier(name, "collection name")
+    if len(name) < _MIN_COLLECTION_NAME_LEN:
+        raise ValueError(
+            f"Invalid collection name {name!r}: zvec requires at least "
+            f"{_MIN_COLLECTION_NAME_LEN} characters."
+        )
+
+
+# =============================================================================
+# Connection
+# =============================================================================
+
+
+def _collection_option(enable_mmap: bool, *, read_only: bool = False) -> Any:
+    return _zvec.CollectionOption(read_only=read_only, enable_mmap=enable_mmap)
+
+
+@dataclass
+class ManagedConnection:
+    """A handle to a base directory holding zvec collections.
+
+    zvec opens each collection as a live handle and takes an exclusive write
+    lock on it. Opening the same collection twice (even within one process)
+    fails, so this class caches open handles by collection name and reuses them.
+    """
+
+    base_path: Path
+    enable_mmap: bool = True
+    _open: dict[str, Any] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def collection_path(self, name: str) -> Path:
+        return self.base_path / name
+
+    def open_or_create(self, name: str, schema: Any) -> Any:
+        """Open the collection, creating it from ``schema`` if it doesn't exist."""
+        with self._lock:
+            col = self._open.get(name)
+            if col is not None:
+                return col
+            path = self.collection_path(name)
+            if path.exists():
+                col = _zvec.open(str(path), option=_collection_option(self.enable_mmap))
+            else:
+                self.base_path.mkdir(parents=True, exist_ok=True)
+                col = _zvec.create_and_open(
+                    path=str(path),
+                    schema=schema,
+                    option=_collection_option(self.enable_mmap),
+                )
+            self._open[name] = col
+            return col
+
+    def open_existing(self, name: str) -> Any:
+        """Open an existing collection (used for user-managed collections)."""
+        with self._lock:
+            col = self._open.get(name)
+            if col is not None:
+                return col
+            col = _zvec.open(
+                str(self.collection_path(name)),
+                option=_collection_option(self.enable_mmap),
+            )
+            self._open[name] = col
+            return col
+
+    def destroy(self, name: str) -> None:
+        """Permanently delete a collection from disk."""
+        with self._lock:
+            col = self._open.pop(name, None)
+            if col is None:
+                path = self.collection_path(name)
+                if not path.exists():
+                    return
+                col = _zvec.open(str(path), option=_collection_option(self.enable_mmap))
+            col.destroy()
+
+    def close(self) -> None:
+        """Release all open collection handles (drops their write locks)."""
+        with self._lock:
+            self._open.clear()
+
+
+def connect(base_path: str | Path, *, enable_mmap: bool = True) -> ManagedConnection:
+    """Create a ManagedConnection rooted at ``base_path``.
+
+    Args:
+        base_path: Directory under which collections are stored. Created if missing.
+        enable_mmap: Whether zvec uses memory-mapped I/O for data files.
+    """
+    path = Path(base_path)
+    path.mkdir(parents=True, exist_ok=True)
+    return ManagedConnection(base_path=path, enable_mmap=enable_mmap)
+
+
+@contextmanager
+def managed_connection(
+    base_path: str | Path, *, enable_mmap: bool = True
+) -> Iterator[ManagedConnection]:
+    """Create a ManagedConnection as a context manager.
+
+    Suitable for ``builder.provide_with()`` in a lifespan function. Closes all
+    open collection handles on exit.
+    """
+    conn = connect(base_path, enable_mmap=enable_mmap)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# Schema and type mapping
+# =============================================================================
+
+
+class ZvecType(NamedTuple):
+    """Annotation to override the scalar field type for a column.
+
+    Use with ``typing.Annotated``:
+
+    ```python
+    from typing import Annotated
+    import zvec
+    from cocoindex.connectors.zvec import ZvecType
+
+    @dataclass
+    class MyRow:
+        # Store as INT32 instead of the default INT64, without a filter index.
+        count: Annotated[int, ZvecType(zvec.DataType.INT32, indexed=False)]
+    ```
+    """
+
+    data_type: Any  # zvec.DataType
+    encoder: ValueEncoder | None = None
+    indexed: bool = True
+
+
+class ZvecVectorDef(NamedTuple):
+    """Annotation to configure a vector field.
+
+    Dense vectors are inferred from a NumPy ``ndarray`` field plus a
+    ``VectorSchema`` (via ``Annotated`` or ``column_overrides``). This annotation
+    tunes the index and marks sparse fields.
+
+    For sparse vectors, set ``sparse=True`` on a ``dict[int, float]`` field.
+    """
+
+    metric: Literal["cosine", "ip", "l2"] = "cosine"
+    quantize: Literal["none", "fp16", "int8", "int4"] = "none"
+    sparse: bool = False
+
+
+_ColumnKind = Literal["scalar", "dense", "sparse"]
+
+
+@dataclass(slots=True)
+class _Column:
+    name: str
+    kind: _ColumnKind
+    data_type: Any  # zvec.DataType
+    nullable: bool = True
+    encoder: ValueEncoder | None = None
+    dimension: int | None = None  # dense vectors only
+    metric: str | None = None  # vectors only
+    quantize: str | None = None  # dense vectors only
+    indexed: bool = False  # scalar fields only (invert index for filtering)
+
+
+_LEAF_SCALAR_MAPPINGS: dict[type, tuple[Any, ValueEncoder | None]] = {
+    bool: (_zvec.DataType.BOOL, None),
+    int: (_zvec.DataType.INT64, None),
+    float: (_zvec.DataType.DOUBLE, None),
+    str: (_zvec.DataType.STRING, None),
+    bytes: (_zvec.DataType.STRING, lambda v: base64.b64encode(v).decode("ascii")),
+    uuid.UUID: (_zvec.DataType.STRING, str),
+    decimal.Decimal: (_zvec.DataType.STRING, str),
+    datetime.date: (_zvec.DataType.STRING, lambda v: v.isoformat()),
+    datetime.datetime: (_zvec.DataType.STRING, lambda v: v.isoformat()),
+    datetime.time: (_zvec.DataType.STRING, lambda v: v.isoformat()),
+    datetime.timedelta: (_zvec.DataType.DOUBLE, lambda v: v.total_seconds()),
+}
+
+_ARRAY_ELEM_MAPPINGS: dict[type, Any] = {
+    str: _zvec.DataType.ARRAY_STRING,
+    int: _zvec.DataType.ARRAY_INT64,
+    float: _zvec.DataType.ARRAY_DOUBLE,
+    bool: _zvec.DataType.ARRAY_BOOL,
+}
+
+
+def _json_encoder(value: Any) -> str:
+    return json.dumps(value, default=str)
+
+
+def _dense_vector_data_type(dtype: np.dtype) -> Any:
+    if dtype == np.float32:
+        return _zvec.DataType.VECTOR_FP32
+    if dtype == np.float16:
+        return _zvec.DataType.VECTOR_FP16
+    if dtype == np.float64:
+        return _zvec.DataType.VECTOR_FP64
+    if dtype == np.int8:
+        return _zvec.DataType.VECTOR_INT8
+    raise ValueError(
+        f"Unsupported dense vector dtype {dtype!r}; expected float32, float16, "
+        "float64, or int8."
+    )
+
+
+def _scalar_data_type(type_info: Any) -> tuple[Any, ValueEncoder | None]:
+    base_type = type_info.base_type
+    if base_type in _LEAF_SCALAR_MAPPINGS:
+        return _LEAF_SCALAR_MAPPINGS[base_type]
+    if isinstance(type_info.variant, SequenceType):
+        elem_info = analyze_type_info(type_info.variant.elem_type)
+        mapped = _ARRAY_ELEM_MAPPINGS.get(elem_info.base_type)
+        if mapped is not None:
+            return mapped, None
+    # Fallback: store complex/unknown types as a JSON string.
+    return _zvec.DataType.STRING, _json_encoder
+
+
+async def _resolve_column(
+    name: str,
+    type_hint: Any,
+    override: ZvecType | ZvecVectorDef | res_schema.VectorSchemaProvider | None,
+) -> _Column:
+    type_info = analyze_type_info(type_hint)
+
+    annotations: list[Any] = []
+    if override is not None:
+        annotations.append(override)
+    annotations.extend(type_info.annotations)
+
+    vector_schema: res_schema.VectorSchema | None = None
+    for annot in annotations:
+        vs = await res_schema.get_vector_schema(annot)
+        if vs is not None:
+            vector_schema = vs
+            break
+
+    vector_def = next((a for a in annotations if isinstance(a, ZvecVectorDef)), None)
+    zvec_type = next((a for a in annotations if isinstance(a, ZvecType)), None)
+
+    # Dense vector: NumPy ndarray with a VectorSchema.
+    if vector_schema is not None:
+        if vector_schema.size <= 0:
+            raise ValueError(
+                f"Invalid vector dimension for {name!r}: {vector_schema.size}"
+            )
+        vd = vector_def or ZvecVectorDef()
+        return _Column(
+            name=name,
+            kind="dense",
+            data_type=_dense_vector_data_type(vector_schema.dtype),
+            nullable=type_info.nullable,
+            dimension=vector_schema.size,
+            metric=vd.metric,
+            quantize=vd.quantize,
+        )
+
+    # Sparse vector: explicitly marked via ZvecVectorDef(sparse=True).
+    if vector_def is not None and vector_def.sparse:
+        return _Column(
+            name=name,
+            kind="sparse",
+            data_type=_zvec.DataType.SPARSE_VECTOR_FP32,
+            nullable=type_info.nullable,
+            metric=vector_def.metric,
+        )
+
+    if type_info.base_type is np.ndarray:
+        raise ValueError(
+            f"Vector column {name!r} requires a VectorSchema (provide it via an "
+            "Annotated NDArray or column_overrides)."
+        )
+
+    # Scalar field.
+    if zvec_type is not None:
+        return _Column(
+            name=name,
+            kind="scalar",
+            data_type=zvec_type.data_type,
+            nullable=type_info.nullable,
+            encoder=zvec_type.encoder,
+            indexed=zvec_type.indexed,
+        )
+
+    data_type, encoder = _scalar_data_type(type_info)
+    return _Column(
+        name=name,
+        kind="scalar",
+        data_type=data_type,
+        nullable=type_info.nullable,
+        encoder=encoder,
+        indexed=True,
+    )
+
+
+@dataclass(slots=True)
+class CollectionSchema(Generic[RowT]):
+    """Schema definition for a zvec collection.
+
+    Built from a record type via ``from_class``. The single primary-key column
+    becomes the document ``id``; the remaining columns become scalar fields or
+    vector fields.
+    """
+
+    columns: dict[str, _Column]
+    primary_key: str
+    row_type: type[RowT] | None
+
+    def __init__(
+        self,
+        columns: dict[str, _Column],
+        primary_key: str,
+        *,
+        row_type: type[RowT] | None = None,
+    ) -> None:
+        self.columns = columns
+        self.primary_key = primary_key
+        self.row_type = row_type
+        if primary_key not in columns:
+            raise ValueError(
+                f"Primary key column {primary_key!r} not found in columns: "
+                f"{list(columns.keys())}"
+            )
+        if columns[primary_key].kind != "scalar":
+            raise ValueError(
+                f"Primary key column {primary_key!r} must be a scalar field, "
+                f"got kind {columns[primary_key].kind!r}."
+            )
+
+    @classmethod
+    async def from_class(
+        cls,
+        record_type: type[RowT],
+        primary_key: list[str],
+        *,
+        column_overrides: dict[
+            str, ZvecType | ZvecVectorDef | res_schema.VectorSchemaProvider
+        ]
+        | None = None,
+    ) -> "CollectionSchema[RowT]":
+        """Build a CollectionSchema from a record type.
+
+        Args:
+            record_type: A dataclass, NamedTuple, or Pydantic model.
+            primary_key: Exactly one column name. Its value becomes the document
+                id (converted to ``str``).
+            column_overrides: Optional per-column type/vector overrides.
+        """
+        if not is_record_type(record_type):
+            raise TypeError(
+                "record_type must be a record type (dataclass, NamedTuple, "
+                f"Pydantic model), got {type(record_type)}"
+            )
+        if len(primary_key) != 1:
+            raise ValueError(
+                "zvec collections require exactly one primary key column "
+                f"(mapped to the document id), got {primary_key}."
+            )
+
+        record_info = RecordType(record_type)
+        columns: dict[str, _Column] = {}
+        for fld in record_info.fields:
+            override = column_overrides.get(fld.name) if column_overrides else None
+            columns[fld.name] = await _resolve_column(fld.name, fld.type_hint, override)
+        return cls(columns, primary_key[0], row_type=record_type)
+
+
+def _metric_type(metric: str) -> Any:
+    key = metric.lower()
+    if key == "cosine":
+        return _zvec.MetricType.COSINE
+    if key == "ip":
+        return _zvec.MetricType.IP
+    if key == "l2":
+        return _zvec.MetricType.L2
+    raise ValueError(f"Unsupported metric type: {metric!r}")
+
+
+def _quantize_type(quantize: str) -> Any | None:
+    key = quantize.lower()
+    if key == "none":
+        return None
+    if key == "fp16":
+        return _zvec.QuantizeType.FP16
+    if key == "int8":
+        return _zvec.QuantizeType.INT8
+    if key == "int4":
+        return _zvec.QuantizeType.INT4
+    raise ValueError(f"Unsupported quantize type: {quantize!r}")
+
+
+def _build_zvec_schema(collection_name: str, schema: CollectionSchema[Any]) -> Any:
+    fields: list[Any] = []
+    vectors: list[Any] = []
+    for name, col in schema.columns.items():
+        if name == schema.primary_key:
+            continue  # primary key maps to the document id, not a field
+        if col.kind == "scalar":
+            index_param = _zvec.InvertIndexParam() if col.indexed else None
+            fields.append(
+                _zvec.FieldSchema(
+                    name=name,
+                    data_type=col.data_type,
+                    nullable=col.nullable,
+                    index_param=index_param,
+                )
+            )
+        elif col.kind == "dense":
+            quantize = _quantize_type(col.quantize or "none")
+            hnsw_kwargs: dict[str, Any] = {
+                "metric_type": _metric_type(col.metric or "cosine")
+            }
+            if quantize is not None:
+                hnsw_kwargs["quantize_type"] = quantize
+            vectors.append(
+                _zvec.VectorSchema(
+                    name=name,
+                    data_type=col.data_type,
+                    dimension=col.dimension,
+                    index_param=_zvec.HnswIndexParam(**hnsw_kwargs),
+                )
+            )
+        else:  # sparse
+            vectors.append(_zvec.VectorSchema(name=name, data_type=col.data_type))
+    return _zvec.CollectionSchema(name=collection_name, fields=fields, vectors=vectors)
+
+
+# =============================================================================
+# Document (row) level
+# =============================================================================
+
+
+class _DocValue(NamedTuple):
+    doc_id: str
+    vectors: dict[str, Any]
+    fields: dict[str, Any]
+
+
+class _DocAction(NamedTuple):
+    doc_id: _DocId
+    value: _DocValue | None  # None means delete
+
+
+def _check_status(result: Any) -> None:
+    """Raise if any zvec Status in the result is not OK."""
+    statuses = result if isinstance(result, list) else [result]
+    for status in statuses:
+        if not status.ok():
+            raise RuntimeError(
+                f"zvec operation failed: code={status.code()} "
+                f"message={status.message()}"
+            )
+
+
+def _build_doc(value: _DocValue) -> Any:
+    vectors = {k: v for k, v in value.vectors.items() if v is not None}
+    fields = {k: v for k, v in value.fields.items() if v is not None}
+    return _zvec.Doc(
+        id=value.doc_id,
+        vectors=vectors or None,
+        fields=fields or None,
+    )
+
+
+class _DocHandler(coco.TargetHandler[_DocValue, bytes]):
+    """Handler for document-level target states within a collection."""
+
+    _conn: ManagedConnection
+    _collection_name: str
+    _sink: coco.TargetActionSink[_DocAction, None]
+
+    def __init__(self, conn: ManagedConnection, collection_name: str) -> None:
+        self._conn = conn
+        self._collection_name = collection_name
+        self._sink = coco.TargetActionSink[_DocAction, None].from_fn(
+            self._apply_actions
+        )
+
+    def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_DocAction]
+    ) -> None:
+        if not actions:
+            return
+        col = self._conn.open_existing(self._collection_name)
+
+        upserts: list[Any] = []
+        deletes: list[str] = []
+        for action in actions:
+            if action.value is None:
+                deletes.append(action.doc_id)
+            else:
+                upserts.append(_build_doc(action.value))
+
+        if upserts:
+            _check_status(col.upsert(upserts))
+        if deletes:
+            _check_status(col.delete(ids=deletes))
+        if upserts or deletes:
+            col.optimize()
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _DocValue | coco.NonExistenceType,
+        prev_possible_records: Collection[bytes],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_DocAction, bytes] | None:
+        doc_id = _DOC_ID_CHECKER.check(key)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_DocAction(doc_id=doc_id, value=None),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(
+            (desired_state.doc_id, desired_state.vectors, desired_state.fields)
+        )
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_DocAction(doc_id=doc_id, value=desired_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# =============================================================================
+# Collection level
+# =============================================================================
+
+
+class _CollectionKey(NamedTuple):
+    db_key: str
+    collection_name: str
+
+
+@dataclass
+class _CollectionSpec:
+    schema: CollectionSchema[Any]
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+
+
+class _ColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
+    name: str
+    kind: str
+    data_type: str
+    nullable: bool
+    dimension: int | None
+    metric: str | None
+    quantize: str | None
+    indexed: bool
+
+
+class _CollectionTrackingRecordCore(msgspec.Struct, frozen=True, array_like=True):
+    primary_key: str
+    columns: tuple[_ColumnTrackingRecord, ...]
+
+
+_CollectionTrackingRecord = statediff.MutualTrackingRecord[
+    _CollectionTrackingRecordCore
+]
+
+
+def _tracking_core_from_spec(spec: _CollectionSpec) -> _CollectionTrackingRecordCore:
+    schema = spec.schema
+    columns = tuple(
+        _ColumnTrackingRecord(
+            name=col.name,
+            kind=col.kind,
+            data_type=str(col.data_type),
+            nullable=col.nullable,
+            dimension=col.dimension,
+            metric=col.metric,
+            quantize=col.quantize,
+            indexed=col.indexed,
+        )
+        for name, col in sorted(schema.columns.items())
+        if name != schema.primary_key
+    )
+    return _CollectionTrackingRecordCore(
+        primary_key=schema.primary_key, columns=columns
+    )
+
+
+class _CollectionAction(NamedTuple):
+    key: _CollectionKey
+    spec: _CollectionSpec | coco.NonExistenceType
+    main_action: statediff.DiffAction | None
+
+
+def _apply_collection_actions(
+    context_provider: ContextProvider, actions: Sequence[_CollectionAction]
+) -> list[coco.ChildTargetDef[_DocHandler] | None]:
+    actions_list = list(actions)
+    outputs: list[coco.ChildTargetDef[_DocHandler] | None] = [None] * len(actions_list)
+
+    by_key: dict[_CollectionKey, list[int]] = {}
+    for i, action in enumerate(actions_list):
+        by_key.setdefault(action.key, []).append(i)
+
+    for key, idxs in by_key.items():
+        conn = context_provider.get(key.db_key, ManagedConnection)
+        for i in idxs:
+            action = actions_list[i]
+
+            # A non-None main action implies a system-managed collection
+            # (resolve_system_transition yields None for user-managed ones).
+            if action.main_action in ("replace", "delete"):
+                conn.destroy(key.collection_name)
+
+            if coco.is_non_existence(action.spec):
+                outputs[i] = None
+                continue
+
+            spec = action.spec
+            outputs[i] = coco.ChildTargetDef(
+                handler=_DocHandler(conn, key.collection_name)
+            )
+
+            if action.main_action in ("insert", "upsert", "replace"):
+                conn.open_or_create(
+                    key.collection_name,
+                    _build_zvec_schema(key.collection_name, spec.schema),
+                )
+
+    return outputs
+
+
+_collection_action_sink = coco.TargetActionSink[_CollectionAction, _DocHandler].from_fn(
+    _apply_collection_actions
+)
+
+
+class _CollectionHandler(
+    coco.TargetHandler[_CollectionSpec, _CollectionTrackingRecord, _DocHandler]
+):
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _CollectionSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_CollectionTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[
+            _CollectionAction, _CollectionTrackingRecord, _DocHandler
+        ]
+        | None
+    ):
+        key = _CollectionKey(*_COLLECTION_KEY_CHECKER.check(key))
+        tracking_record: _CollectionTrackingRecord | coco.NonExistenceType
+        if coco.is_non_existence(desired_state):
+            tracking_record = coco.NON_EXISTENCE
+        else:
+            tracking_record = statediff.MutualTrackingRecord(
+                tracking_record=_tracking_core_from_spec(desired_state),
+                managed_by=desired_state.managed_by,
+            )
+
+        resolved = statediff.resolve_system_transition(
+            statediff.TrackingRecordTransition(
+                tracking_record, prev_possible_records, prev_may_be_missing
+            )
+        )
+        main_action = statediff.diff(resolved)
+
+        # v1 has no in-place schema evolution: any schema change rebuilds the
+        # collection, which destroys all documents.
+        child_invalidation: Literal["destructive"] | None = (
+            "destructive" if main_action == "replace" else None
+        )
+
+        return coco.TargetReconcileOutput(
+            action=_CollectionAction(
+                key=key, spec=desired_state, main_action=main_action
+            ),
+            sink=_collection_action_sink,
+            tracking_record=tracking_record,
+            child_invalidation=child_invalidation,
+        )
+
+
+_collection_provider = coco.register_root_target_states_provider(
+    "cocoindex/zvec/collection", _CollectionHandler()
+)
+
+
+# =============================================================================
+# User-facing API
+# =============================================================================
+
+
+def _row_get(row: Any, name: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(name)
+    return getattr(row, name)
+
+
+def _to_float_list(value: Any) -> list[float]:
+    if isinstance(value, np.ndarray):
+        return cast(list[float], value.astype(float).tolist())
+    return [float(x) for x in value]
+
+
+class CollectionTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["CollectionTarget[RowT]"]
+):
+    """A target for writing documents to a zvec collection."""
+
+    _provider: coco.TargetStateProvider[_DocValue, None, coco.MaybePendingS]
+    _schema: CollectionSchema[RowT]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_DocValue, None, coco.MaybePendingS],
+        schema: CollectionSchema[RowT],
+    ) -> None:
+        self._provider = provider
+        self._schema = schema
+
+    def declare_row(self: "CollectionTarget[RowT]", *, row: RowT) -> None:
+        """Declare a document (row) to be upserted to this collection.
+
+        The primary-key value becomes the document id (converted to ``str``).
+        """
+        schema = self._schema
+        pk_value = _row_get(row, schema.primary_key)
+        if pk_value is None:
+            raise ValueError(
+                f"Primary key {schema.primary_key!r} value cannot be None."
+            )
+        doc_id = str(pk_value)
+
+        vectors: dict[str, Any] = {}
+        fields: dict[str, Any] = {}
+        for name, col in schema.columns.items():
+            if name == schema.primary_key:
+                continue
+            value = _row_get(row, name)
+            if col.kind == "dense":
+                vectors[name] = None if value is None else _to_float_list(value)
+            elif col.kind == "sparse":
+                vectors[name] = (
+                    None
+                    if value is None
+                    else {int(k): float(v) for k, v in dict(value).items()}
+                )
+            else:
+                if value is not None and col.encoder is not None:
+                    value = col.encoder(value)
+                fields[name] = value
+
+        coco.declare_target_state(
+            self._provider.target_state(
+                doc_id, _DocValue(doc_id=doc_id, vectors=vectors, fields=fields)
+            )
+        )
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+def collection_target(
+    db: ContextKey[ManagedConnection],
+    collection_name: str,
+    schema: CollectionSchema[RowT],
+    *,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> "coco.TargetState[_DocHandler]":
+    """Create a TargetState for a zvec collection target.
+
+    Use with ``coco.mount_target()`` or the convenience wrappers
+    ``declare_collection_target()`` / ``mount_collection_target()``.
+
+    Args:
+        db: A ContextKey for the ManagedConnection (provided via lifespan).
+        collection_name: Name of the collection (a subdirectory under the
+            connection's base path).
+        schema: Schema definition built via ``CollectionSchema.from_class``.
+        managed_by: Whether CocoIndex manages the collection lifecycle
+            ("system") or it must already exist ("user", documents only).
+    """
+    _validate_collection_name(collection_name)
+    for name in schema.columns:
+        if name != schema.primary_key:
+            _validate_identifier(name, "field name")
+
+    if not any(
+        col.kind in ("dense", "sparse")
+        for name, col in schema.columns.items()
+        if name != schema.primary_key
+    ):
+        raise ValueError(
+            "zvec collections require at least one vector field (dense or sparse)."
+        )
+
+    key = _CollectionKey(db_key=db.key, collection_name=collection_name)
+    spec = _CollectionSpec(schema=schema, managed_by=managed_by)
+    return _collection_provider.target_state(key, spec)
+
+
+def declare_collection_target(
+    db: ContextKey[ManagedConnection],
+    collection_name: str,
+    schema: CollectionSchema[RowT],
+    *,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> "CollectionTarget[RowT, coco.PendingS]":
+    """Declare a zvec collection target and return a CollectionTarget for rows."""
+    provider = coco.declare_target_state_with_child(
+        collection_target(db, collection_name, schema, managed_by=managed_by)
+    )
+    return CollectionTarget(provider, schema)
+
+
+async def mount_collection_target(
+    db: ContextKey[ManagedConnection],
+    collection_name: str,
+    schema: CollectionSchema[RowT],
+    *,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> "CollectionTarget[RowT]":
+    """Mount a zvec collection target and return a ready-to-use CollectionTarget."""
+    provider = await coco.mount_target(
+        collection_target(db, collection_name, schema, managed_by=managed_by)
+    )
+    return CollectionTarget(provider, schema)
+
+
+__all__ = [
+    "CollectionSchema",
+    "CollectionTarget",
+    "ManagedConnection",
+    "ValueEncoder",
+    "ZvecType",
+    "ZvecVectorDef",
+    "collection_target",
+    "connect",
+    "declare_collection_target",
+    "managed_connection",
+    "mount_collection_target",
+]

--- a/python/tests/connectors/test_zvec_target.py
+++ b/python/tests/connectors/test_zvec_target.py
@@ -361,6 +361,12 @@ def test_sparse_vector(conn: Any) -> None:
     assert doc is not None
     assert doc.fields["title"] == "s"
 
+    col = conn.open_existing("test_sparse")
+    results = col.query(
+        zvec.VectorQuery(field_name="sparse", vector={1: 0.5, 7: 0.9}), topk=5
+    )
+    assert [d.id for d in results] == ["1"]
+
 
 def test_multiple_vector_fields(conn: Any) -> None:
     _reset(MultiVectorDoc, "test_multivec")

--- a/python/tests/connectors/test_zvec_target.py
+++ b/python/tests/connectors/test_zvec_target.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import datetime
+import decimal
 import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any, Iterator
@@ -122,6 +125,66 @@ class MultiVectorDoc:
     id: str
     dense: _Embedding
     sparse: Annotated[dict[int, float], zc.ZvecVectorDef(sparse=True)]
+
+
+_Embedding16 = Annotated[
+    NDArray[np.float16], VectorSchema(dtype=np.dtype(np.float16), size=4)
+]
+_EMB16 = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float16)
+
+
+@dataclass
+class Fp16Doc:
+    id: str
+    title: str
+    embedding: _Embedding16
+
+
+@dataclass
+class QuantizedDoc:
+    id: str
+    title: str
+    embedding: Annotated[
+        NDArray[np.float32],
+        VectorSchema(dtype=np.dtype(np.float32), size=4),
+        zc.ZvecVectorDef(quantize="int8"),
+    ]
+
+
+@dataclass
+class EncoderDoc:
+    id: str
+    uid: uuid.UUID
+    price: decimal.Decimal
+    created: datetime.datetime
+    day: datetime.date
+    moment: datetime.time
+    elapsed: datetime.timedelta
+    blob: bytes
+    embedding: _Embedding
+
+
+@dataclass
+class ArrayDoc:
+    id: str
+    ints: list[int]
+    floats: list[float]
+    flags: list[bool]
+    embedding: _Embedding
+
+
+@dataclass
+class JsonDoc:
+    id: str
+    meta: dict[str, int]
+    embedding: _Embedding
+
+
+@dataclass
+class FilterDoc:
+    id: str
+    year: int
+    embedding: _Embedding
 
 
 # =============================================================================
@@ -412,3 +475,126 @@ async def test_schema_validation(conn: Any) -> None:
     )
     with pytest.raises(ValueError, match="at least one vector field"):
         zc.collection_target(ZVEC_DB, "no_vec_collection", no_vec_schema)
+
+    # zvec dense vectors must be float32 or float16.
+    @dataclass
+    class Float64Doc:
+        id: str
+        embedding: Annotated[
+            NDArray[np.float64], VectorSchema(dtype=np.dtype(np.float64), size=4)
+        ]
+
+    with pytest.raises(ValueError, match="float32 or float16"):
+        await zc.CollectionSchema.from_class(Float64Doc, primary_key=["id"])
+
+
+def test_fp16_dense_vector(conn: Any) -> None:
+    _reset(Fp16Doc, "test_fp16")
+    app = _make_app(conn, "test_fp16_dense_vector")
+
+    _rows.append(Fp16Doc(id="1", title="h", embedding=_EMB16))
+    app.update_blocking()
+
+    col = conn.open_existing("test_fp16")
+    results = col.query(
+        zvec.VectorQuery(field_name="embedding", vector=[0.1, 0.2, 0.3, 0.4]), topk=5
+    )
+    assert [d.id for d in results] == ["1"]
+
+
+def test_int8_quantized_vector(conn: Any) -> None:
+    _reset(QuantizedDoc, "test_quant")
+    app = _make_app(conn, "test_int8_quantized_vector")
+
+    _rows.append(QuantizedDoc(id="1", title="q", embedding=_EMB))
+    app.update_blocking()
+
+    assert fetch_doc(conn, "test_quant", "1") is not None
+
+
+def test_scalar_encoders_round_trip(conn: Any) -> None:
+    _reset(EncoderDoc, "test_enc")
+    app = _make_app(conn, "test_scalar_encoders_round_trip")
+
+    uid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    created = datetime.datetime(2020, 1, 2, 3, 4, 5)
+    day = datetime.date(2020, 1, 2)
+    moment = datetime.time(3, 4, 5)
+    _rows.append(
+        EncoderDoc(
+            id="1",
+            uid=uid,
+            price=decimal.Decimal("3.50"),
+            created=created,
+            day=day,
+            moment=moment,
+            elapsed=datetime.timedelta(hours=1),
+            blob=b"hello",
+            embedding=_EMB,
+        )
+    )
+    app.update_blocking()
+
+    fields = fetch_doc(conn, "test_enc", "1").fields
+    assert fields["uid"] == str(uid)
+    assert fields["price"] == "3.50"
+    assert fields["created"] == created.isoformat()
+    assert fields["day"] == day.isoformat()
+    assert fields["moment"] == moment.isoformat()
+    assert fields["elapsed"] == pytest.approx(3600.0)
+    assert fields["blob"] == "aGVsbG8="  # base64 of b"hello"
+
+
+def test_array_fields_round_trip(conn: Any) -> None:
+    _reset(ArrayDoc, "test_arr")
+    app = _make_app(conn, "test_array_fields_round_trip")
+
+    _rows.append(
+        ArrayDoc(
+            id="1",
+            ints=[1, 2, 3],
+            floats=[1.5, 2.5],
+            flags=[True, False],
+            embedding=_EMB,
+        )
+    )
+    app.update_blocking()
+
+    fields = fetch_doc(conn, "test_arr", "1").fields
+    assert list(fields["ints"]) == [1, 2, 3]
+    assert list(fields["floats"]) == pytest.approx([1.5, 2.5])
+    assert list(fields["flags"]) == [True, False]
+
+
+def test_json_fallback_round_trip(conn: Any) -> None:
+    _reset(JsonDoc, "test_json")
+    app = _make_app(conn, "test_json_fallback_round_trip")
+
+    _rows.append(JsonDoc(id="1", meta={"a": 1, "b": 2}, embedding=_EMB))
+    app.update_blocking()
+
+    import json
+
+    raw = fetch_doc(conn, "test_json", "1").fields["meta"]
+    assert json.loads(raw) == {"a": 1, "b": 2}
+
+
+def test_filter_query(conn: Any) -> None:
+    _reset(FilterDoc, "test_filter")
+    app = _make_app(conn, "test_filter_query")
+
+    _rows.extend(
+        [
+            FilterDoc(id="1", year=1990, embedding=_EMB),
+            FilterDoc(id="2", year=2020, embedding=_EMB),
+        ]
+    )
+    app.update_blocking()
+
+    col = conn.open_existing("test_filter")
+    results = col.query(
+        zvec.VectorQuery(field_name="embedding", vector=[0.1, 0.2, 0.3, 0.4]),
+        topk=5,
+        filter="year > 2000",
+    )
+    assert [d.id for d in results] == ["2"]

--- a/python/tests/connectors/test_zvec_target.py
+++ b/python/tests/connectors/test_zvec_target.py
@@ -1,0 +1,414 @@
+"""Tests for the zvec target connector."""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Any, Iterator
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import cocoindex as coco
+from cocoindex._internal.context_keys import ContextProvider
+from cocoindex.connectorkits import target
+from cocoindex.resources.schema import VectorSchema
+
+from tests import common
+
+try:
+    import zvec
+
+    from cocoindex.connectors import zvec as zc
+
+    HAS_ZVEC = True
+except ImportError:
+    HAS_ZVEC = False
+
+requires_zvec = pytest.mark.skipif(not HAS_ZVEC, reason="zvec is not installed")
+
+pytestmark = requires_zvec
+
+
+ZVEC_DB = coco.ContextKey["zc.ManagedConnection"]("zvec_test_db")
+
+
+# =============================================================================
+# Fixtures and helpers
+# =============================================================================
+
+
+@pytest.fixture
+def conn() -> Iterator[Any]:
+    base = Path(tempfile.mkdtemp(prefix="zvec_test_"))
+    connection = zc.connect(base)
+    yield connection
+    connection.close()
+
+
+_counter = {"n": 0}
+
+
+def make_test_env(connection: Any, env_name: str) -> coco.Environment:
+    ctx = ContextProvider()
+    ctx.provide(ZVEC_DB, connection)
+    _counter["n"] += 1
+    settings = coco.Settings.from_env(
+        db_path=common.get_env_db_path(
+            f"connectors__test_zvec_target__{env_name}__{_counter['n']}"
+        )
+    )
+    return coco.Environment(settings, context_provider=ctx)
+
+
+def fetch_doc(connection: Any, collection_name: str, doc_id: str) -> Any:
+    col = connection.open_existing(collection_name)
+    result = col.fetch(ids=doc_id)
+    return result.get(doc_id)
+
+
+# =============================================================================
+# Row types
+# =============================================================================
+
+
+# zvec collections require at least one vector field, so every row type carries one.
+_Embedding = Annotated[
+    NDArray[np.float32], VectorSchema(dtype=np.dtype(np.float32), size=4)
+]
+
+_EMB = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+
+
+@dataclass
+class SimpleDoc:
+    id: str
+    title: str
+    year: int
+    embedding: _Embedding
+
+
+@dataclass
+class TypedDoc:
+    id: str
+    name: str
+    score: float
+    active: bool
+    tags: list[str]
+    embedding: _Embedding
+
+
+@dataclass
+class VectorDoc:
+    id: str
+    title: str
+    embedding: _Embedding
+
+
+# `from __future__ import annotations` keeps these as strings, so the zc
+# reference is only resolved (via from_class) in tests, which are skipped when
+# zvec is absent.
+@dataclass
+class SparseDoc:
+    id: str
+    title: str
+    sparse: Annotated[dict[int, float], zc.ZvecVectorDef(sparse=True)]
+
+
+@dataclass
+class MultiVectorDoc:
+    id: str
+    dense: _Embedding
+    sparse: Annotated[dict[int, float], zc.ZvecVectorDef(sparse=True)]
+
+
+# =============================================================================
+# Mutable per-test source state
+# =============================================================================
+
+_rows: list[Any] = []
+_row_type: type = SimpleDoc
+_collection: str = "test_collection"
+_managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+_declare_enabled: bool = True
+
+
+async def _declare() -> None:
+    if not _declare_enabled:
+        return
+    table = await coco.use_mount(
+        coco.component_subpath("setup", "col"),
+        zc.declare_collection_target,
+        ZVEC_DB,
+        _collection,
+        await zc.CollectionSchema.from_class(_row_type, primary_key=["id"]),
+        managed_by=_managed_by,
+    )
+    for row in _rows:
+        table.declare_row(row=row)
+
+
+def _make_app(connection: Any, env_name: str) -> coco.App[[], None]:
+    env = make_test_env(connection, env_name)
+    return coco.App(coco.AppConfig(name=env_name, environment=env), _declare)
+
+
+def _reset(row_type: type, collection: str) -> None:
+    global _row_type, _collection, _managed_by, _declare_enabled
+    _row_type = row_type
+    _collection = collection
+    _managed_by = target.ManagedBy.SYSTEM
+    _declare_enabled = True
+    _rows.clear()
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+def test_create_and_insert(conn: Any) -> None:
+    _reset(SimpleDoc, "test_create")
+    app = _make_app(conn, "test_create_and_insert")
+
+    _rows.extend(
+        [
+            SimpleDoc(id="1", title="Alice", year=2020, embedding=_EMB),
+            SimpleDoc(id="2", title="Bob", year=2021, embedding=_EMB),
+        ]
+    )
+    app.update_blocking()
+
+    assert conn.collection_path("test_create").exists()
+    doc = fetch_doc(conn, "test_create", "1")
+    assert doc is not None
+    assert doc.fields == {"title": "Alice", "year": 2020}
+    assert fetch_doc(conn, "test_create", "2").fields == {"title": "Bob", "year": 2021}
+
+
+def test_update_row(conn: Any) -> None:
+    _reset(SimpleDoc, "test_update")
+    app = _make_app(conn, "test_update_row")
+
+    _rows.append(SimpleDoc(id="1", title="Alice", year=2020, embedding=_EMB))
+    app.update_blocking()
+    assert fetch_doc(conn, "test_update", "1").fields["title"] == "Alice"
+
+    _rows[0] = SimpleDoc(id="1", title="Alice v2", year=2099, embedding=_EMB)
+    app.update_blocking()
+    doc = fetch_doc(conn, "test_update", "1")
+    assert doc.fields == {"title": "Alice v2", "year": 2099}
+
+
+def test_delete_row(conn: Any) -> None:
+    _reset(SimpleDoc, "test_delete")
+    app = _make_app(conn, "test_delete_row")
+
+    _rows.extend(
+        [
+            SimpleDoc(id="1", title="A", year=1, embedding=_EMB),
+            SimpleDoc(id="2", title="B", year=2, embedding=_EMB),
+        ]
+    )
+    app.update_blocking()
+    assert fetch_doc(conn, "test_delete", "2") is not None
+
+    _rows[:] = [_rows[0]]
+    app.update_blocking()
+    assert fetch_doc(conn, "test_delete", "1") is not None
+    assert fetch_doc(conn, "test_delete", "2") is None
+
+
+def test_multiple_scalar_types(conn: Any) -> None:
+    _reset(TypedDoc, "test_types")
+    app = _make_app(conn, "test_multiple_scalar_types")
+
+    _rows.append(
+        TypedDoc(
+            id="1", name="x", score=3.5, active=True, tags=["a", "b"], embedding=_EMB
+        )
+    )
+    app.update_blocking()
+
+    doc = fetch_doc(conn, "test_types", "1")
+    assert doc.fields["name"] == "x"
+    assert doc.fields["score"] == pytest.approx(3.5)
+    assert doc.fields["active"] is True
+    assert list(doc.fields["tags"]) == ["a", "b"]
+
+
+def test_drop_collection(conn: Any) -> None:
+    global _declare_enabled
+    _reset(SimpleDoc, "test_drop")
+    # Reuse one app/env so CocoIndex retains tracking state across runs.
+    app = _make_app(conn, "test_drop_collection")
+
+    _rows.append(SimpleDoc(id="1", title="A", year=1, embedding=_EMB))
+    app.update_blocking()
+    assert conn.collection_path("test_drop").exists()
+
+    # Stop declaring the collection: it should be destroyed on the next run.
+    _declare_enabled = False
+    app.update_blocking()
+    assert not conn.collection_path("test_drop").exists()
+
+
+def test_no_op_when_unchanged(conn: Any) -> None:
+    _reset(SimpleDoc, "test_noop")
+    app = _make_app(conn, "test_no_op_when_unchanged")
+
+    _rows.append(SimpleDoc(id="1", title="A", year=1, embedding=_EMB))
+    app.update_blocking()
+    # Running again with identical data should be a no-op and not error.
+    app.update_blocking()
+    assert fetch_doc(conn, "test_noop", "1").fields == {"title": "A", "year": 1}
+
+
+def test_dense_vector(conn: Any) -> None:
+    _reset(VectorDoc, "test_dense")
+    app = _make_app(conn, "test_dense_vector")
+
+    _rows.append(
+        VectorDoc(
+            id="1",
+            title="hello",
+            embedding=np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+        )
+    )
+    app.update_blocking()
+
+    col = conn.open_existing("test_dense")
+    results = col.query(
+        zvec.VectorQuery(field_name="embedding", vector=[0.1, 0.2, 0.3, 0.4]),
+        topk=5,
+    )
+    assert [d.id for d in results] == ["1"]
+
+
+def test_sparse_vector(conn: Any) -> None:
+    _reset(SparseDoc, "test_sparse")
+    app = _make_app(conn, "test_sparse_vector")
+
+    _rows.append(SparseDoc(id="1", title="s", sparse={1: 0.5, 7: 0.9}))
+    app.update_blocking()
+
+    doc = fetch_doc(conn, "test_sparse", "1")
+    assert doc is not None
+    assert doc.fields["title"] == "s"
+
+
+def test_multiple_vector_fields(conn: Any) -> None:
+    _reset(MultiVectorDoc, "test_multivec")
+    app = _make_app(conn, "test_multiple_vector_fields")
+
+    _rows.append(
+        MultiVectorDoc(
+            id="1",
+            dense=np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+            sparse={2: 0.3},
+        )
+    )
+    app.update_blocking()
+
+    col = conn.open_existing("test_multivec")
+    results = col.query(
+        zvec.VectorQuery(field_name="dense", vector=[0.1, 0.2, 0.3, 0.4]), topk=5
+    )
+    assert [d.id for d in results] == ["1"]
+
+
+def test_multiple_collections(conn: Any) -> None:
+    async def _declare_two() -> None:
+        schema = await zc.CollectionSchema.from_class(SimpleDoc, primary_key=["id"])
+        t1 = await coco.use_mount(
+            coco.component_subpath("setup", "c1"),
+            zc.declare_collection_target,
+            ZVEC_DB,
+            "collection_one",
+            schema,
+        )
+        t2 = await coco.use_mount(
+            coco.component_subpath("setup", "c2"),
+            zc.declare_collection_target,
+            ZVEC_DB,
+            "collection_two",
+            schema,
+        )
+        t1.declare_row(row=SimpleDoc(id="1", title="one", year=1, embedding=_EMB))
+        t2.declare_row(row=SimpleDoc(id="1", title="two", year=2, embedding=_EMB))
+
+    env = make_test_env(conn, "test_multiple_collections")
+    app = coco.App(
+        coco.AppConfig(name="test_multiple_collections", environment=env),
+        _declare_two,
+    )
+    app.update_blocking()
+
+    assert fetch_doc(conn, "collection_one", "1").fields["title"] == "one"
+    assert fetch_doc(conn, "collection_two", "1").fields["title"] == "two"
+
+
+def test_user_managed_collection(conn: Any) -> None:
+    # Pre-create the collection outside CocoIndex.
+    schema = zvec.CollectionSchema(
+        name="user_col",
+        fields=[
+            zvec.FieldSchema(
+                name="title", data_type=zvec.DataType.STRING, nullable=True
+            ),
+            zvec.FieldSchema(name="year", data_type=zvec.DataType.INT64, nullable=True),
+        ],
+        vectors=[
+            zvec.VectorSchema(
+                name="embedding",
+                data_type=zvec.DataType.VECTOR_FP32,
+                dimension=4,
+                index_param=zvec.HnswIndexParam(metric_type=zvec.MetricType.COSINE),
+            )
+        ],
+    )
+    conn.open_or_create("user_col", schema)
+
+    global _row_type, _collection, _managed_by
+    _row_type = SimpleDoc
+    _collection = "user_col"
+    _managed_by = target.ManagedBy.USER
+    _rows.clear()
+    _rows.append(SimpleDoc(id="1", title="A", year=1, embedding=_EMB))
+
+    global _declare_enabled
+    app = _make_app(conn, "test_user_managed")
+    app.update_blocking()
+    assert fetch_doc(conn, "user_col", "1").fields["title"] == "A"
+
+    # Stop declaring: a user-managed collection must NOT be destroyed.
+    _declare_enabled = False
+    app.update_blocking()
+    assert conn.collection_path("user_col").exists()
+
+
+@pytest.mark.asyncio
+async def test_schema_validation(conn: Any) -> None:
+    schema = await zc.CollectionSchema.from_class(SimpleDoc, primary_key=["id"])
+
+    # zvec requires collection names of at least 3 characters.
+    with pytest.raises(ValueError, match="at least 3 characters"):
+        zc.collection_target(ZVEC_DB, "ab", schema)
+
+    # Composite primary keys are unsupported (single string id only).
+    with pytest.raises(ValueError, match="exactly one primary key"):
+        await zc.CollectionSchema.from_class(SimpleDoc, primary_key=["id", "title"])
+
+    # A collection must declare at least one vector field.
+    @dataclass
+    class NoVectorDoc:
+        id: str
+        title: str
+
+    no_vec_schema = await zc.CollectionSchema.from_class(
+        NoVectorDoc, primary_key=["id"]
+    )
+    with pytest.raises(ValueError, match="at least one vector field"):
+        zc.collection_target(ZVEC_DB, "no_vec_collection", no_vec_schema)

--- a/uv.lock
+++ b/uv.lock
@@ -587,6 +587,7 @@ all = [
     { name = "sqlite-vec" },
     { name = "surrealdb" },
     { name = "turbopuffer" },
+    { name = "zvec" },
 ]
 amazon-s3 = [
     { name = "aiobotocore" },
@@ -652,6 +653,9 @@ surrealdb = [
 ]
 turbopuffer = [
     { name = "turbopuffer" },
+]
+zvec = [
+    { name = "zvec" },
 ]
 
 [package.dev-dependencies]
@@ -779,8 +783,10 @@ requires-dist = [
     { name = "turbopuffer", marker = "extra == 'turbopuffer'", specifier = ">=0.5.0" },
     { name = "typing-extensions", specifier = ">=4.12" },
     { name = "watchdog", specifier = ">=6.0.0" },
+    { name = "zvec", marker = "extra == 'all'", specifier = ">=0.4.0" },
+    { name = "zvec", marker = "extra == 'zvec'", specifier = ">=0.4.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer"]
+provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer", "zvec"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -4577,4 +4583,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zvec"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ae/734f58872f6bfa61d8a86bd459cba1527977213ba9e76fa29f820989ffa2/zvec-0.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e49b14b9137b2de0b5df50df8370b07922c135e05e8c3087d53fe8b6788c862", size = 38742420, upload-time = "2026-05-09T03:15:04.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ad/2e9c22b89e9428b2fc545b38303011630b8b64d5402cf8062364cf10f809/zvec-0.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4bf2eb70a727c8b467c23ab9e696169c6d5c82bae002f8db1dc002c28dab6daf", size = 55543421, upload-time = "2026-05-09T03:28:59.43Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/b63fc8f4f0ddae3f55721d30dd7fec47844c67fc8b692676b6f9131e895a/zvec-0.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d0f74540ac48da3172aee2a49221a8f6aa9de426a9c0bb1c65bd36caf0d2622e", size = 62496091, upload-time = "2026-05-09T03:34:04.067Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/9ea8e6b2bece421fec6629c58c8138c82280142d835023bb961763b0caec/zvec-0.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5d456af34c5e6995bf2d33d1b746e3fd8263c2b25b45e9f8d4cac613094dcd39", size = 64105357, upload-time = "2026-05-09T03:15:16.395Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/0a/3daa85e8eed5396d27943832f0dcce9a20cd4bfe94dbc7f71b46d26a6c42/zvec-0.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0736a6d659cea82b9eaaae3da0d7477ba651d87d014f855a3eac8e865201a8cc", size = 38745403, upload-time = "2026-05-09T03:15:07.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6c/543580c77fe998fb0aaf18af0b72472b941801516cf3c0e5bbe322bab7dd/zvec-0.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:70baa0c6da15a1fb825b6d69e1927263ca0bb3bef586dcff295def7dae409c16", size = 55543857, upload-time = "2026-05-09T03:29:03.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/49/a80348e1762985ed59f75e603a5f969d8f045d84520976a56af6853bdc4c/zvec-0.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8e08f82a7895f369392dc8fde8767e493b728b59ca9a318224204d66a0c7f6df", size = 62499342, upload-time = "2026-05-09T03:34:09.411Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/dc/55967a821113a0c091ff3e643fe0e6af2543af5356635ac6b8e9a97aca3b/zvec-0.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:2a7d3ef7c0580fb2d27d976f9774a57337aeb62fb9e924e8ee4f089e046bc090", size = 64107207, upload-time = "2026-05-09T03:15:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/55/904c26c32297511d3f55ce253a13d0776bb4ec543315fc4ca557b18f7639/zvec-0.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f82289d92cd3e100b44b07307d94e89bd399340856b09939e582ee2dda60a10", size = 38745211, upload-time = "2026-05-09T03:15:10.336Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/74/4a5b881c46a2364ceb629ecf465445cd0f8f31e7b0e3fbc5d7f9d699d9e1/zvec-0.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a6f81c827943060ed654fe6b8ebb7cd20bd5677922c5a9d9fad3083cb8d96245", size = 55543623, upload-time = "2026-05-09T03:29:07.046Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/1417cc6645b46e0d530d45f5bb20c0799baecf5fdba92cb13958f9421188/zvec-0.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6942085ca86fe671368b0c433f39d1576bf8ef67937814bc192774dd41fa9740", size = 62499276, upload-time = "2026-05-09T03:34:14.678Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/33/f0d45a40178ea2084c484c7bad2e4fcc931e23846af61fc134926b297743/zvec-0.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:46ee324a878ea4f5a43409ebca87c2a554541bd5459137aa769b7bedff6d32d6", size = 64106938, upload-time = "2026-05-09T03:15:32.676Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/84911b8cbd330975f8868ed4b76407aa99accf7185d57a22f54162140370/zvec-0.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e8776fcf1874e541c20ce1baaeda1dbf092ac1cccc18d765483ca7906792fbb", size = 38746347, upload-time = "2026-05-09T03:15:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a6/9d00e0bec5ef7d2b3de1bf2dc32453150fcb27abece695a13edcd01d8896/zvec-0.4.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7dbd6325c929960d4ad1adb8e976f5fcafd45b0a404a6b08e04d376a2b3d183e", size = 55544984, upload-time = "2026-05-09T03:29:11.177Z" },
+    { url = "https://files.pythonhosted.org/packages/74/bf/3edbc4b37ecf096750e1a7fe1c5e10495e0d8c41523c41d4f9d50cc973ba/zvec-0.4.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:da97077cdbeffde5131d848c4c050bcda5990eba41a887701005bf4ab7a3611c", size = 62500218, upload-time = "2026-05-09T03:34:20.32Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/4e513e32beac5dcf8fe16474d964eca167a8828d6f6ac6cba0f2375f9008/zvec-0.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab531aeb44629e246eb4241df0b356b12c30b26bf14ed95e503d967a04bb345c", size = 65601056, upload-time = "2026-05-09T03:15:40.431Z" },
 ]


### PR DESCRIPTION
Closes #1701

First pass at a `zvec` target connector. zvec runs in-process (just a pip install, no server), so it slotted in cleanly as a target-only connector built on a local `ManagedConnection` over a base directory. The shape ended up close to Qdrant's collection/document target, with the typed `from_class` schema borrowed from SQLite/LanceDB. Each CocoIndex collection is a zvec collection directory, and each row is a `Doc` keyed by a single string id.

A few things I pinned down against the real `zvec==0.4.0` wheel: every collection needs at least one vector field, the primary key has to be a single column since it maps to the string `Doc.id` (so composite keys are rejected), and collection names need 3+ characters, and dense vectors have to be float32 or float16. zvec's index rejects anything wider, so for smaller storage you set `quantize` on the vector (e.g. `"int8"`) instead of reaching for a narrower element type.

Left out `MultiVectorSchemaProvider` for now. zvec's "multi-vector retrieval with reranking" is a query-time thing over named vector fields, not a per-doc _ColBERT-style_ storage type, so there's nothing to map on the write side yet.

Tests, mypy, and `ruff format` are green. `ruff check` only grumbles about the `from ._target import *` line, which every existing connector already does too.

~Opening as a draft for now...~ Marking ready for review.

(Re-opening from a proper feature branch; supersedes #2084, which I accidentally based on my fork's `main`.)

CC: @feihongxu0824, @egolearner

_Edit:_ Updated the document handler to match the newer resolve-at-apply convention from #2120/#2121. It now stores`db_key + collection_name` and resolves `ManagedConnection` from context during apply, instead of carrying the resolved connection from the parent.