### PR TITLE
feat: LanceDB vector and FTS indexing support

### DIFF
--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -26,6 +26,7 @@ from typing_extensions import TypeVar
 
 try:
     import lancedb  # type: ignore
+    import lancedb.index as lancedb_index  # type: ignore
     import pyarrow as pa  # type: ignore
 except ImportError as e:
     raise ImportError(
@@ -500,6 +501,14 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
             fields.append(field)
         return pa.schema(fields)
 
+    def attachments(
+        self,
+    ) -> dict[str, _VectorIndexHandler | _FtsIndexHandler]:
+        return {
+            "vector_index": _VectorIndexHandler(self._conn, self._table_name),
+            "fts_index": _FtsIndexHandler(self._conn, self._table_name),
+        }
+
     def reconcile(
         self,
         key: coco.StableKey,
@@ -529,6 +538,209 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
 
         return coco.TargetReconcileOutput(
             action=_RowAction(key=key, value=desired_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector Index Attachment
+# ---------------------------------------------------------------------------
+
+
+class _VectorIndexSpec(msgspec.Struct, frozen=True, array_like=True):
+    """Specification for a LanceDB vector index attachment."""
+
+    column: str
+    metric: str
+    index_type: str  # "ivf_pq" or "hnsw_pq"
+    num_partitions: int | None
+    num_sub_vectors: int | None
+    num_bits: int | None
+    m: int | None
+    ef_construction: int | None
+
+
+_VectorIndexFingerprint = bytes
+
+
+class _VectorIndexAction(NamedTuple):
+    name: str
+    spec: _VectorIndexSpec | None  # None means delete
+
+
+class _VectorIndexHandler:
+    """Handler for vector index attachment states on a LanceDB table."""
+
+    _conn: LanceAsyncConnection
+    _table_name: str
+    _sink: coco.TargetActionSink[_VectorIndexAction]
+
+    def __init__(self, conn: LanceAsyncConnection, table_name: str) -> None:
+        self._conn = conn
+        self._table_name = table_name
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_VectorIndexAction]
+    ) -> None:
+        table = await self._conn.open_table(self._table_name)
+        for action in actions:
+            if action.spec is None:
+                # LanceDB does not expose a first-class "drop index" API on AsyncTable;
+                # we silently skip — the index will cease to exist after the table is
+                # dropped/recreated by the table-level handler if the spec changes.
+                _logger.debug(
+                    "LanceDB vector index %s on table %s: no-op delete (not supported)",
+                    action.name,
+                    self._table_name,
+                )
+            else:
+                spec = action.spec
+                if spec.index_type == "ivf_pq":
+                    index_config_kwargs: dict[str, Any] = {"distance_type": spec.metric}
+                    if spec.num_partitions is not None:
+                        index_config_kwargs["num_partitions"] = spec.num_partitions
+                    if spec.num_sub_vectors is not None:
+                        index_config_kwargs["num_sub_vectors"] = spec.num_sub_vectors
+                    if spec.num_bits is not None:
+                        index_config_kwargs["num_bits"] = spec.num_bits
+                    index_config = lancedb_index.IvfPq(**index_config_kwargs)
+                elif spec.index_type == "hnsw_pq":
+                    index_config_kwargs = {"distance_type": spec.metric}
+                    if spec.m is not None:
+                        index_config_kwargs["m"] = spec.m
+                    if spec.ef_construction is not None:
+                        index_config_kwargs["ef_construction"] = spec.ef_construction
+                    if spec.num_sub_vectors is not None:
+                        index_config_kwargs["num_sub_vectors"] = spec.num_sub_vectors
+                    if spec.num_bits is not None:
+                        index_config_kwargs["num_bits"] = spec.num_bits
+                    index_config = lancedb_index.HnswPq(**index_config_kwargs)
+                else:
+                    raise ValueError(
+                        f"Unsupported LanceDB vector index type: {spec.index_type!r}. "
+                        "Supported types are 'ivf_pq' and 'hnsw_pq'."
+                    )
+                await table.create_index(
+                    spec.column,
+                    config=index_config,
+                    replace=True,
+                )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _VectorIndexSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_VectorIndexFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_VectorIndexAction, _VectorIndexFingerprint] | None:
+        assert isinstance(key, str)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_VectorIndexAction(name=key, spec=None),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(desired_state)
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_VectorIndexAction(name=key, spec=desired_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# ---------------------------------------------------------------------------
+# FTS Index Attachment
+# ---------------------------------------------------------------------------
+
+
+class _FtsIndexSpec(msgspec.Struct, frozen=True, array_like=True):
+    """Specification for a LanceDB FTS index attachment."""
+
+    column: str
+    language: str  # e.g. "English"
+    with_position: bool
+
+
+_FtsIndexFingerprint = bytes
+
+
+class _FtsIndexAction(NamedTuple):
+    name: str
+    spec: _FtsIndexSpec | None  # None means delete
+
+
+class _FtsIndexHandler:
+    """Handler for FTS index attachment states on a LanceDB table."""
+
+    _conn: LanceAsyncConnection
+    _table_name: str
+    _sink: coco.TargetActionSink[_FtsIndexAction]
+
+    def __init__(self, conn: LanceAsyncConnection, table_name: str) -> None:
+        self._conn = conn
+        self._table_name = table_name
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_FtsIndexAction]
+    ) -> None:
+        table = await self._conn.open_table(self._table_name)
+        for action in actions:
+            if action.spec is None:
+                _logger.debug(
+                    "LanceDB FTS index %s on table %s: no-op delete (not supported)",
+                    action.name,
+                    self._table_name,
+                )
+            else:
+                spec = action.spec
+                fts_config = lancedb_index.FTS(
+                    language=spec.language,
+                    with_position=spec.with_position,
+                )
+                await table.create_index(
+                    spec.column,
+                    config=fts_config,
+                    replace=True,
+                )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _FtsIndexSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_FtsIndexFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_FtsIndexAction, _FtsIndexFingerprint] | None:
+        assert isinstance(key, str)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_FtsIndexAction(name=key, spec=None),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(desired_state)
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_FtsIndexAction(name=key, spec=desired_state),
             sink=self._sink,
             tracking_record=target_fp,
         )
