### PR TITLE
feat(oci): skip startup full scan on unchanged logic

### DIFF
--- a/docs/src/content/docs/connectors/oci_object_storage.mdx
+++ b/docs/src/content/docs/connectors/oci_object_storage.mdx
@@ -58,6 +58,7 @@ def list_objects(
     path_matcher: FilePathMatcher | None = None,
     max_file_size: int | None = None,
     live_stream: LiveStream[bytes] | None = None,
+    logic_version: str | None = None,
 ) -> OCIWalker
 ```
 
@@ -70,6 +71,7 @@ def list_objects(
 - `path_matcher` — Optional filter for files. Patterns are matched against the relative path (after prefix stripping). See [PatternFilePathMatcher](../common_resources/data_types#patternfilepathmatcher).
 - `max_file_size` — Skip objects larger than this size in bytes.
 - `live_stream` — Optional `LiveStream[bytes]` of OCI Object Storage event payloads. When provided, `OCIWalker.items()` returns a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) that performs an initial scan and continues watching for changes via the supplied stream. See [Live mode](#live-bucket-watching).
+- `logic_version` — Opt into skipping the startup full scan on reruns. See [Skipping the startup scan](#skipping-the-startup-scan).
 
 **Returns:** An `OCIWalker` that can be used with `async for` loops.
 
@@ -241,6 +243,27 @@ await coco.mount_each(process_file, walker.items(), target)
 ```
 
 See [Live Mode](../programming_guide/live_mode) for how live mode works and how to enable it on the app.
+
+### Skipping the startup scan
+
+By default, every live run begins with a full bucket scan to reconcile current state before processing stream events. On a long-lived deployment that restarts often, this scan is redundant work when nothing relevant has changed since the last run.
+
+Set `logic_version` to opt into skipping it:
+
+```python
+walker = oci_object_storage.list_objects(
+    client, "my-namespace", "my-bucket",
+    live_stream=topic_stream.payloads(),
+    logic_version="v1",
+)
+```
+
+After a successful scan, the connector records `logic_version`. On a later run, if the recorded version still matches, the scan is skipped and the durable stream is replayed from its committed cursor to catch up on changes that happened while the app was down.
+
+This is safe only when two conditions hold, and **you are responsible for both**:
+
+- **Durable stream.** The stream must resume exactly where it left off — e.g. a Kafka consumer with a stable `group.id` and committed offsets (as in the setup above). Without durable resumption, skipping the scan loses changes that occurred during downtime.
+- **Bump `logic_version` whenever your processing logic changes.** The recorded version is the only signal the connector has that a rescan is needed. If you change your pipeline (e.g. how `process_file` transforms content) without bumping it, the run reuses stale results instead of reprocessing. Leave `logic_version` unset (the default) to always scan on startup.
 
 ### Example
 

--- a/docs/src/content/docs/connectors/oci_object_storage.mdx
+++ b/docs/src/content/docs/connectors/oci_object_storage.mdx
@@ -58,7 +58,6 @@ def list_objects(
     path_matcher: FilePathMatcher | None = None,
     max_file_size: int | None = None,
     live_stream: LiveStream[bytes] | None = None,
-    logic_version: str | None = None,
 ) -> OCIWalker
 ```
 
@@ -71,7 +70,6 @@ def list_objects(
 - `path_matcher` — Optional filter for files. Patterns are matched against the relative path (after prefix stripping). See [PatternFilePathMatcher](../common_resources/data_types#patternfilepathmatcher).
 - `max_file_size` — Skip objects larger than this size in bytes.
 - `live_stream` — Optional `LiveStream[bytes]` of OCI Object Storage event payloads. When provided, `OCIWalker.items()` returns a [`LiveMapView`](../advanced_topics/live_component#livemapfeed-and-livemapview) that performs an initial scan and continues watching for changes via the supplied stream. See [Live mode](#live-bucket-watching).
-- `logic_version` — Opt into skipping the startup full scan on reruns. See [Skipping the startup scan](#skipping-the-startup-scan).
 
 **Returns:** An `OCIWalker` that can be used with `async for` loops.
 
@@ -243,27 +241,6 @@ await coco.mount_each(process_file, walker.items(), target)
 ```
 
 See [Live Mode](../programming_guide/live_mode) for how live mode works and how to enable it on the app.
