### PR TITLE
fix(core): round LMDB map size up to system page size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix 0.30.1",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/benchmarks/file_summarization/rust/Cargo.lock
+++ b/benchmarks/file_summarization/rust/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "heed",
  "indexmap 2.13.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.2",
  "rmp",

--- a/docs/src/content/docs/advanced_topics/internal_storage.mdx
+++ b/docs/src/content/docs/advanced_topics/internal_storage.mdx
@@ -39,7 +39,7 @@ The LMDB database has two tunable settings, grouped under `coco.LmdbSettings` an
 | Setting | Default | Env Variable | Description |
 |---------|---------|-------------|-------------|
 | `max_dbs` | `1024` | `COCOINDEX_LMDB_MAX_DBS` | Maximum number of named LMDB databases. Must be &ge; 1. |
-| `map_size` | `4294967296` (4 GiB) | `COCOINDEX_LMDB_MAP_SIZE` | Maximum size of the LMDB memory map in bytes. Must be &gt; 0. |
+| `map_size` | `4294967296` (4 GiB) | `COCOINDEX_LMDB_MAP_SIZE` | Maximum size of the LMDB memory map in bytes. Must be &gt; 0; rounded up to the nearest multiple of the system page size. |
 
 ### When to adjust
 

--- a/examples/rust/amazon_s3_embedding/Cargo.lock
+++ b/examples/rust/amazon_s3_embedding/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/audio_to_text/Cargo.lock
+++ b/examples/rust/audio_to_text/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/code_embedding/Cargo.lock
+++ b/examples/rust/code_embedding/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/code_embedding_lancedb/Cargo.lock
+++ b/examples/rust/code_embedding_lancedb/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/conversation_to_knowledge/Cargo.lock
+++ b/examples/rust/conversation_to_knowledge/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/csv_to_iggy/Cargo.lock
+++ b/examples/rust/csv_to_iggy/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix 0.30.1",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/csv_to_kafka/Cargo.lock
+++ b/examples/rust/csv_to_kafka/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/files_to_sqlite/Cargo.lock
+++ b/examples/rust/files_to_sqlite/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/files_transform/Cargo.lock
+++ b/examples/rust/files_transform/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/gdrive_text_embedding/Cargo.lock
+++ b/examples/rust/gdrive_text_embedding/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/hn_trending_topics/Cargo.lock
+++ b/examples/rust/hn_trending_topics/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/image_search/Cargo.lock
+++ b/examples/rust/image_search/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/image_search_colpali/Cargo.lock
+++ b/examples/rust/image_search_colpali/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/kafka_consume/Cargo.lock
+++ b/examples/rust/kafka_consume/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/multi_codebase_summarization/Cargo.lock
+++ b/examples/rust/multi_codebase_summarization/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "heed",
  "indexmap 2.13.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.2",
  "rmp",

--- a/examples/rust/oci_object_storage_embedding/Cargo.lock
+++ b/examples/rust/oci_object_storage_embedding/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/paper_metadata/Cargo.lock
+++ b/examples/rust/paper_metadata/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/pdf_embedding/Cargo.lock
+++ b/examples/rust/pdf_embedding/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/pdf_to_markdown/Cargo.lock
+++ b/examples/rust/pdf_to_markdown/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/postgres_source/Cargo.lock
+++ b/examples/rust/postgres_source/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/text_embedding/Cargo.lock
+++ b/examples/rust/text_embedding/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/text_embedding_lancedb/Cargo.lock
+++ b/examples/rust/text_embedding_lancedb/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/text_embedding_qdrant/Cargo.lock
+++ b/examples/rust/text_embedding_qdrant/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/examples/rust/text_embedding_turbopuffer/Cargo.lock
+++ b/examples/rust/text_embedding_turbopuffer/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "heed",
  "indexmap 2.14.0",
  "nix",
+ "page_size",
  "parking_lot",
  "rand 0.9.4",
  "rmp",

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -12,6 +12,9 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 env_logger = { workspace = true }
 heed = "0.22.0"
+# Page-size lookup for aligning the LMDB map size; matches the crate heed uses
+# internally to validate `map_size` against the system page size.
+page_size = "0.6"
 nix = { workspace = true }
 storekey = { workspace = true }
 serde = { workspace = true, features = ["rc", "derive"] }

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -81,6 +81,24 @@ fn default_map_size() -> usize {
     DEFAULT_MAP_SIZE
 }
 
