### PR TITLE
test(rust-sdk): loosen nested-scope liveness timeout to avoid Windows CI flake

### DIFF
--- a/rust/sdk/cocoindex/tests/pipeline.rs
+++ b/rust/sdk/cocoindex/tests/pipeline.rs
@@ -2230,7 +2230,14 @@ async fn max_inflight_components_limits_mount_each_concurrency() {
 async fn max_inflight_components_allows_nested_scope_with_single_permit() {
     let (app, _dir) = temp_app_with_max_inflight("nested_scope_max_inflight_one", 1).await;
 
-    tokio::time::timeout(Duration::from_secs(3), async {
+    // This is a liveness check: with a single permit, nested scopes must not
+    // deadlock (the parent releases its permit before a child acquires one).
+    // The timeout only exists to turn a genuine deadlock-hang into a failure
+    // instead of hanging the whole test binary — a real deadlock never makes
+    // progress, so a generous bound still catches it. Keep it generous: the 8
+    // nested components each commit LMDB write txns with fsync, which is slow on
+    // Windows CI under load and was flaking a tighter 3s bound (issue: Elapsed).
+    tokio::time::timeout(Duration::from_secs(60), async {
         app.update(|ctx| async move {
             for i in 0..4 {
                 let key = format!("child-{i}");


### PR DESCRIPTION
## Problem

CI failed on `main` ([run 27290026474](https://github.com/cocoindex-io/cocoindex/actions/runs/27290026474/job/80607768775)) with a panic in the Rust test `max_inflight_components_allows_nested_scope_with_single_permit`:

```
thread '...' panicked at rust\sdk\cocoindex\tests\pipeline.rs:2250:6:
nested scopes should not deadlock with max_inflight_components=1: Elapsed(())
```

This is a `tokio::time::timeout` firing (`Elapsed`), **only on Windows**, not an assertion failure.

## Root cause

The test is a pure **liveness** check: with `max_inflight_components=1`, nested scopes must not deadlock (the parent releases its inflight permit before a child acquires one). The timeout only exists to convert a genuine deadlock-hang into a failure instead of hanging the test binary.

It is a timing flake, not a logic bug:
- No engine or test-logic changed between the last green main run and the failure (the HEAD commit was a Python-only litellm change).
- Earlier Windows runs passed this exact test. A real deadlock would hang **100%** of the time on Windows, not intermittently.
- The 8 nested components each commit LMDB write txns with `fsync`, serialized through the single-writer batcher. `fsync` is slow on Windows CI under load, and the old **3s** bound was too tight.

## Fix

Raise the timeout to **60s**. A real deadlock never makes progress, so the generous bound still catches it while no longer flaking on slow Windows fsync. Added a comment explaining the timeout is a deadlock safety-net, not a perf bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
