### PR TITLE
feat(code_match): structural code-search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoindex_code_match"
+version = "999.0.0"
+dependencies = [
+ "cocoindex_utils",
+ "regex",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-sequel",
+ "tree-sitter-typescript",
+]
+
+[[package]]
 name = "cocoindex_core"
 version = "999.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "rust/py",
     "rust/py_utils",
     "rust/ops_text",
+    "rust/code_match",
     "rust/sdk/cocoindex",
     "rust/sdk/cocoindex_macros",
 ]

--- a/rust/code_match/Cargo.toml
+++ b/rust/code_match/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "cocoindex_code_match"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+cocoindex_utils = { path = "../utils" }
+regex = { workspace = true }
+
+# tree-sitter + grammars are pinned to the SAME versions as `cocoindex_ops_text`.
+# `tree-sitter` uses `links = "tree-sitter"`, so the whole workspace must resolve
+# to a single version — keep these in lockstep with rust/ops_text/Cargo.toml.
+tree-sitter = "0.25.10"
+tree-sitter-bash = "0.25.1"
+tree-sitter-c = "0.24.1"
+tree-sitter-c-sharp = "0.23.1"
+tree-sitter-cpp = "0.23.4"
+tree-sitter-go = "0.23.4"
+tree-sitter-java = "0.23.5"
+tree-sitter-javascript = "0.23.1"
+tree-sitter-php = "0.23.11"
+tree-sitter-python = "0.23.6"
+tree-sitter-ruby = "0.23.1"
+tree-sitter-rust = "0.24.0"
+tree-sitter-scala = "0.24.0"
+tree-sitter-sequel = "0.3.11"
+tree-sitter-typescript = "0.23.2"

