### PR TITLE
docs(lancedb): fix callout syntax, document vector/FTS indexes, tighten prose

### DIFF
--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -12,14 +12,14 @@ The `lancedb` connector provides target state APIs for writing rows to LanceDB t
 from cocoindex.connectors import lancedb
 ```
 
-::::note Dependencies
+:::note[Dependencies]
 This connector requires additional dependencies. Install with:
 
 ```bash
 pip install cocoindex[lancedb]
 ```
 
-::::
+:::
 
 ## Connection setup
 

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -110,9 +110,9 @@ def TableTarget.declare_row(
 
 - `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
 
-#### Vector indexes (child states)
+#### Vector indexes (attachment)
 
-Declare a vector index on a vector column to accelerate similarity search. The index is created and kept in sync as part of the table's target state:
+Declare a vector index on a vector column to accelerate similarity search. Vector indexes are an [attachment](../advanced_topics/custom_target_connector#implementing-attachment-providers) to a `TableTarget`:
 
 ```python
 def TableTarget.declare_vector_index(
@@ -150,9 +150,9 @@ Parameters left as `None` fall back to LanceDB's defaults.
 table.declare_vector_index(column="embedding", metric="cosine")
 ```
 
-#### FTS indexes (child states)
+#### FTS indexes (attachment)
 
-Declare a full-text search (FTS) index on a text column to enable keyword and phrase search:
+Declare a full-text search (FTS) index on a text column to enable keyword and phrase search. Like vector indexes, FTS indexes are an [attachment](../advanced_topics/custom_target_connector#implementing-attachment-providers) to a `TableTarget`:
 
 ```python
 def TableTarget.declare_fts_index(

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -6,7 +6,7 @@ description: >
   Python classes, vector columns via VectorSchemaProvider, and both
   system-managed and user-managed table lifecycles.
 ---
-The `lancedb` connector provides target state APIs for writing rows to LanceDB tables.
+The `lancedb` connector provides utilities for writing rows to LanceDB tables, with automatic schema inference from Python classes and support for declaring vector and full-text search (FTS) indexes. CocoIndex manages the table lifecycle — creating, dropping, and evolving the schema — and keeps rows in sync via incremental upserts and deletions.
 
 ```python
 from cocoindex.connectors import lancedb
@@ -45,7 +45,7 @@ conn = await lancedb.connect_async("./lancedb_data")
 
 ## As target
 
-The `lancedb` connector provides target state APIs for writing rows to tables. With it, CocoIndex tracks what rows should exist and automatically handles upserts and deletions.
+The `lancedb` connector provides target state APIs for writing rows to tables. CocoIndex tracks what rows should exist and automatically handles upserts and deletions.
 
 ### Declaring target states
 
@@ -109,6 +109,78 @@ def TableTarget.declare_row(
 **Parameters:**
 
 - `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
+
+#### Vector indexes (child states)
+
+Declare a vector index on a vector column to accelerate similarity search. The index is created and kept in sync as part of the table's target state:
+
+```python
+def TableTarget.declare_vector_index(
+    self,
+    *,
+    name: str | None = None,
+    column: str,
+    metric: Literal["cosine", "l2", "dot"] = "cosine",
+    index_type: Literal["ivf_pq", "hnsw_pq"] = "ivf_pq",
+    num_partitions: int | None = None,
+    num_sub_vectors: int | None = None,
+    num_bits: int | None = None,
+    m: int | None = None,
+    ef_construction: int | None = None,
+) -> None
+```
+
+**Parameters:**
+
+- `name` — Logical index name (defaults to `column`).
+- `column` — Vector column to index.
+- `metric` — Distance metric: `"cosine"` (default), `"l2"`, or `"dot"`.
+- `index_type` — Index algorithm: `"ivf_pq"` (IVF-PQ, default) or `"hnsw_pq"` (HNSW-PQ).
+- `num_partitions` — *(IVF-PQ only)* Number of IVF partitions.
+- `num_sub_vectors` — *(IVF-PQ / HNSW-PQ)* Number of PQ sub-vectors.
+- `num_bits` — *(IVF-PQ / HNSW-PQ)* Number of bits per PQ code.
+- `m` — *(HNSW-PQ only)* Maximum number of HNSW edges per node.
+- `ef_construction` — *(HNSW-PQ only)* Size of the HNSW candidate list during build.
+
+Parameters left as `None` fall back to LanceDB's defaults.
+
+**Example:**
+
+```python
+table.declare_vector_index(column="embedding", metric="cosine")
+```
+
+#### FTS indexes (child states)
+
+Declare a full-text search (FTS) index on a text column to enable keyword and phrase search:
+
+```python
+def TableTarget.declare_fts_index(
+    self,
+    *,
+    name: str | None = None,
+    column: str,
+    language: str = "English",
+    with_position: bool = True,
+) -> None
+```
+
+**Parameters:**
+
+- `name` — Logical index name (defaults to `column`).
+- `column` — Text column to index.
+- `language` — Tokenizer language (e.g. `"English"`, `"Chinese"`).
+- `with_position` — Whether to store token positions (enables phrase queries). Defaults to `True`.
+
+**Example:**
+
+```python
+table.declare_fts_index(column="content")
+```
+
+:::note
+Indexes are reconciled as part of the table's target state: changing a declaration replaces the index in place, and dropping the table removes its indexes. Removing only an index declaration is currently a no-op — the index persists until the table is rebuilt.
+:::
 
 ### Table schema: from Python class
 
@@ -181,7 +253,7 @@ class MyRow:
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
+For `NDArray` fields, a `VectorSchemaProvider` annotation specifies the vector dimension and dtype. The annotation accepts a `VectorSchemaProvider`, a `ContextKey`, or an explicit `VectorSchema`. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for details.
 
 ### Table schema: explicit column definitions
 
@@ -243,6 +315,9 @@ async def app_main() -> None:
             primary_key=["doc_id"],
         ),
     )
+
+    # Declare a vector index for similarity search
+    table.declare_vector_index(column="embedding", metric="cosine")
 
     # Declare rows
     for doc in documents:


### PR DESCRIPTION
## Summary

Documentation-only improvements to the LanceDB connector page (`docs/src/content/docs/connectors/lancedb.mdx`). No code or dependency changes.

### What changed

1. **Callout box syntax** — the Dependencies callout used `::::note Dependencies` (four colons + space-separated title, which dropped the title). Corrected to `:::note[Dependencies]`, matching every sibling connector page.

2. **Documented vector and FTS indexes** — `declare_vector_index` (IVF-PQ / HNSW-PQ params + metrics) and `declare_fts_index` (language, `with_position`) were entirely undocumented. Added them as `(attachment)` subsections, mirroring the postgres/surrealdb/neo4j/falkordb convention, with a cross-link to the custom-target-connector attachment guide. Also wired a vector-index declaration into the end-to-end example.

3. **Tightened prose** — expanded the intro to accurately describe the connector (schema inference, index declaration, lifecycle management) instead of just "writing rows"; removed the redundant "target state APIs" overlap between the intro and the "As target" section; and de-duplicated the VectorSchemaProvider links.

### Note on index removal behavior

The page documents that **removing an index declaration is currently a no-op** — the index persists until the table is rebuilt. This is accurate to the connector's current behavior ([the delete branch is a no-op](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/lancedb/_target.py)). A follow-up PR will implement real index dropping via LanceDB's `AsyncTable.drop_index` (available in newer LanceDB) and bump the `lancedb` dependency floor accordingly; the docs note will be updated to match at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)