### PR TITLE
fix(ci): trigger generate-cli-docs hook on cli.mdx edits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,5 +107,9 @@ repos:
           name: generate CLI documentation
           entry: uv run python dev/generate_cli_docs.py
           language: system
-          files: ^(python/cocoindex/cli\.py|dev/generate_cli_docs\.py)$
+          # Includes cli.mdx itself so a manual edit to the generated file
+          # re-runs the generator and is caught on PR CI (which runs prek only
+          # on changed files). Otherwise a hand-edit to cli.mdx slips through
+          # every PR and only surfaces on the all-files run after merge to main.
+          files: ^(python/cocoindex/cli\.py|dev/generate_cli_docs\.py|docs/src/content/docs/cli\.mdx)$
           pass_filenames: false

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -56,7 +56,7 @@ CocoIndex CLI supports the following global options:
 
 ### `drop`
 
-Drop an app and all its [target states](./programming_guide/target_state).
+Drop an app and all its target states.
 
 This will:
 
@@ -164,7 +164,7 @@ cocoindex show [OPTIONS] [APP_TARGET]
 
 ### `update`
 
-Run an app in catch-up mode. With --live, run in [live mode](./programming_guide/live_mode).
+Run an app in catch-up mode. With --live, run in live mode.
 
 `APP_TARGET`: `path/to/app.py`, `module`, `path/to/app.py:app_name`, or
 `module:app_name`.


### PR DESCRIPTION
## Summary

- The `generate-cli-docs` pre-commit hook only listed `cli.py` and the generator script in its `files:` filter. PR CI runs prek on changed files only, so a hand-edit to the generated `docs/src/content/docs/cli.mdx` never re-ran the hook — such an edit slips through every PR and only surfaces on the all-files run after merge to `main`.
- Add `docs/src/content/docs/cli.mdx` to the hook's `files:` filter so a manual edit to the generated file re-runs the generator and fails at PR time, not after merge.
- Revert the stale hand-edited links in `cli.mdx` (added in #2100) back to the generator's plain-text output. The `cli.py` docstrings that drive generation contain no markdown links, so the generator emits plain text; the committed file had drifted.

## Test plan

- CI (the `generate CLI documentation` hook now passes; with the filter change it also runs whenever `cli.mdx` is edited in a PR).
- Verified locally: re-running `uv run python dev/generate_cli_docs.py` reports the file is up to date.
