### PR TITLE
feat(py): enforce single-subscriber on live feeds

### DIFF
--- a/docs/src/content/docs/advanced_topics/live_component.mdx
+++ b/docs/src/content/docs/advanced_topics/live_component.mdx
@@ -250,6 +250,24 @@ To add live support to a source connector, make your source return an object tha
 - **`LiveMapView` example**: The [`localfs`](../connectors/localfs) connector's `DirWalker` — `walk_dir(..., live=True).items()` returns a `LiveMapView` backed by `watchfiles`.
 - **`LiveMapFeed` example**: The [`kafka`](../connectors/kafka) connector — `topic_as_map()` returns a `LiveMapFeed` that consumes messages from Kafka topics.
 
+### Single-subscriber contract
+
+A live feed — `LiveMapView`, `LiveMapFeed`, or `LiveStream` — is **single-subscriber**. Its `watch()` typically owns an exclusive underlying resource (a consumer subscription, an OS file watch, a single in-memory change channel) that can't be fanned out to two concurrent callers — e.g. two subscriptions would race one consumer's offset commits. So a given feed instance supports **one active `watch()` (one `mount_each`) at a time**; consuming it from two places concurrently is unsupported. Fan-out to multiple subscribers, if ever needed, belongs in a layer above the feed.
+
+Enforce this in your `watch()` with `cocoindex.connectorkits.SingleWatcherGuard`, which raises `RuntimeError` on a second concurrent call:
+
+```python
+from cocoindex.connectorkits import SingleWatcherGuard
+
+class MyView:
+    def __init__(self, ...) -> None:
+        self._watch_guard = SingleWatcherGuard("MyView")
+
+    async def watch(self, subscriber) -> None:
+        with self._watch_guard:
+            ...  # existing body
+```
+
 ## LiveStream
 
 Some change sources are not naturally keyed maps — they deliver opaque event payloads (e.g. cloud-storage event notifications, raw message buses) that the consuming connector translates into map updates on its own terms. For these, CocoIndex provides **`LiveStream`**: a keyless sibling of `LiveMapFeed` — an unkeyed sequence of messages without any "key" or "delete" semantics. Connectors typically wrap a user-supplied `LiveStream` into their own `LiveMapView` (or `LiveMapFeed`) by translating each event into the appropriate key-level operation.
@@ -274,6 +292,7 @@ A connector built on `LiveStream` typically:
 1. Accepts a user-supplied `LiveStream[...]` as a constructor argument — the user wires up the underlying transport.
 2. Wraps the stream into a `LiveMapView` (or `LiveMapFeed`): `__aiter__()` runs an initial scan if the source has scannable state; `watch()` subscribes to the stream and translates each event into `subscriber.update(key, value)` / `subscriber.delete(key)`.
 3. Lets the underlying `LiveStream` handle offset commits, readiness signaling, and back-pressure.
