### PR TITLE
docs(v0): unify V0 legacy banners + pin them under the nav

### DIFF
--- a/docs/src/components/Banner.astro
+++ b/docs/src/components/Banner.astro
@@ -1,123 +1,21 @@
 ---
-// Slim announcement strip below the top nav. V1 is now generally available;
-// the banner nudges V0 readers to the new docs.
+// Slim announcement strip pinned just below the top nav on the V0 docs.
+// V1 is now generally available; the banner nudges V0 readers to the new
+// docs. Styling + wrap behaviour live in the shared `.v0-banner` rules in
+// globals.css, identical to LegacyExampleBanner.astro.
+const DOCS_HREF = 'https://cocoindex.io/docs/';
 ---
 
-<div class="banner" role="status">
+<aside class="v0-banner" role="status" aria-label="Legacy documentation notice">
   <div class="banner-accent" aria-hidden="true"></div>
   <div class="banner-in">
-    <span class="tag">V0 Docs</span>
-    <span class="msg">
-      You are viewing <strong>CocoIndex&nbsp;V0</strong> Documentation.
-      <strong>CocoIndex&nbsp;V1</strong> is now available.
+    <span class="tag">Legacy · V0</span>
+    <p class="msg">
+      This is a <strong>CocoIndex&nbsp;V0</strong>. For the current
+      version, see the new docs.
+    </p>
+    <span class="cta-group">
+      <a class="cta" href={DOCS_HREF}>New docs →</a>
     </span>
-    <a class="cta" href="/docs">Try V1 →</a>
   </div>