-
-### Skipping the startup scan
-
-By default, every live run begins with a full bucket scan to reconcile current state before processing stream events. On a long-lived deployment that restarts often, this scan is redundant work when nothing relevant has changed since the last run.
-
-Set `logic_version` to opt into skipping it:
-
-```python
-walker = oci_object_storage.list_objects(
-    client, "my-namespace", "my-bucket",
-    live_stream=topic_stream.payloads(),
-    logic_version="v1",
-)
-```
-
-After a successful scan, the connector records `logic_version`. On a later run, if the recorded version still matches, the scan is skipped and the durable stream is replayed from its committed cursor to catch up on changes that happened while the app was down.
-
-This is safe only when two conditions hold, and **you are responsible for both**:
-
-- **Durable stream.** The stream must resume exactly where it left off — e.g. a Kafka consumer with a stable `group.id` and committed offsets (as in the setup above). Without durable resumption, skipping the scan loses changes that occurred during downtime.
-- **Bump `logic_version` whenever your processing logic changes.** The recorded version is the only signal the connector has that a rescan is needed. If you change your pipeline (e.g. how `process_file` transforms content) without bumping it, the run reuses stale results instead of reprocessing. Leave `logic_version` unset (the default) to always scan on startup.
 
 ### Example
 

--- a/python/cocoindex/connectors/oci_object_storage/_source.py
+++ b/python/cocoindex/connectors/oci_object_storage/_source.py
@@ -59,6 +59,11 @@ _OBJECT_EVENT_PREFIX = "com.oraclecloud.objectstorage."
 # concrete need emerges (per AGENTS.md "Minimize API surface").
 _SKEW_TOLERANCE = timedelta(seconds=5)
 
+# Committed-state key under which the live view records the user-declared
+# ``logic_version`` after a successful full scan. Read back on a later run to
+# decide whether the startup scan can be skipped. See ``list_objects``.
+_SCAN_VERSION_KEY = "__coco_oci_scan_version__"
+
 
 def _parse_event_time(s: Any) -> datetime | None:
     """Parse an OCI event ``eventTime`` (ISO-8601). Returns ``None`` on
@@ -259,6 +264,7 @@ class OCIWalker:
     _path_matcher: file.FilePathMatcher
     _max_file_size: int | None
     _live_stream: LiveStream[bytes] | None
+    _logic_version: str | None
 
     def __init__(
         self,
@@ -270,6 +276,7 @@ class OCIWalker:
         path_matcher: file.FilePathMatcher | None = None,
         max_file_size: int | None = None,
         live_stream: LiveStream[bytes] | None = None,
+        logic_version: str | None = None,
     ) -> None:
         self._client = client
         self._namespace = namespace
@@ -278,6 +285,7 @@ class OCIWalker:
         self._path_matcher = path_matcher or file.MatchAllFilePathMatcher()
         self._max_file_size = max_file_size
         self._live_stream = live_stream
+        self._logic_version = logic_version
 
     @property
     def namespace(self) -> str:
@@ -371,6 +379,13 @@ class _LiveOCIItems:
     5. Set ``adapter.mark_ready_complete()`` — unblocks any post-cutoff
        ``send()`` calls parked on ``_ready_complete``.
     6. Await the stream task; it runs until cancellation.
+
+    Skip-scan mode (opt-in via ``OCIWalker(logic_version=...)``): when a prior
+    run committed the same ``logic_version``, steps 1+3 are replaced — the scan
+    is skipped and ``cutoff`` is ``None`` so the durable stream's replayed
+    backlog (resumed from its committed cursor) is processed rather than
+    dropped. The committed version is (re)written after step 4 on any run that
+    actually scans.
     """
 
     __slots__ = ("_walker", "_live_stream", "_watch_guard")
