### PR TITLE
fix(lancedb): escape single quotes in delete filter predicates

### DIFF
--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -319,6 +319,11 @@ class TableSchema(Generic[RowT]):
         return columns
 
 
+def _escape_sql_string(value: str) -> str:
+    """Escape a string for safe embedding in a DataFusion SQL string literal."""
+    return value.replace("'", "''")
+
+
 class _RowAction(NamedTuple):
     """Action to perform on a row."""
 
@@ -486,7 +491,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
                 pk_value = action.key[i]
                 # Handle different types appropriately
                 if isinstance(pk_value, str):
-                    conditions.append(f"{pk_col} = '{pk_value}'")
+                    conditions.append(f"{pk_col} = '{_escape_sql_string(pk_value)}'")
                 else:
                     conditions.append(f"{pk_col} = {pk_value}")
 

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -890,3 +890,107 @@ def test_declare_fts_index_rejects_unknown_column() -> None:
     )
     with pytest.raises(ValueError, match="Column 'no_such_col' not found"):
         tbl.declare_fts_index(column="no_such_col")
+
+
+# =============================================================================
+# SQL string escaping tests (delete path)
+# =============================================================================
+
+
+@requires_lancedb
+def test_escape_sql_string_doubles_single_quotes() -> None:
+    """_escape_sql_string doubles embedded single quotes for DataFusion SQL."""
+    assert _target._escape_sql_string("hello") == "hello"
+    assert _target._escape_sql_string("it's") == "it''s"
+    assert _target._escape_sql_string("O'Brien") == "O''Brien"
+    assert _target._escape_sql_string("a''b") == "a''''b"
+    assert _target._escape_sql_string("") == ""
+    # Backslashes pass through unchanged (DataFusion does not use backslash escaping)
+    assert _target._escape_sql_string("path\\to\\file") == "path\\to\\file"
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_execute_deletes_escapes_string_pk() -> None:
+    """_execute_deletes properly escapes single quotes in string primary key values."""
+    table_schema = lancedb.TableSchema(
+        columns={
+            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+            "name": lancedb.ColumnDef(type=pa.string()),
+        },
+        primary_key=["id"],
+    )
+
+    delete_filters: list[str] = []
+
+    class _DeletableFakeTable(_FakeAsyncTable):
+        async def delete(self, filter: str) -> None:  # noqa: A002
+            delete_filters.append(filter)
+
+    fake_table = _DeletableFakeTable()
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=table_schema,
+        num_transactions_before_optimize=50,
+    )
+    await handler._execute_deletes(
+        cast(Any, fake_table),
+        [
+            _target._RowAction(key=("O'Brien",), value=None),
+        ],
+    )
+    assert delete_filters == ["id = 'O''Brien'"]
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_execute_deletes_with_real_lancedb(lancedb_dir: Path) -> None:
+    """Integration test: insert and then delete a row whose PK contains a single quote."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_delete_escape"
+
+    # Insert a row with a quote in the PK
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array(["O'Brien", "normal"]), pa.array(["Alice", "Bob"])],
+        schema=pa.schema(
+            [
+                pa.field("id", pa.string(), nullable=False),
+                pa.field("name", pa.string()),
+            ]
+        ),
+    )
+    await conn.create_table(table_name, batch, mode="overwrite")
+
+    # Verify both rows exist
+    rows = await _read_rows(conn, table_name)
+    assert sorted(rows, key=lambda r: r["id"]) == [
+        {"id": "O'Brien", "name": "Alice"},
+        {"id": "normal", "name": "Bob"},
+    ]
+
+    # Delete the row with the problematic PK via _execute_deletes
+    table_schema = lancedb.TableSchema(
+        columns={
+            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
+            "name": lancedb.ColumnDef(type=pa.string()),
+        },
+        primary_key=["id"],
+    )
+    table = await conn.open_table(table_name)
+    handler = _target._RowHandler(
+        conn=conn,
+        table_name=table_name,
+        table_schema=table_schema,
+        num_transactions_before_optimize=50,
+    )
+    await handler._execute_deletes(
+        table,
+        [
+            _target._RowAction(key=("O'Brien",), value=None),
+        ],
+    )
+
+    # Verify only the quoted-PK row was deleted
+    rows = await _read_rows(conn, table_name)
+    assert rows == [{"id": "normal", "name": "Bob"}]


### PR DESCRIPTION
## Summary

Fix a SQL injection vulnerability in the LanceDB connector's delete path. String primary-key values containing single quotes (e.g. `"O'Brien"`) were interpolated directly into DataFusion SQL filter predicates without escaping, producing malformed SQL or enabling injection.

## Root Cause

In `_RowHandler._execute_deletes`, string PK values are embedded into a SQL filter string via f-string interpolation:

```python
conditions.append(f"{pk_col} = '{pk_value}'")
```

When `pk_value` contains a single quote, the resulting predicate is broken. For example, the PK `"O'Brien"` produces `id = 'O'Brien'` — invalid SQL. A crafted value like `"x' OR 1=1 --"` would delete every row in the table.

LanceDB's `table.delete(filter)` API accepts raw SQL and has no parameterized variant ([lancedb#1368](https://github.com/lancedb/lancedb/issues/1368)), so escaping is the only defense.

## Fix

Add a 4-line private helper that doubles single quotes per the standard SQL / DataFusion string literal convention:

```python
def _escape_sql_string(value: str) -> str:
    """Escape a string for safe embedding in a DataFusion SQL string literal."""
    return value.replace("'", "''")
```

Applied only in the string branch of `_execute_deletes`. No changes to non-string type handling (int, float, bool, etc.).

## Tests

- **`test_escape_sql_string_doubles_single_quotes`** — Unit test verifying the helper on normal strings, quotes, empty strings, and backslashes.
- **`test_execute_deletes_escapes_string_pk`** — Unit test with a mock table that captures the filter string, asserting `"O'Brien"` produces `id = 'O''Brien'`.
- **`test_execute_deletes_with_real_lancedb`** — Integration test that inserts a row with PK `"O'Brien"` into a real LanceDB table, deletes it via `_execute_deletes`, and verifies the row is removed while other rows remain.