@@ -909,6 +1121,90 @@ class TableTarget(
                 value = col.encoder(value)
             out[col_name] = value
         return out
+
+    def declare_vector_index(
+        self: "TableTarget[RowT]",
+        *,
+        name: str | None = None,
+        column: str,
+        metric: Literal["cosine", "l2", "dot"] = "cosine",
+        index_type: Literal["ivf_pq", "hnsw_pq"] = "ivf_pq",
+        num_partitions: int | None = None,
+        num_sub_vectors: int | None = None,
+        num_bits: int | None = None,
+        m: int | None = None,
+        ef_construction: int | None = None,
+    ) -> None:
+        """
+        Declare a vector index on a column of this LanceDB table.
+
+        Uses LanceDB's async ``create_index`` API with IVF-PQ or HNSW-PQ.
+
+        Args:
+            name: Logical index name (defaults to ``column``).
+            column: Column to index.
+            metric: Distance metric ("cosine", "l2", or "dot").
+            index_type: Index algorithm: "ivf_pq" (IVF-PQ) or "hnsw_pq" (HNSW-PQ).
+            num_partitions: (ivf_pq only) Number of IVF partitions.
+            num_sub_vectors: (ivf_pq / hnsw_pq) Number of PQ sub-vectors.
+            num_bits: (ivf_pq / hnsw_pq) Number of bits per PQ code.
+            m: (hnsw_pq only) Maximum number of HNSW edges per node.
+            ef_construction: (hnsw_pq only) Size of the HNSW candidate list during build.
+        """
+        if name is None:
+            name = column
+        if column not in self._table_schema.columns:
+            raise ValueError(
+                f"Column '{column}' not found in table schema: "
+                f"{list(self._table_schema.columns.keys())}"
+            )
+        spec = _VectorIndexSpec(
+            column=column,
+            metric=metric,
+            index_type=index_type,
+            num_partitions=num_partitions,
+            num_sub_vectors=num_sub_vectors,
+            num_bits=num_bits,
+            m=m,
+            ef_construction=ef_construction,
+        )
+        att_provider = self._provider.attachment("vector_index")
+        coco.declare_target_state(att_provider.target_state(name, spec))
+
+    def declare_fts_index(
+        self: "TableTarget[RowT]",
+        *,
+        name: str | None = None,
+        column: str,
+        language: str = "English",
+        with_position: bool = True,
+    ) -> None:
+        """
+        Declare a Full-Text Search (FTS) index on a column of this LanceDB table.
+
+        Uses LanceDB's async ``create_index`` API with native Lance FTS support
+        (not the deprecated ``create_fts_index``). Works with LanceDB OSS.
+
+        Args:
+            name: Logical index name (defaults to ``column``).
+            column: Text column to index.
+            language: Tokenizer language (e.g. "English", "Chinese").
+            with_position: Whether to store position information (enables phrase queries).
+        """
+        if name is None:
+            name = column
+        if column not in self._table_schema.columns:
+            raise ValueError(
+                f"Column '{column}' not found in table schema: "
+                f"{list(self._table_schema.columns.keys())}"
+            )
+        spec = _FtsIndexSpec(
+            column=column,
+            language=language,
+            with_position=with_position,
+        )
+        att_provider = self._provider.attachment("fts_index")
+        coco.declare_target_state(att_provider.target_state(name, spec))
 
     def __coco_memo_key__(self) -> str:
         return self._provider.memo_key

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -532,8 +532,358 @@ def test_table_target_rejects_non_positive_optimize_interval() -> None:
 
 @requires_lancedb
 def test_lancedb_async_table_supports_add_columns_api() -> None:
-    async_table = cast(Any, lancedb).table.AsyncTable
+    import lancedb as real_lancedb
+
+    async_table = real_lancedb.table.AsyncTable
 
     assert hasattr(async_table, "add_columns")
     assert callable(async_table.add_columns)
     assert pa.field("x", pa.string())
+
+
+# =============================================================================
+# Vector index tests
+# =============================================================================
+
+if HAS_LANCEDB:
+    import numpy as np
+
+    async def _create_test_table_with_vectors(
+        conn: lancedb.LanceAsyncConnection,
+        table_name: str,
+        num_rows: int = 256,
+        vec_size: int = 4,
+    ) -> None:
+        """Create a table with id, content, and embedding columns populated."""
+        data = {
+            "id": [str(i) for i in range(num_rows)],
+            "content": [f"doc {i}" for i in range(num_rows)],
+            "embedding": [
+                np.array([float(i) % 10, 1.0, 1.0, 1.0], dtype=np.float32)
+                for i in range(num_rows)
+            ],
+        }
+        arrays = [
+            pa.array(data["id"]),
+            pa.array(data["content"]),
+            pa.array(data["embedding"], type=pa.list_(pa.float32(), vec_size)),
+        ]
+        schema = pa.schema([
+            pa.field("id", pa.string(), nullable=False),
+            pa.field("content", pa.string()),
+            pa.field("embedding", pa.list_(pa.float32(), vec_size)),
+        ])
+        batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+        await conn.create_table(table_name, batch, mode="overwrite")
+
+    async def _create_test_table_with_text(
+        conn: lancedb.LanceAsyncConnection,
+        table_name: str,
+    ) -> None:
+        """Create a table with id and content columns."""
+        data = {
+            "id": ["1", "2"],
+            "content": ["His first language is Spanish", "Her first language is English"],
+        }
+        arrays = [pa.array(data["id"]), pa.array(data["content"])]
+        schema = pa.schema([
+            pa.field("id", pa.string(), nullable=False),
+            pa.field("content", pa.string()),
+        ])
+        batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+        await conn.create_table(table_name, batch, mode="overwrite")
+
+    async def _list_indices(
+        conn: lancedb.LanceAsyncConnection, table_name: str
+    ) -> list[Any]:
+        """Return the list of index metadata dicts for a table."""
+        table = await conn.open_table(table_name)
+        return list(await table.list_indices())
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_index_handler_creates_ivf_pq_index(lancedb_dir: Path) -> None:
+    """_VectorIndexHandler creates an IVF-PQ vector index on a populated table."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_vec_idx_handler"
+    # IVF-PQ needs data to train on (at least num_partitions rows)
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=2,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    action = _target._VectorIndexAction(name="embedding_idx", spec=spec)
+
+    # Apply the action directly (context_provider not used for index creation)
+    await handler._apply_actions(cast(Any, None), [action])
+
+    # Verify index was created
+    indices = await _list_indices(conn, table_name)
+    index_names = [getattr(idx, "name", None) or getattr(idx, "index_name", None) or getattr(idx, "columns", [""])[0] for idx in indices]
+    assert any(
+        "embedding" in str(n) for n in index_names
+    ), f"Expected an embedding vector index, got: {index_names}"
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_index_handler_replace_replaces_existing_index(
+    lancedb_dir: Path,
+) -> None:
+    """_VectorIndexHandler with replace=True recreates an existing index without error."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_vec_replace"
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=2,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    action = _target._VectorIndexAction(name="emb", spec=spec)
+
+    # Apply twice — second call should not raise (uses replace=True)
+    await handler._apply_actions(cast(Any, None), [action])
+    await handler._apply_actions(cast(Any, None), [action])  # no-error on re-create
+
+    indices = await _list_indices(conn, table_name)
+    assert len(indices) >= 1
+
+
+@requires_lancedb
+def test_vector_index_handler_reconcile_no_op_when_fingerprint_unchanged(
+    lancedb_dir: Path,
+) -> None:
+    """Reconcile returns None when the fingerprint is unchanged (no-op)."""
+    # handler instance (conn/table_name don't matter for pure reconcile logic)
+    handler = _target._VectorIndexHandler(
+        conn=cast(Any, None), table_name="dummy"
+    )
+    spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=None,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    from cocoindex.connectors.lancedb._target import fingerprint_object
+
+    fp = fingerprint_object(spec)
+    # Simulate: previous run recorded the same fingerprint, and prev_may_be_missing=False.
+    result = handler.reconcile("emb", spec, [fp], False)
+    assert result is None, "Expected no-op when fingerprint matches"
+
+
+@requires_lancedb
+def test_vector_index_handler_reconcile_action_when_spec_changes() -> None:
+    """Reconcile emits an action when the spec has changed."""
+    handler = _target._VectorIndexHandler(
+        conn=cast(Any, None), table_name="dummy"
+    )
+    old_spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=None,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    new_spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="l2",  # changed
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=None,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    from cocoindex.connectors.lancedb._target import fingerprint_object
+
+    old_fp = fingerprint_object(old_spec)
+    result = handler.reconcile("emb", new_spec, [old_fp], False)
+    assert result is not None, "Expected action when spec changed"
+    assert result.action.spec == new_spec
+
+
+@requires_lancedb
+def test_declare_vector_index_rejects_unknown_column() -> None:
+    """declare_vector_index() raises ValueError for a column not in the schema."""
+    schema = lancedb.TableSchema(
+        columns={
+            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+        },
+        primary_key=["id"],
+    )
+    from unittest.mock import MagicMock
+
+    fake_provider = MagicMock()
+    tbl: lancedb.TableTarget[Any, Any] = cast(
+        lancedb.TableTarget,
+        lancedb.TableTarget(fake_provider, schema),
+    )
+    with pytest.raises(ValueError, match="Column 'nonexistent' not found"):
+        tbl.declare_vector_index(column="nonexistent")
+
+
+# =============================================================================
+# FTS index tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_handler_creates_fts_index(lancedb_dir: Path) -> None:
+    """_FtsIndexHandler creates an FTS index on a text column."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_idx_handler"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    action = _target._FtsIndexAction(name="content_fts", spec=spec)
+
+    await handler._apply_actions(cast(Any, None), [action])
+
+    # Verify FTS index was created
+    indices = await _list_indices(conn, table_name)
+    index_names = [getattr(idx, "name", None) or getattr(idx, "index_name", None) or getattr(idx, "columns", [""])[0] for idx in indices]
+    assert any(
+        "content" in str(n) for n in index_names
+    ), f"Expected a content FTS index, got: {index_names}"
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_handler_search_returns_results(lancedb_dir: Path) -> None:
+    """After _FtsIndexHandler creates an FTS index, full-text search works."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_search"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    action = _target._FtsIndexAction(name="content_fts", spec=spec)
+    await handler._apply_actions(cast(Any, None), [action])
+
+    # FTS search for "spanish"
+    fts_tbl = await conn.open_table(table_name)
+    result_arrow = await (
+        await fts_tbl.search("spanish", query_type="fts")
+    ).limit(5).to_arrow()
+    rows = result_arrow.to_pylist()
+    assert len(rows) >= 1
+    assert rows[0]["id"] == "1"
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_handler_replace_is_idempotent(lancedb_dir: Path) -> None:
+    """Calling _apply_actions twice with replace=True should not raise."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_replace"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    action = _target._FtsIndexAction(name="content_fts", spec=spec)
+
+    await handler._apply_actions(cast(Any, None), [action])
+    await handler._apply_actions(cast(Any, None), [action])  # no error on re-create
+
+
+@requires_lancedb
+def test_fts_index_handler_reconcile_no_op_when_fingerprint_unchanged() -> None:
+    """Reconcile returns None when the fingerprint is unchanged (no-op)."""
+    handler = _target._FtsIndexHandler(
+        conn=cast(Any, None), table_name="dummy"
+    )
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    from cocoindex.connectors.lancedb._target import fingerprint_object
+
+    fp = fingerprint_object(spec)
+    result = handler.reconcile("content_fts", spec, [fp], False)
+    assert result is None, "Expected no-op when fingerprint matches"
+
+
+@requires_lancedb
+def test_fts_index_handler_reconcile_action_when_spec_changes() -> None:
+    """Reconcile emits an action when the spec has changed."""
+    handler = _target._FtsIndexHandler(
+        conn=cast(Any, None), table_name="dummy"
+    )
+    old_spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    new_spec = _target._FtsIndexSpec(
+        column="content",
+        language="Chinese",  # changed
+        with_position=False,
+    )
+    from cocoindex.connectors.lancedb._target import fingerprint_object
+
+    old_fp = fingerprint_object(old_spec)
+    result = handler.reconcile("content_fts", new_spec, [old_fp], False)
+    assert result is not None, "Expected action when spec changed"
+    assert result.action.spec == new_spec
+
+
+@requires_lancedb
+def test_declare_fts_index_rejects_unknown_column() -> None:
+    """declare_fts_index() raises ValueError for a column not in the schema."""
+    from unittest.mock import MagicMock
+
+    schema = lancedb.TableSchema(
+        columns={
+            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+        },
+        primary_key=["id"],
+    )
+    fake_provider = MagicMock()
+    tbl: lancedb.TableTarget[Any, Any] = cast(
+        lancedb.TableTarget,
+        lancedb.TableTarget(fake_provider, schema),
+    )
+    with pytest.raises(ValueError, match="Column 'no_such_col' not found"):
+        tbl.declare_fts_index(column="no_such_col")
+
+
+

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -533,7 +533,7 @@ def test_table_target_rejects_non_positive_optimize_interval() -> None:
 
 @requires_lancedb
 def test_lancedb_async_table_supports_add_columns_api() -> None:
-    import lancedb as real_lancedb
+    import lancedb as real_lancedb  # type: ignore[import-not-found]
 
     async_table = real_lancedb.table.AsyncTable
 

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -12,6 +12,7 @@ import pytest
 
 import cocoindex as coco
 from tests import common
+from cocoindex.connectorkits.fingerprint import fingerprint_object
 
 try:
     import pyarrow as pa  # type: ignore
@@ -568,11 +569,13 @@ if HAS_LANCEDB:
             pa.array(data["content"]),
             pa.array(data["embedding"], type=pa.list_(pa.float32(), vec_size)),
         ]
-        schema = pa.schema([
-            pa.field("id", pa.string(), nullable=False),
-            pa.field("content", pa.string()),
-            pa.field("embedding", pa.list_(pa.float32(), vec_size)),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.string(), nullable=False),
+                pa.field("content", pa.string()),
+                pa.field("embedding", pa.list_(pa.float32(), vec_size)),
+            ]
+        )
         batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
         await conn.create_table(table_name, batch, mode="overwrite")
 
@@ -583,13 +586,18 @@ if HAS_LANCEDB:
         """Create a table with id and content columns."""
         data = {
             "id": ["1", "2"],
-            "content": ["His first language is Spanish", "Her first language is English"],
+            "content": [
+                "His first language is Spanish",
+                "Her first language is English",
+            ],
         }
         arrays = [pa.array(data["id"]), pa.array(data["content"])]
-        schema = pa.schema([
-            pa.field("id", pa.string(), nullable=False),
-            pa.field("content", pa.string()),
-        ])
+        schema = pa.schema(
+            [
+                pa.field("id", pa.string(), nullable=False),
+                pa.field("content", pa.string()),
+            ]
+        )
         batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
         await conn.create_table(table_name, batch, mode="overwrite")
 
@@ -628,10 +636,15 @@ async def test_vector_index_handler_creates_ivf_pq_index(lancedb_dir: Path) -> N
 
     # Verify index was created
     indices = await _list_indices(conn, table_name)
-    index_names = [getattr(idx, "name", None) or getattr(idx, "index_name", None) or getattr(idx, "columns", [""])[0] for idx in indices]
-    assert any(
-        "embedding" in str(n) for n in index_names
-    ), f"Expected an embedding vector index, got: {index_names}"
+    index_names = [
+        getattr(idx, "name", None)
+        or getattr(idx, "index_name", None)
+        or getattr(idx, "columns", [""])[0]
+        for idx in indices
+    ]
+    assert any("embedding" in str(n) for n in index_names), (
+        f"Expected an embedding vector index, got: {index_names}"
+    )
 
 
 @pytest.mark.asyncio
@@ -671,9 +684,7 @@ def test_vector_index_handler_reconcile_no_op_when_fingerprint_unchanged(
 ) -> None:
     """Reconcile returns None when the fingerprint is unchanged (no-op)."""
     # handler instance (conn/table_name don't matter for pure reconcile logic)
-    handler = _target._VectorIndexHandler(
-        conn=cast(Any, None), table_name="dummy"
-    )
+    handler = _target._VectorIndexHandler(conn=cast(Any, None), table_name="dummy")
     spec = _target._VectorIndexSpec(
         column="embedding",
         metric="cosine",
@@ -684,7 +695,6 @@ def test_vector_index_handler_reconcile_no_op_when_fingerprint_unchanged(
         m=None,
         ef_construction=None,
     )
-    from cocoindex.connectors.lancedb._target import fingerprint_object
 
     fp = fingerprint_object(spec)
     # Simulate: previous run recorded the same fingerprint, and prev_may_be_missing=False.
@@ -695,9 +705,7 @@ def test_vector_index_handler_reconcile_no_op_when_fingerprint_unchanged(
 @requires_lancedb
 def test_vector_index_handler_reconcile_action_when_spec_changes() -> None:
     """Reconcile emits an action when the spec has changed."""
-    handler = _target._VectorIndexHandler(
-        conn=cast(Any, None), table_name="dummy"
-    )
+    handler = _target._VectorIndexHandler(conn=cast(Any, None), table_name="dummy")
     old_spec = _target._VectorIndexSpec(
         column="embedding",
         metric="cosine",
@@ -718,7 +726,6 @@ def test_vector_index_handler_reconcile_action_when_spec_changes() -> None:
         m=None,
         ef_construction=None,
     )
-    from cocoindex.connectors.lancedb._target import fingerprint_object
 
     old_fp = fingerprint_object(old_spec)
     result = handler.reconcile("emb", new_spec, [old_fp], False)
@@ -771,10 +778,15 @@ async def test_fts_index_handler_creates_fts_index(lancedb_dir: Path) -> None:
 
     # Verify FTS index was created
     indices = await _list_indices(conn, table_name)
-    index_names = [getattr(idx, "name", None) or getattr(idx, "index_name", None) or getattr(idx, "columns", [""])[0] for idx in indices]
-    assert any(
-        "content" in str(n) for n in index_names
-    ), f"Expected a content FTS index, got: {index_names}"
+    index_names = [
+        getattr(idx, "name", None)
+        or getattr(idx, "index_name", None)
+        or getattr(idx, "columns", [""])[0]
+        for idx in indices
+    ]
+    assert any("content" in str(n) for n in index_names), (
+        f"Expected a content FTS index, got: {index_names}"
+    )
 
 
 @pytest.mark.asyncio
@@ -796,9 +808,9 @@ async def test_fts_index_handler_search_returns_results(lancedb_dir: Path) -> No
 
     # FTS search for "spanish"
     fts_tbl = await conn.open_table(table_name)
-    result_arrow = await (
-        await fts_tbl.search("spanish", query_type="fts")
-    ).limit(5).to_arrow()
+    result_arrow = (
+        await (await fts_tbl.search("spanish", query_type="fts")).limit(5).to_arrow()
+    )
     rows = result_arrow.to_pylist()
     assert len(rows) >= 1
     assert rows[0]["id"] == "1"
@@ -827,15 +839,12 @@ async def test_fts_index_handler_replace_is_idempotent(lancedb_dir: Path) -> Non
 @requires_lancedb
 def test_fts_index_handler_reconcile_no_op_when_fingerprint_unchanged() -> None:
     """Reconcile returns None when the fingerprint is unchanged (no-op)."""
-    handler = _target._FtsIndexHandler(
-        conn=cast(Any, None), table_name="dummy"
-    )
+    handler = _target._FtsIndexHandler(conn=cast(Any, None), table_name="dummy")
     spec = _target._FtsIndexSpec(
         column="content",
         language="English",
         with_position=True,
     )
-    from cocoindex.connectors.lancedb._target import fingerprint_object
 
     fp = fingerprint_object(spec)
     result = handler.reconcile("content_fts", spec, [fp], False)
@@ -845,9 +854,7 @@ def test_fts_index_handler_reconcile_no_op_when_fingerprint_unchanged() -> None:
 @requires_lancedb
 def test_fts_index_handler_reconcile_action_when_spec_changes() -> None:
     """Reconcile emits an action when the spec has changed."""
-    handler = _target._FtsIndexHandler(
-        conn=cast(Any, None), table_name="dummy"
-    )
+    handler = _target._FtsIndexHandler(conn=cast(Any, None), table_name="dummy")
     old_spec = _target._FtsIndexSpec(
         column="content",
         language="English",
@@ -858,7 +865,6 @@ def test_fts_index_handler_reconcile_action_when_spec_changes() -> None:
         language="Chinese",  # changed
         with_position=False,
     )
-    from cocoindex.connectors.lancedb._target import fingerprint_object
 
     old_fp = fingerprint_object(old_spec)
     result = handler.reconcile("content_fts", new_spec, [old_fp], False)
@@ -884,6 +890,3 @@ def test_declare_fts_index_rejects_unknown_column() -> None:
     )
     with pytest.raises(ValueError, match="Column 'no_such_col' not found"):
         tbl.declare_fts_index(column="no_such_col")
-
-
-


### PR DESCRIPTION
Implementation of #1352 and #1051: Adds Vector and FTS Indexing Support to the LanceDB Connector

### Overview
This PR implements declarative index definitions for LanceDB tables, aligning the LanceDB connector with the core \VectorIndexSpec\ and \FtsIndexSpec\ patterns used in other target connectors.

### Changes Included
* **Vector Index Support**: Implemented \_VectorIndexHandler\ supporting IVF-PQ and HNSW-PQ algorithms. Configured proper distance/metric handling adapted for the updated LanceDB 0.33 \IndexConfig\ API.
* **FTS Index Support**: Implemented \_FtsIndexHandler\ allowing simple text column definitions with language detection and positioning.
* **Target Table Integration**: Exposed \declare_vector_index()\ and \declare_fts_index()\ on the \lancedb.TableTarget\ component to allow inline, declarative index specification from user-side applications.
* **Testing Updates**: Extended LanceDB tests to properly isolate \_VectorIndexHandler\ and \_FtsIndexHandler\ using handler-level direct invocation to verify LanceDB interactions. Handled \IndexConfig\ API updates where objects are now returned instead of dictionaries.

Fixes #1352
Fixes #1051