@@ -393,12 +408,27 @@ class _LiveOCIItems:
             await self._watch(subscriber)
 
     async def _watch(self, subscriber: LiveMapSubscriber[str, OCIFile]) -> None:
-        cutoff = datetime.now(timezone.utc) - _SKEW_TOLERANCE
+        logic_version = self._walker._logic_version
+        skip_scan = False
+        if logic_version is not None:
+            stored = await subscriber.read_committed_state(_SCAN_VERSION_KEY)
+            skip_scan = stored == logic_version
+
+        # With no scan, the wall-clock cutoff must not fire: the durable stream
+        # (resumed from its committed cursor) replays the downtime backlog, and
+        # there is no scan covering it. With a scan, the cutoff dedupes
+        # stream-vs-scan as before.
+        cutoff = None if skip_scan else datetime.now(timezone.utc) - _SKEW_TOLERANCE
         adapter = _OCIStreamSubscriber(self._walker, subscriber, cutoff)
         stream_task = asyncio.create_task(self._live_stream.watch(adapter))
         try:
-            await subscriber.update_all()
+            if not skip_scan:
+                await subscriber.update_all()
             await subscriber.mark_ready()
+            # Record the version only after mark_ready (the scan has committed),
+            # so a later run skips only when the bootstrap durably landed.
+            if not skip_scan and logic_version is not None:
+                await subscriber.write_committed_state(_SCAN_VERSION_KEY, logic_version)
             adapter.mark_ready_complete()
             await stream_task
         finally:
@@ -422,7 +452,8 @@ class _OCIStreamSubscriber:
     3. Namespace + bucket filter (cross-bucket events on a shared topic).
     4. **Event-time cutoff.** ``event_time < self._cutoff`` → drop (the scan
        covers this state). Missing / unparseable / future-dated events fall
-       through to be processed.
+       through to be processed. Disabled entirely when ``cutoff is None``
+       (skip-scan mode): the replayed backlog is processed, not dropped.
     5. Prefix + path-matcher filter.
     6. **Block on ``self._ready_complete``** — ensures dispatch happens
        strictly after both the scan's ``update_full`` has committed and
@@ -444,7 +475,7 @@ class _OCIStreamSubscriber:
         self,
         walker: OCIWalker,
         map_sub: LiveMapSubscriber[str, OCIFile],
-        cutoff: datetime,
+        cutoff: datetime | None,
     ) -> None:
         self._walker = walker
         self._map_sub = map_sub
@@ -491,9 +522,12 @@ class _OCIStreamSubscriber:
             return _IMMEDIATE_READY
 
         # Event-time cutoff. Missing / unparseable / future-dated → fall through.
-        event_time = _parse_event_time(event_time_raw)
-        if event_time is not None and event_time < self._cutoff:
-            return _IMMEDIATE_READY
+        # In skip-scan mode (cutoff is None) the cutoff is disabled entirely so
+        # the replayed downtime backlog is processed instead of dropped.
+        if self._cutoff is not None:
+            event_time = _parse_event_time(event_time_raw)
+            if event_time is not None and event_time < self._cutoff:
+                return _IMMEDIATE_READY
 
         # Prefix + path-matcher filter
         prefix = self._walker._prefix