+4. Guards its `watch()` against concurrent subscription — see [Single-subscriber contract](#single-subscriber-contract) — with `connectorkits.SingleWatcherGuard`.
 
 **Example**: The [`oci_object_storage`](../connectors/oci_object_storage#live-bucket-watching) connector takes a `LiveStream[bytes]` (typically [`kafka.topic_as_stream(...).payloads()`](../connectors/kafka#as-a-live-stream)) and translates OCI Object Storage events into bucket-keyed updates. The Kafka connector exposes `topic_as_stream()` precisely so that downstream connectors like this one can plug into Kafka without inheriting the keyed-map semantics of `topic_as_map()`.
 

--- a/docs/src/content/docs/common_resources/live_map.mdx
+++ b/docs/src/content/docs/common_resources/live_map.mdx
@@ -70,7 +70,7 @@ await coco.mount_each(process_entry, lm)
 
 `mount_each` mounts one processing component per entry (keyed by the entry key), scans the current entries first, then reacts to incremental changes — re-mounting a component when its value changes and removing it when its entry is deleted. The processor receives the entry **value**.
 
-A LiveMap supports **one active consumer** (`mount_each`) at a time.
+A LiveMap supports **one active consumer** (`mount_each`) at a time; a second concurrent consumer raises `RuntimeError`.
 
 ## Semantics
 

--- a/docs/src/content/docs/connectors/kafka.mdx
+++ b/docs/src/content/docs/connectors/kafka.mdx
@@ -174,7 +174,7 @@ walker = oci_object_storage.list_objects(
 For a complete app using this pattern, see the [OCI Object Storage live-mode example](./oci_object_storage#example).
 
 :::caution
-A `TopicStream` (and any `payloads()` view of it) supports at most one active watcher — the underlying consumer can hold only one subscription. This is not runtime-checked.
+A `TopicStream` (and any `payloads()` view of it) supports at most one active watcher — the underlying consumer can hold only one subscription. A second concurrent `watch()` raises `RuntimeError`.
 :::
 
 ## As target

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -164,6 +164,10 @@ class LiveStream(Protocol[_M_co]):
     The implementation buffers inflight messages, acks the underlying source
     once earlier messages have been processed, and signals readiness when it
     has caught up to its initial watermark.
+
+    Single-subscriber: one active ``watch()`` at a time (implementations enforce
+    this via ``cocoindex.connectorkits.SingleWatcherGuard``). Fan-out to multiple
+    subscribers, if ever needed, belongs in a layer above the stream.
     """
 
     async def watch(self, subscriber: LiveStreamSubscriber[_M_co]) -> None: ...
@@ -468,6 +472,11 @@ class LiveMapFeed(Protocol[_K, _V]):
 
     For sources like Kafka that stream change events but have no scannable snapshot.
     Consumed by ``mount_each()``.
+
+    Single-subscriber: one active ``watch()`` at a time (implementations enforce
+    this via ``cocoindex.connectorkits.SingleWatcherGuard``, except ``LiveMap``
+    whose watcher queue already serves as the guard). Fan-out belongs in a layer
+    above the feed.
     """
 
     async def watch(self, subscriber: LiveMapSubscriber[_K, _V]) -> None: ...

--- a/python/cocoindex/connectorkits/__init__.py
+++ b/python/cocoindex/connectorkits/__init__.py
@@ -4,7 +4,56 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["default_subpath_name"]
+__all__ = ["SingleWatcherGuard", "default_subpath_name"]
+
+
+class SingleWatcherGuard:
+    """Enforces the single-active-subscriber contract for a ``watch()`` feed.
+
+    The live-source protocols consumed by ``mount_each`` — ``coco.LiveStream`` /
+    ``coco.LiveMapFeed`` / ``coco.LiveMapView`` — are **single-subscriber**: a
+    ``watch()`` typically owns an exclusive underlying resource (a broker consumer
+    subscription, an OS file watch, a single in-memory change channel) that cannot
+    be safely fanned out to two concurrent callers — e.g. two subscriptions would
+    race one consumer's offset commits. Fan-out to multiple subscribers, if ever
+    needed, belongs in a layer above the feed, not in the feed itself.
+
+    A feed holds one guard (constructed in ``__init__``) and wraps its ``watch()``
+    body with it, so a second concurrent ``watch()`` raises ``RuntimeError``
+    immediately instead of silently corrupting the first::
+
+        class MyStream:
+            def __init__(self, ...):
+                self._watch_guard = SingleWatcherGuard("MyStream")
+
+            async def watch(self, subscriber):
+                with self._watch_guard:
+                    ...  # body
+
+    The flag resets on every exit — normal return, exception, or cancellation (a
+    cancelled ``await`` inside the ``with`` unwinds through ``__exit__``) — so the
+    feed can be re-watched sequentially after a prior ``watch()`` finishes.
+
+    A plain flag (no lock) suffices when ``watch()`` runs entirely on one event
+    loop, as the framework's live consumer does. A feed that already carries
+    equivalent "is being watched" state can guard on that instead.
+    """
+
+    __slots__ = ("_label", "_active")
+
+    def __init__(self, label: str) -> None:
+        self._label = label
+        self._active = False
+
+    def __enter__(self) -> None:
+        if self._active:
+            raise RuntimeError(
+                f"{self._label} supports a single active watch() at a time."
+            )
+        self._active = True
+
+    def __exit__(self, *exc: object) -> None:
+        self._active = False
 
 
 def default_subpath_name(processor_fn: Any) -> str | None:

--- a/python/cocoindex/connectors/iggy/_source.py
+++ b/python/cocoindex/connectors/iggy/_source.py
@@ -34,6 +34,7 @@ from cocoindex._internal.live_component import (
     ReadyAwaitable,
 )
 from cocoindex._internal.typing import StableKey
+from cocoindex.connectorkits import SingleWatcherGuard
 
 _logger = logging.getLogger(__name__)
 
@@ -248,6 +249,7 @@ class TopicStream:
         "_init_retry_interval",
         "_allow_replay",
         "_initial_high_watermark",
+        "_watch_guard",
     )
 
     def __init__(
@@ -278,6 +280,7 @@ class TopicStream:
         self._init_retry_interval = init_retry_interval
         self._allow_replay = allow_replay
         self._initial_high_watermark = initial_high_watermark
+        self._watch_guard = SingleWatcherGuard("Iggy TopicStream")
 
     def payloads(self) -> LiveStream[bytes]:
         """View of this stream yielding each message payload as bytes."""
@@ -320,6 +323,10 @@ class TopicStream:
 
     async def watch(self, subscriber: LiveStreamSubscriber[ReceiveMessage]) -> None:
         """Consume messages and deliver them to the subscriber."""
+        with self._watch_guard:
+            await self._watch(subscriber)
+
+    async def _watch(self, subscriber: LiveStreamSubscriber[ReceiveMessage]) -> None:
         high_watermark = await self._resolve_initial_high_watermark()
         consumer = await self._create_consumer()
         tracker = _OffsetTracker()

--- a/python/cocoindex/connectors/kafka/_source.py
+++ b/python/cocoindex/connectors/kafka/_source.py
@@ -34,6 +34,7 @@ from cocoindex._internal.live_component import (
     ReadyAwaitable,
 )
 from cocoindex._internal.typing import StableKey
+from cocoindex.connectorkits import SingleWatcherGuard
 
 _logger = logging.getLogger(__name__)
 
@@ -246,14 +247,17 @@ class TopicStream:
     The underlying ``AIOConsumer`` can only be subscribed once at a time, so
     ``watch()`` is single-shot per :class:`TopicStream` instance: at most one
     of ``watch()`` and ``payloads().watch()`` (across all ``payloads()``
-    views) may be active concurrently. Documented contract; not runtime-checked.
+    views) may be active concurrently — they all funnel through this
+    ``watch()``, which is runtime-guarded, so a second concurrent call raises
+    ``RuntimeError``.
     """
 
-    __slots__ = ("_consumer", "_topics")
+    __slots__ = ("_consumer", "_topics", "_watch_guard")
 
     def __init__(self, consumer: AIOConsumer, topics: list[str]) -> None:
         self._consumer = consumer
         self._topics = topics
+        self._watch_guard = SingleWatcherGuard("Kafka TopicStream")
 
     def payloads(self) -> LiveStream[bytes]:
         """View of this stream yielding each message's payload as bytes.
@@ -266,6 +270,10 @@ class TopicStream:
 
     async def watch(self, subscriber: LiveStreamSubscriber[Message]) -> None:
         """Consume messages from the topics and deliver them to the subscriber."""
+        with self._watch_guard:
+            await self._watch(subscriber)
+
+    async def _watch(self, subscriber: LiveStreamSubscriber[Message]) -> None:
         tracker = _OffsetTracker(self._consumer)
         ready_signaled = False
 

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -20,6 +20,7 @@ from cocoindex.resources.file import (
 
 from cocoindex._internal.context_keys import ContextKey
 from cocoindex._internal.live_component import LiveMapSubscriber
+from cocoindex.connectorkits import SingleWatcherGuard
 
 from ._common import FilePath, to_file_path
 
@@ -174,6 +175,7 @@ class _LiveDirItems:
     def __init__(self, walker: DirWalker) -> None:
         self._walker = walker
         self._resolved_root = walker._root_path.resolve()
+        self._watch_guard = SingleWatcherGuard("localfs live directory")
 
     def __aiter__(self) -> AsyncIterator[tuple[str, File]]:
         return self._aiter_impl()
@@ -183,6 +185,11 @@ class _LiveDirItems:
             yield pair
 
     async def watch(self, subscriber: LiveMapSubscriber[str, File]) -> None:
+        """Deliver an initial scan then live filesystem changes to the subscriber."""
+        with self._watch_guard:
+            await self._watch(subscriber)
+
+    async def _watch(self, subscriber: LiveMapSubscriber[str, File]) -> None:
         from watchdog.events import (
             EVENT_TYPE_CREATED,
             EVENT_TYPE_DELETED,

--- a/python/cocoindex/connectors/oci_object_storage/_source.py
+++ b/python/cocoindex/connectors/oci_object_storage/_source.py
@@ -46,6 +46,7 @@ from cocoindex._internal.live_component import (
     LiveStream,
     ReadyAwaitable,
 )
+from cocoindex.connectorkits import SingleWatcherGuard
 from cocoindex.resources import file
 
 _logger = logging.getLogger(__name__)
@@ -372,11 +373,12 @@ class _LiveOCIItems:
     6. Await the stream task; it runs until cancellation.
     """
 
-    __slots__ = ("_walker", "_live_stream")
+    __slots__ = ("_walker", "_live_stream", "_watch_guard")
 
     def __init__(self, walker: OCIWalker, live_stream: LiveStream[bytes]) -> None:
         self._walker = walker
         self._live_stream = live_stream
+        self._watch_guard = SingleWatcherGuard("OCI Object Storage live view")
 
     def __aiter__(self) -> AsyncIterator[tuple[str, OCIFile]]:
         return self._aiter_impl()
@@ -386,6 +388,11 @@ class _LiveOCIItems:
             yield pair
 
     async def watch(self, subscriber: LiveMapSubscriber[str, OCIFile]) -> None:
+        """Deliver an initial scan then live bucket changes to the subscriber."""
+        with self._watch_guard:
+            await self._watch(subscriber)
+
+    async def _watch(self, subscriber: LiveMapSubscriber[str, OCIFile]) -> None:
         cutoff = datetime.now(timezone.utc) - _SKEW_TOLERANCE
         adapter = _OCIStreamSubscriber(self._walker, subscriber, cutoff)
         stream_task = asyncio.create_task(self._live_stream.watch(adapter))

--- a/python/tests/connectors/test_kafka_source.py
+++ b/python/tests/connectors/test_kafka_source.py
@@ -698,3 +698,12 @@ async def test_topic_stream_payloads_filters_null_values() -> None:
     await asyncio.sleep(0.05)
     final_committed = max((tp.offset for tp in consumer._committed), default=-1)
     assert final_committed == 3
+
+
+@pytest.mark.asyncio
+async def test_single_watcher_raises() -> None:
+    """A second concurrent watch() on one TopicStream fails loudly."""
+    stream = TopicStream(MockAIOConsumer(), ["test-topic"])  # type: ignore[arg-type]
+    with stream._watch_guard:  # simulate an already-active watch
+        with pytest.raises(RuntimeError, match="single active watch"):
+            await stream.watch(MagicMock())  # type: ignore[arg-type]

--- a/python/tests/connectors/test_localfs_live.py
+++ b/python/tests/connectors/test_localfs_live.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -123,5 +124,32 @@ async def test_localfs_live_add_edit_delete(tmp_path: Path) -> None:
         update_task.cancel()
         try:
             await update_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_localfs_live_single_watcher(tmp_path: Path) -> None:
+    """A second concurrent watch() on one live view fails loudly."""
+    items: Any = localfs.walk_dir(tmp_path, live=True).items()
+
+    class _DummySub:
+        async def update_all(self) -> None: ...
+        async def mark_ready(self) -> None: ...
+        async def update(self, key: Any, value: Any) -> Any:
+            raise AssertionError("unreached")
+
+        async def delete(self, key: Any) -> Any:
+            raise AssertionError("unreached")
+
+    first = asyncio.create_task(items.watch(_DummySub()))
+    await asyncio.sleep(0.1)  # let the first watch enter the guard
+    try:
+        with pytest.raises(RuntimeError, match="single active watch"):
+            await items.watch(_DummySub())
+    finally:
+        first.cancel()
+        try:
+            await first
         except asyncio.CancelledError:
             pass

--- a/python/tests/core/test_single_watcher_guard.py
+++ b/python/tests/core/test_single_watcher_guard.py
@@ -1,0 +1,41 @@
+"""Unit tests for :class:`SingleWatcherGuard`.
+
+The guard enforces the single-active-subscriber contract shared by the
+``LiveStream`` / ``LiveMapFeed`` / ``LiveMapView`` ``watch()`` implementations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cocoindex.connectorkits import SingleWatcherGuard
+
+
+def test_reentry_raises() -> None:
+    """A second concurrent acquisition raises with the labeled message."""
+    guard = SingleWatcherGuard("Feed")
+    with guard:
+        with pytest.raises(
+            RuntimeError, match="Feed supports a single active watch\\(\\) at a time."
+        ):
+            with guard:
+                pass
+
+
+def test_resets_after_normal_exit() -> None:
+    """The flag clears on normal exit, so sequential re-watch is allowed."""
+    guard = SingleWatcherGuard("Feed")
+    with guard:
+        pass
+    with guard:  # would raise if the flag had not been reset
+        pass
+
+
+def test_resets_after_exception() -> None:
+    """The flag clears even when the guarded body raises."""
+    guard = SingleWatcherGuard("Feed")
+    with pytest.raises(ValueError):
+        with guard:
+            raise ValueError("boom")
+    with guard:  # re-entry works because __exit__ ran despite the exception
+        pass


### PR DESCRIPTION
## Summary
- Live-source feeds (`LiveStream` / `LiveMapFeed` / `LiveMapView`, consumed by `mount_each`) are **single-subscriber**: `watch()` owns an exclusive resource (a broker consumer subscription, an OS file watch, an in-memory change channel) that can't be safely fanned out to two concurrent callers. Previously only `LiveMap` guarded against a second `watch()`; localfs, OCI, Kafka, and Iggy would silently misbehave (e.g. racing one consumer's offset commits).
- Add `SingleWatcherGuard` to `connectorkits` (public connector-author helper): a flag + context manager that raises `RuntimeError` on a second concurrent `watch()` and resets on every exit, incl. cancellation. Applied at each exclusive-resource owner via a thin `watch()` → `_watch()` wrapper — Kafka/Iggy `TopicStream` (also covers their `topic_as_map` / `payloads` views), localfs `_LiveDirItems`, OCI `_LiveOCIItems`. `LiveMap` keeps its existing `_watcher_queue` guard.
- Document the contract and helper in `advanced_topics/live_component.mdx`; fix the now-false "not runtime-checked" notes in the Kafka and LiveMap docs.

## Test plan
- New `SingleWatcherGuard` unit tests (reentry raises; resets after normal exit and after exception).
- New Kafka and localfs behavioral single-watcher tests (a second concurrent `watch()` raises).
- CI: full `pytest python/`, mypy, ruff-format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