-</div>
-
-<style>
-  /* Slim announcement strip sitting between the top nav and the docs
-     layout. Uses the brand "pipeline" (stripes) motif as a 4px top
-     accent — signals migration/in-transition. Body is solid maroon so
-     the cream text stays legible. */
-  .banner {
-    position: relative;
-    background: var(--maroon);
-    color: var(--cream);
-    border-bottom: 1px solid rgba(252, 243, 216, 0.08);
-  }
-  /* 4px top accent using the brand "pipeline" stripes. We animate the
-     gradient offset so the stripes flow left→right — conveys data
-     moving through a migration pipeline, not just a static notice.
-     One full period in 3s keeps it subtle; stripes are small. */
-  .banner-accent {
-    position: absolute; inset: 0 0 auto 0;
-    height: 4px;
-    background: repeating-linear-gradient(135deg, var(--peach) 0 12px, var(--coral) 12px 24px);
-    background-size: 34px 34px;
-    animation: banner-flow 3s linear infinite;
-    will-change: background-position;
-  }
-  @keyframes banner-flow {
-    from { background-position: 0 0; }
-    to   { background-position: 34px 0; }
-  }
-  .banner-in {
-    max-width: 1480px;
-    margin: 0 auto;
-    padding: 10px 32px;
-    display: flex; align-items: center; gap: 12px;
-    font-family: var(--sans);
-    font-size: 13px;
-    line-height: 1.4;
-  }
-  .banner .tag {
-    font-family: var(--mono);
-    font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
-    padding: 3px 8px;
-    background: color-mix(in oklab, var(--coral) 30%, transparent);
-    color: var(--cream);
-    border: 1px solid color-mix(in oklab, var(--coral) 55%, transparent);
-    border-radius: 999px;
-    flex: none;
-  }
-  .banner .msg { opacity: 0.92; }
-  .banner .msg strong {
-    font-weight: 600;
-    color: var(--peach);
-    white-space: nowrap;
-  }
-  .banner .cta {
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 600;
-    padding: 4px 12px;
-    background: var(--coral);
-    color: var(--cream);
-    border-radius: 999px;
-    text-decoration: none;
-    flex: none;
-    transition: background 120ms ease;
-  }
-  .banner .cta:hover {
-    background: color-mix(in oklab, var(--coral) 80%, var(--cream));
-  }
-  /* `V1` gets a quiet sheen that drifts across it — hint of arrival. */
-  .banner .msg strong:last-of-type {
-    background: linear-gradient(
-      110deg,
-      var(--peach) 0%,
-      var(--cream) 45%,
-      var(--peach) 55%,
-      var(--peach) 100%
-    );
-    background-size: 220% 100%;
-    background-clip: text;
-    -webkit-background-clip: text;
-    color: transparent;
-    animation: banner-sheen 5s ease-in-out infinite;
-  }
-  @keyframes banner-sheen {
-    0%, 40%   { background-position: 100% 0; }
-    70%, 100% { background-position: 0 0; }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .banner-accent,
-    .banner .msg strong:last-of-type {
-      animation: none;
-    }
-    .banner .msg strong:last-of-type {
-      color: var(--peach);
-      background: none;
-    }
-  }
-
-  @media (max-width: 820px) {
-    .banner-in {
-      padding: 10px 16px;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-  }
-</style>
+</aside>

--- a/docs/src/components/LegacyExampleBanner.astro
+++ b/docs/src/components/LegacyExampleBanner.astro
@@ -1,108 +1,23 @@
 ---
-// Legacy notice shown just below the Topbar on the V0 example listing
+// Legacy notice pinned just below the Topbar on the V0 example listing
 // (/docs-v0/examples) and on every example walkthrough
-// (/docs-v0/examples/<slug>). These were ported from the V0 examples; the
-// banner points readers to the current V1 example docs and the up-to-date
-// example code on `main`. Full-bleed strip mirroring the site-wide
-// Banner.astro so it reads as a page-level notice, not page content.
+// (/docs-v0/examples/<slug>). Styling + wrap behaviour live in the shared
+// `.v0-banner` rules in globals.css, identical to Banner.astro.
 const DOCS_HREF = 'https://cocoindex.io/docs/examples/';
 const CODE_HREF = 'https://github.com/cocoindex-io/cocoindex/tree/main/examples';
 ---
 
-<aside class="legacy-banner" role="note" aria-label="Legacy example notice">
-  <div class="lb-accent" aria-hidden="true"></div>
-  <div class="lb-in">
-    <span class="lb-tag">Legacy · V0</span>
-    <p class="lb-msg">
+<aside class="v0-banner" role="note" aria-label="Legacy example notice">
+  <div class="banner-accent" aria-hidden="true"></div>
+  <div class="banner-in">
+    <span class="tag">Legacy · V0</span>
+    <p class="msg">
       This is a <strong>CocoIndex&nbsp;V0</strong> example. For the current
       version, see the new example docs and code.
     </p>
-    <div class="lb-cta">
-      <a class="lb-btn" href={DOCS_HREF}>New example docs →</a>
-      <a class="lb-btn lb-btn-ghost" href={CODE_HREF}>Example code on GitHub →</a>
-    </div>
+    <span class="cta-group">
+      <a class="cta" href={DOCS_HREF}>New example docs →</a>
+      <a class="cta cta-ghost" href={CODE_HREF}>Example code on GitHub →</a>
+    </span>
   </div>
 </aside>
-
-<style>
-  /* Full-bleed strip sitting between the Topbar and the page layout, like
-     the site-wide Banner.astro. Palette comes from globals.css. Cream body
-     keeps the maroon-ink text legible; the coral CTAs carry the eye. */
-  .legacy-banner {
-    position: relative;
-    background: linear-gradient(90deg, var(--cream) 0%, var(--paper) 100%);
-    border-bottom: 1px solid var(--rule);
-  }
-  /* 4px top accent using the brand "pipeline" stripes, animated left→right
-     to mirror Banner.astro — signals a migration/in-transition state. */
-  .lb-accent {
-    position: absolute;
-    inset: 0 0 auto 0;
-    height: 4px;
-    background: repeating-linear-gradient(135deg, var(--peach) 0 12px, var(--coral) 12px 24px);
-    background-size: 34px 34px;
-    animation: lb-flow 3s linear infinite;
-    will-change: background-position;
-  }
-  @keyframes lb-flow {
-    from { background-position: 0 0; }
-    to   { background-position: 34px 0; }
-  }
-  .lb-in {
-    max-width: 1480px;
-    margin: 0 auto;
-    padding: 12px 32px;
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 10px 16px;
-    font-family: var(--sans);
-  }
-  .lb-tag {
-    flex: none;
-    font-family: var(--mono);
-    font-size: 10px;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    padding: 4px 10px;
-    border-radius: 999px;
-    background: color-mix(in oklab, var(--coral) 16%, transparent);
-    border: 1px solid color-mix(in oklab, var(--coral) 45%, transparent);
-    color: var(--maroon);
-  }
-  .lb-msg {
-    margin: 0;
-    flex: 1 1 260px;
-    min-width: 220px;
-    font-size: 14px;
-    line-height: 1.5;
-    color: var(--maroon-ink);
-  }
-  .lb-msg strong { color: var(--maroon); font-weight: 600; white-space: nowrap; }
-  .lb-cta { display: flex; gap: 10px; flex-wrap: wrap; flex: none; }
-  .lb-btn {
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    padding: 7px 14px;
-    border-radius: 999px;
-    background: var(--coral);
-    color: var(--cream);
-    border: 1px solid var(--coral);
-    text-decoration: none;
-    white-space: nowrap;
-    transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-  }
-  .lb-btn:hover { background: var(--maroon); border-color: var(--maroon); }
-  .lb-btn-ghost { background: transparent; color: var(--maroon); border-color: var(--rule-strong); }
-  .lb-btn-ghost:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
-
-  @media (prefers-reduced-motion: reduce) {
-    .lb-accent { animation: none; }
-  }
-  @media (max-width: 820px) {
-    .lb-in { padding: 12px 16px; }
-    .lb-cta { width: 100%; }
-  }
-</style>

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -230,8 +230,8 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .ex-main { padding: 28px 48px 96px; min-width: 0; }
 
       body.ex-detail .ex-side {
-        position: sticky; top: 57px; align-self: start;
-        height: calc(100vh - 57px);
+        position: sticky; top: var(--header-h); align-self: start;
+        height: calc(100vh - var(--header-h));
         overflow-y: auto;
         padding: 28px 20px 40px 28px;
         border-right: 1px solid var(--rule);
@@ -276,8 +276,8 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .ex-side ol li.on a .n { color: var(--coral); }
 
       body.ex-detail .ex-toc {
-        position: sticky; top: 57px; align-self: start;
-        height: calc(100vh - 57px);
+        position: sticky; top: var(--header-h); align-self: start;
+        height: calc(100vh - var(--header-h));
         overflow-y: auto;
         padding: 28px 28px 40px 20px;
         border-left: 1px solid var(--rule);
@@ -362,7 +362,7 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
       body.ex-detail .toc .toc-aside a:hover { color: var(--coral); }
 
       body.ex-detail .doc .col-main { min-width: 0; }
-      body.ex-detail section.blk { padding: 72px 0; border-top: 1px solid var(--rule); position: relative; scroll-margin-top: 84px; }
+      body.ex-detail section.blk { padding: 72px 0; border-top: 1px solid var(--rule); position: relative; scroll-margin-top: calc(var(--header-h) + 16px); }
       body.ex-detail section.blk:first-of-type { border-top: none; padding-top: 24px; }
       body.ex-detail .sec-head { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 40px; }
       body.ex-detail .sec-idx { display: inline-flex; gap: 10px; align-items: baseline; font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
@@ -429,7 +429,7 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
 
       /* Steps */
       body.ex-detail .steps-wrap { display: grid; grid-template-columns: 1fr; gap: 14px; margin-bottom: 48px; }
-      body.ex-detail .step { display: grid; grid-template-columns: 72px 1fr; grid-template-rows: auto auto; column-gap: 24px; row-gap: 20px; align-items: start; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); padding: 28px 30px; position: relative; scroll-margin-top: 90px; }
+      body.ex-detail .step { display: grid; grid-template-columns: 72px 1fr; grid-template-rows: auto auto; column-gap: 24px; row-gap: 20px; align-items: start; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); padding: 28px 30px; position: relative; scroll-margin-top: calc(var(--header-h) + 22px); }
       body.ex-detail .step-num { grid-row: 1 / 3; display: flex; flex-direction: column; align-items: flex-start; gap: 10px; align-self: stretch; }
       body.ex-detail .step-num .chip-num { width: 46px; height: 46px; border-radius: 50%; display: grid; place-items: center; background: var(--maroon); color: var(--cream); font-family: var(--mono); font-weight: 500; font-size: 14px; letter-spacing: 0; }
       body.ex-detail .step.coral .step-num .chip-num { background: var(--coral); }
@@ -549,9 +549,9 @@ const tocHeadings = (rendered?.headings ?? []).filter((h) => h.depth === 2);
          narrower column and a different heading scale. */
       body.ex-detail .ex-prose { padding-top: 40px; max-width: 72ch; min-width: 0; font-size: 16px; line-height: 1.65; color: var(--maroon-ink); }
       body.ex-detail .ex-prose > :first-child { margin-top: 0; }
-      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: 84px; padding-top: 28px; border-top: 1px solid var(--rule); }
+      body.ex-detail .ex-prose h2 { font-family: var(--sans); font-weight: 600; font-size: clamp(26px, 2.6vw, 34px); line-height: 1.1; letter-spacing: -0.025em; margin: 56px 0 18px; scroll-margin-top: calc(var(--header-h) + 16px); padding-top: 28px; border-top: 1px solid var(--rule); }
       body.ex-detail .ex-prose > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 24px; }