@@ -612,6 +646,7 @@ def list_objects(
     path_matcher: file.FilePathMatcher | None = None,
     max_file_size: int | None = None,
     live_stream: LiveStream[bytes] | None = None,
+    logic_version: str | None = None,
 ) -> OCIWalker:
     """List objects in an OCI bucket and yield file entries.
 
@@ -631,6 +666,15 @@ def list_objects(
             path, after prefix stripping).
         max_file_size: Skip objects larger than this size in bytes.
         live_stream: Optional ``LiveStream[bytes]`` of OCI Object Storage events.
+        logic_version: Opt into skipping the startup full scan on reruns. When
+            set, the live view records this version after a successful scan and,
+            on a later run, skips the scan if the recorded version matches —
+            relying on the durable stream to replay the downtime backlog from
+            its committed cursor. You MUST bump this whenever your processing
+            logic changes (otherwise stale state is silently kept), and the
+            stream MUST be durable (e.g. a Kafka consumer with a stable
+            ``group_id`` and committed offsets). Leave unset (``None``) to always
+            scan on startup.
     """
     return OCIWalker(
         client,
@@ -640,4 +684,5 @@ def list_objects(
         path_matcher=path_matcher,
         max_file_size=max_file_size,
         live_stream=live_stream,
+        logic_version=logic_version,
     )

--- a/python/tests/connectors/test_oci_object_storage.py
+++ b/python/tests/connectors/test_oci_object_storage.py
@@ -201,6 +201,9 @@ from cocoindex.connectors.oci_object_storage import (  # noqa: E402
     list_objects,
     read,
 )
+from cocoindex.connectors.oci_object_storage._source import (  # noqa: E402
+    _SCAN_VERSION_KEY,
+)
 from cocoindex.resources.file import PatternFilePathMatcher  # noqa: E402
 
 
@@ -355,19 +358,30 @@ async def test_oci_exists_false_on_404(
 
 
 class _MockMapSubscriber:
-    """Records LiveMapSubscriber calls; auto-resolved handles."""
+    """Records LiveMapSubscriber calls; auto-resolved handles.
 
-    def __init__(self) -> None:
+    ``committed`` backs the ``read_committed_state`` / ``write_committed_state``
+    primitives; pass a shared dict to simulate state persisting across runs.
+    """
+
+    def __init__(self, committed: dict[Any, Any] | None = None) -> None:
         self.update_all_called = False
         self.mark_ready_called = False
         self.updates: list[tuple[str, OCIFile]] = []
         self.deletes: list[str] = []
+        self.committed: dict[Any, Any] = {} if committed is None else committed
 
     async def update_all(self) -> None:
         self.update_all_called = True
 
     async def mark_ready(self) -> None:
         self.mark_ready_called = True
+
+    async def read_committed_state(self, key: Any) -> Any | None:
+        return self.committed.get(key)
+
+    async def write_committed_state(self, key: Any, value: Any) -> None:
+        self.committed[key] = value
 
     async def update(self, key: str, value: OCIFile) -> ReadyAwaitable:
         self.updates.append((key, value))
@@ -700,6 +714,116 @@ async def test_oci_live_view_cross_bucket_event_filtered(
     assert stream.send_results[-1] is _IMMEDIATE_READY
     assert oci_client.head_object_calls[head_count_before:] == []
     assert sub.updates == [] and sub.deletes == []
+
+    stream.end()
+    await watch_task
+
+
+# ===========================================================================
+# Live view — skip-full-scan on unchanged logic (logic_version)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_oci_live_view_no_logic_version_always_scans(
+    oci_client: MockObjectStorageClient,
+) -> None:
+    """Without ``logic_version`` the startup scan always runs and nothing is
+    persisted (behavior unchanged)."""
+    oci_client.put("a.txt", b"a")
+    stream = _ManualLiveStream()
+    walker = list_objects(oci_client, "ns", "bucket", live_stream=stream)
+
+    sub = _MockMapSubscriber()
+    items = _live_items(walker)
+    watch_task = asyncio.create_task(items.watch(sub))  # type: ignore[arg-type]
+
+    await _drive_to_ready(stream, sub)
+
+    assert sub.update_all_called
+    assert sub.committed == {}
+
+    stream.end()
+    await watch_task
+
+
+@pytest.mark.asyncio
+async def test_oci_live_view_first_run_scans_and_records_version(
+    oci_client: MockObjectStorageClient,
+) -> None:
+    """First run with ``logic_version`` set (nothing committed yet) scans, then
+    records the version once the scan has committed."""
+    oci_client.put("a.txt", b"a")
+    stream = _ManualLiveStream()
+    walker = list_objects(
+        oci_client, "ns", "bucket", live_stream=stream, logic_version="v1"
+    )
+
+    sub = _MockMapSubscriber()
+    items = _live_items(walker)
+    watch_task = asyncio.create_task(items.watch(sub))  # type: ignore[arg-type]
+
+    await _drive_to_ready(stream, sub)
+
+    assert sub.update_all_called
+    assert sub.committed == {_SCAN_VERSION_KEY: "v1"}
+
+    stream.end()
+    await watch_task
+
+
+@pytest.mark.asyncio
+async def test_oci_live_view_skips_scan_when_version_matches(
+    oci_client: MockObjectStorageClient,
+) -> None:
+    """A rerun whose committed version matches skips the scan, and the cutoff is
+    disabled so the replayed backlog (here a far-past event) is still processed.
+    """
+    oci_client.put("a.txt", b"a")
+    stream = _ManualLiveStream()
+    walker = list_objects(
+        oci_client, "ns", "bucket", live_stream=stream, logic_version="v1"
+    )
+
+    # Simulate a prior run having bootstrapped at "v1".
+    sub = _MockMapSubscriber(committed={_SCAN_VERSION_KEY: "v1"})
+    items = _live_items(walker)
+    watch_task = asyncio.create_task(items.watch(sub))  # type: ignore[arg-type]
+
+    await _drive_to_ready(stream, sub)
+
+    assert not sub.update_all_called  # scan skipped
+    assert sub.mark_ready_called
+
+    # A pre-cutoff event would be dropped in scan mode; in skip mode it is
+    # dispatched (the durable stream's replayed backlog is authoritative).
+    await stream.send_event(_event("ns", "bucket", "a.txt", event_time=_FAR_PAST))
+    assert sub.updates and sub.updates[-1][0] == "a.txt"
+
+    stream.end()
+    await watch_task
+
+
+@pytest.mark.asyncio
+async def test_oci_live_view_rescans_when_version_changed(
+    oci_client: MockObjectStorageClient,
+) -> None:
+    """A rerun whose ``logic_version`` differs from the committed one rescans and
+    records the new version."""
+    oci_client.put("a.txt", b"a")
+    stream = _ManualLiveStream()
+    walker = list_objects(
+        oci_client, "ns", "bucket", live_stream=stream, logic_version="v2"
+    )
+
+    sub = _MockMapSubscriber(committed={_SCAN_VERSION_KEY: "v1"})
+    items = _live_items(walker)
+    watch_task = asyncio.create_task(items.watch(sub))  # type: ignore[arg-type]
+
+    await _drive_to_ready(stream, sub)
+
+    assert sub.update_all_called  # logic changed → full scan
+    assert sub.committed == {_SCAN_VERSION_KEY: "v2"}
 
     stream.end()
     await watch_task


### PR DESCRIPTION
Part 2 of #2017. Wires the committed-state primitives from #2078 into the OCI live source.

Adds an opt-in `logic_version` to `oci_object_storage.list_objects()`. When set, the live
source records it via `write_committed_state` after a successful initial scan; on a later
run it reads the value back (before `update_full`) and skips the startup full scan when the
version matches. In skip mode the wall-clock event-time cutoff is disabled, so the durable
stream, resumed from its committed offset, replays the downtime backlog instead of having
it dropped. A changed version, or no prior bootstrap, falls back to a full scan.

`logic_version` defaults to `None` (always scan) and is keyword-only, so existing callers
are unaffected and nothing is persisted unless opted in.

**Scope:** this is the D2 path from #2078 — a *user-declared* logic version
(the user bumps it on pipeline changes and provides a durable stream). The framework-level
logic-change detection you mentioned (auto-detecting changes across the live subtree) remains
the intended follow-up that would close #2017. Flagging so we can decide whether D2 is
acceptable as an interim step, or whether you'd rather go straight to the framework approach.

Refs #2017 (reserving Closes for the framework-detection follow-up).