### PR TITLE
feat(rust-sdk): qdrant/lancedb/turbopuffer resolve connection at apply (HostCtx)

### DIFF
--- a/examples/rust/code_embedding_lancedb/src/main.rs
+++ b/examples/rust/code_embedding_lancedb/src/main.rs
@@ -108,7 +108,7 @@ fn is_excluded(key: &str) -> bool {
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
-    let table = lancedb::mount_table_target(&ctx, db, TABLE, code_embedding_schema()?).await?;
+    let table = lancedb::mount_table_target(&ctx, &DB, TABLE, code_embedding_schema()?).await?;
 
     let files: Vec<(String, FileEntry)> = walk_items(&sourcedir, INCLUDE_PATTERNS)?
         .into_iter()

--- a/examples/rust/image_search/src/main.rs
+++ b/examples/rust/image_search/src/main.rs
@@ -81,7 +81,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let conn = ctx.get_key(&DB)?;
     let target = qdrant::mount_collection_target(
         &ctx,
-        conn,
+        &DB,
         COLLECTION,
         CollectionSchema::new(EMBED_DIM, Distance::Cosine),
     )

--- a/examples/rust/image_search_colpali/src/main.rs
+++ b/examples/rust/image_search_colpali/src/main.rs
@@ -134,7 +134,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let conn = ctx.get_key(&DB)?;
     let target = qdrant::mount_collection_target(
         &ctx,
-        conn,
+        &DB,
         COLLECTION,
         CollectionSchema::multivector(EMBED_DIM, Distance::Cosine),
     )

--- a/examples/rust/text_embedding_lancedb/src/main.rs
+++ b/examples/rust/text_embedding_lancedb/src/main.rs
@@ -102,7 +102,7 @@ fn doc_embedding_schema() -> Result<TableSchema> {
 
 async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let db = ctx.get_key(&DB)?;
-    let table = lancedb::mount_table_target(&ctx, db, TABLE, doc_embedding_schema()?).await?;
+    let table = lancedb::mount_table_target(&ctx, &DB, TABLE, doc_embedding_schema()?).await?;
 
     let files = walk_items(&sourcedir, &["**/*.md"])?;
     println!(

--- a/examples/rust/text_embedding_qdrant/src/main.rs
+++ b/examples/rust/text_embedding_qdrant/src/main.rs
@@ -93,7 +93,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf) -> Result<()> {
     let conn = ctx.get_key(&DB)?;
     let target = qdrant::mount_collection_target(
         &ctx,
-        conn,
+        &DB,
         COLLECTION,
         CollectionSchema::new(EMBED_DIM, Distance::Cosine),
     )

--- a/examples/rust/text_embedding_turbopuffer/src/main.rs
+++ b/examples/rust/text_embedding_turbopuffer/src/main.rs
@@ -95,7 +95,7 @@ async fn app_main(ctx: Ctx, sourcedir: PathBuf, namespace: String) -> Result<()>
     let conn = ctx.get_key(&DB)?;
     let target = turbopuffer::mount_namespace_target(
         &ctx,
-        conn,
+        &DB,
         &namespace,
         NamespaceSchema::new(EMBED_DIM, DistanceMetric::CosineDistance),
     )

--- a/rust/sdk/cocoindex/src/lancedb.rs
+++ b/rust/sdk/cocoindex/src/lancedb.rs
@@ -25,7 +25,7 @@ use lancedb::table::NewColumnTransform;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::statediff::{
     CompositeTrackingRecord, DiffAction, ManagedBy, ManagedTargetOptions, MutualTrackingRecord,
@@ -199,7 +199,7 @@ pub struct LanceTableTarget {
 /// [`declare_target_state_with_child`]/[`mount_target`]. System-managed.
 pub fn table_target(
     ctx: &Ctx,
-    db: &LanceDatabase,
+    db: &ContextKey<LanceDatabase>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TargetState<TableSpec>> {
@@ -215,7 +215,7 @@ pub fn table_target(
 /// [`table_target`] with explicit [`ManagedTargetOptions`] (`managed_by`).
 pub fn table_target_with_options(
     ctx: &Ctx,
-    db: &LanceDatabase,
+    db: &ContextKey<LanceDatabase>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: ManagedTargetOptions,
@@ -223,8 +223,10 @@ pub fn table_target_with_options(
     let table_name = table_name.into();
     let provider = register_root_target_states_provider(
         ctx,
-        format!("cocoindex/lancedb/table/{}/{}", db.state_id(), table_name),
-        TableHandler { db: db.clone() },
+        format!("cocoindex/lancedb/table/{}/{}", db.name(), table_name),
+        TableHandler {
+            db_key: db.name().to_string(),
+        },
     )?;
     Ok(provider.target_state(
         "default",
@@ -244,7 +246,7 @@ pub fn table_target_with_options(
 /// table schema so destructive schema changes do not skip unchanged rows.
 pub fn declare_table_target(
     ctx: &Ctx,
-    db: &LanceDatabase,
+    db: &ContextKey<LanceDatabase>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<LanceTableTarget> {
@@ -263,12 +265,12 @@ pub fn declare_table_target(
         ctx,
         format!(
             "cocoindex/lancedb/row/{}/{}/{}",
-            db.state_id(),
+            db.name(),
             table_name,
             schema_fp
         ),
         RowHandler {
-            db: db.clone(),
+            db_key: db.name().to_string(),
             spec: spec.clone(),
         },
     )?;
@@ -285,7 +287,7 @@ pub fn declare_table_target(
 /// invalidate child rows.
 pub async fn mount_table_target(
     ctx: &Ctx,
-    db: &LanceDatabase,
+    db: &ContextKey<LanceDatabase>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<LanceTableTarget> {
@@ -302,7 +304,7 @@ pub async fn mount_table_target(
 /// [`mount_table_target`] with explicit [`ManagedTargetOptions`] (`managed_by`).
 pub async fn mount_table_target_with_options(
     ctx: &Ctx,
-    db: &LanceDatabase,
+    db: &ContextKey<LanceDatabase>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: ManagedTargetOptions,
@@ -395,8 +397,19 @@ fn table_tracking_record(
     )
 }
 
+/// Resolve the live LanceDB database from the host context by the connection's
+/// stable `db_key` (the ContextKey name), used at apply time.
+fn resolve_db(host_ctx: &Arc<ContextStore>, db_key: &str) -> Result<Arc<LanceDatabase>> {
+    host_ctx.resolve::<LanceDatabase>(db_key).ok_or_else(|| {
+        Error::engine(format!(
+            "lancedb target: database `{db_key}` was not provided in the environment \
+             (call Environment::builder().provide_key(&KEY, db))"
+        ))
+    })
+}
+
 struct TableHandler {
-    db: LanceDatabase,
+    db_key: String,
 }
 
 impl TargetHandler<TableSpec> for TableHandler {
@@ -470,11 +483,12 @@ impl TargetHandler<TableSpec> for TableHandler {
 
 impl TableHandler {
     fn table_sink(&self) -> TargetActionSink<TableAction> {
-        let db = self.db.clone();
-        TargetActionSink::from_async_fn_with_children(
-            move |actions: Vec<TargetAction<TableAction>>| {
-                let db = db.clone();
+        let db_key = self.db_key.clone();
+        TargetActionSink::from_async_fn_with_children_ctx(
+            move |host_ctx, actions: Vec<TargetAction<TableAction>>| {
+                let db_key = db_key.clone();
                 async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
                     let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                     for action in actions {
                         match action {
@@ -486,7 +500,7 @@ impl TableHandler {
                                     ensure_table(&db, &spec, a.recreate).await?;
                                 }
                                 out.push(Some(ChildTargetDef::new::<RowState, _>(RowHandler {
-                                    db: db.clone(),
+                                    db_key: db_key.clone(),
                                     spec,
                                 })));
                             }
@@ -604,7 +618,7 @@ struct RowAction {
 }
 
 struct RowHandler {
-    db: LanceDatabase,
+    db_key: String,
     spec: TableSpec,
 }
 
@@ -644,28 +658,31 @@ impl TargetHandler<RowState> for RowHandler {
 
 impl RowHandler {
     fn row_sink(&self) -> TargetActionSink<RowAction> {
-        let db = self.db.clone();
+        let db_key = self.db_key.clone();
         let spec = self.spec.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RowAction>>| {
-            let db = db.clone();
-            let spec = spec.clone();
-            async move {
-                let mut upserts: Vec<Map<String, JsonValue>> = Vec::new();
-                let mut deletes: Vec<Vec<JsonValue>> = Vec::new();
-                for action in actions {
-                    let row = match action {
-                        TargetAction::Create(r)
-                        | TargetAction::Update(r)
-                        | TargetAction::Delete(r) => r,
-                    };
-                    match row.state {
-                        Some(state) => upserts.push(state.fields),
-                        None => deletes.push(row.pk),
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<RowAction>>| {
+                let db_key = db_key.clone();
+                let spec = spec.clone();
+                async move {
+                    let db = resolve_db(&host_ctx, &db_key)?;
+                    let mut upserts: Vec<Map<String, JsonValue>> = Vec::new();
+                    let mut deletes: Vec<Vec<JsonValue>> = Vec::new();
+                    for action in actions {
+                        let row = match action {
+                            TargetAction::Create(r)
+                            | TargetAction::Update(r)
+                            | TargetAction::Delete(r) => r,
+                        };
+                        match row.state {
+                            Some(state) => upserts.push(state.fields),
+                            None => deletes.push(row.pk),
+                        }
                     }
+                    apply_rows(&db, &spec, upserts, deletes).await
                 }
-                apply_rows(&db, &spec, upserts, deletes).await
-            }
-        })
+            },
+        )
     }
 }
 

--- a/rust/sdk/cocoindex/src/qdrant.rs
+++ b/rust/sdk/cocoindex/src/qdrant.rs
@@ -23,7 +23,7 @@ use qdrant_client::qdrant::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::resources::schema::{
     MultiVectorSchema, MultiVectorSchemaProvider, VectorElementType, VectorSchema,
@@ -541,7 +541,7 @@ pub struct CollectionTarget {
 /// changing the vector schema recreates the collection.
 pub async fn mount_collection_target(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
 ) -> Result<CollectionTarget> {
@@ -557,7 +557,7 @@ pub async fn mount_collection_target(
 
 pub async fn mount_collection_target_with_options(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
     options: ManagedTargetOptions,
@@ -580,7 +580,7 @@ pub async fn mount_collection_target_with_options(
 /// or use [`declare_collection_target`]/[`mount_collection_target`].
 pub fn collection_target(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
 ) -> Result<TargetState<CollectionSpec>> {
@@ -596,7 +596,7 @@ pub fn collection_target(
 /// [`collection_target`] with explicit [`ManagedTargetOptions`].
 pub fn collection_target_with_options(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
     options: ManagedTargetOptions,
@@ -606,10 +606,10 @@ pub fn collection_target_with_options(
         ctx,
         format!(
             "cocoindex/qdrant/collection/{}/{}",
-            conn.state_id(),
+            conn.name(),
             collection_name
         ),
-        CollectionHandler::new(conn.client.clone()),
+        CollectionHandler::new(conn.name().to_string()),
     )?;
     Ok(provider.target_state(
         "default",
@@ -627,7 +627,7 @@ pub fn collection_target_with_options(
 /// immediately.
 pub fn declare_collection_target(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
 ) -> Result<CollectionTarget> {
@@ -643,7 +643,7 @@ pub fn declare_collection_target(
 /// [`declare_collection_target`] with explicit [`ManagedTargetOptions`].
 pub fn declare_collection_target_with_options(
     ctx: &Ctx,
-    conn: &QdrantConnection,
+    conn: &ContextKey<QdrantConnection>,
     collection_name: impl Into<String>,
     schema: CollectionSchema,
     options: ManagedTargetOptions,
@@ -757,14 +757,28 @@ struct CollectionAction {
     managed_by: ManagedBy,
 }
 
+/// Resolve the live Qdrant client from the host context by the connection's
+/// stable `db_key` (the ContextKey name), used at apply time.
+fn resolve_client(host_ctx: &Arc<ContextStore>, conn_key: &str) -> Result<Arc<Qdrant>> {
+    host_ctx
+        .resolve::<QdrantConnection>(conn_key)
+        .map(|conn| conn.client.clone())
+        .ok_or_else(|| {
+            Error::engine(format!(
+                "qdrant target: connection `{conn_key}` was not provided in the environment \
+                 (call Environment::builder().provide_key(&KEY, conn))"
+            ))
+        })
+}
+
 struct CollectionHandler {
     sink: TargetActionSink<CollectionAction>,
 }
 
 impl CollectionHandler {
-    fn new(client: Arc<Qdrant>) -> Self {
+    fn new(conn_key: String) -> Self {
         Self {
-            sink: collection_sink(client),
+            sink: collection_sink(conn_key),
         }
     }
 }
@@ -841,18 +855,19 @@ impl TargetHandler<CollectionSpec> for CollectionHandler {
     }
 }
 
-fn collection_sink(client: Arc<Qdrant>) -> TargetActionSink<CollectionAction> {
-    TargetActionSink::from_async_fn_with_children(
-        move |actions: Vec<TargetAction<CollectionAction>>| {
-            let client = client.clone();
+fn collection_sink(conn_key: String) -> TargetActionSink<CollectionAction> {
+    TargetActionSink::from_async_fn_with_children_ctx(
+        move |host_ctx, actions: Vec<TargetAction<CollectionAction>>| {
+            let conn_key = conn_key.clone();
             async move {
+                let client = resolve_client(&host_ctx, &conn_key)?;
                 let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                 for action in actions {
                     match action {
                         TargetAction::Create(a) | TargetAction::Update(a) => {
                             ensure_collection(&client, &a).await?;
                             out.push(Some(ChildTargetDef::new::<Point, _>(PointHandler::new(
-                                client.clone(),
+                                conn_key.clone(),
                                 a.name,
                                 a.schema,
                             ))));
@@ -922,9 +937,9 @@ struct PointHandler {
 }
 
 impl PointHandler {
-    fn new(client: Arc<Qdrant>, collection_name: String, schema: CollectionSchema) -> Self {
+    fn new(conn_key: String, collection_name: String, schema: CollectionSchema) -> Self {
         Self {
-            sink: point_sink(client, collection_name, schema),
+            sink: point_sink(conn_key, collection_name, schema),
         }
     }
 }
@@ -1000,49 +1015,52 @@ fn point_fingerprint(point: &Point) -> String {
 }
 
 fn point_sink(
-    client: Arc<Qdrant>,
+    conn_key: String,
     collection_name: String,
     schema: CollectionSchema,
 ) -> TargetActionSink<PointAction> {
-    TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<PointAction>>| {
-        let client = client.clone();
-        let collection_name = collection_name.clone();
-        let schema = schema.clone();
-        async move {
-            let mut upserts: Vec<PointStruct> = Vec::new();
-            let mut deletes: Vec<qdrant_client::qdrant::PointId> = Vec::new();
-            for action in actions {
-                match action {
-                    TargetAction::Create(a) | TargetAction::Update(a) => {
-                        if let Some(point) = a.point {
-                            let id = point.id.to_qdrant();
-                            let vectors = point.to_qdrant_vectors(&schema)?;
-                            let payload: Payload = point.payload.into();
-                            let struct_ = PointStruct::new(id, vectors, payload);
-                            upserts.push(struct_);
+    TargetActionSink::from_async_fn_with_ctx(
+        move |host_ctx, actions: Vec<TargetAction<PointAction>>| {
+            let conn_key = conn_key.clone();
+            let collection_name = collection_name.clone();
+            let schema = schema.clone();
+            async move {
+                let client = resolve_client(&host_ctx, &conn_key)?;
+                let mut upserts: Vec<PointStruct> = Vec::new();
+                let mut deletes: Vec<qdrant_client::qdrant::PointId> = Vec::new();
+                for action in actions {
+                    match action {
+                        TargetAction::Create(a) | TargetAction::Update(a) => {
+                            if let Some(point) = a.point {
+                                let id = point.id.to_qdrant();
+                                let vectors = point.to_qdrant_vectors(&schema)?;
+                                let payload: Payload = point.payload.into();
+                                let struct_ = PointStruct::new(id, vectors, payload);
+                                upserts.push(struct_);
+                            }
                         }
+                        TargetAction::Delete(a) => deletes.push(a.id.to_qdrant()),
                     }
-                    TargetAction::Delete(a) => deletes.push(a.id.to_qdrant()),
                 }
+                if !upserts.is_empty() {
+                    client
+                        .upsert_points(UpsertPointsBuilder::new(collection_name.clone(), upserts))
+                        .await
+                        .map_err(|e| Error::engine(format!("qdrant upsert_points: {e}")))?;
+                }
+                if !deletes.is_empty() {
+                    client
+                        .delete_points(
+                            DeletePointsBuilder::new(collection_name.clone())
+                                .points(PointsIdsList { ids: deletes }),
+                        )
+                        .await
+                        .map_err(|e| Error::engine(format!("qdrant delete_points: {e}")))?;
+                }
+                Ok(())
             }
-            if !upserts.is_empty() {
-                client
-                    .upsert_points(UpsertPointsBuilder::new(collection_name.clone(), upserts))
-                    .await
-                    .map_err(|e| Error::engine(format!("qdrant upsert_points: {e}")))?;
-            }
-            if !deletes.is_empty() {
-                client
-                    .delete_points(
-                        DeletePointsBuilder::new(collection_name.clone())
-                            .points(PointsIdsList { ids: deletes }),
-                    )
-                    .await
-                    .map_err(|e| Error::engine(format!("qdrant delete_points: {e}")))?;
-            }
-            Ok(())
-        }
-    })
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/sdk/cocoindex/src/turbopuffer.rs
+++ b/rust/sdk/cocoindex/src/turbopuffer.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue, json};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::resources::schema::{VectorElementType, VectorSchema, VectorSchemaProvider};
 use crate::statediff::{
@@ -428,7 +428,7 @@ pub struct NamespaceTarget {
 /// orphaned rows are deleted; changing the vector schema clears the namespace.
 pub async fn mount_namespace_target(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
 ) -> Result<NamespaceTarget> {
@@ -444,7 +444,7 @@ pub async fn mount_namespace_target(
 
 pub async fn mount_namespace_target_with_options(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
     options: ManagedTargetOptions,
@@ -467,7 +467,7 @@ pub async fn mount_namespace_target_with_options(
 /// or use [`declare_namespace_target`]/[`mount_namespace_target`].
 pub fn namespace_target(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
 ) -> Result<TargetState<NamespaceSpec>> {
@@ -483,7 +483,7 @@ pub fn namespace_target(
 /// [`namespace_target`] with explicit [`ManagedTargetOptions`].
 pub fn namespace_target_with_options(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
     options: ManagedTargetOptions,
@@ -494,10 +494,10 @@ pub fn namespace_target_with_options(
         ctx,
         format!(
             "cocoindex/turbopuffer/namespace/{}/{}",
-            conn.state_id(),
+            conn.name(),
             namespace
         ),
-        NamespaceHandler::new(conn.clone()),
+        NamespaceHandler::new(conn.name().to_string()),
     )?;
     Ok(provider.target_state(
         "default",
@@ -515,7 +515,7 @@ pub fn namespace_target_with_options(
 /// immediately.
 pub fn declare_namespace_target(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
 ) -> Result<NamespaceTarget> {
@@ -531,7 +531,7 @@ pub fn declare_namespace_target(
 /// [`declare_namespace_target`] with explicit [`ManagedTargetOptions`].
 pub fn declare_namespace_target_with_options(
     ctx: &Ctx,
-    conn: &TurbopufferConnection,
+    conn: &ContextKey<TurbopufferConnection>,
     namespace: impl Into<String>,
     schema: NamespaceSchema,
     options: ManagedTargetOptions,
@@ -634,14 +634,30 @@ struct NamespaceAction {
     managed_by: ManagedBy,
 }
 
+/// Resolve the live Turbopuffer connection from the host context by its stable
+/// `db_key` (the ContextKey name), used at apply time.
+fn resolve_conn(
+    host_ctx: &Arc<ContextStore>,
+    conn_key: &str,
+) -> Result<Arc<TurbopufferConnection>> {
+    host_ctx
+        .resolve::<TurbopufferConnection>(conn_key)
+        .ok_or_else(|| {
+            Error::engine(format!(
+                "turbopuffer target: connection `{conn_key}` was not provided in the environment \
+                 (call Environment::builder().provide_key(&KEY, conn))"
+            ))
+        })
+}
+
 struct NamespaceHandler {
     sink: TargetActionSink<NamespaceAction>,
 }
 
 impl NamespaceHandler {
-    fn new(conn: TurbopufferConnection) -> Self {
+    fn new(conn_key: String) -> Self {
         Self {
-            sink: namespace_sink(conn),
+            sink: namespace_sink(conn_key),
         }
     }
 }
@@ -715,11 +731,12 @@ impl TargetHandler<NamespaceSpec> for NamespaceHandler {
     }
 }
 
-fn namespace_sink(conn: TurbopufferConnection) -> TargetActionSink<NamespaceAction> {
-    TargetActionSink::from_async_fn_with_children(
-        move |actions: Vec<TargetAction<NamespaceAction>>| {
-            let conn = conn.clone();
+fn namespace_sink(conn_key: String) -> TargetActionSink<NamespaceAction> {
+    TargetActionSink::from_async_fn_with_children_ctx(
+        move |host_ctx, actions: Vec<TargetAction<NamespaceAction>>| {
+            let conn_key = conn_key.clone();
             async move {
+                let conn = resolve_conn(&host_ctx, &conn_key)?;
                 let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                 for action in actions {
                     match action {
@@ -730,7 +747,7 @@ fn namespace_sink(conn: TurbopufferConnection) -> TargetActionSink<NamespaceActi
                                 conn.delete_namespace(&a.namespace).await?;
                             }
                             out.push(Some(ChildTargetDef::new::<Row, _>(RowHandler::new(
-                                conn.clone(),
+                                conn_key.clone(),
                                 a.namespace,
                                 a.schema,
                             ))));
@@ -764,9 +781,9 @@ struct RowHandler {
 }
 
 impl RowHandler {
-    fn new(conn: TurbopufferConnection, namespace: String, schema: NamespaceSchema) -> Self {
+    fn new(conn_key: String, namespace: String, schema: NamespaceSchema) -> Self {
         Self {
-            sink: row_sink(conn, namespace, schema),
+            sink: row_sink(conn_key, namespace, schema),
         }
     }
 }
@@ -830,45 +847,48 @@ fn row_fingerprint(row: &Row) -> String {
 }
 
 fn row_sink(
-    conn: TurbopufferConnection,
+    conn_key: String,
     namespace: String,
     schema: NamespaceSchema,
 ) -> TargetActionSink<RowAction> {
-    TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RowAction>>| {
-        let conn = conn.clone();
-        let namespace = namespace.clone();
-        let schema = schema.clone();
-        async move {
-            let mut upserts: Vec<JsonValue> = Vec::new();
-            let mut deletes: Vec<JsonValue> = Vec::new();
-            for action in actions {
-                match action {
-                    TargetAction::Create(a) | TargetAction::Update(a) => {
-                        if let Some(row) = a.row {
-                            upserts.push(row.to_upsert(&schema)?);
+    TargetActionSink::from_async_fn_with_ctx(
+        move |host_ctx, actions: Vec<TargetAction<RowAction>>| {
+            let conn_key = conn_key.clone();
+            let namespace = namespace.clone();
+            let schema = schema.clone();
+            async move {
+                let conn = resolve_conn(&host_ctx, &conn_key)?;
+                let mut upserts: Vec<JsonValue> = Vec::new();
+                let mut deletes: Vec<JsonValue> = Vec::new();
+                for action in actions {
+                    match action {
+                        TargetAction::Create(a) | TargetAction::Update(a) => {
+                            if let Some(row) = a.row {
+                                upserts.push(row.to_upsert(&schema)?);
+                            }
                         }
+                        TargetAction::Delete(a) => deletes.push(JsonValue::from(a.id)),
                     }
-                    TargetAction::Delete(a) => deletes.push(JsonValue::from(a.id)),
                 }
+                if upserts.is_empty() && deletes.is_empty() {
+                    return Ok(());
+                }
+                let mut body = Map::new();
+                body.insert(
+                    "distance_metric".into(),
+                    JsonValue::from(schema.distance.as_str()),
+                );
+                body.insert("schema".into(), schema.write_schema()?);
+                if !upserts.is_empty() {
+                    body.insert("upsert_rows".into(), JsonValue::Array(upserts));
+                }
+                if !deletes.is_empty() {
+                    body.insert("deletes".into(), JsonValue::Array(deletes));
+                }
+                conn.write(&namespace, JsonValue::Object(body)).await
             }
-            if upserts.is_empty() && deletes.is_empty() {
-                return Ok(());
-            }
-            let mut body = Map::new();
-            body.insert(
-                "distance_metric".into(),
-                JsonValue::from(schema.distance.as_str()),
-            );
-            body.insert("schema".into(), schema.write_schema()?);
-            if !upserts.is_empty() {
-                body.insert("upsert_rows".into(), JsonValue::Array(upserts));
-            }
-            if !deletes.is_empty() {
-                body.insert("deletes".into(), JsonValue::Array(deletes));
-            }
-            conn.write(&namespace, JsonValue::Object(body)).await
-        }
-    })
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/sdk/cocoindex/tests/lancedb_target.rs
+++ b/rust/sdk/cocoindex/tests/lancedb_target.rs
@@ -9,7 +9,7 @@
 #![cfg(feature = "lancedb")]
 
 use cocoindex::lancedb::{self, ColumnDef, ColumnType, LanceDatabase, TableSchema};
-use cocoindex::{App, ContextKey, Environment, ManagedTargetOptions, Result};
+use cocoindex::{ContextKey, Environment, ManagedTargetOptions, Result};
 use serde::Serialize;
 use std::sync::LazyLock;
 
@@ -131,8 +131,7 @@ async fn lancedb_target_creates_upserts_searches_and_reconciles() -> Result<()> 
             app.run(move |ctx| {
                 let rows = rows.clone();
                 async move {
-                    let db = ctx.get_key(&DB)?;
-                    let table = lancedb::mount_table_target(&ctx, db, TABLE, schema()).await?;
+                    let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema()).await?;
                     for row in &rows {
                         table.declare_row(&ctx, row)?;
                     }
@@ -222,8 +221,7 @@ async fn lancedb_target_creates_upserts_searches_and_reconciles() -> Result<()> 
     app.run(move |ctx| {
         let rows = rows_v2.clone();
         async move {
-            let db = ctx.get_key(&DB)?;
-            let table = lancedb::mount_table_target(&ctx, db, TABLE, schema_v2()).await?;
+            let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema_v2()).await?;
             for row in &rows {
                 table.declare_row(&ctx, row)?;
             }
@@ -271,8 +269,7 @@ async fn lancedb_replays_unchanged_rows_after_destructive_schema_change() -> Res
                 let rows = rows.clone();
                 let schema = schema.clone();
                 async move {
-                    let db = ctx.get_key(&DB)?;
-                    let table = lancedb::mount_table_target(&ctx, db, TABLE, schema).await?;
+                    let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema).await?;
                     for row in &rows {
                         table.declare_row(&ctx, row)?;
                     }
@@ -319,8 +316,7 @@ async fn lancedb_replaces_table_on_destructive_schema_change() -> Result<()> {
                 let rows = rows.clone();
                 let schema = schema.clone();
                 async move {
-                    let db = ctx.get_key(&DB)?;
-                    let table = lancedb::mount_table_target(&ctx, db, TABLE, schema).await?;
+                    let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema).await?;
                     for row in &rows {
                         table.declare_row(&ctx, row)?;
                     }
@@ -383,10 +379,9 @@ async fn lancedb_user_managed_target_does_not_create_table() -> Result<()> {
         .await?;
 
     app.run(move |ctx| async move {
-        let db = ctx.get_key(&DB)?;
         let _table = lancedb::mount_table_target_with_options(
             &ctx,
-            db,
+            &DB,
             TABLE,
             schema(),
             ManagedTargetOptions::user_managed(),
@@ -446,8 +441,7 @@ async fn lancedb_adds_vector_column_additively() -> Result<()> {
             .app("LanceAddVecTest")
             .await?;
         app.run(move |ctx| async move {
-            let db = ctx.get_key(&DB)?;
-            let table = lancedb::mount_table_target(&ctx, db, TABLE, schema()).await?;
+            let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema()).await?;
             table.declare_row(
                 &ctx,
                 &Row {
@@ -480,8 +474,7 @@ async fn lancedb_adds_vector_column_additively() -> Result<()> {
             .app("LanceAddVecTest")
             .await?;
         app.run(move |ctx| async move {
-            let db = ctx.get_key(&DB)?;
-            let table = lancedb::mount_table_target(&ctx, db, TABLE, schema_two_vec()).await?;
+            let table = lancedb::mount_table_target(&ctx, &DB, TABLE, schema_two_vec()).await?;
             table.declare_row(
                 &ctx,
                 &RowTwoVec {

--- a/rust/sdk/cocoindex/tests/qdrant_target.rs
+++ b/rust/sdk/cocoindex/tests/qdrant_target.rs
@@ -13,7 +13,7 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cocoindex::qdrant::{self, CollectionSchema, Distance, QdrantConnection};
-use cocoindex::{App, ContextKey, Environment, Result};
+use cocoindex::{ContextKey, Environment, Result};
 use serde_json::json;
 
 static DB: LazyLock<ContextKey<QdrantConnection>> = LazyLock::new(|| {
@@ -65,10 +65,9 @@ async fn qdrant_target_creates_upserts_searches_and_reconciles() -> Result<()> {
                 let collection = collection.clone();
                 let points = points.clone();
                 async move {
-                    let conn = ctx.get_key(&DB)?;
                     let target = qdrant::mount_collection_target(
                         &ctx,
-                        conn,
+                        &DB,
                         &collection,
                         CollectionSchema::new(size, Distance::Cosine),
                     )
@@ -193,10 +192,9 @@ async fn qdrant_target_supports_uuid_point_ids() -> Result<()> {
                 let collection = collection.clone();
                 let ids = ids.clone();
                 async move {
-                    let conn = ctx.get_key(&DB)?;
                     let target = qdrant::mount_collection_target(
                         &ctx,
-                        conn,
+                        &DB,
                         &collection,
                         CollectionSchema::new(3, Distance::Cosine),
                     )

--- a/rust/sdk/cocoindex/tests/turbopuffer_target.rs
+++ b/rust/sdk/cocoindex/tests/turbopuffer_target.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cocoindex::turbopuffer::{self, DistanceMetric, NamespaceSchema, TurbopufferConnection};
-use cocoindex::{App, ContextKey, Environment, Result};
+use cocoindex::{ContextKey, Environment, Result};
 use serde_json::json;
 
 static DB: LazyLock<ContextKey<TurbopufferConnection>> = LazyLock::new(|| {
@@ -62,10 +62,9 @@ async fn turbopuffer_target_upserts_searches_and_reconciles() -> Result<()> {
                 let namespace = namespace.clone();
                 let rows = rows.clone();
                 async move {
-                    let conn = ctx.get_key(&DB)?;
                     let target = turbopuffer::mount_namespace_target(
                         &ctx,
-                        conn,
+                        &DB,
                         &namespace,
                         NamespaceSchema::new(3, DistanceMetric::CosineDistance),
                     )


### PR DESCRIPTION
## Summary
Extends the HostCtx resolve-at-apply pattern (#2074) to the **vector-store target connectors**. Handlers store a stable `db_key` (the `ContextKey` name) and resolve the live client/db/connection from the environment's context store **at apply time** instead of capturing it at declare; declare APIs take `&ContextKey<Conn>`; provider keys use the ContextKey name.

- **qdrant** — `CollectionHandler`/`PointHandler` resolve `QdrantConnection` (use `.client`).
- **lancedb** — `TableHandler`/`RowHandler` resolve `LanceDatabase`.
- **turbopuffer** — `NamespaceHandler`/`RowHandler` resolve `TurbopufferConnection`.
- Examples (text_embedding_qdrant, image_search, image_search_colpali, text_embedding_lancedb, code_embedding_lancedb, text_embedding_turbopuffer): mount targets via `&DB`; the `vector_search` query path keeps the live connection.
- Migrated qdrant_target / lancedb_target / turbopuffer_target tests.

This is the first of two T7b PRs (vector connectors); doris + surrealdb + cypher_graph (neo4j/falkordb) follow.

## Test plan
- Compile-verified locally with `cargo build -p cocoindex --features qdrant,lancedb,turbopuffer` and `cargo test … --no-run` (protoc 34.1 installed); `text_embedding_qdrant` example compiles; `cargo fmt --check` clean.
- Live behavior (collections/tables/namespaces) is gated by CI `build-test` (feature compile) + `cargo-test-rust-externs` (examples); the live tests need running qdrant/lancedb/turbopuffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
