### PR TITLE
feat(code_match): context-sensitive lexer for HTML/XML

### DIFF
--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -35,11 +35,18 @@ pub trait Tokenizer: Send + Sync {
     fn match_len(&self, input: &str) -> Option<usize>;
 }
 
-/// A tokenizer paired with how its match should be emitted.
+/// A tokenizer active in any lexer mode (the default mask).
+pub const ALL_MODES: u8 = 0xFF;
+
+/// A tokenizer paired with how its match should be emitted and which lexer
+/// **modes** it's active in. Most languages have one mode (`ALL_MODES`);
+/// context-sensitive ones (HTML/XML) restrict rules per mode (DESIGN: lexer modes).
 #[derive(Clone)]
 pub struct TokenRule {
     pub tokenizer: Arc<dyn Tokenizer>,
     pub kind: TokKind,
+    /// Bitmask of modes this rule applies in (bit `m` ↔ mode `m`).
+    pub modes: u8,
 }
 
 impl TokenRule {
@@ -47,7 +54,13 @@ impl TokenRule {
         TokenRule {
             tokenizer: Arc::new(tokenizer),
             kind,
+            modes: ALL_MODES,
         }
+    }
+    /// Restrict this rule to a set of lexer modes (a bitmask).
+    pub fn in_modes(mut self, modes: u8) -> Self {
+        self.modes = modes;
+        self
     }
 }
 
@@ -111,6 +124,14 @@ pub fn backtick_string() -> TokenRule {
     regex_rule(r"(?s)^`(?:\\.|[^`\\])*`", TokKind::Str)
 }
 
+/// A free-text run up to (not including) `stop`, emitted atomically like a
+/// string node. Used for markup text content (HTML/XML), where the run has no
+/// special punctuation and a `"` is a literal char, not a string delimiter.
+/// `stop` must be safe inside a regex character class (e.g. `<`).
+pub fn free_text(stop: char) -> TokenRule {
+    regex_rule(&format!("^[^{stop}]+"), TokKind::Str)
+}
+
 /// The default tokenizer set (identifier, number, the three quote styles).
 pub fn generic_tokenizers() -> Vec<TokenRule> {
     vec![
@@ -140,6 +161,14 @@ pub struct LangConfig {
     /// Tokenizers for literal/identifier classes, tried at each position; the
     /// longest match wins.
     pub tokenizers: Vec<TokenRule>,
+    /// Lexer **mode** transitions: in mode `from`, emitting a single-char token
+    /// whose text is `trigger` switches the lexer to mode `to`. Empty ⇒ a single
+    /// mode (mode 0), the default. HTML/XML use this to flip between text and tag
+    /// context (`<` ⇒ tag, `>` ⇒ text).
+    pub transitions: Vec<(u8, char, u8)>,
+    /// Bitmask of modes that **preserve** whitespace (the lexer does not skip it)
+    /// — e.g. HTML text content. Default 0 (whitespace skipped in every mode).
+    pub ws_preserve: u8,
 }
 
 impl LangConfig {
@@ -155,12 +184,23 @@ impl LangConfig {
             splittable,
             meta_char: '\\',
             tokenizers: generic_tokenizers(),
+            transitions: Vec::new(),
+            ws_preserve: 0,
         }
     }
 
     /// Replace the tokenizer set (per-language literal profiles).
     pub fn with_tokenizers(mut self, tokenizers: Vec<TokenRule>) -> Self {
         self.tokenizers = tokenizers;
+        self
+    }
+
+    /// Configure a context-sensitive (multi-mode) lexer: `transitions` flip the
+    /// active mode on single-char tokens, `ws_preserve` marks modes whose
+    /// whitespace is significant.
+    pub fn with_modes(mut self, transitions: Vec<(u8, char, u8)>, ws_preserve: u8) -> Self {
+        self.transitions = transitions;
+        self.ws_preserve = ws_preserve;
         self
     }
 
@@ -172,6 +212,25 @@ impl LangConfig {
 
     pub fn is_splittable(&self, text: &str) -> bool {
         self.splittable.contains(text)
+    }
+
+    /// Whether mode `m` preserves whitespace (the lexer should not skip it).
+    pub fn preserves_ws(&self, mode: u8) -> bool {
+        (self.ws_preserve >> mode) & 1 == 1
+    }
+
+    /// The mode after emitting an operator token `text` in mode `mode`. A token
+    /// *containing* the trigger char flips the mode, so multi-char tag delimiters
+    /// work too (`</`, `/>`, `<!--` carry `<`/`>`). Only the caller's *operator*
+    /// tokens reach here — string/free-text tokens never trigger, so a `>` inside
+    /// an attribute value or text run doesn't spuriously flip the mode.
+    pub fn mode_after(&self, mode: u8, text: &str) -> u8 {
+        for &(from, trigger, to) in &self.transitions {
+            if from == mode && text.contains(trigger) {
+                return to;
+            }
+        }
+        mode
     }
 }
 

--- a/rust/code_match/src/lang/html.rs
+++ b/rust/code_match/src/lang/html.rs
@@ -1,22 +1,36 @@
 //! html.
 //!
 //! Quote tokenization is context-sensitive: in an *attribute* a `"` is paired
-//! (`class="x"`), but in *text* content it's a literal char (`<p>a"b</p>` is
-//! valid, and quotes in separate elements are unrelated). The flat pattern lexer
-//! can't see that context, so write **structural** patterns: anchor at tags and
-//! use a metavar for text content (`<p>\X</p>`), where quotes only appear in
-//! attribute position. A *literal* quote in pattern text would wrongly pair
-//! across structure — unsupported, same as literal free text in general.
-//! Lifting this (literal `attr="v"` *and* safe text) needs a context-sensitive
-//! lexer that tokenizes differently inside vs outside `<…>` — a future addition,
-//! since the stateless tokenizer can't see that region.
-use crate::config::LangConfig;
+//! (`class="x"`), but in *text* it's a literal char (`<p>a"b</p>` is valid, and
+//! quotes in separate elements are unrelated). So the lexer runs in two modes:
+//!   - **text** (outside `<…>`, mode 0): a free-text run, emitted atomically like
+//!     a string node; whitespace is significant; `"` is a literal char.
+//!   - **tag** (inside `<…>`, mode 1): identifiers/numbers + paired attribute
+//!     strings; whitespace skipped.
+//!
+//! `<` flips text→tag, `>` flips tag→text. A pattern thus matches text content
+//! either literally (`<p>hello</p>`) or with a metavar over the whole text
+//! (`<p>\X</p>`); attribute strings (`class="x"`) tokenize correctly.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
+const TEXT: u8 = 0;
+const TAG: u8 = 1;
+
 pub fn html() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_html::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            free_text('<').in_modes(1 << TEXT),
+            identifier().in_modes(1 << TAG),
+            number("").in_modes(1 << TAG),
+            dq_string().in_modes(1 << TAG),
+            sq_string().in_modes(1 << TAG),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_html::LANGUAGE))
+            .with_tokenizers(toks)
+            .with_modes(vec![(TEXT, '<', TAG), (TAG, '>', TEXT)], 1 << TEXT)
+    });
     CFG.clone()
 }
 