-      body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: 84px; }
+      body.ex-detail .ex-prose h3 { font-family: var(--sans); font-weight: 600; font-size: 20px; line-height: 1.25; letter-spacing: -0.015em; margin: 36px 0 12px; scroll-margin-top: calc(var(--header-h) + 16px); }
       body.ex-detail .ex-prose h4 { font-family: var(--sans); font-weight: 600; font-size: 17px; letter-spacing: -0.01em; margin: 28px 0 10px; }
       body.ex-detail .ex-prose p { margin: 0 0 18px; }
       body.ex-detail .ex-prose a { color: var(--coral); text-decoration: none; border-bottom: 1px solid rgba(190, 81, 51, 0.35); transition: border-color .15s, color .15s; }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -384,7 +384,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
 
       /* ── SIDEBAR + MAIN ── */
       body.ex-listing .doc { display: grid; grid-template-columns: 260px 1fr; gap: 56px; align-items: start; padding-top: 32px; }
-      body.ex-listing .side-nav { position: sticky; top: 84px; align-self: start; max-height: calc(100vh - 100px); overflow-y: auto; padding: 0 0 40px; font-family: var(--sans); }
+      body.ex-listing .side-nav { position: sticky; top: calc(84px + var(--banner-h)); align-self: start; max-height: calc(100vh - 100px - var(--banner-h)); overflow-y: auto; padding: 0 0 40px; font-family: var(--sans); }
       body.ex-listing .side-head {
         font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
         color: var(--muted); padding-bottom: 10px; margin-bottom: 14px;
@@ -443,7 +443,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
       body.ex-listing .col-main { min-width: 0; }
 
       /* ── FEATURED ── */
-      body.ex-listing section.feat { padding: 0 0 40px; scroll-margin-top: 84px; }
+      body.ex-listing section.feat { padding: 0 0 40px; scroll-margin-top: calc(84px + var(--banner-h)); }
       body.ex-listing .sec-head { display: flex; align-items: baseline; gap: 18px; margin-bottom: 28px; padding-bottom: 18px; border-bottom: 1px solid var(--rule); flex-wrap: wrap; }
       body.ex-listing .sec-head h2 {
         font-family: var(--sans); font-weight: 600;
@@ -532,7 +532,7 @@ const canonical = new URL(`${base}/examples`, SITE_URL).toString();
       body.ex-listing .feat-viz .qlabel .pulse .d { width: 6px; height: 6px; border-radius: 50%; background: var(--palm); box-shadow: 0 0 0 3px rgba(39, 230, 43, 0.15); }
 
       /* ── CATEGORY SECTIONS ── */
-      body.ex-listing section.cat { padding: 64px 0; scroll-margin-top: 84px; }
+      body.ex-listing section.cat { padding: 64px 0; scroll-margin-top: calc(84px + var(--banner-h)); }
       body.ex-listing .cat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
       body.ex-listing .ex-card {
         display: flex; flex-direction: column;

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -23,6 +23,13 @@
 
   --side: 280px;
   --toc: 240px;
+
+  /* Pinned header geometry. The Topbar and the V0 notice banner are both
+     sticky; everything that sticks below them (sidebars, TOCs) offsets by
+     their combined height, and in-page anchors clear it via --header-h. */
+  --nav-h: 57px;
+  --banner-h: 56px;
+  --header-h: calc(var(--nav-h) + var(--banner-h));
 }
 
 * { box-sizing: border-box; }
@@ -161,6 +168,95 @@ nav.top {
   font-variant-numeric: tabular-nums;
 }
 
+/* ─── V0 legacy banner ───
+   One source of truth shared by Banner.astro (docs) and
+   LegacyExampleBanner.astro (examples) so the V0 notice wraps and styles
+   identically on every page. Light cream strip pinned under the nav; the
+   row wraps (never truncates) so the copy and buttons stay fully visible
+   at every width, including mobile. */
+.v0-banner {
+  position: sticky;
+  top: var(--nav-h);
+  z-index: 40;
+  background: linear-gradient(90deg, var(--cream) 0%, var(--paper) 100%);
+  border-bottom: 1px solid var(--rule);
+}
+/* 4px top accent using the brand "pipeline" stripes, animated left→right
+   — signals a migration/in-transition state. */
+.v0-banner .banner-accent {
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: repeating-linear-gradient(135deg, var(--peach) 0 12px, var(--coral) 12px 24px);
+  background-size: 34px 34px;
+  animation: v0-banner-flow 3s linear infinite;
+  will-change: background-position;
+}
+@keyframes v0-banner-flow {
+  from { background-position: 0 0; }
+  to   { background-position: 34px 0; }
+}
+.v0-banner .banner-in {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 12px 32px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-family: var(--sans);
+}
+.v0-banner .tag {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--coral) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--coral) 45%, transparent);
+  color: var(--maroon);
+}
+.v0-banner .msg {
+  margin: 0;
+  flex: 1 1 260px;
+  min-width: 220px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--maroon-ink);
+}
+.v0-banner .msg strong { color: var(--maroon); font-weight: 600; white-space: nowrap; }
+.v0-banner .cta-group { display: flex; gap: 10px; flex-wrap: wrap; flex: none; }
+.v0-banner .cta {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 7px 14px;
+  border-radius: 999px;
+  background: var(--coral);
+  color: var(--cream);
+  border: 1px solid var(--coral);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.v0-banner .cta:hover { background: var(--maroon); border-color: var(--maroon); }
+/* Secondary action: outline that fills maroon on hover. */
+.v0-banner .cta-ghost { background: transparent; color: var(--maroon); border-color: var(--rule-strong); }
+.v0-banner .cta-ghost:hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
+
+@media (prefers-reduced-motion: reduce) {
+  .v0-banner .banner-accent { animation: none; }
+}
+/* Mobile: tighter gutters and the buttons take their own full-width row.
+   The message is never hidden — full context stays visible. */
+@media (max-width: 820px) {
+  .v0-banner .banner-in { padding: 12px 16px; }
+  .v0-banner .cta-group { width: 100%; }
+}
+
 /* ─── layout ─── */
 .layout {
   display: grid;
@@ -169,15 +265,15 @@ nav.top {
   margin: 0 auto;
 }
 aside.side {
-  position: sticky; top: 57px; align-self: start;
-  height: calc(100vh - 57px);
+  position: sticky; top: var(--header-h); align-self: start;
+  height: calc(100vh - var(--header-h));
   overflow-y: auto;
   padding: 28px 20px 40px 28px;
   border-right: 1px solid var(--rule);
 }
 aside.toc {
-  position: sticky; top: 57px; align-self: start;
-  height: calc(100vh - 57px);
+  position: sticky; top: var(--header-h); align-self: start;
+  height: calc(100vh - var(--header-h));
   overflow-y: auto;
   padding: 28px 28px 40px 20px;
   border-left: 1px solid var(--rule);
@@ -584,20 +680,20 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
   font-family: var(--sans); font-weight: 600;
   font-size: 28px; line-height: 1.1; letter-spacing: -0.025em;
   margin: 56px 0 12px;
-  scroll-margin-top: 80px;
+  scroll-margin-top: calc(var(--header-h) + 12px);
 }
 .prose h2 em { font-style: normal; color: var(--coral); }
 .prose h3 {
   font-family: var(--sans); font-weight: 600;
   font-size: 18px; line-height: 1.3; letter-spacing: -0.01em;
   margin: 28px 0 10px;
-  scroll-margin-top: 80px;
+  scroll-margin-top: calc(var(--header-h) + 12px);
 }
 .prose h4 {
   font-family: var(--sans); font-weight: 600;
   font-size: 15px; line-height: 1.3; letter-spacing: -0.005em;
   margin: 22px 0 8px;
-  scroll-margin-top: 80px;
+  scroll-margin-top: calc(var(--header-h) + 12px);
 }
 
 .prose p { margin: 12px 0; max-width: 68ch; }


### PR DESCRIPTION
## What

Unifies the two V0 legacy banners and pins them under the nav.

- **One source of truth:** both the site-wide docs banner (`Banner.astro`) and the examples banner (`LegacyExampleBanner.astro`) now share a single `.v0-banner` style block in `globals.css`, so wrap behaviour and styling are identical and can't drift apart.
- **Pinned:** light cream strip, `position: sticky` just under the nav. The row wraps and never truncates, so the copy + buttons stay fully visible at every width, including mobile.
- **Offsets:** sticky rails (docs + example sidebars/TOCs) and in-page anchor `scroll-margin-top` now account for the pinned banner height via `--nav-h` / `--banner-h` / `--header-h`.

## Copy

- **Docs banner:** "This is a CocoIndex V0. For the current version, see the new docs." → **New docs →** (V1 docs).
- **Examples banner:** unchanged copy + its two CTAs (**New example docs →**, **Example code on GitHub →**).

## Test

Ran the V0 docs site locally (`/docs-v0/`); `/docs-v0/core/flow_def/` and `/docs-v0/examples/` both render the unified banner, pinned, with full context on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)