### PR TITLE
fix(py): make coco.fn directly callable outside a component context

### DIFF
--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -35,7 +35,6 @@ from . import core
 from .component_ctx import (
     _context_var,
     _enter_component_context,
-    get_context_from_ctx,
 )
 from .context_keys import resolve_awaitables_sync
 from .memo_fingerprint import (
@@ -738,7 +737,10 @@ class SyncFunction(Function[P, R_co]):
         if _in_subprocess():
             return self._fn(*args, **kwargs)
 
-        parent_ctx = get_context_from_ctx()
+        # Outside any component context (e.g. a direct standalone call), run the raw
+        # function with no memoization — mirroring the async `__call__` path below. Use
+        # the non-raising getter so this is a graceful fallback, not an error.
+        parent_ctx = _context_var.get(None)
         if parent_ctx is None:
             return self._fn(*args, **kwargs)
 

--- a/python/tests/core/test_function_misc.py
+++ b/python/tests/core/test_function_misc.py
@@ -16,3 +16,29 @@ def async_wrapped_fn_2(s: str, i: int) -> str:
 async def test_async_wrapped_fn() -> None:
     assert await async_wrapped_fn_1("Hello", 3) == "Hello 3"
     assert await async_wrapped_fn_2("Hello", 3) == "Hello 3"
+
+
+@coco.fn
+def sync_fn(s: str, i: int) -> str:
+    return f"{s} {i}"
+
+
+def test_sync_fn_callable_standalone() -> None:
+    # A @coco.fn is callable outside any component context: it runs the raw
+    # function with no memoization, mirroring the async __call__ path.
+    assert sync_fn("Hello", 3) == "Hello 3"
+
+
+class _StandaloneHolder:
+    def __init__(self, factor: int) -> None:
+        self._factor = factor
+
+    @coco.fn(version=1, logic_tracking="self")
+    def run(self, x: int) -> int:
+        return x * self._factor
+
+
+def test_sync_method_fn_standalone() -> None:
+    # A versioned, self-tracked @coco.fn method is directly callable outside a
+    # component context.
+    assert _StandaloneHolder(2).run(21) == 42


### PR DESCRIPTION
## Summary
The sync `__call__` of a `@coco.fn` read the active component context via the **raising** `get_context_from_ctx()`, so calling a `@coco.fn` outside any component context raised instead of falling back to running the raw function. The dead `if parent_ctx is None: return self._fn(...)` branch right below it shows the intended behavior — and the async `__call__` already does the right thing (it uses the non-raising `_context_var.get(None)`).

This aligns the sync path with the async one: outside a component context, a `@coco.fn` runs the wrapped function directly with no memoization, so it stays directly callable from tests and scripts while still memoizing inside a pipeline.

## Test plan
- CI. New `test_sync_fn_callable_standalone` and `test_sync_method_fn_standalone` (the latter mirrors a versioned, `logic_tracking="self"` method) in `test_function_misc.py`.