@@ -26,16 +40,61 @@ mod tests {
     use crate::lang::testutil::*;
 
     #[test]
-    fn element_text() {
+    fn metavar_over_text() {
         let ms = matches(html(), r"<p>\X</p>", "<p>hi</p>");
         assert_eq!(cap(&ms, "X").as_deref(), Some("hi"));
     }
 
     #[test]
-    fn metavar_captures_quoted_text() {
-        // A `"` in text content is just part of the captured node — the metavar
-        // handles it; no literal quote needed in the pattern.
+    fn literal_text() {
+        // text content matches literally (a free-text run, not split into words).
+        assert!(has_kind(
+            &matches(html(), "<p>hello world</p>", "<p>hello world</p>"),
+            "element"
+        ));
+    }
+
+    #[test]
+    fn quote_in_text_is_literal() {
+        // a `"` in text is part of the text run — captured by a metavar, and not
+        // paired across structure.
         let ms = matches(html(), r"<div>\X</div>", r#"<div>a"b</div>"#);
         assert_eq!(cap(&ms, "X").as_deref(), Some(r#"a"b"#));
+    }
+
+    #[test]
+    fn no_cross_element_quote_pairing() {
+        // The hazard: with a context-free `"…"` tokenizer the two text quotes
+        // would pair across the tags. Here each `<div>` matches independently and
+        // nothing spans the gap.
+        let src = r#"<div>a"b</div><div>c"d</div>"#;
+        let ms = matches(html(), r"<div>\X</div>", src);
+        let texts: Vec<&str> = ms
+            .iter()
+            .filter(|m| m.kind == "element")
+            .filter_map(|m| m.capture_text("X"))
+            .collect();
+        assert!(
+            texts.contains(&r#"a"b"#) && texts.contains(&r#"c"d"#),
+            "got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn attribute_string() {
+        // inside a tag, `"x"` is a paired string and matches the attribute value.
+        let ms = matches(
+            html(),
+            r#"<div class="x">\*</div>"#,
+            r#"<div class="x">hi</div>"#,
+        );
+        assert!(has_kind(&ms, "element"));
+    }
+
+    #[test]
+    fn attribute_metavar() {
+        // a metavar over the attribute value.
+        let ms = matches(html(), r"<a href=\V>\*</a>", r#"<a href="/x">hi</a>"#);
+        assert_eq!(cap(&ms, "V").as_deref(), Some(r#""/x""#));
     }
 }

--- a/rust/code_match/src/lang/xml.rs
+++ b/rust/code_match/src/lang/xml.rs
@@ -1,15 +1,28 @@
 //! xml.
 //!
-//! Like HTML, quote tokenization is context-sensitive (paired in attributes,
-//! literal in text). Write structural patterns and use a metavar for text
-//! content (`<tag>\X</tag>`); literal quotes in pattern text are unsupported.
-use crate::config::LangConfig;
+//! Same context-sensitive lexing as HTML (see `html.rs`): a **text** mode
+//! outside `<…>` (free-text run, `"` literal) and a **tag** mode inside (paired
+//! attribute strings), flipped by `<` / `>`.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
+const TEXT: u8 = 0;
+const TAG: u8 = 1;
+
 pub fn xml() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_xml::LANGUAGE_XML)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            free_text('<').in_modes(1 << TEXT),
+            identifier().in_modes(1 << TAG),
+            number("").in_modes(1 << TAG),
+            dq_string().in_modes(1 << TAG),
+            sq_string().in_modes(1 << TAG),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_xml::LANGUAGE_XML))
+            .with_tokenizers(toks)
+            .with_modes(vec![(TEXT, '<', TAG), (TAG, '>', TEXT)], 1 << TEXT)
+    });
     CFG.clone()
 }
 
@@ -19,8 +32,28 @@ mod tests {
     use crate::lang::testutil::*;
 
     #[test]
-    fn element_text() {
+    fn metavar_over_text() {
         let ms = matches(xml(), r"<a>\X</a>", "<a>hi</a>");
         assert_eq!(cap(&ms, "X").as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn literal_text() {
+        assert!(has_kind(
+            &matches(xml(), "<a>hello world</a>", "<a>hello world</a>"),
+            "element"
+        ));
+    }
+
+    #[test]
+    fn quote_in_text_is_literal() {
+        let ms = matches(xml(), r"<a>\X</a>", r#"<a>x"y</a>"#);
+        assert_eq!(cap(&ms, "X").as_deref(), Some(r#"x"y"#));
+    }
+
+    #[test]
+    fn attribute_string() {
+        let ms = matches(xml(), r#"<a id="x">\*</a>"#, r#"<a id="x">hi</a>"#);
+        assert!(has_kind(&ms, "element"));
     }
 }

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -67,6 +67,9 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
     let bytes = pattern.as_bytes();
     let mut i = 0usize;
     let mut out = Vec::new();
+    // Lexer mode — single-mode (0) for most languages; HTML/XML flip between
+    // text (0) and tag (1) on `<`/`>`, which gates the tokenizers + whitespace.
+    let mut mode: u8 = 0;
 
     // We dispatch on the leading `char` at `i` (not a raw byte). `i` is always
     // advanced by char-aligned amounts (a decoded char, a regex match `end()`,
@@ -78,8 +81,10 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         let first = pattern[i..].chars().next().expect("i is a char boundary");
         let clen = first.len_utf8();
 
-        // whitespace (decode the char so non-ASCII whitespace, e.g. U+3000, skips too)
-        if first.is_whitespace() {
+        // whitespace (decode the char so non-ASCII whitespace, e.g. U+3000, skips
+        // too) — unless the current mode preserves it (e.g. HTML text content,
+        // where it's part of the text node).
+        if first.is_whitespace() && !cfg.preserves_ws(mode) {
             i += clen;
             continue;
         }
@@ -112,6 +117,9 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         let mut best_len = 0usize;
         let mut best_kind = TokKind::Token;
         for rule in &cfg.tokenizers {
+            if rule.modes & (1 << mode) == 0 {
+                continue; // not active in the current mode
+            }
             if let Some(l) = rule.tokenizer.match_len(rest)
                 && l > best_len
             {
@@ -138,6 +146,11 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         }
         if best_len > 0 {
             let text = pattern[i..i + best_len].to_string();
+            // Only operator tokens flip the mode (e.g. `<`/`>` in HTML); a string
+            // or free-text token carrying `<`/`>` must not.
+            if best_kind == TokKind::Token {
+                mode = cfg.mode_after(mode, &text);
+            }
             out.push(match best_kind {
                 TokKind::Str => PatternItem::Str(text),
                 TokKind::Token => PatternItem::Token(text),
@@ -147,7 +160,9 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         }
 
         // single-char fallback (a char in neither a literal class nor the op table)
-        out.push(PatternItem::Token(pattern[i..i + clen].to_string()));
+        let text = pattern[i..i + clen].to_string();
+        mode = cfg.mode_after(mode, &text);
+        out.push(PatternItem::Token(text));
         i += clen;
     }
 


### PR DESCRIPTION
## Summary
- Generalizes the lexer with **modes**: a tokenizer is active in a bitmask of modes, operator tokens flip the mode via transitions (a token *containing* the trigger char, so multi-char `</`/`/>` work; strings/free-text never trigger), and a mode can preserve whitespace.
- **HTML/XML** use two modes — *text* (outside `<…>`: a free-text run emitted atomically like a string node, whitespace significant, `"` literal) and *tag* (inside: identifiers/numbers + paired attribute strings). `<` flips text→tag, `>` flips tag→text.
- Fixes the quote-context hazard: a `"` in text is part of the text run, not a string delimiter, so quotes no longer pair across structure; attribute strings still tokenize. Literal text (`<p>hello</p>`) and metavar-over-text (`<p>\X</p>`) both match. Single-mode languages unaffected.

## Test plan
- `cargo test -p cocoindex_code_match` — 103 tests (10 new HTML/XML cases incl. literal text, quotes-as-literal, no cross-element pairing, attribute strings/metavars).
