### PR TITLE
feat(lancedb): implement drop_index; bump lancedb to 0.33.0 and pyarrow to 23.0.0

### DIFF
--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -12,14 +12,14 @@ The `lancedb` connector provides target state APIs for writing rows to LanceDB t
 from cocoindex.connectors import lancedb
 ```
 
-::::note Dependencies
+:::note[Dependencies]
 This connector requires additional dependencies. Install with:
 
 ```bash
 pip install cocoindex[lancedb]
 ```
 
-::::
+:::
 
 ## Connection setup
 

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -179,7 +179,7 @@ table.declare_fts_index(column="content")
 ```
 
 :::note
-Indexes are reconciled as part of the table's target state: changing a declaration replaces the index in place, and dropping the table removes its indexes. Removing only an index declaration is currently a no-op — the index persists until the table is rebuilt.
+Indexes are reconciled as part of the table's target state: changing a declaration replaces the index in place, removing a declaration drops the index, and dropping the table removes all its indexes.
 :::
 
 ### Table schema: from Python class

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -110,9 +110,9 @@ def TableTarget.declare_row(
 
 - `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
 
-#### Vector indexes (child states)
+#### Vector indexes (attachment)
 
-Declare a vector index on a vector column to accelerate similarity search. The index is created and kept in sync as part of the table's target state:
+Declare a vector index on a vector column to accelerate similarity search. Vector indexes are an [attachment](../advanced_topics/custom_target_connector#implementing-attachment-providers) to a `TableTarget`:
 
 ```python
 def TableTarget.declare_vector_index(
@@ -150,9 +150,9 @@ Parameters left as `None` fall back to LanceDB's defaults.
 table.declare_vector_index(column="embedding", metric="cosine")
 ```
 
-#### FTS indexes (child states)
+#### FTS indexes (attachment)
 
-Declare a full-text search (FTS) index on a text column to enable keyword and phrase search:
+Declare a full-text search (FTS) index on a text column to enable keyword and phrase search. Like vector indexes, FTS indexes are an [attachment](../advanced_topics/custom_target_connector#implementing-attachment-providers) to a `TableTarget`:
 
 ```python
 def TableTarget.declare_fts_index(

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -6,7 +6,7 @@ description: >
   Python classes, vector columns via VectorSchemaProvider, and both
   system-managed and user-managed table lifecycles.
 ---
-The `lancedb` connector provides target state APIs for writing rows to LanceDB tables.
+The `lancedb` connector provides utilities for writing rows to LanceDB tables, with automatic schema inference from Python classes and support for declaring vector and full-text search (FTS) indexes. CocoIndex manages the table lifecycle — creating, dropping, and evolving the schema — and keeps rows in sync via incremental upserts and deletions.
 
 ```python
 from cocoindex.connectors import lancedb
@@ -45,7 +45,7 @@ conn = await lancedb.connect_async("./lancedb_data")
 
 ## As target
 
-The `lancedb` connector provides target state APIs for writing rows to tables. With it, CocoIndex tracks what rows should exist and automatically handles upserts and deletions.
+The `lancedb` connector provides target state APIs for writing rows to tables. CocoIndex tracks what rows should exist and automatically handles upserts and deletions.
 
 ### Declaring target states
 
@@ -109,6 +109,78 @@ def TableTarget.declare_row(
 **Parameters:**
 
 - `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
+
+#### Vector indexes (child states)
+
+Declare a vector index on a vector column to accelerate similarity search. The index is created and kept in sync as part of the table's target state:
+
+```python
+def TableTarget.declare_vector_index(
+    self,
+    *,
+    name: str | None = None,
+    column: str,
+    metric: Literal["cosine", "l2", "dot"] = "cosine",
+    index_type: Literal["ivf_pq", "hnsw_pq"] = "ivf_pq",
+    num_partitions: int | None = None,
+    num_sub_vectors: int | None = None,
+    num_bits: int | None = None,
+    m: int | None = None,
+    ef_construction: int | None = None,
+) -> None
+```
+
+**Parameters:**
+
+- `name` — Logical index name (defaults to `column`).
+- `column` — Vector column to index.
+- `metric` — Distance metric: `"cosine"` (default), `"l2"`, or `"dot"`.
+- `index_type` — Index algorithm: `"ivf_pq"` (IVF-PQ, default) or `"hnsw_pq"` (HNSW-PQ).
+- `num_partitions` — *(IVF-PQ only)* Number of IVF partitions.
+- `num_sub_vectors` — *(IVF-PQ / HNSW-PQ)* Number of PQ sub-vectors.
+- `num_bits` — *(IVF-PQ / HNSW-PQ)* Number of bits per PQ code.
+- `m` — *(HNSW-PQ only)* Maximum number of HNSW edges per node.
+- `ef_construction` — *(HNSW-PQ only)* Size of the HNSW candidate list during build.
+
+Parameters left as `None` fall back to LanceDB's defaults.
+
+**Example:**
+
+```python
+table.declare_vector_index(column="embedding", metric="cosine")
+```
+
+#### FTS indexes (child states)
+
+Declare a full-text search (FTS) index on a text column to enable keyword and phrase search:
+
+```python
+def TableTarget.declare_fts_index(
+    self,
+    *,
+    name: str | None = None,
+    column: str,
+    language: str = "English",
+    with_position: bool = True,
+) -> None
+```
+
+**Parameters:**
+
+- `name` — Logical index name (defaults to `column`).
+- `column` — Text column to index.
+- `language` — Tokenizer language (e.g. `"English"`, `"Chinese"`).
+- `with_position` — Whether to store token positions (enables phrase queries). Defaults to `True`.
+
+**Example:**
+
+```python
+table.declare_fts_index(column="content")
+```
+
+:::note
+Indexes are reconciled as part of the table's target state: changing a declaration replaces the index in place, and dropping the table removes its indexes. Removing only an index declaration is currently a no-op — the index persists until the table is rebuilt.
+:::
 
 ### Table schema: from Python class
 
@@ -181,7 +253,7 @@ class MyRow:
 
 #### VectorSchemaProvider
 
-For `NDArray` fields, a [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider) annotation specifies the vector dimension and dtype. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for the full list of annotation options (`ContextKey`, embedder instance, or explicit `VectorSchema`).
+For `NDArray` fields, a `VectorSchemaProvider` annotation specifies the vector dimension and dtype. The annotation accepts a `VectorSchemaProvider`, a `ContextKey`, or an explicit `VectorSchema`. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for details.
 
 ### Table schema: explicit column definitions
 
@@ -243,6 +315,9 @@ async def app_main() -> None:
             primary_key=["doc_id"],
         ),
     )
+
+    # Declare a vector index for similarity search
+    table.declare_vector_index(column="embedding", metric="cosine")
 
     # Declare rows
     for doc in documents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ editable-profile = "dev" # local editable builds
 litellm = ["litellm>=1.81.0"]
 sentence_transformers = ["sentence-transformers>=3.3.1"]
 colpali = ["colpali-engine"]
-lancedb = ["lancedb>=0.25.0", "pyarrow>=19.0.0"]
+lancedb = ["lancedb>=0.33.0", "pyarrow>=23.0.0"]
 postgres = ["asyncpg>=0.31.0"]
 qdrant = ["qdrant-client>=1.6.0"]
 sqlite = ["sqlite-vec>=0.1.6"]
@@ -103,8 +103,8 @@ all = [
     "litellm>=1.81.0",
     "sentence-transformers>=3.3.1",
     "colpali-engine",
-    "lancedb>=0.25.0",
-    "pyarrow>=19.0.0",
+    "lancedb>=0.33.0",
+    "pyarrow>=23.0.0",
     "asyncpg>=0.31.0",
     "pgvector>=0.4.2",
     "qdrant-client>=1.6.0",

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -324,6 +324,24 @@ def _escape_sql_string(value: str) -> str:
     return value.replace("'", "''")
 
 
+async def _drop_index_if_exists(
+    table: lancedb.table.AsyncTable, index_name: str, table_name: str
+) -> None:
+    """Drop an index by name if it currently exists on the table.
+
+    LanceDB's ``drop_index`` only detaches the index from the table; the storage
+    is reclaimed on the next ``table.optimize()``, which the row handler already
+    schedules periodically after mutation batches.
+    """
+    existing = {idx.name for idx in await table.list_indices()}
+    if index_name not in existing:
+        _logger.debug(
+            "LanceDB index %s on table %s: nothing to drop", index_name, table_name
+        )
+        return
+    await table.drop_index(index_name)
+
+
 class _RowAction(NamedTuple):
     """Action to perform on a row."""
 
@@ -592,14 +610,7 @@ class _VectorIndexHandler:
         table = await self._conn.open_table(self._table_name)
         for action in actions:
             if action.spec is None:
-                # LanceDB does not expose a first-class "drop index" API on AsyncTable;
-                # we silently skip — the index will cease to exist after the table is
-                # dropped/recreated by the table-level handler if the spec changes.
-                _logger.debug(
-                    "LanceDB vector index %s on table %s: no-op delete (not supported)",
-                    action.name,
-                    self._table_name,
-                )
+                await _drop_index_if_exists(table, action.name, self._table_name)
             else:
                 spec = action.spec
                 if spec.index_type == "ivf_pq":
@@ -631,6 +642,7 @@ class _VectorIndexHandler:
                     spec.column,
                     config=index_config,
                     replace=True,
+                    name=action.name,
                 )
 
     def reconcile(
@@ -703,11 +715,7 @@ class _FtsIndexHandler:
         table = await self._conn.open_table(self._table_name)
         for action in actions:
             if action.spec is None:
-                _logger.debug(
-                    "LanceDB FTS index %s on table %s: no-op delete (not supported)",
-                    action.name,
-                    self._table_name,
-                )
+                await _drop_index_if_exists(table, action.name, self._table_name)
             else:
                 spec = action.spec
                 fts_config = lancedb_index.FTS(
@@ -718,6 +726,7 @@ class _FtsIndexHandler:
                     spec.column,
                     config=fts_config,
                     replace=True,
+                    name=action.name,
                 )
 
     def reconcile(

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -533,7 +533,7 @@ def test_table_target_rejects_non_positive_optimize_interval() -> None:
 
 @requires_lancedb
 def test_lancedb_async_table_supports_add_columns_api() -> None:
-    import lancedb as real_lancedb  # type: ignore[import-not-found]
+    import lancedb as real_lancedb  # type: ignore[import-not-found, import-untyped]
 
     async_table = real_lancedb.table.AsyncTable
 
@@ -676,6 +676,41 @@ async def test_vector_index_handler_replace_replaces_existing_index(
 
     indices = await _list_indices(conn, table_name)
     assert len(indices) >= 1
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_vector_index_handler_drops_index_on_delete(lancedb_dir: Path) -> None:
+    """A delete action (spec=None) drops the previously created vector index."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_vec_drop"
+    await _create_test_table_with_vectors(conn, table_name, num_rows=256)
+
+    handler = _target._VectorIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._VectorIndexSpec(
+        column="embedding",
+        metric="cosine",
+        index_type="ivf_pq",
+        num_partitions=2,
+        num_sub_vectors=2,
+        num_bits=None,
+        m=None,
+        ef_construction=None,
+    )
+    await handler._apply_actions(
+        cast(Any, None), [_target._VectorIndexAction(name="emb_idx", spec=spec)]
+    )
+    names_before = {idx.name for idx in await _list_indices(conn, table_name)}
+    assert "emb_idx" in names_before
+
+    # Delete action (spec=None) drops the index by name.
+    delete = _target._VectorIndexAction(name="emb_idx", spec=None)
+    await handler._apply_actions(cast(Any, None), [delete])
+    names_after = {idx.name for idx in await _list_indices(conn, table_name)}
+    assert "emb_idx" not in names_after
+
+    # Dropping again is a safe no-op when the index is already gone.
+    await handler._apply_actions(cast(Any, None), [delete])
 
 
 @requires_lancedb
@@ -834,6 +869,33 @@ async def test_fts_index_handler_replace_is_idempotent(lancedb_dir: Path) -> Non
 
     await handler._apply_actions(cast(Any, None), [action])
     await handler._apply_actions(cast(Any, None), [action])  # no error on re-create
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_fts_index_handler_drops_index_on_delete(lancedb_dir: Path) -> None:
+    """A delete action (spec=None) drops the previously created FTS index."""
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_fts_drop"
+    await _create_test_table_with_text(conn, table_name)
+
+    handler = _target._FtsIndexHandler(conn=conn, table_name=table_name)
+    spec = _target._FtsIndexSpec(
+        column="content",
+        language="English",
+        with_position=True,
+    )
+    await handler._apply_actions(
+        cast(Any, None), [_target._FtsIndexAction(name="content_fts", spec=spec)]
+    )
+    assert "content_fts" in {idx.name for idx in await _list_indices(conn, table_name)}
+
+    # Delete action (spec=None) drops the index by name.
+    delete = _target._FtsIndexAction(name="content_fts", spec=None)
+    await handler._apply_actions(cast(Any, None), [delete])
+    assert "content_fts" not in {
+        idx.name for idx in await _list_indices(conn, table_name)
+    }
 
 
 @requires_lancedb

--- a/uv.lock
+++ b/uv.lock
@@ -752,8 +752,8 @@ requires-dist = [
     { name = "httplib2", marker = "extra == 'google-drive'", specifier = ">=0.22.0" },
     { name = "instructor", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "instructor", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.0" },
-    { name = "lancedb", marker = "extra == 'all'", specifier = ">=0.25.0" },
-    { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.25.0" },
+    { name = "lancedb", marker = "extra == 'all'", specifier = ">=0.33.0" },
+    { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.33.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0" },
@@ -765,8 +765,8 @@ requires-dist = [
     { name = "oci", marker = "extra == 'oci'", specifier = ">=2.0" },
     { name = "pgvector", marker = "extra == 'all'", specifier = ">=0.4.2" },
     { name = "psutil", specifier = ">=7.2.1" },
-    { name = "pyarrow", marker = "extra == 'all'", specifier = ">=19.0.0" },
-    { name = "pyarrow", marker = "extra == 'lancedb'", specifier = ">=19.0.0" },
+    { name = "pyarrow", marker = "extra == 'all'", specifier = ">=23.0.0" },
+    { name = "pyarrow", marker = "extra == 'lancedb'", specifier = ">=23.0.0" },
     { name = "pymysql", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "pymysql", marker = "extra == 'doris'", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
@@ -1696,7 +1696,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.27.0"
+version = "0.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1709,12 +1709,12 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/57/c6f557499f94c8ab4b3afe9af26510dfa4aeca9b5d30806e3dd4d25d14e3/lancedb-0.27.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:b0f2ad52fef7248056f8db1e6ca2b2c052807f1c8074e3e3e33a44f5082465b7", size = 43534233, upload-time = "2026-01-22T01:28:00.689Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/1b/dbb097f589fba64acf981161e0e42978b3a39ffe3c1680ac7bbf00edffa8/lancedb-0.27.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d643ee9d86e1250f0e63a68841c8f4da73a2c35fdc5e0d741e731ce30f4f0e41", size = 45411790, upload-time = "2026-01-22T01:36:03.829Z" },
-    { url = "https://files.pythonhosted.org/packages/38/36/1e643e3b409416182cdb4c8df9fccf5101ef6b19580aaadc917739a7c8ec/lancedb-0.27.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b90c12d36be1362f7f9b9b897c80400389d9c81ba4f6c2297f374d0ec5facb3a", size = 48497419, upload-time = "2026-01-22T01:39:22.941Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f8/52fc37bb20d7cf43771d5251acc351223d8833afd4e330ee6ed2cc4bf312/lancedb-0.27.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:79422a916843c08435ff2f7f2e9778a4efda8a73c847ce21df80e548bae0f752", size = 45426994, upload-time = "2026-01-22T01:34:53.128Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/12/cbd8b634ad0d6e821fadd4fa63332c277b382d89860389341419b995222f/lancedb-0.27.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d70eb1ec33a18d5afc1210e30870c3ca29ef562271253b6953f6c32208caa8c", size = 48542425, upload-time = "2026-01-22T01:40:15.522Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/3d/dc276a98e53a17a4c8d31c93852f2b69e23a9145bf9b616a0d813cb56aa8/lancedb-0.27.0-cp39-abi3-win_amd64.whl", hash = "sha256:3c36ba6941a69405e45750d3bbc94899d141fe68c7e24c3b92ecb7c4e4d84bc7", size = 53378515, upload-time = "2026-01-22T02:10:10.048Z" },
+    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115, upload-time = "2026-05-28T20:37:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262, upload-time = "2026-05-28T20:37:59.101Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368, upload-time = "2026-05-28T20:38:02.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986, upload-time = "2026-05-28T20:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958, upload-time = "2026-05-28T20:38:08.474Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944, upload-time = "2026-05-28T20:38:11.549Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements real index dropping for the LanceDB connector and bumps the connector's dependencies to support it.

Fixes #2131.

### Dependency bumps
- **lancedb** `>=0.25.0` → `>=0.33.0` — `AsyncTable.drop_index` was added in newer LanceDB (absent in 0.27.0).
- **pyarrow** `>=19.0.0` → `>=23.0.0`.

Both bumped in the `lancedb` and `all` extras.

### Behavior change: index removal now drops the index
Previously, removing a `declare_vector_index` / `declare_fts_index` declaration was a **no-op** — the index lingered until the table was rebuilt. This surprised users whose code no longer declared an index but whose table still carried it. Now the connector drops it, mirroring the postgres/surrealdb connectors.

Implementation details:
- Pass an explicit `name=` to `create_index`, so the LanceDB index name matches the connector's tracking name. (Previously the index was auto-named, so a user-supplied `name=` never actually reached LanceDB.)
- Replace both no-op delete branches with a shared `_drop_index_if_exists` helper that checks `list_indices()` and drops by name — a missing index is a clean no-op rather than an exception (per the repo's "no exceptions for not-found" convention).
- `drop_index` detaches the index immediately; on-disk reclamation happens on the next `table.optimize()`, which the row handler already schedules periodically.

### Tests
Added delete-path tests for both index handlers (`test_vector_index_handler_drops_index_on_delete`, `test_fts_index_handler_drops_index_on_delete`), verifying the index disappears from `list_indices()` after a delete action and that a repeated drop is a safe no-op. Full suite: **28 passed**. mypy + ruff clean; docs build clean.

### ⚠️ Relationship to #2130 (docs PR)
This branch **includes the three docs commits from #2130** (callout fix + vector/FTS index documentation), because it needs that documentation present in order to update the index-reconciliation note from "removal is a no-op" to "removal drops the index."

**Recommended merge order:** merge #2130 first, then rebase this branch — the duplicate docs commits drop out cleanly, leaving only the `feat` commit + the one-line note update. Alternatively, this PR can supersede #2130 if you'd prefer a single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)