### PR TITLE
fix(amazon_s3): normalize content_fingerprint ETags to bytes

### DIFF
--- a/python/cocoindex/connectors/amazon_s3/_source.py
+++ b/python/cocoindex/connectors/amazon_s3/_source.py
@@ -32,6 +32,10 @@ except ImportError as e:
 from cocoindex.resources import file
 
 
+def _etag_to_bytes(etag: str | None) -> bytes | None:
+    return etag.encode("utf-8") if isinstance(etag, str) else None
+
+
 def _parse_s3_uri(uri: str) -> tuple[str, str]:
     """Parse an ``s3://bucket/key`` URI into *(bucket_name, key)*."""
     if not uri.startswith("s3://"):
@@ -113,7 +117,7 @@ class S3File(file.FileLike[str]):
         return file.FileMetadata(
             size=int(head["ContentLength"]),
             modified_time=head["LastModified"],
-            content_fingerprint=head.get("ETag"),
+            content_fingerprint=_etag_to_bytes(head.get("ETag")),
         )
 
     async def _read_impl(self, size: int = -1) -> bytes:
@@ -150,7 +154,7 @@ async def _s3file_from_head(
     metadata = file.FileMetadata(
         size=int(head["ContentLength"]),
         modified_time=head["LastModified"],
-        content_fingerprint=head.get("ETag"),
+        content_fingerprint=_etag_to_bytes(head.get("ETag")),
     )
     return S3File(client=client, file_path=fp, _metadata=metadata)
 
@@ -320,7 +324,7 @@ class S3Walker:
                 metadata = file.FileMetadata(
                     size=obj_size,
                     modified_time=obj["LastModified"],
-                    content_fingerprint=obj.get("ETag"),
+                    content_fingerprint=_etag_to_bytes(obj.get("ETag")),
                 )
 
                 yield S3File(

--- a/python/tests/connectors/test_amazon_s3.py
+++ b/python/tests/connectors/test_amazon_s3.py
@@ -351,6 +351,33 @@ class TestMemoization:
         memo_keys = {f.file_path.__coco_memo_key__() for f in files}
         assert len(memo_keys) == len(files)
 
+    async def test_memo_state_serde_regression(
+        self, s3_client: tuple[Any, str]
+    ) -> None:
+        """Verify that memo state generated from S3File can be successfully serialized and deserialized using CocoIndex serde machinery."""
+        import cocoindex
+        from cocoindex._internal.memo_fingerprint import _make_state_deserialize_fn
+        from cocoindex._internal.serde import serialize
+        from cocoindex.resources.file import FileLike
+
+        client, bucket_name = s3_client
+        f = await amazon_s3.get_object(client, bucket_name, "file1.txt")
+
+        # 1. Generate memo-state
+        outcome = await f.__coco_memo_state__(cocoindex.NON_EXISTENCE)
+        state = outcome.state
+
+        # 2. Serialize using CocoIndex serialization machinery
+        serialized = serialize(state)
+
+        # 3. Deserialize using the type expected by FileLike.__coco_memo_state__
+        deser = _make_state_deserialize_fn(FileLike.__coco_memo_state__)
+
+        # This will fail on main if the ETag in content_fingerprint is str
+        # but succeeds with the fix because it is normalized to bytes.
+        deserialized = deser(serialized)
+        assert deserialized == state
+
 
 # ---------------------------------------------------------------------------
 # S3FilePath unit tests


### PR DESCRIPTION
### Summary
Normalize ETag strings retrieved from S3 to `bytes` before assigning them to `FileMetadata.content_fingerprint`.

### Root Cause
`FileMetadata.content_fingerprint` expects a value of type `bytes | None`. The Amazon S3 connector was populating this field directly with string ETags. During incremental reruns, the engine deserializes the cached memo state using the type hint signature of `FileLike.__coco_memo_state__`, which expects `tuple[datetime, bytes]`. Because of `msgspec`-based serialization changes introduced in commit `4133c403`, deserialization strictly enforces types, leading to a `ValidationError` when decoding string ETags.

### Fix
Added a helper function `_etag_to_bytes` in S3 connector `_source.py` that encodes `str` ETag values to UTF-8 `bytes`. Wrapped all S3 object ETag assignments to `content_fingerprint` in this helper function.

### Regression Test
Added `test_memo_state_serde_regression` to `TestMemoization` in `python/tests/connectors/test_amazon_s3.py`. This test:
1. Creates an S3 file object whose ETag is mocked as a string.
2. Generates the initial memo state of the file.
3. Serializes the generated state using CocoIndex's `serde.serialize` function.
4. Deserializes the state using the deserializer resolved from `FileLike.__coco_memo_state__`.
5. Asserts the deserialized value matches the original state.

The test correctly reproduces the `msgspec.ValidationError: Expected bytes, got str` failure on main, and successfully passes with the fix applied.

### Validation Results
All 25 tests in `python/tests/connectors/test_amazon_s3.py` passed successfully.
Ruff format and check validations have been run against the modified files with no warnings or errors.
