### PR TITLE
fix(lancedb): physically drop indices on declarative removal

### DIFF
--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -64,6 +64,12 @@ _RowValue = dict[str, Any]  # Column name -> value
 _RowFingerprint = bytes
 ValueEncoder = Callable[[Any], Any]
 
+# Prefix for physical LanceDB index names to avoid cross-type collisions
+# (vector_index and fts_index are separate CocoIndex attachment providers
+# sharing the same per-table LanceDB index namespace).
+_VECTOR_INDEX_NAME_PREFIX = "coco_idx_vector_"
+_FTS_INDEX_NAME_PREFIX = "coco_idx_fts_"
+
 
 class LanceType(NamedTuple):
     """
@@ -591,15 +597,12 @@ class _VectorIndexHandler:
     ) -> None:
         table = await self._conn.open_table(self._table_name)
         for action in actions:
+            physical_name = f"{_VECTOR_INDEX_NAME_PREFIX}{action.name}"
             if action.spec is None:
-                # LanceDB does not expose a first-class "drop index" API on AsyncTable;
-                # we silently skip — the index will cease to exist after the table is
-                # dropped/recreated by the table-level handler if the spec changes.
-                _logger.debug(
-                    "LanceDB vector index %s on table %s: no-op delete (not supported)",
-                    action.name,
-                    self._table_name,
-                )
+                try:
+                    await table.drop_index(physical_name)
+                except Exception:
+                    pass
             else:
                 spec = action.spec
                 if spec.index_type == "ivf_pq":
@@ -630,6 +633,7 @@ class _VectorIndexHandler:
                 await table.create_index(
                     spec.column,
                     config=index_config,
+                    name=physical_name,
                     replace=True,
                 )
 
@@ -702,12 +706,12 @@ class _FtsIndexHandler:
     ) -> None:
         table = await self._conn.open_table(self._table_name)
         for action in actions:
+            physical_name = f"{_FTS_INDEX_NAME_PREFIX}{action.name}"
             if action.spec is None:
-                _logger.debug(
-                    "LanceDB FTS index %s on table %s: no-op delete (not supported)",
-                    action.name,
-                    self._table_name,
-                )
+                try:
+                    await table.drop_index(physical_name)
+                except Exception:
+                    pass
             else:
                 spec = action.spec
                 fts_config = lancedb_index.FTS(
@@ -717,6 +721,7 @@ class _FtsIndexHandler:
                 await table.create_index(
                     spec.column,
                     config=fts_config,
+                    name=physical_name,
                     replace=True,
                 )
 

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -994,3 +994,161 @@ async def test_execute_deletes_with_real_lancedb(lancedb_dir: Path) -> None:
     # Verify only the quoted-PK row was deleted
     rows = await _read_rows(conn, table_name)
     assert rows == [{"id": "normal", "name": "Bob"}]
+
+
+# =============================================================================
+# Index lifecycle tests (create -> delete)
+# =============================================================================
+
+
+@requires_lancedb
+def test_physical_index_name_prefixes_avoid_collision() -> None:
+    """Physical LanceDB index names are namespaced by attachment type."""
+    assert _target._VECTOR_INDEX_NAME_PREFIX == "coco_idx_vector_"
+    assert _target._FTS_INDEX_NAME_PREFIX == "coco_idx_fts_"
+    # Same logical name produces different physical names
+    assert _target._VECTOR_INDEX_NAME_PREFIX + "text_col" != (
+        _target._FTS_INDEX_NAME_PREFIX + "text_col"
+    )
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_index_lifecycle_create_then_delete(lancedb_dir: Path) -> None:
+    """Creating a vector index then removing it leaves no physical index."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_vec_lifecycle"
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+
+    # Create
+    spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=2,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    create_action = _target._VectorIndexAction(name="embedding", spec=spec)
+    await handler._apply_actions(cast(Any, None), [create_action])
+    indices_after_create = await _list_indices(conn, table_name)
+    assert len(indices_after_create) >= 1, "Expected at least one index after create"
+
+    # Delete
+    delete_action = _target._VectorIndexAction(name="embedding", spec=None)
+    await handler._apply_actions(cast(Any, None), [delete_action])
+    indices_after_delete = await _list_indices(conn, table_name)
+    assert len(indices_after_delete) == 0, (
+        f"Expected no indices after delete, got: {indices_after_delete}"
+    )
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_lifecycle_create_then_delete(lancedb_dir: Path) -> None:
+    """Creating an FTS index then removing it leaves no physical index."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_lifecycle"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+
+    # Create
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    create_action = _target._FtsIndexAction(name="content", spec=spec)
+    await handler._apply_actions(cast(Any, None), [create_action])
+    indices_after_create = await _list_indices(conn, table_name)
+    assert len(indices_after_create) >= 1, "Expected at least one index after create"
+
+    # Delete
+    delete_action = _target._FtsIndexAction(name="content", spec=None)
+    await handler._apply_actions(cast(Any, None), [delete_action])
+    indices_after_delete = await _list_indices(conn, table_name)
+    assert len(indices_after_delete) == 0, (
+        f"Expected no indices after delete, got: {indices_after_delete}"
+    )
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_index_delete_no_error_if_absent(lancedb_dir: Path) -> None:
+    """Deleting a vector index that doesn't exist is a silent no-op (not an error)."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_vec_delete_absent"
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+    delete_action = _target._VectorIndexAction(name="nonexistent", spec=None)
+    # Should not raise
+    await handler._apply_actions(cast(Any, None), [delete_action])
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_delete_no_error_if_absent(lancedb_dir: Path) -> None:
+    """Deleting an FTS index that doesn't exist is a silent no-op (not an error)."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_delete_absent"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+    delete_action = _target._FtsIndexAction(name="nonexistent", spec=None)
+    # Should not raise
+    await handler._apply_actions(cast(Any, None), [delete_action])
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_and_fts_indices_coexist_with_same_logical_name(
+    lancedb_dir: Path,
+) -> None:
+    """A vector index and an FTS index with the same logical name don't collide
+    because they use different physical name prefixes."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_coexist"
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    vec_handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+    fts_handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+
+    vec_spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=2,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    fts_spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+
+    # Both use the same logical name "myindex"
+    await vec_handler._apply_actions(
+        cast(Any, None), [_target._VectorIndexAction(name="myindex", spec=vec_spec)]
+    )
+    await fts_handler._apply_actions(
+        cast(Any, None), [_target._FtsIndexAction(name="myindex", spec=fts_spec)]
+    )
+
+    indices = await _list_indices(conn, table_name)
+    index_names = [getattr(idx, "name", None) for idx in indices]
+    assert "coco_idx_vector_myindex" in index_names, (
+        f"Expected coco_idx_vector_myindex, got: {index_names}"
+    )
+    assert "coco_idx_fts_myindex" in index_names, (
+        f"Expected coco_idx_fts_myindex, got: {index_names}"
+    )
+    assert len(indices) == 2