+/// Round `requested` up to the next multiple of the OS page size.
+///
+/// heed/LMDB require `map_size` to be a multiple of the system page size
+/// (4 KiB on most Linux, 16 KiB on Apple Silicon), rejecting other values
+/// with a hard error. Users shouldn't have to know their page size, so we
+/// align for them here. Rounding *up* only raises the cap on how far the
+/// memory map may grow — it never shrinks the user's request. We read the
+/// page size via the same `page_size` crate heed validates against, so the
+/// aligned value is guaranteed to satisfy heed.
+fn align_map_size_to_page(requested: usize) -> usize {
+    let page = page_size::get();
+    // `page` is a power of two on every supported platform, so it can't be 0
+    // and `div_ceil` won't divide by zero. `saturating_mul` guards the
+    // (practically impossible) case of `requested` being within one page of
+    // `usize::MAX`.
+    requested.div_ceil(page).saturating_mul(page)
+}
+
 /// Configuration for opening the storage environment.
 ///
 /// The on-disk schema (field names, defaults) is the public configuration
@@ -149,11 +167,20 @@ impl Storage {
         if settings.lmdb_map_size == 0 {
             client_bail!("lmdb_map_size must be > 0, got {}", settings.lmdb_map_size);
         }
+        let map_size = align_map_size_to_page(settings.lmdb_map_size);
+        if map_size != settings.lmdb_map_size {
+            debug!(
+                "Rounded lmdb_map_size up from {} to {} to match the system page size ({})",
+                settings.lmdb_map_size,
+                map_size,
+                page_size::get()
+            );
+        }
         let db_env = unsafe {
             heed::EnvOpenOptions::new()
                 .read_txn_without_tls()
                 .max_dbs(settings.lmdb_max_dbs)
-                .map_size(settings.lmdb_map_size)
+                .map_size(map_size)
                 .open(db_path)
         }?;
         let cleared_count = db_env.clear_stale_readers()?;
@@ -391,5 +418,48 @@ impl Storage {
             }
         }
         Ok(names)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn align_map_size_rounds_up_to_page_multiple() {
+        let page = page_size::get();
+        // Exact multiples are left untouched.
+        assert_eq!(align_map_size_to_page(page), page);
+        assert_eq!(align_map_size_to_page(4 * page), 4 * page);
+        // Anything below a full page rounds up to a single page.
+        assert_eq!(align_map_size_to_page(1), page);
+        assert_eq!(align_map_size_to_page(page - 1), page);
+        // A value just past a page boundary rounds up to the next page.
+        assert_eq!(align_map_size_to_page(page + 1), 2 * page);
+
+        // The value from the original bug report (10 KiB) becomes a valid
+        // page multiple no smaller than what was requested.
+        let aligned = align_map_size_to_page(10 * 1024);
+        assert_eq!(aligned % page, 0);
+        assert!(aligned >= 10 * 1024);
+    }
+
+    /// Regression test for the user-facing failure: a `lmdb_map_size` that
+    /// isn't a multiple of the system page size used to surface heed's hard
+    /// error ("map size (N) must be a multiple of the system page size").
+    /// We now align it up transparently, so opening the env just works.
+    #[tokio::test]
+    async fn new_accepts_unaligned_map_size() {
+        let dir = TempDir::new().unwrap();
+        let settings = StorageSettings {
+            db_path: dir.path().to_path_buf(),
+            lmdb_max_dbs: DEFAULT_MAX_DBS,
+            // 4 MiB + 1 byte: deliberately not a multiple of any page size,
+            // yet large enough to back a real env on both 4 KiB and 16 KiB
+            // page platforms once aligned up.
+            lmdb_map_size: 4 * 1024 * 1024 + 1,
+        };
+        Storage::new(&settings).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- `COCOINDEX_LMDB_MAP_SIZE` (and the `lmdb_map_size` setting) no longer require a value that is an exact multiple of the system page size. Previously a value like `10240` surfaced heed's hard error: `map size (10240) must be a multiple of the system page size (16384)`, which is unfriendly for users who shouldn't need to know their page size.
- `Storage::new` now rounds the requested map size **up** to the next page multiple before opening the LMDB env, reading the page size via the same `page_size` crate heed validates against. Rounding up only raises the cap on how far the memory map may grow — it never shrinks the request.
- The fix lives at the single choke point (`Storage::new`) that both the Python (`COCOINDEX_LMDB_MAP_SIZE` / `lmdb_map_size`) and Rust SDK paths funnel through, so it covers every caller without duplicated logic. Documented the rounding behavior in `internal_storage.mdx`.

## Test plan

- New unit test covers the alignment arithmetic (exact multiples, sub-page, just-past-boundary, and the `10240` value from the report), written relative to `page_size::get()` so it's portable across 4 KiB / 16 KiB page platforms.
- New end-to-end regression test opens a real env via `Storage::new` with a deliberately non-page-aligned `lmdb_map_size` and asserts it succeeds.
- Verified manually from Python: opening an `Environment` with `lmdb_map_size=10240` now succeeds (previously raised `RuntimeError`).
- CI (`cargo test`, `maturin develop`).
