### PR TITLE
feat(rust-sdk): doris/surrealdb resolve connection at apply (HostCtx)

### DIFF
--- a/rust/sdk/cocoindex/src/doris.rs
+++ b/rust/sdk/cocoindex/src/doris.rs
@@ -31,7 +31,7 @@ use serde_json::{Map, Value as JsonValue};
 use sqlx::MySqlPool;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::sql_ident::validate_ident;
 use crate::statediff::{
@@ -468,7 +468,7 @@ pub struct TableTarget {
 /// indexes).
 pub fn table_target(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TargetState<TableSpec>> {
@@ -485,7 +485,7 @@ pub fn table_target(
 /// vector/inverted indexes).
 pub fn table_target_with_options(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: DorisTableOptions,
@@ -495,8 +495,10 @@ pub fn table_target_with_options(
     validate_indexes(&table_schema, &options)?;
     let provider = register_root_target_states_provider(
         ctx,
-        format!("cocoindex/doris/table/{}/{}", conn.state_id(), table_name),
-        TableHandler { conn: conn.clone() },
+        format!("cocoindex/doris/table/{}/{}", conn.name(), table_name),
+        TableHandler {
+            conn_key: conn.name().to_string(),
+        },
     )?;
     Ok(provider.target_state(
         "default",
@@ -514,7 +516,7 @@ pub fn table_target_with_options(
 /// provider resolves at this component's commit) and return a handle.
 pub fn declare_table_target(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TableTarget> {
@@ -530,7 +532,7 @@ pub fn declare_table_target(
 /// [`declare_table_target`] with explicit [`DorisTableOptions`].
 pub fn declare_table_target_with_options(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: DorisTableOptions,
@@ -545,7 +547,7 @@ pub fn declare_table_target_with_options(
 /// and return a handle.
 pub async fn mount_table_target(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
 ) -> Result<TableTarget> {
@@ -562,7 +564,7 @@ pub async fn mount_table_target(
 /// [`mount_table_target`] with explicit [`DorisTableOptions`].
 pub async fn mount_table_target_with_options(
     ctx: &Ctx,
-    conn: &DorisConnection,
+    conn: &ContextKey<DorisConnection>,
     table_name: impl Into<String>,
     table_schema: TableSchema,
     options: DorisTableOptions,
@@ -717,8 +719,21 @@ struct RowAction {
 // Table container handler (root) + sink yielding row children
 // ---------------------------------------------------------------------------
 
+/// Resolve the live Doris connection from the host context by its stable
+/// `db_key` (the ContextKey name), used at apply time.
+fn resolve_conn(host_ctx: &Arc<ContextStore>, conn_key: &str) -> Result<Arc<DorisConnection>> {
+    host_ctx
+        .resolve::<DorisConnection>(conn_key)
+        .ok_or_else(|| {
+            Error::engine(format!(
+                "doris target: connection `{conn_key}` was not provided in the environment \
+             (call Environment::builder().provide_key(&KEY, conn))"
+            ))
+        })
+}
+
 struct TableHandler {
-    conn: DorisConnection,
+    conn_key: String,
 }
 
 impl TargetHandler<TableSpec> for TableHandler {
@@ -800,11 +815,12 @@ impl TargetHandler<TableSpec> for TableHandler {
 
 impl TableHandler {
     fn table_sink(&self) -> TargetActionSink<TableAction> {
-        let conn = self.conn.clone();
-        TargetActionSink::from_async_fn_with_children(
-            move |actions: Vec<TargetAction<TableAction>>| {
-                let conn = conn.clone();
+        let conn_key = self.conn_key.clone();
+        TargetActionSink::from_async_fn_with_children_ctx(
+            move |host_ctx, actions: Vec<TargetAction<TableAction>>| {
+                let conn_key = conn_key.clone();
                 async move {
+                    let conn = resolve_conn(&host_ctx, &conn_key)?;
                     let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                     for action in actions {
                         let a = match action {
@@ -812,7 +828,7 @@ impl TableHandler {
                             | TargetAction::Update(a)
                             | TargetAction::Delete(a) => a,
                         };
-                        out.push(apply_table_action(&conn, a).await?);
+                        out.push(apply_table_action(&conn, &conn_key, a).await?);
                     }
                     Ok(out)
                 }
@@ -825,6 +841,7 @@ impl TableHandler {
 /// for a drop). Mirrors Python's `_apply_table_actions`.
 async fn apply_table_action(
     conn: &DorisConnection,
+    conn_key: &str,
     action: TableAction,
 ) -> Result<Option<ChildTargetDef>> {
     let TableAction {
@@ -863,7 +880,7 @@ async fn apply_table_action(
     }
 
     Ok(Some(ChildTargetDef::new::<RowState, _>(RowHandler {
-        conn: conn.clone(),
+        conn_key: conn_key.to_string(),
         spec,
     })))
 }
@@ -873,7 +890,7 @@ async fn apply_table_action(
 // ---------------------------------------------------------------------------
 
 struct RowHandler {
-    conn: DorisConnection,
+    conn_key: String,
     spec: TableSpec,
 }
 
@@ -916,24 +933,27 @@ impl TargetHandler<RowState> for RowHandler {
 
 impl RowHandler {
     fn row_sink(&self) -> TargetActionSink<RowAction> {
-        let conn = self.conn.clone();
+        let conn_key = self.conn_key.clone();
         let spec = self.spec.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RowAction>>| {
-            let conn = conn.clone();
-            let spec = spec.clone();
-            async move {
-                let mut mutations = Vec::with_capacity(actions.len());
-                for action in actions {
-                    let row = match action {
-                        TargetAction::Create(r)
-                        | TargetAction::Update(r)
-                        | TargetAction::Delete(r) => r,
-                    };
-                    mutations.push((row.pk, row.state));
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<RowAction>>| {
+                let conn_key = conn_key.clone();
+                let spec = spec.clone();
+                async move {
+                    let conn = resolve_conn(&host_ctx, &conn_key)?;
+                    let mut mutations = Vec::with_capacity(actions.len());
+                    for action in actions {
+                        let row = match action {
+                            TargetAction::Create(r)
+                            | TargetAction::Update(r)
+                            | TargetAction::Delete(r) => r,
+                        };
+                        mutations.push((row.pk, row.state));
+                    }
+                    apply_rows(&conn, &spec, mutations).await
                 }
-                apply_rows(&conn, &spec, mutations).await
-            }
-        })
+            },
+        )
     }
 }
 

--- a/rust/sdk/cocoindex/src/surrealdb.rs
+++ b/rust/sdk/cocoindex/src/surrealdb.rs
@@ -21,7 +21,7 @@ use surrealdb::engine::remote::ws::{Client, Ws};
 use surrealdb::opt::auth::Root;
 use surrealdb::types::RecordId;
 
-use crate::ctx::Ctx;
+use crate::ctx::{ContextKey, ContextStore, Ctx};
 use crate::error::{Error, Result};
 use crate::sql_ident::validate_ident;
 use crate::statediff::{
@@ -468,17 +468,21 @@ fn relation_handle(spec: TableSpec, records: TargetStateProvider<RecordState>) -
 // Spec constructors (the composable `TargetState<TableSpec>`)
 // ---------------------------------------------------------------------------
 
-fn table_target_state(ctx: &Ctx, graph: &Graph, spec: TableSpec) -> Result<TargetState<TableSpec>> {
+fn table_target_state(
+    ctx: &Ctx,
+    graph: &ContextKey<Graph>,
+    spec: TableSpec,
+) -> Result<TargetState<TableSpec>> {
     validate_ident(&spec.table_name, "table name")?;
     let provider = register_root_target_states_provider(
         ctx,
         format!(
             "cocoindex/surrealdb/table/{}/{}",
-            graph.state_id(),
+            graph.name(),
             spec.table_name
         ),
         TableHandler {
-            graph: graph.clone(),
+            graph_key: graph.name().to_string(),
         },
     )?;
     Ok(provider.target_state("default", spec))
@@ -489,7 +493,7 @@ fn table_target_state(ctx: &Ctx, graph: &Graph, spec: TableSpec) -> Result<Targe
 /// or the generic target-state helpers.
 pub fn table_target(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<TargetState<TableSpec>> {
     table_target_with_schema_and_options(
@@ -504,7 +508,7 @@ pub fn table_target(
 /// [`table_target`] with an explicit schema and [`ManagedTargetOptions`].
 pub fn table_target_with_schema_and_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     table_schema: Option<TableSchema>,
     options: ManagedTargetOptions,
@@ -520,7 +524,7 @@ pub fn table_target_with_schema_and_options(
 /// connect any of `from_tables` to any of `to_tables`.
 pub fn relation_target_many(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -540,7 +544,7 @@ pub fn relation_target_many(
 /// [`relation_target_many`] with explicit [`ManagedTargetOptions`].
 pub fn relation_target_many_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -582,7 +586,7 @@ pub fn relation_target_many_with_options(
 /// table (no fixed `from`/`to` tables).
 pub fn relation_target_unconstrained(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<TargetState<TableSpec>> {
     relation_target_unconstrained_with_options(
@@ -596,7 +600,7 @@ pub fn relation_target_unconstrained(
 /// [`relation_target_unconstrained`] with explicit [`ManagedTargetOptions`].
 pub fn relation_target_unconstrained_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     options: ManagedTargetOptions,
 ) -> Result<TargetState<TableSpec>> {
@@ -623,7 +627,7 @@ pub fn relation_target_unconstrained_with_options(
 /// immediately.
 pub fn declare_table_target(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<TableTarget> {
     declare_table_target_with_schema_and_options(
@@ -638,7 +642,7 @@ pub fn declare_table_target(
 /// [`declare_table_target`] with an explicit schema and [`ManagedTargetOptions`].
 pub fn declare_table_target_with_schema_and_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     table_schema: Option<TableSchema>,
     options: ManagedTargetOptions,
@@ -655,7 +659,7 @@ pub fn declare_table_target_with_schema_and_options(
 /// be declared immediately.
 pub fn declare_relation_target_many(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -675,7 +679,7 @@ pub fn declare_relation_target_many(
 /// [`declare_relation_target_many`] with explicit [`ManagedTargetOptions`].
 pub fn declare_relation_target_many_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -699,7 +703,7 @@ pub fn declare_relation_target_many_with_options(
 /// Declare an unconstrained SurrealDB relation target in the current component.
 pub fn declare_relation_target_unconstrained(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<RelationTarget> {
     declare_relation_target_unconstrained_with_options(
@@ -713,7 +717,7 @@ pub fn declare_relation_target_unconstrained(
 /// [`declare_relation_target_unconstrained`] with explicit [`ManagedTargetOptions`].
 pub fn declare_relation_target_unconstrained_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     options: ManagedTargetOptions,
 ) -> Result<RelationTarget> {
@@ -729,7 +733,7 @@ pub fn declare_relation_target_unconstrained_with_options(
 
 pub async fn mount_table_target(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<TableTarget> {
     mount_table_target_with_schema_and_options(
@@ -744,7 +748,7 @@ pub async fn mount_table_target(
 
 pub async fn mount_table_target_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     options: ManagedTargetOptions,
 ) -> Result<TableTarget> {
@@ -753,7 +757,7 @@ pub async fn mount_table_target_with_options(
 
 pub async fn mount_table_target_with_schema(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     table_schema: Option<TableSchema>,
 ) -> Result<TableTarget> {
@@ -769,7 +773,7 @@ pub async fn mount_table_target_with_schema(
 
 pub async fn mount_table_target_with_schema_and_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     table_schema: Option<TableSchema>,
     options: ManagedTargetOptions,
@@ -783,7 +787,7 @@ pub async fn mount_table_target_with_schema_and_options(
 
 pub async fn mount_relation_target(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_table: &TableTarget,
     to_table: &TableTarget,
@@ -802,7 +806,7 @@ pub async fn mount_relation_target(
 
 pub async fn mount_relation_target_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_table: &TableTarget,
     to_table: &TableTarget,
@@ -822,7 +826,7 @@ pub async fn mount_relation_target_with_options(
 
 pub async fn mount_relation_target_many(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -842,7 +846,7 @@ pub async fn mount_relation_target_many(
 
 pub async fn mount_relation_target_many_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     from_tables: &[&TableTarget],
     to_tables: &[&TableTarget],
@@ -865,7 +869,7 @@ pub async fn mount_relation_target_many_with_options(
 
 pub async fn mount_relation_target_unconstrained(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
 ) -> Result<RelationTarget> {
     mount_relation_target_unconstrained_with_options(
@@ -879,7 +883,7 @@ pub async fn mount_relation_target_unconstrained(
 
 pub async fn mount_relation_target_unconstrained_with_options(
     ctx: &Ctx,
-    graph: &Graph,
+    graph: &ContextKey<Graph>,
     table_name: impl Into<String>,
     options: ManagedTargetOptions,
 ) -> Result<RelationTarget> {
@@ -1023,8 +1027,19 @@ struct RecordAction {
 // Table container handler (root) + sink yielding record children
 // ---------------------------------------------------------------------------
 
+/// Resolve the live SurrealDB graph connection from the host context by its
+/// stable `db_key` (the ContextKey name), used at apply time.
+fn resolve_graph(host_ctx: &Arc<ContextStore>, graph_key: &str) -> Result<Arc<Graph>> {
+    host_ctx.resolve::<Graph>(graph_key).ok_or_else(|| {
+        Error::engine(format!(
+            "surrealdb target: connection `{graph_key}` was not provided in the environment \
+             (call Environment::builder().provide_key(&KEY, graph))"
+        ))
+    })
+}
+
 struct TableHandler {
-    graph: Graph,
+    graph_key: String,
 }
 
 impl TargetHandler<TableSpec> for TableHandler {
@@ -1141,7 +1156,7 @@ impl TargetHandler<TableSpec> for TableHandler {
         Ok(vec![(
             "vector_index".to_string(),
             ChildTargetDef::new::<VectorIndexSpec, _>(VectorIndexHandler {
-                graph: self.graph.clone(),
+                graph_key: self.graph_key.clone(),
             }),
         )])
     }
@@ -1149,11 +1164,12 @@ impl TargetHandler<TableSpec> for TableHandler {
 
 impl TableHandler {
     fn table_sink(&self) -> TargetActionSink<TableAction> {
-        let graph = self.graph.clone();
-        TargetActionSink::from_async_fn_with_children(
-            move |actions: Vec<TargetAction<TableAction>>| {
-                let graph = graph.clone();
+        let graph_key = self.graph_key.clone();
+        TargetActionSink::from_async_fn_with_children_ctx(
+            move |host_ctx, actions: Vec<TargetAction<TableAction>>| {
+                let graph_key = graph_key.clone();
                 async move {
+                    let graph = resolve_graph(&host_ctx, &graph_key)?;
                     let mut out: Vec<Option<ChildTargetDef>> = Vec::with_capacity(actions.len());
                     for action in actions {
                         match action {
@@ -1179,7 +1195,7 @@ impl TableHandler {
                                 }
                                 out.push(Some(ChildTargetDef::new::<RecordState, _>(
                                     RecordHandler {
-                                        graph: graph.clone(),
+                                        graph_key: graph_key.clone(),
                                         spec,
                                     },
                                 )));
@@ -1204,7 +1220,7 @@ impl TableHandler {
 // ---------------------------------------------------------------------------
 
 struct RecordHandler {
-    graph: Graph,
+    graph_key: String,
     spec: TableSpec,
 }
 
@@ -1248,24 +1264,27 @@ impl TargetHandler<RecordState> for RecordHandler {
 
 impl RecordHandler {
     fn record_sink(&self) -> TargetActionSink<RecordAction> {
-        let graph = self.graph.clone();
+        let graph_key = self.graph_key.clone();
         let spec = self.spec.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<RecordAction>>| {
-            let graph = graph.clone();
-            let spec = spec.clone();
-            async move {
-                let mut mutations = Vec::with_capacity(actions.len());
-                for action in actions {
-                    let record = match action {
-                        TargetAction::Create(r)
-                        | TargetAction::Update(r)
-                        | TargetAction::Delete(r) => r,
-                    };
-                    mutations.push((record.record_id, record.state));
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<RecordAction>>| {
+                let graph_key = graph_key.clone();
+                let spec = spec.clone();
+                async move {
+                    let graph = resolve_graph(&host_ctx, &graph_key)?;
+                    let mut mutations = Vec::with_capacity(actions.len());
+                    for action in actions {
+                        let record = match action {
+                            TargetAction::Create(r)
+                            | TargetAction::Update(r)
+                            | TargetAction::Delete(r) => r,
+                        };
+                        mutations.push((record.record_id, record.state));
+                    }
+                    apply_records(&graph, &spec, mutations).await
                 }
-                apply_records(&graph, &spec, mutations).await
-            }
-        })
+            },
+        )
     }
 }
 
@@ -1297,7 +1316,7 @@ struct VectorIndexAction {
 }
 
 struct VectorIndexHandler {
-    graph: Graph,
+    graph_key: String,
 }
 
 impl TargetHandler<VectorIndexSpec> for VectorIndexHandler {
@@ -1348,21 +1367,24 @@ impl TargetHandler<VectorIndexSpec> for VectorIndexHandler {
 
 impl VectorIndexHandler {
     fn vector_index_sink(&self) -> TargetActionSink<VectorIndexAction> {
-        let graph = self.graph.clone();
-        TargetActionSink::from_async_fn(move |actions: Vec<TargetAction<VectorIndexAction>>| {
-            let graph = graph.clone();
-            async move {
-                for action in actions {
-                    let action = match action {
-                        TargetAction::Create(a)
-                        | TargetAction::Update(a)
-                        | TargetAction::Delete(a) => a,
-                    };
-                    apply_vector_index(&graph, action).await?;
+        let graph_key = self.graph_key.clone();
+        TargetActionSink::from_async_fn_with_ctx(
+            move |host_ctx, actions: Vec<TargetAction<VectorIndexAction>>| {
+                let graph_key = graph_key.clone();
+                async move {
+                    let graph = resolve_graph(&host_ctx, &graph_key)?;
+                    for action in actions {
+                        let action = match action {
+                            TargetAction::Create(a)
+                            | TargetAction::Update(a)
+                            | TargetAction::Delete(a) => a,
+                        };
+                        apply_vector_index(&graph, action).await?;
+                    }
+                    Ok(())
                 }
-                Ok(())
-            }
-        })
+            },
+        )
     }
 }
 

--- a/rust/sdk/cocoindex/tests/doris_target.rs
+++ b/rust/sdk/cocoindex/tests/doris_target.rs
@@ -17,14 +17,18 @@
 //! unit test rather than live here.
 #![cfg(feature = "doris")]
 
+use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cocoindex::doris::{
     self, ColumnDef, DorisConfig, DorisConnection, DorisTableOptions, InvertedIndexDef, TableSchema,
 };
-use cocoindex::{App, Result};
+use cocoindex::{ContextKey, Environment, Result};
 use serde::Serialize;
 use sqlx::Row;
+
+static DORIS_DB: LazyLock<ContextKey<DorisConnection>> =
+    LazyLock::new(|| ContextKey::new("doris_target_test_db"));
 
 #[derive(Serialize, Clone)]
 struct Item {
@@ -84,18 +88,19 @@ async fn declare(
     table: &str,
     rows: Vec<Item>,
 ) -> Result<()> {
-    let conn = conn.clone();
     let table = table.to_string();
-    let app = App::builder("DorisTargetTest")
+    let app = Environment::builder()
         .db_path(db_path)
+        .provide_key(&DORIS_DB, conn.clone())
         .build()
+        .await?
+        .app("DorisTargetTest")
         .await?;
     app.run(move |ctx| {
-        let conn = conn.clone();
         let table = table.clone();
         let rows = rows.clone();
         async move {
-            let target = doris::mount_table_target(&ctx, &conn, table, item_schema()).await?;
+            let target = doris::mount_table_target(&ctx, &DORIS_DB, table, item_schema()).await?;
             for row in &rows {
                 target.declare_row(&ctx, row)?;
             }
@@ -286,14 +291,18 @@ async fn doris_value_map_rows() -> Result<()> {
     let tmp = tempfile::tempdir().unwrap();
     let db = tmp.path().join("db");
 
-    let conn2 = conn.clone();
     let table2 = table.clone();
-    let app = App::builder("DorisMapRows").db_path(&db).build().await?;
+    let app = Environment::builder()
+        .db_path(&db)
+        .provide_key(&DORIS_DB, conn.clone())
+        .build()
+        .await?
+        .app("DorisMapRows")
+        .await?;
     app.run(move |ctx| {
-        let conn = conn2.clone();
         let table = table2.clone();
         async move {
-            let target = doris::mount_table_target(&ctx, &conn, table, item_schema()).await?;
+            let target = doris::mount_table_target(&ctx, &DORIS_DB, table, item_schema()).await?;
             target.declare_row(
                 &ctx,
                 &serde_json::json!({"id": "1", "name": "Zoe", "value": 7}),
@@ -368,20 +377,22 @@ async fn doris_inverted_index_table() -> Result<()> {
         ..Default::default()
     };
 
-    let conn2 = conn.clone();
     let table2 = table.clone();
-    let app = App::builder("DorisInvertedIndex")
+    let app = Environment::builder()
         .db_path(&db)
+        .provide_key(&DORIS_DB, conn.clone())
         .build()
+        .await?
+        .app("DorisInvertedIndex")
         .await?;
     app.run(move |ctx| {
-        let conn = conn2.clone();
         let table = table2.clone();
         let schema = schema.clone();
         let options = options.clone();
         async move {
             let target =
-                doris::mount_table_target_with_options(&ctx, &conn, table, schema, options).await?;
+                doris::mount_table_target_with_options(&ctx, &DORIS_DB, table, schema, options)
+                    .await?;
             target.declare_row(
                 &ctx,
                 &serde_json::json!({"id": "1", "content": "the quick brown fox"}),

--- a/rust/sdk/cocoindex/tests/schema_from_row.rs
+++ b/rust/sdk/cocoindex/tests/schema_from_row.rs
@@ -194,7 +194,7 @@ async fn sqlite_from_row_round_trips_a_row() -> cocoindex::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn doris_from_row_round_trips_a_row() -> cocoindex::Result<()> {
     use cocoindex::doris::{self, DorisConfig, DorisConnection, TableSchema};
-    use cocoindex::{App, SchemaFields};
+    use cocoindex::{ContextKey, Environment, SchemaFields};
     use sqlx::Row as _;
 
     let Ok(fe_host) = std::env::var("DORIS_FE_HOST") else {
@@ -244,19 +244,21 @@ async fn doris_from_row_round_trips_a_row() -> cocoindex::Result<()> {
     ];
 
     let tmp = tempfile::tempdir().unwrap();
-    let conn2 = conn.clone();
+    let conn_key = ContextKey::<DorisConnection>::new("doris_from_row_db");
     let table2 = table.clone();
-    let app = App::builder("DorisFromRow")
+    let app = Environment::builder()
         .db_path(tmp.path().join("db"))
+        .provide_key(&conn_key, conn.clone())
         .build()
+        .await?
+        .app("DorisFromRow")
         .await?;
     app.run(move |ctx| {
-        let conn = conn2.clone();
         let table = table2.clone();
         let rows = rows.clone();
         async move {
             let schema = TableSchema::from_row::<Doc>(["id"])?;
-            let target = doris::mount_table_target(&ctx, &conn, table, schema).await?;
+            let target = doris::mount_table_target(&ctx, &conn_key, table, schema).await?;
             for row in &rows {
                 target.declare_row(&ctx, row)?;
             }

--- a/rust/sdk/cocoindex/tests/surrealdb_target.rs
+++ b/rust/sdk/cocoindex/tests/surrealdb_target.rs
@@ -92,13 +92,12 @@ async fn surrealdb_targets_e2e_conversation_graph_write_when_available() {
 
 async fn run_graph(app: &App, people: &'static [&'static str]) {
     app.run(move |ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
         let person_schema = TableSchema::new([("name", ColumnDef::new("string"))])?;
         let person =
-            surrealdb::mount_table_target_with_schema(&ctx, graph, "person", Some(person_schema))
+            surrealdb::mount_table_target_with_schema(&ctx, &GRAPH, "person", Some(person_schema))
                 .await?;
         let knows =
-            surrealdb::mount_relation_target(&ctx, graph, "knows", &person, &person).await?;
+            surrealdb::mount_relation_target(&ctx, &GRAPH, "knows", &person, &person).await?;
 
         for name in people {
             person.declare_record(&ctx, *name, &serde_json::json!({ "name": name }))?;
@@ -114,7 +113,6 @@ async fn run_graph(app: &App, people: &'static [&'static str]) {
 
 async fn run_conversation_graph(app: &App, include_all_entities: bool) {
     app.run(move |ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
         let session_schema = TableSchema::new([
             ("youtube_id", ColumnDef::new("string")),
             ("name", ColumnDef::new("string")),
@@ -122,36 +120,40 @@ async fn run_conversation_graph(app: &App, include_all_entities: bool) {
         let statement_schema = TableSchema::new([("statement", ColumnDef::new("string"))])?;
         let entity_schema = TableSchema::new([("name", ColumnDef::new("string"))])?;
 
-        let session =
-            surrealdb::mount_table_target_with_schema(&ctx, graph, "session", Some(session_schema))
-                .await?;
+        let session = surrealdb::mount_table_target_with_schema(
+            &ctx,
+            &GRAPH,
+            "session",
+            Some(session_schema),
+        )
+        .await?;
         let statement = surrealdb::mount_table_target_with_schema(
             &ctx,
-            graph,
+            &GRAPH,
             "statement",
             Some(statement_schema),
         )
         .await?;
         let person = surrealdb::mount_table_target_with_schema(
             &ctx,
-            graph,
+            &GRAPH,
             "person",
             Some(entity_schema.clone()),
         )
         .await?;
         let tech = surrealdb::mount_table_target_with_schema(
             &ctx,
-            graph,
+            &GRAPH,
             "tech",
             Some(entity_schema.clone()),
         )
         .await?;
         let org =
-            surrealdb::mount_table_target_with_schema(&ctx, graph, "org", Some(entity_schema))
+            surrealdb::mount_table_target_with_schema(&ctx, &GRAPH, "org", Some(entity_schema))
                 .await?;
         let session_statement = surrealdb::mount_relation_target(
             &ctx,
-            graph,
+            &GRAPH,
             "session_statement",
             &session,
             &statement,
@@ -159,7 +161,7 @@ async fn run_conversation_graph(app: &App, include_all_entities: bool) {
         .await?;
         let statement_mentions = surrealdb::mount_relation_target_many(
             &ctx,
-            graph,
+            &GRAPH,
             "statement_mentions",
             &[&statement],
             &[&person, &tech, &org],
@@ -240,8 +242,7 @@ async fn surrealdb_declare_row_derives_id_from_row_when_available() {
     let (app, _dir) = temp_app(&graph, "surrealdb_declare_row").await;
 
     app.run(|ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
-        let people = surrealdb::mount_table_target(&ctx, graph, "human").await?;
+        let people = surrealdb::mount_table_target(&ctx, &GRAPH, "human").await?;
         // `declare_row` takes the record id from the row's own `id` field.
         people.declare_row(&ctx, &serde_json::json!({ "id": "alice", "age": 30 }))?;
         people.declare_row(&ctx, &serde_json::json!({ "id": "bob", "age": 41 }))?;
@@ -285,8 +286,7 @@ async fn surrealdb_vector_index_attachment_lifecycle_when_available() {
 
     async fn run(app: &App, metric: &'static str, declare_index: bool) {
         app.run(move |ctx| async move {
-            let graph = ctx.get_key(&GRAPH)?;
-            let docs = surrealdb::mount_table_target(&ctx, graph, "doc").await?;
+            let docs = surrealdb::mount_table_target(&ctx, &GRAPH, "doc").await?;
             if declare_index {
                 docs.declare_vector_index(
                     &ctx,
@@ -344,7 +344,6 @@ async fn surrealdb_schema_evolution_adds_field_when_available() {
 
     async fn run(app: &App, with_email: bool) {
         app.run(move |ctx| async move {
-            let graph = ctx.get_key(&GRAPH)?;
             let columns: Vec<(&str, ColumnDef)> = if with_email {
                 vec![
                     ("name", ColumnDef::new("string")),
@@ -355,7 +354,7 @@ async fn surrealdb_schema_evolution_adds_field_when_available() {
             };
             let schema = TableSchema::new(columns)?;
             let person =
-                surrealdb::mount_table_target_with_schema(&ctx, graph, "member", Some(schema))
+                surrealdb::mount_table_target_with_schema(&ctx, &GRAPH, "member", Some(schema))
                     .await?;
             if with_email {
                 person.declare_record(
@@ -404,8 +403,7 @@ async fn surrealdb_table_dropped_when_no_longer_declared_when_available() {
 
     // Declare the table + a record.
     app.run(|ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
-        let widget = surrealdb::mount_table_target(&ctx, graph, "widget").await?;
+        let widget = surrealdb::mount_table_target(&ctx, &GRAPH, "widget").await?;
         widget.declare_record(&ctx, "w1", &serde_json::json!({ "name": "gear" }))?;
         Ok(())
     })
@@ -424,8 +422,7 @@ async fn surrealdb_table_dropped_when_no_longer_declared_when_available() {
     // declared in the previous run is now orphaned, so the system-managed table
     // is dropped (`REMOVE TABLE`) and its rows go with it.
     app.run(|ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
-        let _ = surrealdb::table_target(&ctx, graph, "widget")?;
+        let _ = surrealdb::table_target(&ctx, &GRAPH, "widget")?;
         Ok(())
     })
     .await
@@ -457,13 +454,12 @@ async fn surrealdb_schema_evolution_drops_field_when_available() {
 
     // v1: name + email.
     app.run(|ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
         let schema = TableSchema::new(vec![
             ("name", ColumnDef::new("string")),
             ("email", ColumnDef::new("string")),
         ])?;
         let t =
-            surrealdb::mount_table_target_with_schema(&ctx, graph, "acct", Some(schema)).await?;
+            surrealdb::mount_table_target_with_schema(&ctx, &GRAPH, "acct", Some(schema)).await?;
         t.declare_record(
             &ctx,
             "p1",
@@ -483,10 +479,9 @@ async fn surrealdb_schema_evolution_drops_field_when_available() {
 
     // v2: drop the email field. The undeclared field must be REMOVEd.
     app.run(|ctx| async move {
-        let graph = ctx.get_key(&GRAPH)?;
         let schema = TableSchema::new(vec![("name", ColumnDef::new("string"))])?;
         let t =
-            surrealdb::mount_table_target_with_schema(&ctx, graph, "acct", Some(schema)).await?;
+            surrealdb::mount_table_target_with_schema(&ctx, &GRAPH, "acct", Some(schema)).await?;
         t.declare_record(&ctx, "p1", &serde_json::json!({ "name": "Ann" }))?;
         Ok(())
     })


### PR DESCRIPTION
## Summary
Continues the HostCtx resolve-at-apply migration (#2074, #2120) for the **doris** and **surrealdb** target connectors. Handlers store a stable `db_key` (the `ContextKey` name) and resolve the live connection from the environment's context store **at apply time**; declare APIs take `&ContextKey<Conn>`; provider keys use the ContextKey name.

- **doris** — `TableHandler`/`RowHandler` resolve `DorisConnection` (`apply_table_action` threads `conn_key` to the child `RowHandler`).
- **surrealdb** — `TableHandler`/`RecordHandler`/`VectorIndexHandler` resolve `Graph`.
- Tests: `doris_target` (now provides via a `DORIS_DB` ContextKey + `Environment`), `surrealdb_target` (mount via `&GRAPH`), and `schema_from_row`'s doris part.

cypher_graph (neo4j/falkordb) is generic over the Cypher executor (`C: CypherExecutor`) and needs a `PhantomData` treatment — it follows in a separate PR.

## Test plan
- Compile-verified locally: `cargo build -p cocoindex --features doris,surrealdb` and `cargo test … --no-run` (both green, no warnings).
- Live behavior needs running Doris/SurrealDB — gated by CI `build-test` (feature compile) and the live tests' env-var guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
