### PR TITLE
fix(release): use native pypa manylinux_2_28 images for linux wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,14 @@ jobs:
             target: x86_64
             python-version: "3.13"
             free-threaded: false
-            container: "ghcr.io/rust-cross/manylinux_2_28-cross:x86_64"
+            container: "quay.io/pypa/manylinux_2_28_x86_64"
             maturin-args: "--interpreter 3.13"
           - os: linux
             runner: ubuntu-24.04-arm
             target: aarch64
             python-version: "3.13"
             free-threaded: false
-            container: "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+            container: "quay.io/pypa/manylinux_2_28_aarch64"
             maturin-args: "--interpreter 3.13"
           - os: macos
             runner: macos-latest
@@ -85,14 +85,14 @@ jobs:
             target: x86_64
             python-version: "3.14"
             free-threaded: true
-            container: "ghcr.io/rust-cross/manylinux_2_28-cross:x86_64"
+            container: "quay.io/pypa/manylinux_2_28_x86_64"
             maturin-args: "--no-default-features --interpreter 3.14t"
           - os: linux
             runner: ubuntu-24.04-arm
             target: aarch64
             python-version: "3.14"
             free-threaded: true
-            container: "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+            container: "quay.io/pypa/manylinux_2_28_aarch64"
             maturin-args: "--no-default-features --interpreter 3.14t"
           - os: macos
             runner: macos-latest


### PR DESCRIPTION
## Problem

The v1.0.10 release build failed ([run](https://github.com/cocoindex-io/cocoindex/actions/runs/27491011908/job/81256316190)) with:

```
error: linker `x86_64-unknown-linux-gnu-gcc` not found
error: could not compile `tree-sitter-language` (build script)
💥 maturin failed
```

This is not a code or workflow change on our side. The release matrix pinned the linux wheel builds to the **floating** `ghcr.io/rust-cross/manylinux_2_28-cross:{arch}` tags. That image was rebuilt upstream on 2026-06-12 (rust-cross/manylinux-cross #152 "Drop Python 3.7/3.8", #153 "Bump Python", #155 "Update dependencies") — *after* v1.0.9 released successfully (2026-06-12 01:01Z) and *before* v1.0.10 (2026-06-14 06:49Z). The new image no longer provides the `x86_64-unknown-linux-gnu-gcc` linker maturin-action expected.

## Fix

Both linux jobs run on **native-arch** runners (`ubuntu-latest` x86_64, `ubuntu-24.04-arm` aarch64), so the `-cross` images were never needed for cross-compilation. Point both at the canonical native **pypa** `manylinux_2_28` images. maturin-action installs the Rust toolchain and sccache into them — it already uses the pypa aarch64 image as its native-arm64 default.

Note: maturin-action's own default for x86_64-on-x64-host is *also* the broken `-cross:x86_64` image, so the override must be set explicitly (removing it would not help).

## Verification

Triggered a `workflow_dispatch` dry-run on this branch (build-only, no publish): https://github.com/cocoindex-io/cocoindex/actions/runs/27491274030

🤖 Generated with [Claude Code](https://claude.com/claude-code)