### PR DESCRIPTION
## Summary

Completes the declarative lifecycle for LanceDB vector and FTS indices introduced in #2115.

Currently, removing a declared index from the target configuration produces a delete action during reconciliation, but both `_VectorIndexHandler` and `_FtsIndexHandler` treat index deletion as a no-op. As a result, indices persist indefinitely even after being removed from the desired state.

## Root Cause

The handlers were implemented under the assumption that LanceDB did not expose an index deletion API on `AsyncTable`.

However, `AsyncTable.drop_index()` and `create_index(..., name=...)` are available across the entire LanceDB version range supported by CocoIndex:

| Tag | `async def drop_index`? | `create_index(name=)`? |
|---|---|---|
| v0.24.1 | ✅ | ✅ |
| v0.25.0-beta.0 | ✅ | ✅ |
| v0.26.0 (effective floor) | ✅ | ✅ |
| v0.33.0 | ✅ | ✅ |

`pyproject.toml` pins `lancedb>=0.25.0`; since no `v0.25.0` stable tag exists, the constraint resolves to **v0.26.0** as the lowest satisfying release.

## Changes

- Assign explicit physical LanceDB index names when creating vector and FTS indices.
- Namespace physical index names by attachment type (`coco_idx_vector_` / `coco_idx_fts_`) to avoid cross-type collisions — `vector_index` and `fts_index` are separate CocoIndex attachment providers but share the same per-table LanceDB index namespace.
- Replace the existing deletion no-op with `drop_index(...)`, tolerating a missing index so reconciliation stays idempotent.
- Add lifecycle tests covering create → delete behavior for both vector and FTS indices, a coexistence test for same-named vector + FTS indices, and delete-on-absent tests.

## Behavior Change

Indices are now physically removed when their corresponding declarative definitions are removed from the target configuration, restoring the expected convergence behavior of the attachment system.

Physical LanceDB index names are now explicitly managed by CocoIndex (`coco_idx_vector_{name}` / `coco_idx_fts_{name}`) instead of relying on LanceDB-generated defaults (`{column}_idx`).

### Notes for reviewers

- No existing code or tests depend on the old auto-generated index names (tests use substring matching).
- No persisted tracking records, migrations, or LMDB keys reference physical LanceDB index names — the fingerprints are derived from the index specs (`column`, `metric`, `index_type`, ...), not the physical name.
- Per the `drop_index` docs, dropped indices are reclaimed from disk by a subsequent `table.optimize()`, which the connector already runs periodically.