### PR TITLE
fix(amazon_s3): encode ETag to bytes for content fingerprint (#2111)

### DIFF
--- a/python/cocoindex/connectors/amazon_s3/_source.py
+++ b/python/cocoindex/connectors/amazon_s3/_source.py
@@ -32,6 +32,18 @@ except ImportError as e:
 from cocoindex.resources import file
 
 
+def _etag_to_fingerprint(etag: object) -> bytes | None:
+    """Convert an S3 ETag (a ``str``) to the ``bytes`` content fingerprint.
+
+    botocore returns ETags as quoted strings (e.g. ``'"d41d8cd9..."'``), but
+    :class:`~cocoindex.resources.file.FileMetadata.content_fingerprint` is typed
+    ``bytes``.  Storing the raw ``str`` makes the memo state's
+    ``tuple[datetime, bytes]`` round-trip fail on re-run (msgspec encodes a str
+    but the decoder expects bin), so encode it to bytes here.
+    """
+    return etag.encode("utf-8") if isinstance(etag, str) else None
+
+
 def _parse_s3_uri(uri: str) -> tuple[str, str]:
     """Parse an ``s3://bucket/key`` URI into *(bucket_name, key)*."""
     if not uri.startswith("s3://"):
@@ -113,7 +125,7 @@ class S3File(file.FileLike[str]):
         return file.FileMetadata(
             size=int(head["ContentLength"]),
             modified_time=head["LastModified"],
-            content_fingerprint=head.get("ETag"),
+            content_fingerprint=_etag_to_fingerprint(head.get("ETag")),
         )
 
     async def _read_impl(self, size: int = -1) -> bytes:
@@ -150,7 +162,7 @@ async def _s3file_from_head(
     metadata = file.FileMetadata(
         size=int(head["ContentLength"]),
         modified_time=head["LastModified"],
-        content_fingerprint=head.get("ETag"),
+        content_fingerprint=_etag_to_fingerprint(head.get("ETag")),
     )
     return S3File(client=client, file_path=fp, _metadata=metadata)
 
@@ -320,7 +332,7 @@ class S3Walker:
                 metadata = file.FileMetadata(
                     size=obj_size,
                     modified_time=obj["LastModified"],
-                    content_fingerprint=obj.get("ETag"),
+                    content_fingerprint=_etag_to_fingerprint(obj.get("ETag")),
                 )
 
                 yield S3File(

--- a/python/tests/connectors/test_amazon_s3.py
+++ b/python/tests/connectors/test_amazon_s3.py
@@ -339,6 +339,43 @@ class TestMemoization:
                 outcome2 = await f2.__coco_memo_state__(outcome1.state)
                 assert outcome2.memo_valid is True
 
+    async def test_memo_state_serde_roundtrip(self) -> None:
+        """Memo state must survive a serialize/deserialize round-trip.
+
+        Regression test for the incremental-update crash on S3 sources: the S3
+        ETag is a ``str``, but ``FileMetadata.content_fingerprint`` (and hence
+        the memo state's ``tuple[datetime, bytes]``) is typed ``bytes``.  Storing
+        the raw ``str`` encodes fine on the first run but fails to decode on
+        re-run (msgspec sees a str where it expects bin), so the fingerprint
+        must be ``bytes`` and the state must round-trip through serde.
+        """
+        import cocoindex
+        from cocoindex._internal import serde
+
+        async with mock_aws():
+            sync_client = boto3.client("s3", region_name="us-east-1")
+            sync_client.create_bucket(Bucket="memo-serde-test")
+            sync_client.put_object(Bucket="memo-serde-test", Key="f.txt", Body=b"hello")
+
+            session = aiobotocore.session.get_session()
+            async with session.create_client("s3", region_name="us-east-1") as client:
+                f = await amazon_s3.get_object(client, "memo-serde-test", "f.txt")
+
+                # Fingerprint must be bytes, not the raw ETag str.
+                fp = await f.content_fingerprint()
+                assert isinstance(fp, bytes)
+
+                outcome = await f.__coco_memo_state__(cocoindex.NON_EXISTENCE)
+
+                # Resolve the prev_state type hint exactly as the engine does,
+                # then verify the persisted state decodes back without error.
+                hint = serde.strip_non_existence_type(
+                    serde.get_param_annotation(f.__coco_memo_state__, 0)
+                )
+                payload = serde.serialize(outcome.state)
+                restored = serde.make_deserialize_fn(hint)(payload)
+                assert restored == outcome.state
+
     async def test_file_path_memo_key(self, s3_client: tuple[Any, str]) -> None:
         """S3FilePath.__coco_memo_key__() incorporates bucket and path."""
         client, bucket_name = s3_client


### PR DESCRIPTION
## Summary
- Fixes #2111: incremental `cocoindex update` crashed with `DeserializationError` on `FileLike.__coco_memo_state__` (`tuple[datetime, bytes]`) for AmazonS3/MinIO sources.
- Root cause: botocore returns the S3 ETag as a `str`, but `FileMetadata.content_fingerprint` is typed `bytes`. The memo state encoded fine on the first run (msgspec str) but failed to decode on re-run (decoder expects bin), so only `--full-reprocess` worked.
- Added `_etag_to_fingerprint()` to encode the ETag `str` → `bytes` (mirroring the OCI connector) and applied it at all three `FileMetadata` construction sites.

## Test plan
- New regression test `test_memo_state_serde_roundtrip` asserts the fingerprint is `bytes` and that the memo state survives a real serde round-trip using the engine's type-hint resolution.
- All 25 S3 tests pass; mypy and ruff clean. Reproduced the exact error string from the issue and confirmed it's resolved.