--- a/rust/code_match/README.md
+++ b/rust/code_match/README.md
@@ -1,0 +1,40 @@
+# cocoindex_code_match
+
+Match **by-example code patterns** against **tree-sitter ASTs**, with metavariables.
+
+The bet: parse the *source* with a full tree-sitter grammar, but keep the *pattern* a flat token + metavar skeleton, and match it against the AST with metavariables snapping to node boundaries. This gives Comby-style pattern ergonomics (fragments like `else { \(*) }` need not parse as a node) together with tree-sitter's correctness — balanced/context-sensitive nesting (`>>`, `<>`), AST-resolved precedence, and matches that are integral subtrees.
+
+## Example
+
+```rust
+use cocoindex_code_match::{lang, Pattern};
+
+let cfg = lang::typescript();
+let pat = Pattern::compile(r"console.log(\(ARGS*))", &cfg).unwrap();
+
+let src = r#"console.log("hi", x);"#;
+for m in pat.matches(src) {
+    println!("{} -> ARGS = {:?}", m.text, m.capture_text("ARGS"));
+    // console.log("hi", x) -> ARGS = Some("\"hi\", x")
+}
+```
+
+### Metavariables
+
+The sigil is `\` by default (shell-safe; configurable to `$` via `LangConfig::with_meta_char('$')`). Names are `[A-Za-z0-9_]+` (uppercase by convention; lowercase/digits allowed).
+
+- `\NAME` — one node (named); `\_` — one node, anonymous.
+- `\(NAME*)` — a run of **same-level** sibling nodes (many); `\*` — anonymous. A cross-level skip is written as multiple `\*`, one per grammar level.
+- `\(NAME?)` — optional (zero or one node); `\?` — anonymous.
+- `\(NAME:/regex/)` — the captured source text must match the regex (unanchored; `^…$` for whole-node).
+- A repeated name must capture equal text: `\X == \X` matches `a == a`, not `a == b`.
+
+Use raw strings (`r"..."`) when writing patterns in Rust so the backslashes stay literal.
+
+## Supported languages
+
+TypeScript/TSX, JavaScript, C, C++, Python, Rust, Go, Java, C#, Ruby, PHP, Scala, Bash, SQL — each a one-line `LangConfig` constructor; the matcher and lexer are language-agnostic.
+
+## Status
+
+Matching + captures (same-level runs, leading/trailing tolerance, regex matchers); no rewriting yet. Planned: descendant containment (`\{{ … \}}`), node-kind matchers, rewriting, a rule DSL, prefiltering/indexing.

--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -1,0 +1,248 @@
+//! Language configuration and the tokenizer framework — the abstraction the
+//! engine (`lexer`, `matcher`) consumes. This module is *not* language-specific:
+//! the per-language constructors live in `lang`, which depends on this.
+//!
+//! A language = a tree-sitter grammar + a list of **tokenizers** for the
+//! structured token classes (identifiers, numbers, strings, raw strings, …).
+//! The operator/punctuation table and the `>>`-style "splittable" set are
+//! *derived from the grammar*. Comments need no config (the source side is
+//! tree-sitter; `collect` skips comment nodes).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use regex::Regex;
+use tree_sitter::Language;
+
+// ---------------------------------------------------------------------------
+// Tokenizer interface
+// ---------------------------------------------------------------------------
+
+/// How a matched pattern token aligns against the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokKind {
+    /// Word / number / operator — matched against a single source *leaf* by text.
+    Token,
+    /// String / char / raw literal — matched against a source *node* by text.
+    Str,
+}
+
+/// A pattern tokenizer: given the input at a position, return the byte length of
+/// a token at the start, or `None`. `RegexTokenizer` covers the easy cases;
+/// hand-written impls (e.g. `lang::cpp`'s raw-string scanner) cover
+/// delimiter-balanced forms the `regex` crate can't (no backreferences).
+pub trait Tokenizer: Send + Sync {
+    fn match_len(&self, input: &str) -> Option<usize>;
+}
+
+/// A tokenizer paired with how its match should be emitted.
+#[derive(Clone)]
+pub struct TokenRule {
+    pub tokenizer: Arc<dyn Tokenizer>,
+    pub kind: TokKind,
+}
+
+impl TokenRule {
+    pub fn new(tokenizer: impl Tokenizer + 'static, kind: TokKind) -> Self {
+        TokenRule {
+            tokenizer: Arc::new(tokenizer),
+            kind,
+        }
+    }
+}
+
+/// A position-anchored regex tokenizer (the pattern is compiled with a leading `^`).
+pub struct RegexTokenizer {
+    re: Regex,
+}
+
+impl RegexTokenizer {
+    pub fn new(pat: &str) -> Self {
+        RegexTokenizer {
+            re: Regex::new(pat).expect("valid tokenizer regex"),
+        }
+    }
+}
+
+impl Tokenizer for RegexTokenizer {
+    fn match_len(&self, input: &str) -> Option<usize> {
+        // `^` anchors at the start, so a match (if any) starts at 0.
+        self.re.find(input).map(|m| m.end()).filter(|&l| l > 0)
+    }
+}
+
+/// Convenience: a regex-based rule.
+pub fn regex_rule(pat: &str, kind: TokKind) -> TokenRule {
+    TokenRule::new(RegexTokenizer::new(pat), kind)
+}
+
+// --- shared (generic) token-class builders, composed by the language modules ---
+
+/// Identifier, Unicode-aware (`XID_Start`/`XID_Continue` + leading `_`), so a
+/// pattern can contain non-ASCII identifiers (Python/JS allow them). The source
+/// side decides what's a real identifier; over-matching in the pattern is
+/// harmless (a pattern identifier the source lacks just won't match).
+pub fn identifier() -> TokenRule {
+    regex_rule(r"^[_\p{XID_Start}][_\p{XID_Continue}]*", TokKind::Token)
+}
+
+/// Number: starts with a digit or `.digit` (so `.5`, `1.`, `1.5` all work),
+/// then a run of digits/letters/`_`/`.` (covers `0xFF`, `1_000`, suffixes,
+/// fractions) — with `[eEpP][-+]` tried *first* so signed exponents (`1.5e-10`)
+/// aren't swallowed by the alnum branch. `extra` adds chars like `'` (C/C++).
+/// A leading `.` only starts a number when followed by a digit, so `a.b` member
+/// access still splits.
+pub fn number(extra: &str) -> TokenRule {
+    regex_rule(
+        &format!(r"^(?:[0-9]|\.[0-9])(?:[eEpP][-+]|[0-9A-Za-z_.{extra}])*"),
+        TokKind::Token,
+    )
+}
+
+pub fn dq_string() -> TokenRule {
+    regex_rule(r#"(?s)^"(?:\\.|[^"\\])*""#, TokKind::Str)
+}
+pub fn sq_string() -> TokenRule {
+    // also a C/C++/Rust char literal; a bare `'a` (Rust lifetime) has no closing
+    // quote so this fails and `'` falls through to the op table.
+    regex_rule(r"(?s)^'(?:\\.|[^'\\])*'", TokKind::Str)
+}
+pub fn backtick_string() -> TokenRule {
+    regex_rule(r"(?s)^`(?:\\.|[^`\\])*`", TokKind::Str)
+}
+
+/// The default tokenizer set (identifier, number, the three quote styles).
+pub fn generic_tokenizers() -> Vec<TokenRule> {
+    vec![
+        identifier(),
+        number(""),
+        dq_string(),
+        sq_string(),
+        backtick_string(),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// LangConfig
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct LangConfig {
+    pub language: Language,
+    /// Anonymous punctuation/operator tokens, longest-first, excluding the
+    /// splittable compounds. Derived from the grammar; used for maximal munch.
+    pub op_tokens: Vec<String>,
+    /// Compound operators normalized to single chars on both sides (e.g. `>>` ->
+    /// `>` `>`). Auto-detected from the grammar.
+    pub splittable: HashSet<String>,
+    /// Metavariable sigil. Default `\` (shell-safe).
+    pub meta_char: char,
+    /// Tokenizers for literal/identifier classes, tried at each position; the
+    /// longest match wins.
+    pub tokenizers: Vec<TokenRule>,
+}
+
+impl LangConfig {
+    /// Build a config from a grammar with the generic tokenizers and derived
+    /// op/splittable tables. Language modules call this, then `with_tokenizers`.
+    pub fn from_grammar(language: Language) -> Self {
+        let single_char = single_char_punct_tokens(&language);
+        let splittable = detect_splittable(&language, &single_char);
+        let op_tokens = derive_op_tokens(&language, &splittable);
+        LangConfig {
+            language,
+            op_tokens,
+            splittable,
+            meta_char: '\\',
+            tokenizers: generic_tokenizers(),
+        }
+    }
+
+    /// Replace the tokenizer set (per-language literal profiles).
+    pub fn with_tokenizers(mut self, tokenizers: Vec<TokenRule>) -> Self {
+        self.tokenizers = tokenizers;
+        self
+    }
+
+    /// Override the metavariable sigil (default `\`).
+    pub fn with_meta_char(mut self, c: char) -> Self {
+        self.meta_char = c;
+        self
+    }
+
+    pub fn is_splittable(&self, text: &str) -> bool {
+        self.splittable.contains(text)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Grammar-derived tables
+// ---------------------------------------------------------------------------
+
+fn is_punct_token(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| !c.is_alphanumeric() && c != '_')
+}
+
+/// The single-character punctuation tokens the grammar defines.
+fn single_char_punct_tokens(lang: &Language) -> HashSet<String> {
+    let mut set = HashSet::new();
+    for id in 0..lang.node_kind_count() as u16 {
+        if lang.node_kind_is_named(id) {
+            continue;
+        }
+        if let Some(s) = lang.node_kind_for_id(id)
+            && s.chars().count() == 1
+            && is_punct_token(s)
+        {
+            set.insert(s.to_string());
+        }
+    }
+    set
+}
+
+/// A compound token is splittable when it is all-punctuation, longer than one
+/// char, and every character is itself a single-char token. Splitting it on both
+/// sides aligns context-sensitive tokenizations like C++/Rust `>>`. Over-split
+/// (e.g. `==`) is safe — both sides normalize identically.
+fn detect_splittable(lang: &Language, single_char: &HashSet<String>) -> HashSet<String> {
+    let mut set = HashSet::new();
+    for id in 0..lang.node_kind_count() as u16 {
+        if lang.node_kind_is_named(id) {
+            continue;
+        }
+        let Some(s) = lang.node_kind_for_id(id) else {
+            continue;
+        };
+        if !is_punct_token(s) || s.chars().count() < 2 {
+            continue;
+        }
+        if s.chars().all(|c| single_char.contains(&c.to_string())) {
+            set.insert(s.to_string());
+        }
+    }
+    set
+}
+
+/// Operator/punctuation tokens for maximal munch. Dropping the splittables here
+/// already implements "remove a compound whose every char is an existing token":
+/// what survives is single-char tokens plus the few multi-char tokens with a
+/// *non-token* component (e.g. TS `${`, Python `!=` — `$`/`!` aren't standalone
+/// tokens there), which must stay whole.
+fn derive_op_tokens(lang: &Language, splittable: &HashSet<String>) -> Vec<String> {
+    let mut toks: Vec<String> = Vec::new();
+    for id in 0..lang.node_kind_count() as u16 {
+        if lang.node_kind_is_named(id) {
+            continue;
+        }
+        let Some(s) = lang.node_kind_for_id(id) else {
+            continue;
+        };
+        if s.is_empty() || s == "ERROR" || !is_punct_token(s) || splittable.contains(s) {
+            continue;
+        }
+        toks.push(s.to_string());
+    }
+    toks.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    toks.dedup();
+    toks
+}

--- a/rust/code_match/src/lang/bash.rs
+++ b/rust/code_match/src/lang/bash.rs
@@ -1,0 +1,24 @@
+//! Bash.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn bash() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_bash::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bash;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn command() {
+        // `\MSG` (not `$MSG`) — the `\` sigil keeps this shell-safe.
+        let src = "echo hello";
+        let ms = matches(bash(), r"echo \MSG", src);
+        assert_eq!(cap(&ms, "MSG").as_deref(), Some("hello"));
+    }
+}

--- a/rust/code_match/src/lang/c.rs
+++ b/rust/code_match/src/lang/c.rs
@@ -1,0 +1,80 @@
+//! C: `'` digit separators, no backtick strings.
+
+use crate::config::*;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+/// Identifier, number (with `'` separators), `"…"` and `'…'`.
+pub(crate) fn c_tokenizers() -> Vec<TokenRule> {
+    vec![identifier(), number("'"), dq_string(), sq_string()]
+}
+
+pub fn c() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(Language::new(tree_sitter_c::LANGUAGE))
+            .with_tokenizers(c_tokenizers())
+    });
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::c;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call_multi_args() {
+        let src = "void g(){ foo(a, b); }";
+        let ms = matches(c(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    #[test]
+    fn balanced_nested() {
+        let src = "void g(){ foo(bar(x), baz); }";
+        let ms = matches(c(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("bar(x), baz"));
+    }
+
+    /// Conformance: a literal in a pattern must lex as one token and match the
+    /// source construct (the tokenizer aligns with tree-sitter).
+    #[test]
+    fn number_forms() {
+        for (lit, ctx) in [
+            ("0xFF", "int x = 0xFF;"),
+            ("0b1010", "int x = 0b1010;"),
+            ("017", "int x = 017;"),
+            ("42u", "unsigned x = 42u;"),
+            ("100UL", "unsigned long x = 100UL;"),
+            ("3.14", "double x = 3.14;"),
+            (".5", "double x = .5;"),
+            ("1.", "double x = 1.;"),
+            ("1.5e-10", "double x = 1.5e-10;"),
+            ("0x1p4", "double x = 0x1p4;"),
+            ("1'000", "int x = 1'000;"),
+        ] {
+            assert!(!matches(c(), lit, ctx).is_empty(), "C number `{lit}`");
+        }
+    }
+
+    #[test]
+    fn string_and_char_forms() {
+        for (lit, ctx) in [
+            (r#""hi""#, r#"const char* s = "hi";"#),
+            (r#""a\tb""#, r#"const char* s = "a\tb";"#),
+            ("'a'", "char c = 'a';"),
+            (r"'\n'", r"char c = '\n';"),
+        ] {
+            assert!(!matches(c(), lit, ctx).is_empty(), "C literal `{lit}`");
+        }
+    }
+
+    #[test]
+    fn pointer_member_arrow_split() {
+        // `->` splits into `-` `>`; member access must still match.
+        let src = "void g(){ p->field = 1; }";
+        let ms = matches(c(), r"\P->\F", src);
+        assert_eq!(cap(&ms, "P").as_deref(), Some("p"));
+        assert_eq!(cap(&ms, "F").as_deref(), Some("field"));
+    }
+}

--- a/rust/code_match/src/lang/cpp.rs
+++ b/rust/code_match/src/lang/cpp.rs
@@ -1,0 +1,102 @@
+//! C++: C-like literals plus raw strings `R"tag(...)tag"`.
+
+use super::c::c_tokenizers;
+use crate::config::*;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn cpp() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = c_tokenizers();
+        toks.push(TokenRule::new(CppRawString, TokKind::Str));
+        LangConfig::from_grammar(Language::new(tree_sitter_cpp::LANGUAGE)).with_tokenizers(toks)
+    });
+    CFG.clone()
+}
+
+/// `R"delim(...)delim"` — a delimiter-balanced raw string. The matching `delim`
+/// is a backreference the `regex` crate can't express, so this is a hand scanner.
+struct CppRawString;
+
+impl Tokenizer for CppRawString {
+    fn match_len(&self, input: &str) -> Option<usize> {
+        let b = input.as_bytes();
+        if b.first() != Some(&b'R') || b.get(1) != Some(&b'"') {
+            return None;
+        }
+        let dstart = 2;
+        let mut p = dstart;
+        // delimiter: up to 16 chars, none of ( ) \ " whitespace
+        while p < b.len() && b[p] != b'(' && p - dstart < 16 {
+            let ch = b[p];
+            if ch == b')' || ch == b'\\' || ch == b'"' || ch.is_ascii_whitespace() {
+                return None;
+            }
+            p += 1;
+        }
+        if b.get(p) != Some(&b'(') {
+            return None;
+        }
+        let delim = &input[dstart..p];
+        let close = format!("){delim}\"");
+        input[p..].find(&close).map(|idx| p + idx + close.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cpp;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn nested_generics_split() {
+        let src = "vector<vector<int>> v;";
+        let ms = matches(cpp(), r"vector<vector<\T>>", src);
+        assert_eq!(cap(&ms, "T").as_deref(), Some("int"));
+    }
+
+    #[test]
+    fn right_shift() {
+        let src = "int n = a >> 2;";
+        let ms = matches(cpp(), r"\X >> \Y", src);
+        assert_eq!(cap(&ms, "X").as_deref(), Some("a"));
+        assert_eq!(cap(&ms, "Y").as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn apostrophe_separator_literal() {
+        let src = "int x = 1'000;";
+        assert!(!matches(cpp(), "1'000", src).is_empty());
+    }
+
+    #[test]
+    fn raw_string_with_custom_delimiter() {
+        // R"x(a)b)x" contains a literal `)` that only the matching delimiter ends.
+        let src = r#"const char* s = R"x(a)b)x";"#;
+        let ms = matches(cpp(), r#"R"x(a)b)x""#, src);
+        assert!(!ms.is_empty(), "C++ raw string with delimiter should match");
+    }
+
+    #[test]
+    fn class_with_destructor() {
+        // `~\NAME()` ties the destructor name to the class name (metavar
+        // equality); the same-level `\*` holes absorb an optional base/access
+        // section and the members before the destructor. The two trailing `\*`
+        // are one per grammar level: the first absorbs the destructor's own tail
+        // (inline body or `;`), the second the following members.
+        let pat = r"class \NAME \* { \* ~\NAME() \* \* }";
+        // inlined destructor, with a leading access specifier
+        let ms = matches(cpp(), pat, "class Foo { public: ~Foo() {} };");
+        assert_eq!(cap(&ms, "NAME").as_deref(), Some("Foo"));
+        // declared (non-inline) destructor, members before and after
+        assert!(has_kind(
+            &matches(cpp(), pat, "class Bar { int x; ~Bar(); void f(); };"),
+            "class_specifier",
+        ));
+        // no destructor → no match
+        assert!(
+            matches(cpp(), pat, "class Baz { int x; void f(); };").is_empty(),
+            "class without a destructor must not match",
+        );
+    }
+}

--- a/rust/code_match/src/lang/csharp.rs
+++ b/rust/code_match/src/lang/csharp.rs
@@ -1,0 +1,23 @@
+//! csharp.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn csharp() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_c_sharp::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::csharp;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "class C { void M() { foo(a, b); } }";
+        let ms = matches(csharp(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/go.rs
+++ b/rust/code_match/src/lang/go.rs
@@ -1,0 +1,23 @@
+//! go.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn go() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_go::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::go;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "package main\nfunc m() { foo(a, b) }";
+        let ms = matches(go(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/java.rs
+++ b/rust/code_match/src/lang/java.rs
@@ -1,0 +1,23 @@
+//! java.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn java() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_java::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::java;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "class C { void m() { foo(a, b); } }";
+        let ms = matches(java(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/javascript.rs
+++ b/rust/code_match/src/lang/javascript.rs
@@ -1,0 +1,23 @@
+//! javascript.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn javascript() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_javascript::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::javascript;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "foo(a, b);";
+        let ms = matches(javascript(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/mod.rs
+++ b/rust/code_match/src/lang/mod.rs
@@ -1,0 +1,55 @@
+//! Per-language constructors. Each language is a private submodule holding its
+//! `LangConfig` constructor, its bespoke tokenizers, and its tests; the
+//! constructor is re-exported here as `lang::<name>()`. The shared framework
+//! (`LangConfig`, `Tokenizer`, …) lives in `crate::config`, which this depends on.
+
+mod bash;
+mod c;
+mod cpp;
+mod csharp;
+mod go;
+mod java;
+mod javascript;
+mod php;
+mod python;
+mod ruby;
+mod rust;
+mod scala;
+mod sql;
+mod typescript;
+
+pub use bash::bash;
+pub use c::c;
+pub use cpp::cpp;
+pub use csharp::csharp;
+pub use go::go;
+pub use java::java;
+pub use javascript::javascript;
+pub use php::php;
+pub use python::python;
+pub use ruby::ruby;
+pub use rust::rust;
+pub use scala::scala;
+pub use sql::sql;
+pub use typescript::{tsx, typescript};
+
+#[cfg(test)]
+pub(crate) mod testutil {
+    use crate::config::LangConfig;
+    use crate::{Match, Pattern};
+
+    pub fn matches<'s>(cfg: LangConfig, pat: &str, src: &'s str) -> Vec<Match<'s>> {
+        Pattern::compile(pat, &cfg)
+            .expect("valid test pattern")
+            .matches(src)
+    }
+
+    pub fn cap(ms: &[Match], name: &str) -> Option<String> {
+        ms.iter()
+            .find_map(|m| m.capture_text(name).map(str::to_string))
+    }
+
+    pub fn has_kind(ms: &[Match], kind: &str) -> bool {
+        ms.iter().any(|m| m.kind == kind)
+    }
+}

--- a/rust/code_match/src/lang/php.rs
+++ b/rust/code_match/src/lang/php.rs
@@ -1,0 +1,30 @@
+//! PHP. Config-wise generic; `$` is ordinary source (the sigil is `\`).
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn php() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_php::LANGUAGE_PHP)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::php;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call_captures_dollar_vars() {
+        let src = "<?php foo($a, $b); ?>";
+        let ms = matches(php(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("$a, $b"));
+    }
+
+    #[test]
+    fn literal_dollar_variable() {
+        let src = "<?php $result = compute(); ?>";
+        let ms = matches(php(), r"$result = \VAL", src);
+        assert_eq!(cap(&ms, "VAL").as_deref(), Some("compute()"));
+    }
+}

--- a/rust/code_match/src/lang/python.rs
+++ b/rust/code_match/src/lang/python.rs
@@ -1,0 +1,79 @@
+//! Python: triple-quoted strings.
+
+use crate::config::*;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn python() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        // triple-quoted (with optional r/b/f/u prefixes), then prefixed single
+        // line strings. Interpolation inside f-strings is treated opaquely.
+        toks.push(regex_rule(r#"(?s)^[rbfuRBFU]{0,2}""".*?""""#, TokKind::Str));
+        toks.push(regex_rule(r"(?s)^[rbfuRBFU]{0,2}'''.*?'''", TokKind::Str));
+        toks.push(regex_rule(
+            r#"^[rbfuRBFU]{1,2}"(?:\\.|[^"\\])*""#,
+            TokKind::Str,
+        ));
+        toks.push(regex_rule(
+            r"^[rbfuRBFU]{1,2}'(?:\\.|[^'\\])*'",
+            TokKind::Str,
+        ));
+        LangConfig::from_grammar(Language::new(tree_sitter_python::LANGUAGE)).with_tokenizers(toks)
+    });
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::python;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call_multi_args() {
+        let src = "foo(a, b, c)";
+        let ms = matches(python(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b, c"));
+    }
+
+    #[test]
+    fn string_atomic() {
+        let src = r#"print("a)b")"#;
+        let ms = matches(python(), r"print(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a)b""#));
+    }
+
+    #[test]
+    fn keyword_args() {
+        let src = "f(x=1, y=2)";
+        let ms = matches(python(), r"f(\(KW*))", src);
+        assert_eq!(cap(&ms, "KW").as_deref(), Some("x=1, y=2"));
+    }
+
+    #[test]
+    fn triple_string_literal() {
+        let src = "x = \"\"\"a\nb\"\"\"\n";
+        let ms = matches(python(), "x = \"\"\"a\nb\"\"\"", src);
+        assert!(!ms.is_empty(), "python triple-quoted string should match");
+    }
+
+    /// Conformance over Python string/number forms (prefixed strings included).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            (r#""hi""#, r#"x = "hi""#),
+            (r#"r"a\b""#, r#"x = r"a\b""#),
+            (r#"f"hi""#, r#"x = f"hi""#),
+            (r#"b"hi""#, r#"x = b"hi""#),
+            ("0xFF", "x = 0xFF"),
+            ("1_000", "x = 1_000"),
+            ("1.5e-10", "x = 1.5e-10"),
+            (".5", "x = .5"),
+        ] {
+            assert!(
+                !matches(python(), lit, ctx).is_empty(),
+                "Python literal `{lit}`"
+            );
+        }
+    }
+}

--- a/rust/code_match/src/lang/ruby.rs
+++ b/rust/code_match/src/lang/ruby.rs
@@ -1,0 +1,23 @@
+//! ruby.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn ruby() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_ruby::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ruby;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "foo(a, b)";
+        let ms = matches(ruby(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/rust.rs
+++ b/rust/code_match/src/lang/rust.rs
@@ -1,0 +1,157 @@
+//! Rust: raw strings `r#"..."#` (any `#` count), byte strings.
+
+use crate::config::*;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn rust() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),
+            sq_string(),
+            TokenRule::new(RustRawString, TokKind::Str),
+            regex_rule(r#"(?s)^b"(?:\\.|[^"\\])*""#, TokKind::Str), // byte string b"..."
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_rust::LANGUAGE)).with_tokenizers(toks)
+    });
+    CFG.clone()
+}
+
+/// `r#*"..."#*` with a matching number of `#` (and an optional `b` prefix). The
+/// `#` count is a balance the `regex` crate can't express, so it's a hand scanner.
+struct RustRawString;
+
+impl Tokenizer for RustRawString {
+    fn match_len(&self, input: &str) -> Option<usize> {
+        let b = input.as_bytes();
+        let mut p = 0;
+        if b.first() == Some(&b'b') {
+            p = 1; // br#"..."#
+        }
+        if b.get(p) != Some(&b'r') {
+            return None;
+        }
+        p += 1;
+        let hashes = {
+            let start = p;
+            while b.get(p) == Some(&b'#') {
+                p += 1;
+            }
+            p - start
+        };
+        if b.get(p) != Some(&b'"') {
+            return None;
+        }
+        p += 1;
+        loop {
+            while p < b.len() && b[p] != b'"' {
+                p += 1;
+            }
+            if p >= b.len() {
+                return None; // unterminated
+            }
+            // need `hashes` '#' right after the closing quote
+            let mut q = p + 1;
+            let mut h = 0;
+            while h < hashes && b.get(q) == Some(&b'#') {
+                h += 1;
+                q += 1;
+            }
+            if h == hashes {
+                return Some(q);
+            }
+            p += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rust;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call_multi_args() {
+        let src = "fn m(){ foo(a, b); }";
+        let ms = matches(rust(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    #[test]
+    fn nested_generics_split() {
+        let src = "fn m(){ let v: Vec<Vec<i32>> = mk(); }";
+        let ms = matches(rust(), r"Vec<Vec<\T>>", src);
+        assert_eq!(cap(&ms, "T").as_deref(), Some("i32"));
+    }
+
+    #[test]
+    fn path_separator_split() {
+        let src = "fn m(){ let x = std::mem::size_of(); }";
+        let ms = matches(rust(), r"std::mem::\F()", src);
+        assert_eq!(cap(&ms, "F").as_deref(), Some("size_of"));
+    }
+
+    #[test]
+    fn raw_string_literal() {
+        let src = r##"fn m() { log(r#"a"b"#); }"##;
+        let ms = matches(rust(), r##"log(r#"a"b"#)"##, src);
+        assert!(has_kind(&ms, "call_expression"));
+    }
+
+    #[test]
+    fn raw_string_metavar() {
+        let src = r##"fn m() { log(r#"a"b"#); }"##;
+        let ms = matches(rust(), r"log(\S)", src);
+        assert_eq!(cap(&ms, "S").as_deref(), Some(r##"r#"a"b"#"##));
+    }
+
+    #[test]
+    fn number_suffix_and_separator() {
+        let src = "fn m() { let n = 1_000u64; }";
+        assert!(!matches(rust(), "1_000u64", src).is_empty());
+    }
+
+    #[test]
+    fn signature_ignores_visibility_and_body() {
+        // Leading/trailing tolerance: `fn clone(self)` matches the function
+        // regardless of a leading visibility modifier and the trailing body.
+        for src in [
+            "pub fn clone(self) {}",
+            "pub(crate) fn clone(self) {}",
+            "fn clone(self) {}",
+        ] {
+            let ms = matches(rust(), r"fn clone(self)", src);
+            // exactly one match — the function_item, reported with its full
+            // range; no enclosing-level (source_file) noise.
+            assert_eq!(ms.len(), 1, "one match for `{src}`");
+            assert_eq!(ms[0].kind, "function_item");
+            assert_eq!(ms[0].text, src);
+        }
+    }
+
+    /// Conformance over Rust literal forms.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("0xFFu8", "fn m(){ let x = 0xFFu8; }"),
+            ("0b1010_i32", "fn m(){ let x = 0b1010_i32; }"),
+            ("1_000_000", "fn m(){ let x = 1_000_000; }"),
+            ("1.5e-10", "fn m(){ let x = 1.5e-10; }"),
+            ("2.0f64", "fn m(){ let x = 2.0f64; }"),
+            (r#"b"hi""#, r#"fn m(){ let s = b"hi"; }"#),
+            (r#"r"a\b""#, r#"fn m(){ let s = r"a\b"; }"#),
+            (r##"r#"a"b"#"##, r##"fn m(){ let s = r#"a"b"#; }"##),
+            (
+                r###"r##"a"#b"##"###,
+                r###"fn m(){ let s = r##"a"#b"##; }"###,
+            ),
+        ] {
+            assert!(
+                !matches(rust(), lit, ctx).is_empty(),
+                "Rust literal `{lit}`"
+            );
+        }
+    }
+}

--- a/rust/code_match/src/lang/scala.rs
+++ b/rust/code_match/src/lang/scala.rs
@@ -1,0 +1,23 @@
+//! scala.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn scala() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_scala::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scala;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call() {
+        let src = "object O { def m = foo(a, b) }";
+        let ms = matches(scala(), r"foo(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+}

--- a/rust/code_match/src/lang/sql.rs
+++ b/rust/code_match/src/lang/sql.rs
@@ -1,0 +1,23 @@
+//! SQL (tree-sitter-sequel).
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn sql() -> LangConfig {
+    static CFG: LazyLock<LangConfig> =
+        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_sequel::LANGUAGE)));
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sql;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn select() {
+        let src = "SELECT name FROM users";
+        let ms = matches(sql(), r"SELECT \COL FROM \TBL", src);
+        assert!(!ms.is_empty(), "expected SELECT pattern to match");
+    }
+}

--- a/rust/code_match/src/lang/typescript.rs
+++ b/rust/code_match/src/lang/typescript.rs
@@ -1,0 +1,69 @@
+//! TypeScript / TSX.
+use crate::config::LangConfig;
+use std::sync::LazyLock;
+use tree_sitter::Language;
+
+pub fn typescript() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(Language::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT))
+    });
+    CFG.clone()
+}
+
+pub fn tsx() -> LangConfig {
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(Language::new(tree_sitter_typescript::LANGUAGE_TSX))
+    });
+    CFG.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::typescript;
+    use crate::lang::testutil::*;
+
+    #[test]
+    fn call_multi_args() {
+        let src = r#"console.log("a", b);"#;
+        let ms = matches(typescript(), r"console.log(\(ARGS*))", src);
+        assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a", b"#));
+    }
+
+    #[test]
+    fn nested_generics() {
+        let src = "let x: Array<Array<number>> = mk();";
+        let ms = matches(typescript(), r"Array<Array<\T>>", src);
+        assert_eq!(cap(&ms, "T").as_deref(), Some("number"));
+    }
+
+    #[test]
+    fn typed_parameter() {
+        // `\VAR: string` matches a type-annotated parameter; VAR snaps to the
+        // name leaf, `: string` is matched literally. The candidate is the whole
+        // `required_parameter` node (which the pattern covers exactly).
+        let src = "function foo(x: string) { return x; }";
+        let ms = matches(typescript(), r"\VAR: string", src);
+        assert_eq!(cap(&ms, "VAR").as_deref(), Some("x"));
+        assert!(has_kind(&ms, "required_parameter"));
+    }
+
+    /// Conformance over the generic literal profile (numbers, strings, template).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("0xff", "let x = 0xff;"),
+            ("0b1010", "let x = 0b1010;"),
+            ("1_000", "let x = 1_000;"),
+            ("1.5e-10", "let x = 1.5e-10;"),
+            (".5", "let x = .5;"),
+            (r#""hi""#, r#"let s = "hi";"#),
+            ("'hi'", "let s = 'hi';"),
+            ("`hi`", "let s = `hi`;"),
+        ] {
+            assert!(
+                !matches(typescript(), lit, ctx).is_empty(),
+                "TS literal `{lit}`"
+            );
+        }
+    }
+}

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -1,0 +1,278 @@
+//! Pattern lexer: turns a pattern string into a flat `Vec<PatternItem>`.
+//!
+//! Metavariables are first-class tokens. Everything else is lexed with a small
+//! hand engine + the per-language op-token table.
+//!
+//! Metavar syntax (sigil `S` is configurable, default `\`):
+//!   `S NAME`        single, named (sugar for `S(NAME)`)
+//!   `S(NAME)`       single, named
+//!   `S(NAME*)`      many   (zero or more **same-level** sibling nodes)
+//!   `S(NAME?)`      optional (zero or one node)
+//!   `S_` / `S(_)`   anonymous single        `S*` / `S(*)`  anonymous many
+//!   `S?` / `S(?)`   anonymous optional
+//!   `S(NAME:/re/)`  single, regex-constrained — see below
+//! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
+//! written as multiple `*`, one per grammar level.
+//! Names are `[A-Za-z0-9_]+` (upper/lower/digit, sed-like `\1`); UPPERCASE is a
+//! readability convention, not a rule. With the `\` sigil, lowercase `\foo` only
+//! collides with bare-`\` escapes (Bash `\n`) / Haskell lambdas.
+//!
+//! Regex matcher `:/re/` constrains a **single-node** metavar: the captured
+//! source text must `is_match` (unanchored) the regex (use `^…$` for whole-node).
+//! Applies to `One`/`Optional`; ignored on `Many` (sibling runs, out of scope).
+//! The closing `/` is optional (`:/re`): a `/` at the matcher's top paren level
+//! closes (delimited), else the matcher's `)` closes (shorthand). Balanced `()`
+//! inside the regex (alternations) need no escaping; escape a literal `/` or an
+//! unbalanced `)` as `\/` / `\)`. An unparseable (or unterminated) regex is a
+//! `client` error from `lex` / `Pattern::compile`.
+
+use crate::config::{LangConfig, TokKind};
+use cocoindex_utils::error::{Error, Result};
+use regex::Regex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cardinality {
+    /// `\X` — exactly one node
+    One,
+    /// `\(X*)` — zero or more sibling nodes
+    Many,
+    /// `\(X?)` — zero or one node
+    Optional,
+}
+
+// `Regex` is not `PartialEq`/`Eq`, so `PatternItem` isn't either (it's only ever
+// pattern-matched, never compared for equality).
+#[derive(Debug, Clone)]
+pub enum PatternItem {
+    /// Word (identifier / keyword / number) or operator/punctuation token.
+    /// Matched against a single source *leaf* by text.
+    Token(String),
+    /// String literal (with quotes). Matched against a source string *node* by text.
+    Str(String),
+    /// Metavariable. `name` == None for anonymous (`\_`, `\*`, `\?`). `regex`, if
+    /// present, constrains the captured text (unanchored `is_match`); honored for
+    /// single-node cardinalities (`One`/`Optional`) only. `Many` (`*`) is always
+    /// same-level; cross-level skips use multiple `*`.
+    Meta {
+        name: Option<String>,
+        card: Cardinality,
+        regex: Option<Regex>,
+    },
+}
+
+pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
+    let bytes = pattern.as_bytes();
+    let mut i = 0usize;
+    let mut out = Vec::new();
+
+    // We dispatch on the leading `char` at `i` (not a raw byte). `i` is always
+    // advanced by char-aligned amounts (a decoded char, a regex match `end()`,
+    // or an ASCII op length), so every slice below is on a char boundary —
+    // emoji/CJK anywhere can never panic or mis-slice. Inside `lex_metavar`,
+    // the byte scans search only for *ASCII* delimiters, which (by UTF-8's
+    // self-synchronizing property) never occur inside a multi-byte char.
+    while i < bytes.len() {
+        let first = pattern[i..].chars().next().expect("i is a char boundary");
+        let clen = first.len_utf8();
+
+        // whitespace (decode the char so non-ASCII whitespace, e.g. U+3000, skips too)
+        if first.is_whitespace() {
+            i += clen;
+            continue;
+        }
+
+        // metavar sigil (compare as a char; any sigil works, not just ASCII)
+        if first == cfg.meta_char {
+            let after = i + clen;
+            if let Some((item, next)) = lex_metavar(pattern, bytes, after)? {
+                out.push(item);
+                i = next;
+                continue;
+            }
+            // bare sigil (e.g. `$` in PHP/JS source, or a lone `\`): literal token
+            out.push(PatternItem::Token(pattern[i..after].to_string()));
+            i = after;
+            continue;
+        }
+
+        // tokenizers (per-language literal/identifier classes) + operator table:
+        // try all, take the LONGEST match (maximal munch). Tokenizers emit Token
+        // (word/number → leaf) or Str (string/char/raw → node); operators are Token.
+        let rest = &pattern[i..];
+        let mut best_len = 0usize;
+        let mut best_kind = TokKind::Token;
+        for rule in &cfg.tokenizers {
+            if let Some(l) = rule.tokenizer.match_len(rest)
+                && l > best_len
+            {
+                best_len = l;
+                best_kind = rule.kind;
+            }
+        }
+        // Linear scan over ~25-30 mostly-single-char ops, longest-first.
+        // Deliberately not unioned into a regex/Aho-Corasick automaton: this is a
+        // cold path (lexing runs once per `Pattern::compile` on a short pattern;
+        // the matcher — the hot path — never touches `op_tokens`), so a single-
+        // pass matcher would add per-call overhead + escaping/ordering risk for
+        // no measurable gain. If lexing ever profiles hot, switch to anchored
+        // Aho-Corasick in LeftmostLongest mode (not a hand regex, which is
+        // leftmost-*first* and needs escaping).
+        for op in &cfg.op_tokens {
+            if rest.starts_with(op.as_str()) {
+                if op.len() > best_len {
+                    best_len = op.len();
+                    best_kind = TokKind::Token;
+                }
+                break; // op_tokens is sorted longest-first
+            }
+        }
+        if best_len > 0 {
+            let text = pattern[i..i + best_len].to_string();
+            out.push(match best_kind {
+                TokKind::Str => PatternItem::Str(text),
+                TokKind::Token => PatternItem::Token(text),
+            });
+            i += best_len;
+            continue;
+        }
+
+        // single-char fallback (a char in neither a literal class nor the op table)
+        out.push(PatternItem::Token(pattern[i..i + clen].to_string()));
+        i += clen;
+    }
+
+    Ok(out)
+}
+
+/// Parse a metavar given `s` = the index just past the sigil. `Ok(Some(..))` is
+/// the parsed item + index past it; `Ok(None)` means the sigil isn't a valid
+/// metavar (the caller treats it as a literal sigil); `Err` is a malformed
+/// matcher (e.g. a bad regex). The metavar syntax is ASCII, so byte reads from
+/// `s` are safe even if a non-ASCII char follows the sigil (ASCII checks just
+/// fail → `Ok(None)`).
+fn lex_metavar(pattern: &str, bytes: &[u8], s: usize) -> Result<Option<(PatternItem, usize)>> {
+    Ok(match bytes.get(s).copied() {
+        // qualified form: S( ... )
+        Some(b'(') => return lex_qualified(pattern, bytes, s + 1),
+        // anonymous shorthands: S*  S?
+        Some(b'*') => Some((meta(None, Cardinality::Many, None), s + 1)),
+        Some(b'?') => Some((meta(None, Cardinality::Optional, None), s + 1)),
+        // sugar: S NAME  /  S_  (single). Names may start with any alnum/`_`
+        // (lowercase + digit allowed; the `\` sigil makes collisions rare).
+        Some(c) if c.is_ascii_alphanumeric() || c == b'_' => {
+            let (name, end) = read_name(pattern, bytes, s);
+            Some((meta(name_binding(name), Cardinality::One, None), end))
+        }
+        _ => None,
+    })
+}
+
+/// Parse the inside of `S( ... )` given `j` pointing just after `(`:
+/// `NAME [*|?] [ : /regex/ ] )`. A `:` commits to a regex matcher (a bad regex
+/// is an `Err`); a missing closing `)` is lenient (`Ok(None)` → literal sigil).
+fn lex_qualified(pattern: &str, bytes: &[u8], j: usize) -> Result<Option<(PatternItem, usize)>> {
+    let (name, mut k) = read_name(pattern, bytes, j);
+    let card = match bytes.get(k).copied() {
+        Some(b'*') => {
+            k += 1;
+            Cardinality::Many
+        }
+        Some(b'?') => {
+            k += 1;
+            Cardinality::Optional
+        }
+        _ => Cardinality::One,
+    };
+    // optional `: /regex/` matcher
+    k = skip_spaces(bytes, k);
+    let regex = if bytes.get(k) == Some(&b':') {
+        let (re, nk) = lex_regex(pattern, bytes, skip_spaces(bytes, k + 1))?;
+        k = nk;
+        Some(re)
+    } else {
+        None
+    };
+    k = skip_spaces(bytes, k);
+    if bytes.get(k) != Some(&b')') {
+        return Ok(None); // unterminated / malformed `S(` — treat the sigil as literal
+    }
+    Ok(Some((meta(name_binding(name), card, regex), k + 1)))
+}
+
+/// Parse `/regex/` (or shorthand `/regex`) starting at `k` (which must point at
+/// the opening `/`). Returns `(compiled_regex, index_past_the_regex)`. A missing
+/// `/`, an unterminated regex, or one that fails to compile is a `client` error.
+///
+/// Delimiting uses **paren depth** (the matcher's `\(` is depth 1): a `/` at
+/// depth 1 closes (delimited form); a `)` that drops depth to 0 closes (shorthand
+/// form). So *balanced* `()` inside the regex — alternations like `(foo|bar)` —
+/// are free, no escaping. Escape a literal `/` (or an unbalanced `)`) as `\/` /
+/// `\)`; the `regex` crate accepts `\<punct>` as the literal, so the slice is
+/// passed through verbatim. Scanning for these ASCII bytes is UTF-8-safe (they
+/// never occur mid multi-byte char).
+fn lex_regex(pattern: &str, bytes: &[u8], k: usize) -> Result<(Regex, usize)> {
+    if bytes.get(k) != Some(&b'/') {
+        return Err(Error::client(
+            "metavar matcher must be a regex: expected `/` after `:`",
+        ));
+    }
+    let start = k + 1;
+    let mut p = start;
+    let mut depth = 1usize; // the matcher's `\(` is open
+    let (close, delimited) = loop {
+        match bytes.get(p) {
+            None => return Err(Error::client("unterminated regex in metavar matcher")),
+            Some(b'\\') => p += 2, // skip the escaped char (\/ \) \( …)
+            Some(b'(') => {
+                depth += 1;
+                p += 1;
+            }
+            Some(b')') => {
+                depth -= 1;
+                if depth == 0 {
+                    break (p, false); // matcher close → shorthand
+                }
+                p += 1;
+            }
+            Some(b'/') if depth == 1 => break (p, true), // top-level `/` → delimited
+            Some(_) => p += 1,
+        }
+    };
+    // `start`/`close` land on ASCII (`/`, `)`) → char boundaries; safe slice.
+    let raw = &pattern[start..close];
+    let regex =
+        Regex::new(raw).map_err(|e| Error::client(format!("invalid regex `/{raw}/`: {e}")))?;
+    let next = if delimited { close + 1 } else { close };
+    Ok((regex, next))
+}
+
+fn skip_spaces(bytes: &[u8], mut k: usize) -> usize {
+    while bytes.get(k) == Some(&b' ') {
+        k += 1;
+    }
+    k
+}
+
+/// Read a metavar name `[A-Za-z0-9_]*` starting at `j`. Returns the name slice
+/// and the index past it.
+fn read_name<'a>(pattern: &'a str, bytes: &[u8], j: usize) -> (&'a str, usize) {
+    let start = j;
+    let mut k = j;
+    while k < bytes.len() && (bytes[k].is_ascii_alphanumeric() || bytes[k] == b'_') {
+        k += 1;
+    }
+    (&pattern[start..k], k)
+}
+
+/// A name of `""` or `"_"` is anonymous.
+fn name_binding(name: &str) -> Option<String> {
+    if name.is_empty() || name == "_" {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn meta(name: Option<String>, card: Cardinality, regex: Option<Regex>) -> PatternItem {
+    PatternItem::Meta { name, card, regex }
+}

--- a/rust/code_match/src/lib.rs
+++ b/rust/code_match/src/lib.rs
@@ -1,0 +1,19 @@
+//! `cocoindex_code_match` — match by-example structural patterns against
+//! tree-sitter ASTs (14 languages). Patterns are flat token+metavar skeletons;
+//! the source is a full tree-sitter parse, so precedence/balancing/context come
+//! from the AST for free.
+//!
+//! Pattern compilation is fallible: a malformed metavar regex surfaces as a
+//! [`cocoindex_utils::error::Error::client`] via [`Pattern::compile`].
+
+mod config;
+pub mod lang;
+mod lexer;
+mod matcher;
+
+pub use config::{LangConfig, RegexTokenizer, TokKind, TokenRule, Tokenizer};
+pub use lexer::{Cardinality, PatternItem};
+pub use matcher::{Capture, Match, Pattern};
+
+// The crate's fallible surface uses the workspace-standard error type.
+pub use cocoindex_utils::error::{Error, Result};

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -1,0 +1,574 @@
+//! The matcher: flatten a candidate node into a leaf frontier + node spans, then
+//! match the flat pattern against it with a memoized DP. Metavariables snap to
+//! node boundaries.
+//!
+//! Bindings are threaded *forward* (insert on bind, restore on backtrack) so
+//! repeated metavar names enforce equality (`$A ... $A` must capture equal
+//! text). The fail-memo on `(pi, li)` is only sound when names are unique, so it
+//! is disabled for patterns that repeat a name.
+//!
+//! `Match`/`Capture` borrow the source string (`'s`): their `text` is a slice of
+//! it, so callers can't accidentally pass the wrong source.
+
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+
+use cocoindex_utils::error::Result;
+use regex::Regex;
+use tree_sitter::{Node, Parser};
+
+use crate::config::LangConfig;
+use crate::lexer::{Cardinality, PatternItem, lex};
+
+/// A captured metavariable: the matched source text and its byte range.
+#[derive(Debug, Clone)]
+pub struct Capture<'s> {
+    pub text: &'s str,
+    pub range: Range<usize>,
+    /// true for a `$$$` (sibling-run) capture, false for a single-node `$X`
+    pub multi: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Match<'s> {
+    pub kind: String,
+    pub range: Range<usize>,
+    pub text: &'s str,
+    pub captures: HashMap<String, Capture<'s>>,
+}
+
+impl<'s> Match<'s> {
+    pub fn capture(&self, name: &str) -> Option<&Capture<'s>> {
+        self.captures.get(name)
+    }
+    /// Convenience: the captured text for `name`, if bound.
+    pub fn capture_text(&self, name: &str) -> Option<&'s str> {
+        self.captures.get(name).map(|c| c.text)
+    }
+}
+
+#[derive(Clone)]
+struct Leaf {
+    text: String,
+    anon: bool,
+    start_byte: usize,
+    end_byte: usize,
+}
+
+#[derive(Clone)]
+struct Span {
+    start_leaf: usize,
+    end_leaf: usize, // inclusive
+    start_byte: usize,
+    end_byte: usize,
+    node_kind: String,
+    /// `[start_leaf, end_leaf]` of each direct child that produced leaves, in
+    /// order. Used only for candidates (partial child-aligned matching); empty
+    /// for leaf nodes. (Carried on every span for simplicity; see §matches.)
+    child_bounds: Vec<(usize, usize)>,
+}
+
+struct Indexed {
+    leaves: Vec<Leaf>,
+    /// spans (named nodes) grouped by first leaf, sorted by end_leaf desc (greedy-largest-first)
+    spans_by_start: Vec<Vec<Span>>,
+    /// every named node, used as a match candidate
+    candidates: Vec<Span>,
+    /// Per leaf, the ids of nodes for which it is a direct-child **start** /
+    /// **end**. A same-level (`*`) run `[li, next)` is a sibling slice iff some
+    /// node owns `li` as a child-start *and* `next-1` as a child-end (children
+    /// tile a node contiguously in leaf space). Used by `match_multi`.
+    child_start_owners: Vec<Vec<u32>>,
+    child_end_owners: Vec<Vec<u32>>,
+}
+
+impl Indexed {
+    /// Is `[li, next)` a contiguous run of one node's direct children?
+    fn same_level(&self, li: usize, next: usize) -> bool {
+        if next <= li {
+            return true; // empty run
+        }
+        let starts = &self.child_start_owners[li];
+        let ends = &self.child_end_owners[next - 1];
+        starts.iter().any(|n| ends.contains(n))
+    }
+}
+
+/// Compiled, language-bound pattern.
+pub struct Pattern {
+    items: Vec<PatternItem>,
+    cfg: LangConfig,
+    /// true when some metavar name appears more than once (disables the fail-memo)
+    has_dup_names: bool,
+}
+
+impl Pattern {
+    /// Compile a pattern for `cfg`. Fails with a `client` error on a malformed
+    /// metavar matcher (e.g. an unparseable regex).
+    pub fn compile(pattern: &str, cfg: &LangConfig) -> Result<Pattern> {
+        let items = lex(pattern, cfg)?;
+        let has_dup_names = detect_dup_names(&items);
+        Ok(Pattern {
+            items,
+            cfg: cfg.clone(),
+            has_dup_names,
+        })
+    }
+
+    pub fn matches<'s>(&self, source: &'s str) -> Vec<Match<'s>> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&self.cfg.language)
+            .expect("load language");
+        let tree = parser.parse(source, None).expect("parse source");
+        let idx = index_tree(tree.root_node(), source.as_bytes(), &self.cfg);
+
+        // Run the DP over leaves `[start, hi)` with a fresh binding context;
+        // return the captures on an exact match.
+        let run = |start: usize, hi: usize| -> Option<HashMap<String, Capture<'s>>> {
+            let mut ctx = Ctx {
+                items: &self.items,
+                idx: &idx,
+                source,
+                use_memo: !self.has_dup_names,
+                bound: HashMap::new(),
+                fail: HashSet::new(),
+            };
+            ctx.dp(0, start, hi).then_some(ctx.bound)
+        };
+
+        let mut out = Vec::new();
+        for cand in &idx.candidates {
+            // 1) Whole-node coverage (the pattern spans the entire candidate).
+            let captures = run(cand.start_leaf, cand.end_leaf + 1).or_else(|| {
+                // 2) Leading/trailing tolerance: the pattern may instead cover a
+                // contiguous run of the candidate's *direct children* that spans
+                // **≥2** children (`j > i`). Leading/trailing siblings — e.g. a
+                // Rust `pub` and the fn body around `fn clone(self)` — are free
+                // context. The ≥2 rule means a single-child run isn't matched
+                // here; that child is the integral match on its own iteration
+                // (so `\A = \B` matches the assignment, not the `expr;` around it).
+                let kids = &cand.child_bounds;
+                (0..kids.len()).find_map(|i| {
+                    // Cheap prune: if the pattern starts with a literal token, the
+                    // run must start at a child whose first leaf is that token —
+                    // skip hopeless starts without allocating a match context.
+                    // (Keeps the O(children²) partial scan from churning on the
+                    // common no-match candidates during a search.)
+                    if let Some(PatternItem::Token(t)) = self.items.first()
+                        && &idx.leaves[kids[i].0].text != t
+                    {
+                        return None;
+                    }
+                    (i + 1..kids.len()).find_map(|j| {
+                        let (a, hi) = (kids[i].0, kids[j].1 + 1);
+                        // skip the whole-node run — already tried in (1)
+                        if a == cand.start_leaf && hi == cand.end_leaf + 1 {
+                            return None;
+                        }
+                        run(a, hi)
+                    })
+                })
+            });
+            if let Some(captures) = captures {
+                out.push(Match {
+                    kind: cand.node_kind.clone(),
+                    range: cand.start_byte..cand.end_byte,
+                    text: &source[cand.start_byte..cand.end_byte],
+                    captures,
+                });
+            }
+        }
+        out
+    }
+}
+
+fn detect_dup_names(items: &[PatternItem]) -> bool {
+    let mut seen = HashSet::new();
+    for it in items {
+        if let PatternItem::Meta { name: Some(n), .. } = it
+            && !seen.insert(n)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn index_tree(root: Node, src: &[u8], cfg: &LangConfig) -> Indexed {
+    let mut c = Collector {
+        src,
+        cfg,
+        leaves: Vec::new(),
+        spans: Vec::new(),
+        cs_pairs: Vec::new(),
+        ce_pairs: Vec::new(),
+        next_id: 0,
+    };
+    c.collect(root);
+
+    let n = c.leaves.len();
+    let mut spans_by_start: Vec<Vec<Span>> = vec![Vec::new(); n];
+    for sp in &c.spans {
+        spans_by_start[sp.start_leaf].push(sp.clone());
+    }
+    for v in spans_by_start.iter_mut() {
+        // greedy-largest-first: by leaf extent, then by byte width — the latter
+        // breaks ties when a node and a child share the same single leaf but the
+        // node's byte range is wider (e.g. a raw string whose delimiters aren't
+        // leaf children), so a metavar binds the outer node.
+        v.sort_by_key(|s| {
+            (
+                std::cmp::Reverse(s.end_leaf),
+                std::cmp::Reverse(s.end_byte - s.start_byte),
+            )
+        });
+    }
+
+    let mut child_start_owners: Vec<Vec<u32>> = vec![Vec::new(); n];
+    let mut child_end_owners: Vec<Vec<u32>> = vec![Vec::new(); n];
+    for (leaf, id) in c.cs_pairs {
+        child_start_owners[leaf].push(id);
+    }
+    for (leaf, id) in c.ce_pairs {
+        child_end_owners[leaf].push(id);
+    }
+
+    Indexed {
+        leaves: c.leaves,
+        spans_by_start,
+        candidates: c.spans,
+        child_start_owners,
+        child_end_owners,
+    }
+}
+
+/// Flattens the tree into the leaf frontier + node spans + child-boundary
+/// ownership in a single pass.
+struct Collector<'a> {
+    src: &'a [u8],
+    cfg: &'a LangConfig,
+    leaves: Vec<Leaf>,
+    spans: Vec<Span>,
+    cs_pairs: Vec<(usize, u32)>, // (child_start_leaf, parent_id)
+    ce_pairs: Vec<(usize, u32)>, // (child_end_leaf, parent_id)
+    next_id: u32,
+}
+
+impl Collector<'_> {
+    fn collect(&mut self, node: Node) {
+        // treat comments as insignificant
+        if node.kind().contains("comment") {
+            return;
+        }
+        let my_id = self.next_id; // pre-order id; this node is the parent of its children
+        self.next_id += 1;
+        let first = self.leaves.len();
+        let mut child_bounds: Vec<(usize, usize)> = Vec::new();
+
+        if node.child_count() == 0 {
+            let text = node.utf8_text(self.src).unwrap_or("").to_string();
+            if self.cfg.is_splittable(&text) {
+                let mut b = node.start_byte();
+                for ch in text.chars() {
+                    let cl = ch.len_utf8();
+                    self.leaves.push(Leaf {
+                        text: ch.to_string(),
+                        anon: true,
+                        start_byte: b,
+                        end_byte: b + cl,
+                    });
+                    b += cl;
+                }
+            } else {
+                self.leaves.push(Leaf {
+                    text,
+                    anon: !node.is_named(),
+                    start_byte: node.start_byte(),
+                    end_byte: node.end_byte(),
+                });
+            }
+        } else {
+            let mut cursor = node.walk();
+            let children: Vec<Node> = node.children(&mut cursor).collect();
+            for ch in children {
+                let before = self.leaves.len();
+                self.collect(ch);
+                // record this child's leaf span (skip children that yielded none,
+                // e.g. comments) for partial matching + same-level ownership
+                if self.leaves.len() > before {
+                    let last = self.leaves.len() - 1;
+                    child_bounds.push((before, last));
+                    self.cs_pairs.push((before, my_id));
+                    self.ce_pairs.push((last, my_id));
+                }
+            }
+        }
+
+        if node.is_named() && self.leaves.len() > first {
+            self.spans.push(Span {
+                start_leaf: first,
+                end_leaf: self.leaves.len() - 1,
+                start_byte: node.start_byte(),
+                end_byte: node.end_byte(),
+                node_kind: node.kind().to_string(),
+                child_bounds,
+            });
+        }
+    }
+}
+
+struct Ctx<'a, 's> {
+    items: &'a [PatternItem],
+    idx: &'a Indexed,
+    source: &'s str,
+    use_memo: bool,
+    bound: HashMap<String, Capture<'s>>,
+    fail: HashSet<(usize, usize)>,
+}
+
+impl<'s> Ctx<'_, 's> {
+    /// Match `items[pi..]` against leaves `[li, hi)`. On success, `bound` holds
+    /// the captures.
+    fn dp(&mut self, pi: usize, li: usize, hi: usize) -> bool {
+        if pi == self.items.len() {
+            return li == hi;
+        }
+        if self.use_memo && self.fail.contains(&(pi, li)) {
+            return false;
+        }
+
+        // Copy the shared (`Copy`) reference out of `self` so matching on it
+        // doesn't borrow `self`, leaving `self` free for the `&mut self` calls.
+        let items = self.items;
+        let ok = match &items[pi] {
+            PatternItem::Token(t) => {
+                li < hi && &self.idx.leaves[li].text == t && self.dp(pi + 1, li + 1, hi)
+            }
+            PatternItem::Str(s) => self.match_literal(pi, li, hi, s),
+            PatternItem::Meta { name, card, regex } => match card {
+                Cardinality::One => self.match_single(pi, li, hi, name.as_deref(), regex.as_ref()),
+                // Many ignores the regex (sibling runs are out of the single-node scope).
+                Cardinality::Many => self.match_multi(pi, li, hi, name.as_deref()),
+                Cardinality::Optional => {
+                    self.match_optional(pi, li, hi, name.as_deref(), regex.as_ref())
+                }
+            },
+        };
+
+        if !ok && self.use_memo {
+            self.fail.insert((pi, li));
+        }
+        ok
+    }
+
+    fn match_literal(&mut self, pi: usize, li: usize, hi: usize, s: &str) -> bool {
+        if li >= hi {
+            return false;
+        }
+        // A string/char literal is one node whose text includes its quotes;
+        // match any span with equal text (language-agnostic).
+        let idx = self.idx;
+        let source = self.source;
+        for sp in &idx.spans_by_start[li] {
+            if sp.end_leaf < hi
+                && &source[sp.start_byte..sp.end_byte] == s
+                && self.dp(pi + 1, sp.end_leaf + 1, hi)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn match_single(
+        &mut self,
+        pi: usize,
+        li: usize,
+        hi: usize,
+        name: Option<&str>,
+        regex: Option<&Regex>,
+    ) -> bool {
+        if li >= hi {
+            return false;
+        }
+        let idx = self.idx;
+        // greedy: spans are sorted largest-first. The regex (if any) filters the
+        // candidates *inside* this loop, so every nesting level that satisfies it
+        // stays a live, backtrackable candidate — not just the greedy-largest.
+        for sp in &idx.spans_by_start[li] {
+            if sp.end_leaf >= hi {
+                continue;
+            }
+            if !regex_ok(regex, &self.source[sp.start_byte..sp.end_byte]) {
+                continue;
+            }
+            let cap = self.make_capture(sp.start_byte, sp.end_byte, false);
+            match self.bind(name, cap) {
+                BindResult::Inconsistent => continue,
+                bind => {
+                    if self.dp(pi + 1, sp.end_leaf + 1, hi) {
+                        return true;
+                    }
+                    self.unbind(name, bind);
+                }
+            }
+        }
+        false
+    }
+
+    /// `\(X*)` — match a run of sibling subtrees, restricted to a contiguous run
+    /// of *one parent's* direct children (same-level), so a `*` run can't
+    /// silently leak out of the subtree the pattern entered. A cross-level skip
+    /// is written as multiple `*`, one per grammar level.
+    fn match_multi(&mut self, pi: usize, li: usize, hi: usize, name: Option<&str>) -> bool {
+        let idx = self.idx;
+        let reach = reachable(li, hi, idx); // descending => greedy longest first
+        for next in reach {
+            // a same-level `*` run must be a single parent's sibling slice
+            if !idx.same_level(li, next) {
+                continue;
+            }
+            let (sb, eb) = if next > li {
+                (idx.leaves[li].start_byte, idx.leaves[next - 1].end_byte)
+            } else {
+                let b = idx.leaves.get(li).map(|l| l.start_byte).unwrap_or(0);
+                (b, b)
+            };
+            let cap = self.make_capture(sb, eb, true);
+            match self.bind(name, cap) {
+                BindResult::Inconsistent => continue,
+                bind => {
+                    if self.dp(pi + 1, next, hi) {
+                        return true;
+                    }
+                    self.unbind(name, bind);
+                }
+            }
+        }
+        false
+    }
+
+    /// `\(X?)` — match zero or one node. Greedy: try one node first, then none
+    /// (binding an empty capture at `li`). A regex constrains the node *when
+    /// present*; absence is always allowed (the `?` keeps its meaning).
+    fn match_optional(
+        &mut self,
+        pi: usize,
+        li: usize,
+        hi: usize,
+        name: Option<&str>,
+        regex: Option<&Regex>,
+    ) -> bool {
+        let idx = self.idx;
+        // one node (greedy, largest span first)
+        if li < hi {
+            for sp in &idx.spans_by_start[li] {
+                if sp.end_leaf >= hi {
+                    continue;
+                }
+                if !regex_ok(regex, &self.source[sp.start_byte..sp.end_byte]) {
+                    continue;
+                }
+                let cap = self.make_capture(sp.start_byte, sp.end_byte, false);
+                match self.bind(name, cap) {
+                    BindResult::Inconsistent => continue,
+                    bind => {
+                        if self.dp(pi + 1, sp.end_leaf + 1, hi) {
+                            return true;
+                        }
+                        self.unbind(name, bind);
+                    }
+                }
+            }
+        }
+        // zero nodes: empty capture, do not advance the leaf cursor
+        let b = if li < idx.leaves.len() {
+            idx.leaves[li].start_byte
+        } else if li > 0 {
+            idx.leaves[li - 1].end_byte
+        } else {
+            0
+        };
+        let cap = self.make_capture(b, b, false);
+        match self.bind(name, cap) {
+            BindResult::Inconsistent => false,
+            bind => {
+                if self.dp(pi + 1, li, hi) {
+                    return true;
+                }
+                self.unbind(name, bind);
+                false
+            }
+        }
+    }
+
+    fn make_capture(&self, start_byte: usize, end_byte: usize, multi: bool) -> Capture<'s> {
+        Capture {
+            text: &self.source[start_byte..end_byte],
+            range: start_byte..end_byte,
+            multi,
+        }
+    }
+
+    /// Try to bind `name` to `cap`. Returns whether we inserted (so backtracking
+    /// can restore), or `Inconsistent` if an existing binding of the same name
+    /// has different text.
+    fn bind(&mut self, name: Option<&str>, cap: Capture<'s>) -> BindResult {
+        let Some(n) = name else {
+            return BindResult::NotInserted;
+        };
+        match self.bound.get(n) {
+            Some(existing) if existing.text != cap.text => BindResult::Inconsistent,
+            Some(_) => BindResult::NotInserted,
+            None => {
+                self.bound.insert(n.to_string(), cap);
+                BindResult::Inserted
+            }
+        }
+    }
+
+    fn unbind(&mut self, name: Option<&str>, bind: BindResult) {
+        if let (Some(n), BindResult::Inserted) = (name, bind) {
+            self.bound.remove(n);
+        }
+    }
+}
+
+enum BindResult {
+    Inserted,
+    NotInserted,
+    Inconsistent,
+}
+
+/// A metavar's regex constraint (if any) against a candidate's source text.
+/// Unanchored (`is_match`): `/get/` is a substring test, `^…$` pins the whole node.
+fn regex_ok(regex: Option<&Regex>, text: &str) -> bool {
+    regex.is_none_or(|re| re.is_match(text))
+}
+
+/// Positions reachable from `li` (within `[li, hi]`) by consuming whole units:
+/// a complete named subtree span, or a single anonymous leaf. Returns them
+/// descending so the multi-metavar binds greedily (longest first).
+fn reachable(li: usize, hi: usize, idx: &Indexed) -> Vec<usize> {
+    let n = hi - li;
+    let mut reach = vec![false; n + 1];
+    reach[0] = true;
+    for off in 0..n {
+        if !reach[off] {
+            continue;
+        }
+        let p = li + off;
+        for sp in &idx.spans_by_start[p] {
+            if sp.end_leaf < hi {
+                reach[sp.end_leaf + 1 - li] = true;
+            }
+        }
+        if idx.leaves[p].anon {
+            reach[p + 1 - li] = true;
+        }
+    }
+    let mut res: Vec<usize> = (0..=n).filter(|&o| reach[o]).map(|o| li + o).collect();
+    res.sort_by(|a, b| b.cmp(a));
+    res
+}

--- a/rust/code_match/tests/common/mod.rs
+++ b/rust/code_match/tests/common/mod.rs
@@ -1,0 +1,27 @@
+//! Shared helpers for the integration tests.
+#![allow(dead_code)] // each test crate uses a subset
+
+use cocoindex_code_match::{LangConfig, Match, Pattern};
+
+/// Compile `pat` for `cfg` and match it against `src`.
+pub fn matches<'s>(cfg: LangConfig, pat: &str, src: &'s str) -> Vec<Match<'s>> {
+    Pattern::compile(pat, &cfg)
+        .expect("valid test pattern")
+        .matches(src)
+}
+
+/// First captured value for `name` across the matches, as an owned String.
+pub fn cap(ms: &[Match], name: &str) -> Option<String> {
+    ms.iter()
+        .find_map(|m| m.capture_text(name).map(str::to_string))
+}
+
+/// Whether any match has node kind `kind`.
+pub fn has_kind(ms: &[Match], kind: &str) -> bool {
+    ms.iter().any(|m| m.kind == kind)
+}
+
+/// The first match whose matched text equals `text`.
+pub fn by_text<'a, 's>(ms: &'a [Match<'s>], text: &str) -> Option<&'a Match<'s>> {
+    ms.iter().find(|m| m.text == text)
+}

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1,0 +1,460 @@
+//! Engine-feature tests (language-agnostic behavior, illustrated in whatever
+//! language is convenient): balancing, precedence, the wildcard DP, cardinality,
+//! metavar equality, the `>>` split, number-lexing limits, and the sigil config.
+
+mod common;
+use common::*;
+
+use cocoindex_code_match::{Pattern, lang};
+
+// ---------------- structural matching ----------------
+
+#[test]
+fn string_is_atomic() {
+    // The `)` inside the string literal must be invisible — strings are one node.
+    let src = r#"foo("a)b");"#;
+    let ms = matches(lang::typescript(), r"foo(\(ARGS*))", src);
+    assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a)b""#));
+}
+
+#[test]
+fn precedence_from_ast() {
+    // `a = b = c` is right-associative; the outer node binds \B = (b = c).
+    let src = "a = b = c;";
+    let ms = matches(lang::typescript(), r"\A = \B", src);
+    let outer = by_text(&ms, "a = b = c").expect("outer assignment");
+    assert_eq!(outer.capture_text("A"), Some("a"));
+    assert_eq!(outer.capture_text("B"), Some("b = c"));
+    let inner = by_text(&ms, "b = c").expect("inner assignment");
+    assert_eq!(inner.capture_text("A"), Some("b"));
+    assert_eq!(inner.capture_text("B"), Some("c"));
+}
+
+#[test]
+fn leading_trailing_tolerance() {
+    // A pattern may cover a contiguous run of a node's direct children that
+    // spans ≥2 children; leading/trailing siblings are free context. Here the
+    // arrow function's params + body are covered, ignoring the leading `async`.
+    let src = "const f = async (x) => x + 1;";
+    let ms = matches(lang::typescript(), r"(\P) => \B", src);
+    assert!(
+        ms.iter().any(|m| m.kind == "arrow_function"),
+        "should match the arrow function ignoring leading `async`, got {ms:?}",
+    );
+}
+
+#[test]
+fn star_is_same_level() {
+    // `\*` is same-level: `~D() \* }` requires the destructor to be the LAST
+    // member — a same-level run can't leak past the class body into siblings.
+    let same = r"class \NAME \* { \* ~\NAME() \* }";
+    assert!(!matches(lang::cpp(), same, "class Foo { ~Foo() {} };").is_empty());
+    assert!(
+        matches(lang::cpp(), same, "class Bar { ~Bar(); int x; };").is_empty(),
+        "same-level `*` must not skip past following members",
+    );
+}
+
+#[test]
+fn multiple_stars_cross_levels() {
+    // A cross-level skip is written as multiple `\*`, one per grammar level: the
+    // first absorbs the destructor's own tail, the second the following members
+    // (which sit at a different depth). No single hole crosses, so nothing leaks.
+    let pat = r"class \NAME \* { \* ~\NAME() \* \* }";
+    // destructor anywhere in the class
+    assert!(!matches(lang::cpp(), pat, "class Bar { int x; ~Bar(); void f(); };").is_empty());
+    // and it can't leak out of one class into the next — only the two real
+    // classes match, no `translation_unit` span across the `;`.
+    let ms = matches(
+        lang::cpp(),
+        pat,
+        "class Foo { ~Foo() {} }; class Bar { ~Bar() {} };",
+    );
+    assert!(
+        ms.iter().all(|m| !m.text.contains(';')),
+        "no match may span the `;` between classes, got {ms:?}",
+    );
+    let names: Vec<&str> = ms.iter().filter_map(|m| m.capture_text("NAME")).collect();
+    assert!(names.contains(&"Foo") && names.contains(&"Bar"));
+}
+
+#[test]
+fn partial_match_dedup() {
+    // The ≥2-children rule: a single-child run is left to the child, so the
+    // assignment is the match — not the `expr;` statement that wraps it.
+    let ms = matches(lang::typescript(), r"\A = \B", "a = b;");
+    assert!(ms.iter().any(|m| m.kind == "assignment_expression"));
+    assert!(
+        !ms.iter().any(|m| m.kind == "expression_statement"),
+        "the enclosing statement must not also match (dedup), got {ms:?}",
+    );
+}
+
+#[test]
+fn multiple_gaps_dp() {
+    // Two `\(*)` gaps around an anchor — exercises the wildcard DP / backtracking.
+    let src = "function f() { a(); foo(); b(); }";
+    let ms = matches(lang::typescript(), r"{ \(A*) foo(); \(B*) }", src);
+    let m = ms
+        .iter()
+        .find(|m| m.kind == "statement_block")
+        .expect("statement_block match");
+    assert_eq!(m.capture_text("A"), Some("a();"));
+    assert_eq!(m.capture_text("B"), Some("b();"));
+}
+
+#[test]
+fn optional_metavar() {
+    // `\(ARG?)` matches calls with zero or one argument.
+    let ms = matches(lang::typescript(), r"f(\(ARG?))", "f(x);");
+    assert_eq!(cap(&ms, "ARG").as_deref(), Some("x"));
+    let ms = matches(lang::typescript(), r"f(\(ARG?))", "f();");
+    assert!(has_kind(&ms, "call_expression"), "no-arg call should match");
+}
+
+#[test]
+fn anonymous_metavars() {
+    // `\_` single + `\*` anonymous many: matches but captures nothing.
+    let src = "obj.method(1, 2, 3);";
+    let ms = matches(lang::typescript(), r"\_.method(\*)", src);
+    assert!(has_kind(&ms, "call_expression"));
+}
+
+#[test]
+fn multiple_match_sites() {
+    let src = "log(1); log(2); other(3);";
+    let ms = matches(lang::typescript(), r"log(\A)", src);
+    let caps: Vec<Option<&str>> = ms
+        .iter()
+        .filter(|m| m.kind == "call_expression")
+        .map(|m| m.capture_text("A"))
+        .collect();
+    assert!(caps.contains(&Some("1")) && caps.contains(&Some("2")));
+    assert_eq!(caps.len(), 2);
+}
+
+#[test]
+fn no_false_match() {
+    let ms = matches(lang::typescript(), r"console.log(\*)", "foo(1);");
+    assert!(ms.is_empty(), "should not match anything, got {ms:?}");
+}
+
+// ---------------- metavar equality ----------------
+
+#[test]
+fn repeated_metavar_must_be_equal() {
+    let ms = matches(lang::typescript(), r"\X == \X", "if (a == a) {}");
+    assert_eq!(cap(&ms, "X").as_deref(), Some("a"));
+
+    let src = "if (a == b) {}";
+    let ms = matches(lang::typescript(), r"\X == \X", src);
+    assert!(ms.is_empty(), "a == b must not match \\X == \\X");
+}
+
+#[test]
+fn distinct_metavars_need_not_be_equal() {
+    let src = "x = y;";
+    let ms = matches(lang::typescript(), r"\A = \B", src);
+    assert!(
+        ms.iter()
+            .any(|m| m.capture_text("A") == Some("x") && m.capture_text("B") == Some("y"))
+    );
+}
+
+// ---------------- regex metavar matcher ----------------
+
+fn caps_all<'a>(ms: &'a [cocoindex_code_match::Match], name: &str) -> Vec<&'a str> {
+    let mut v: Vec<&str> = ms.iter().filter_map(|m| m.capture_text(name)).collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn regex_constrains_identifier() {
+    // `\(F:/^get/)` filters the callee to names starting with `get`.
+    let src = "getUser(1); setName(2); getId(3);";
+    let ms = matches(lang::typescript(), r"\(F:/^get/)(\*)", src);
+    assert_eq!(caps_all(&ms, "F"), vec!["getId", "getUser"]);
+}
+
+#[test]
+fn regex_pins_nesting_level() {
+    // Larger spans (`foo.bar`, `foo.bar(x)`) all start at `foo`; `^foo$` filters
+    // the candidates down to the leaf. Exercises "every sub-layer is a candidate".
+    let src = "foo.bar(x);";
+    let ms = matches(lang::typescript(), r"\(OBJ:/^foo$/).bar(\*)", src);
+    assert_eq!(cap(&ms, "OBJ").as_deref(), Some("foo"));
+}
+
+#[test]
+fn regex_on_subtree() {
+    // The metavar binds a whole expression; the regex tests its source text.
+    let yes = matches(lang::typescript(), r"f(\(A:/\+/))", "f(a + b);");
+    assert_eq!(cap(&yes, "A").as_deref(), Some("a + b"));
+    let no = matches(lang::typescript(), r"f(\(A:/\+/))", "f(ab);");
+    assert!(no.iter().all(|m| m.kind != "call_expression"));
+}
+
+#[test]
+fn regex_alternation_parens_free() {
+    // Balanced `()` inside a delimited regex need no escaping (paren-depth close).
+    let src = "foo; bar; baz;";
+    let ms = matches(lang::typescript(), r"\(N:/^(foo|bar)$/)", src);
+    assert_eq!(caps_all(&ms, "N"), vec!["bar", "foo"]);
+}
+
+#[test]
+fn regex_shorthand_no_closing_slash() {
+    let src = "getUser(1); setName(2);";
+    let ms = matches(lang::typescript(), r"\(F:/^get)(\*)", src);
+    assert_eq!(cap(&ms, "F").as_deref(), Some("getUser"));
+}
+
+#[test]
+fn regex_escaped_slash() {
+    // `\/` is a literal slash (the `regex` crate accepts `\<punct>`).
+    let ms = matches(lang::typescript(), r"f(\(P:/a\/b/))", "f(a/b); f(ab);");
+    assert_eq!(cap(&ms, "P").as_deref(), Some("a/b"));
+}
+
+#[test]
+fn regex_dotstar_equals_bare() {
+    // `/.*/ ` is a pure pass-through filter, so it must behave exactly like `\X`.
+    let src = "a = b = c;";
+    let bare = matches(lang::typescript(), r"\X = \Y", src);
+    let dotstar = matches(lang::typescript(), r"\(X:/.*/) = \Y", src);
+    assert_eq!(bare.len(), dotstar.len());
+    assert_eq!(caps_all(&bare, "X"), caps_all(&dotstar, "X"));
+}
+
+#[test]
+fn regex_optional_constrains_when_present() {
+    // Present must match the regex; absence is still allowed (the `?` is kept).
+    let ts = lang::typescript();
+    assert_eq!(
+        cap(&matches(ts.clone(), r"f(\(A?:/^x/))", "f(x);"), "A").as_deref(),
+        Some("x")
+    );
+    assert!(has_kind(
+        &matches(ts.clone(), r"f(\(A?:/^x/))", "f();"),
+        "call_expression"
+    ));
+    assert!(
+        matches(ts, r"f(\(A?:/^x/))", "f(y);")
+            .iter()
+            .all(|m| m.kind != "call_expression")
+    );
+}
+
+#[test]
+fn regex_invalid_errors() {
+    // An unparseable regex surfaces as a `client` compile error (not a panic,
+    // not a silently-dropped constraint).
+    let res = Pattern::compile(r"\(Z:/[/) = \Y", &lang::typescript());
+    assert!(
+        matches!(res, Err(cocoindex_code_match::Error::Client { .. })),
+        "expected a client error"
+    );
+}
+
+// ---------------- metavar names (digit / lowercase) ----------------
+
+#[test]
+fn metavar_digit_name_equality() {
+    // sed-like `\1`; repeated name still enforces equality.
+    assert!(!matches(lang::typescript(), r"\1 == \1", "if (a == a) {}").is_empty());
+    assert!(matches(lang::typescript(), r"\1 == \1", "if (a == b) {}").is_empty());
+}
+
+#[test]
+fn metavar_lowercase_name() {
+    let ms = matches(lang::typescript(), r"\x = \y", "m = n;");
+    assert!(
+        ms.iter()
+            .any(|m| m.capture_text("x") == Some("m") && m.capture_text("y") == Some("n"))
+    );
+}
+
+// ---------------- configurable sigil ----------------
+
+#[test]
+fn configurable_dollar_sigil() {
+    let cfg = lang::typescript().with_meta_char('$');
+    let src = "foo(a, b);";
+    let ms = Pattern::compile("foo($(ARGS*))", &cfg)
+        .unwrap()
+        .matches(src);
+    assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    let ms = Pattern::compile("foo($A, $B)", &cfg).unwrap().matches(src);
+    assert!(
+        ms.iter()
+            .any(|m| m.capture_text("A") == Some("a") && m.capture_text("B") == Some("b"))
+    );
+}
+
+// ---------------- lexer robustness ----------------
+
+#[test]
+fn malformed_string_pattern_does_not_panic() {
+    let cfg = lang::typescript();
+    // A bare/unterminated sigil is lenient (compiles, lexed as a literal).
+    let _ = Pattern::compile("foo(\"\\", &cfg)
+        .unwrap()
+        .matches("foo();");
+    let _ = Pattern::compile("\\", &cfg).unwrap().matches("x;");
+}
+
+// ---------------- numbers ----------------
+
+#[test]
+fn float_literal_is_one_token() {
+    let src = "void g(){ foo(3.14); }";
+    let ms = matches(lang::c(), "foo(3.14)", src);
+    assert!(has_kind(&ms, "call_expression"));
+}
+
+#[test]
+fn float_literal_capture() {
+    let src = "let x = f(2.5e3);";
+    let ms = matches(lang::typescript(), r"f(\N)", src);
+    assert_eq!(cap(&ms, "N").as_deref(), Some("2.5e3"));
+}
+
+#[test]
+fn cpp_separated_number_metavar_ok() {
+    // Metavar over a `'`-separated C++ number works (source node matched whole).
+    let src = "int x = 1'000 + 5;";
+    let ms = matches(lang::cpp(), r"\N + 5", src);
+    assert_eq!(cap(&ms, "N").as_deref(), Some("1'000"));
+}
+
+#[test]
+fn cpp_apostrophe_separator_literal() {
+    // The C++ number rule includes `'`, so a literal `1'000` in a pattern lexes
+    // as one token and aligns with the source number (M2.5).
+    let src = "int x = 1'000;";
+    assert!(!matches(lang::cpp(), "1'000", src).is_empty());
+}
+
+// ---------------- per-language literal lexing (M2.5) ----------------
+
+#[test]
+fn rust_raw_string_literal() {
+    // `r#"a"b"#` is one node despite the inner `"`; a literal raw string in the
+    // pattern must lex as a single Str and match.
+    let src = r##"fn m() { log(r#"a"b"#); }"##;
+    let ms = matches(lang::rust(), r##"log(r#"a"b"#)"##, src);
+    assert!(
+        has_kind(&ms, "call_expression"),
+        "rust raw string should match"
+    );
+}
+
+#[test]
+fn rust_raw_string_metavar() {
+    let src = r##"fn m() { log(r#"a"b"#); }"##;
+    let ms = matches(lang::rust(), r"log(\S)", src);
+    assert_eq!(cap(&ms, "S").as_deref(), Some(r##"r#"a"b"#"##));
+}
+
+#[test]
+fn python_triple_string_literal() {
+    let src = "x = \"\"\"a\nb\"\"\"\n";
+    let ms = matches(lang::python(), "x = \"\"\"a\nb\"\"\"", src);
+    assert!(!ms.is_empty(), "python triple-quoted string should match");
+}
+
+#[test]
+fn number_suffix_and_separator() {
+    // Rust suffixed/separated integer lexes as one token.
+    let src = "fn m() { let n = 1_000u64; }";
+    let ms = matches(lang::rust(), "1_000u64", src);
+    assert!(
+        !ms.is_empty(),
+        "rust suffixed/separated number should match"
+    );
+}
+
+// ---------------- non-ASCII / UTF-8 ----------------
+// The lexer scans bytes for ASCII structural decisions but hands content to
+// UTF-8-aware tokenizers, so non-ASCII works without char-by-char scanning.
+
+#[test]
+fn cjk_in_string_literal() {
+    let src = r#"print("你好")"#;
+    assert!(has_kind(
+        &matches(lang::python(), r#"print("你好")"#, src),
+        "call",
+    ));
+    // and captured by a metavar
+    let ms = matches(lang::python(), r"print(\S)", src);
+    assert_eq!(cap(&ms, "S").as_deref(), Some(r#""你好""#));
+}
+
+#[test]
+fn cjk_identifier() {
+    // Unicode-aware identifier tokenizer: `变量` lexes as one identifier.
+    let src = "变量 = 1";
+    let ms = matches(lang::python(), r"变量 = \V", src);
+    assert_eq!(cap(&ms, "V").as_deref(), Some("1"));
+}
+
+#[test]
+fn emoji_in_string_and_as_arg() {
+    let src = r#"f("😀", 你好)"#;
+    let ms = matches(lang::typescript(), r"f(\(ARGS*))", src);
+    assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""😀", 你好"#));
+}
+
+#[test]
+fn non_ascii_never_panics() {
+    // The panic-safety is structural (all slices land on char boundaries), so
+    // arbitrary non-ASCII placements must never crash — only lex as best effort.
+    let cfg = lang::typescript();
+    for pat in [
+        "😀",
+        r"\😀", // sigil then emoji (not a valid name → literal sigil + char)
+        "a😀b",
+        r#""你好\"#, // unterminated string with CJK + trailing backslash
+        "λ + 你好 * \\X",
+        "变量.😀()",
+    ] {
+        // just must not panic (compile may error; matching must never crash)
+        let _ = cocoindex_code_match::Pattern::compile(pat, &cfg).map(|p| p.matches("x;"));
+    }
+}
+
+#[test]
+fn non_ascii_sigil() {
+    // The sigil compares as a char, so a non-ASCII sigil works (and its bytes
+    // are sliced correctly).
+    let cfg = lang::typescript().with_meta_char('§');
+    let src = "a = b;";
+    let ms = cocoindex_code_match::Pattern::compile("§A = §B", &cfg)
+        .unwrap()
+        .matches(src);
+    assert!(
+        ms.iter()
+            .any(|m| m.capture_text("A") == Some("a") && m.capture_text("B") == Some("b"))
+    );
+}
+
+// ---------------- operator/generics alignment ----------------
+
+#[test]
+fn alignment_operators_and_generics() {
+    let ok = |cfg, frag, src| !matches(cfg, frag, src).is_empty();
+    assert!(ok(lang::cpp(), "a >> b", "int n = a >> b;"));
+    assert!(ok(
+        lang::cpp(),
+        "vector<vector<int>>",
+        "vector<vector<int>> v;"
+    ));
+    assert!(ok(lang::c(), "p->field", "void g(){ p->field; }"));
+    assert!(ok(
+        lang::rust(),
+        "std::mem::swap",
+        "fn m(){ std::mem::swap(); }"
+    ));
+    assert!(ok(lang::typescript(), "a === b", "if (a === b) {}"));
+}


### PR DESCRIPTION
## Summary
- New **`cocoindex_code_match`** crate (`rust/code_match`): match by-example structural patterns against tree-sitter ASTs, to back code search in cocoindex-code / ccc.
- Flat token+metavar pattern skeleton matched over a full tree-sitter parse — precedence, balancing, and context-sensitive nesting come from the AST. Metavars (same-level runs, single/optional, repeated-name equality, `\(NAME:/re/)` regex matchers) + leading/trailing tolerance for by-signature search.
- 14 languages (TS/TSX, JS, C, C++, Python, Rust, Go, Java, C#, Ruby, PHP, Scala, Bash, SQL); tree-sitter pinned to `cocoindex_ops_text`'s versions (single `links = "tree-sitter"` across the workspace). Fallible `Pattern::compile` via `cocoindex_utils::error`.

## Test plan
- `cargo test -p cocoindex_code_match` — 77 tests. CI builds the workspace.
