### PR TITLE
feat(code_match): escape sigil + anonymous regex matcher

### DIFF
--- a/rust/code_match/README.md
+++ b/rust/code_match/README.md
@@ -26,7 +26,7 @@ The sigil is `\` by default (shell-safe; configurable to `$` via `LangConfig::wi
 - `\NAME` — one node (named); `\_` — one node, anonymous.
 - `\(NAME*)` — a run of **same-level** sibling nodes (many); `\*` — anonymous. A cross-level skip is written as multiple `\*`, one per grammar level.
 - `\(NAME?)` — optional (zero or one node); `\?` — anonymous.
-- `\(NAME:/regex/)` — the captured source text must match the regex (unanchored; `^…$` for whole-node).
+- `\(NAME:/regex/)` — the captured source text must match the regex (unanchored; `^…$` for whole-node). The name is optional: `\(:/regex/)` constrains a node without capturing it.
 - A repeated name must capture equal text: `\X == \X` matches `a == a`, not `a == b`.
 
 Use raw strings (`r"..."`) when writing patterns in Rust so the backslashes stay literal.

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -11,6 +11,7 @@
 //!   `S_` / `S(_)`   anonymous single        `S*` / `S(*)`  anonymous many
 //!   `S?` / `S(?)`   anonymous optional
 //!   `S(NAME:/re/)`  single, regex-constrained — see below
+//!   `S(:/re/)`      regex-constrained, **anonymous** (filter without capturing)
 //!   `SS`            a doubled sigil is one **literal** sigil (e.g. `\\` → `\`)
 //! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
 //! written as multiple `*`, one per grammar level.
@@ -20,6 +21,7 @@
 //!
 //! Regex matcher `:/re/` constrains a **single-node** metavar: the captured
 //! source text must `is_match` (unanchored) the regex (use `^…$` for whole-node).
+//! The name is optional — `S(:/re/)` constrains a node without capturing it.
 //! Applies to `One`/`Optional`; ignored on `Many` (sibling runs, out of scope).
 //! The closing `/` is optional (`:/re`): a `/` at the matcher's top paren level
 //! closes (delimited), else the matcher's `)` closes (shorthand). Balanced `()`

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -11,6 +11,7 @@
 //!   `S_` / `S(_)`   anonymous single        `S*` / `S(*)`  anonymous many
 //!   `S?` / `S(?)`   anonymous optional
 //!   `S(NAME:/re/)`  single, regex-constrained — see below
+//!   `SS`            a doubled sigil is one **literal** sigil (e.g. `\\` → `\`)
 //! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
 //! written as multiple `*`, one per grammar level.
 //! Names are `[A-Za-z0-9_]+` (upper/lower/digit, sed-like `\1`); UPPERCASE is a
@@ -84,6 +85,13 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         // metavar sigil (compare as a char; any sigil works, not just ASCII)
         if first == cfg.meta_char {
             let after = i + clen;
+            // escaped sigil: a doubled sigil (`\\`) is one *literal* sigil — the
+            // way to write a literal `\` (or whatever the sigil is) in a pattern.
+            if pattern[after..].starts_with(cfg.meta_char) {
+                out.push(PatternItem::Token(cfg.meta_char.to_string()));
+                i = after + cfg.meta_char.len_utf8();
+                continue;
+            }
             if let Some((item, next)) = lex_metavar(pattern, bytes, after)? {
                 out.push(item);
                 i = next;

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -292,6 +292,25 @@ fn configurable_dollar_sigil() {
     );
 }
 
+#[test]
+fn escaped_sigil_is_literal() {
+    // A doubled sigil is one *literal* sigil. `\\X` is a literal `\` + `X`, not a
+    // metavar, so it does not match `a = 1` the way `\X` does.
+    let ts = lang::typescript();
+    assert!(!matches(ts.clone(), r"\X = 1", "a = 1;").is_empty());
+    assert!(
+        matches(ts, r"\\X = 1", "a = 1;").is_empty(),
+        "`\\\\X` must be a literal backslash + X, not a metavar",
+    );
+    // And the escape is sigil-agnostic: with `$` as the sigil, `$$` is a literal
+    // `$` — here matching a jQuery-style `$(…)` call.
+    let dollar = lang::typescript().with_meta_char('$');
+    assert!(has_kind(
+        &matches(dollar, "$$(a)", "$(a);"),
+        "call_expression"
+    ));
+}
+
 // ---------------- lexer robustness ----------------
 
 #[test]

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -178,6 +178,24 @@ fn regex_constrains_identifier() {
 }
 
 #[test]
+fn anonymous_regex_matcher() {
+    // `\(:/re/)` — a regex constraint with no name: filter a node without
+    // capturing it. Here the callee must match `^get`, but isn't bound.
+    let src = "getUser(1); setName(2); getId(3);";
+    let ms = matches(lang::typescript(), r"\(:/^get/)(\*)", src);
+    let callees: Vec<&str> = ms
+        .iter()
+        .filter(|m| m.kind == "call_expression")
+        .map(|m| m.text)
+        .collect();
+    assert!(callees.contains(&"getUser(1)") && callees.contains(&"getId(3)"));
+    assert!(
+        !callees.iter().any(|t| t.contains("setName")),
+        "the `^get` constraint must exclude setName, got {callees:?}",
+    );
+}
+
+#[test]
 fn regex_pins_nesting_level() {
     // Larger spans (`foo.bar`, `foo.bar(x)`) all start at `foo`; `^foo$` filters
     // the candidates down to the leaf. Exercises "every sub-layer is a candidate".


### PR DESCRIPTION
## Summary
- **Escape the sigil** — a doubled metavar sigil is one *literal* sigil: `\\` → a literal `\` (sigil-agnostic, so `$$` → `$` when the sigil is `$`), letting a pattern match a literal backslash. `\\X` is thus a literal `\` + `X`, not a metavar.
- **Anonymous regex matcher** — `\(:/re/)` constrains a node by its source text *without* capturing it (the named `\(NAME:/re/)` minus the name).

## Test plan
- `cargo test -p cocoindex_code_match` — 79 tests. CI builds the workspace.
