### PR TITLE
feat(code_match): per-language literal tokenizers + correct string escaping

### DIFF
--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -124,6 +124,37 @@ pub fn backtick_string() -> TokenRule {
     regex_rule(r"(?s)^`(?:\\.|[^`\\])*`", TokKind::Str)
 }
 
+// --- non-backslash string conventions ---
+//
+// `dq_string`/`sq_string` above bake in C-style backslash escaping (`"a\"b"` is
+// one string). That is *wrong* for languages that escape differently, where it
+// would close the string at the wrong quote. The builders below cover the two
+// other common conventions; a language must pick the one its grammar uses.
+
+/// Single-quoted string where an embedded quote is written by **doubling** it
+/// (`'it''s'`), with no backslash escaping. Used by SQL, Fortran, Pascal.
+pub fn sq_string_doubled() -> TokenRule {
+    regex_rule(r"(?s)^'(?:''|[^'])*'", TokKind::Str)
+}
+
+/// Double-quoted string with doubled-quote escaping (`"a""b"`) — Fortran.
+pub fn dq_string_doubled() -> TokenRule {
+    regex_rule(r#"(?s)^"(?:""|[^"])*""#, TokKind::Str)
+}
+
+/// Single-quoted string with **no** escaping at all — a `'` always closes it
+/// (`'$x\n'` is the five characters `$x\n`). Used by POSIX shells and TOML's
+/// literal strings.
+pub fn sq_string_literal() -> TokenRule {
+    regex_rule(r"^'[^']*'", TokKind::Str)
+}
+
+/// Backtick string with **no** escaping — a backtick always closes it, and `\`
+/// is a literal character (Go raw strings `` `a\b` ``). May span newlines.
+pub fn backtick_string_literal() -> TokenRule {
+    regex_rule(r"^`[^`]*`", TokKind::Str)
+}
+
 /// A free-text run up to (not including) `stop`, emitted atomically like a
 /// string node. Used for markup text content (HTML/XML), where the run has no
 /// special punctuation and a `"` is a literal char, not a string delimiter.
@@ -132,7 +163,25 @@ pub fn free_text(stop: char) -> TokenRule {
     regex_rule(&format!("^[^{stop}]+"), TokKind::Str)
 }
 
-/// The default tokenizer set (identifier, number, the three quote styles).
+/// Triple-double-quoted string `"""..."""` — one node. The generic `"..."`
+/// would mis-split the opening `""` as an empty string, so languages with raw /
+/// multiline triple strings (Kotlin, Julia, Elm, TOML basic, …) add this.
+/// Interpolations inside are matched opaquely via the whole node's text.
+pub fn triple_dq_string() -> TokenRule {
+    regex_rule(r#"(?s)^""".*?""""#, TokKind::Str)
+}
+
+/// Triple-single-quoted string `'''...'''` — one node (TOML literal multiline).
+pub fn triple_sq_string() -> TokenRule {
+    regex_rule(r"(?s)^'''.*?'''", TokKind::Str)
+}
+
+/// A convenience tokenizer set for **C-style** languages: identifier, number,
+/// and the three quote styles with *backslash* escaping. Correct for the large
+/// family (C/C++/Rust/Java/JS/TS/C#/Go/…), but **not** universal — languages
+/// that escape differently (SQL/Fortran/Pascal `''` doubling, shells/TOML
+/// literal `'...'`, Go raw backticks) must build their own set from the
+/// `*_doubled` / `*_literal` builders above. Verify with a `literal_forms` test.
 pub fn generic_tokenizers() -> Vec<TokenRule> {
     vec![
         identifier(),
@@ -172,8 +221,11 @@ pub struct LangConfig {
 }
 
 impl LangConfig {
-    /// Build a config from a grammar with the generic tokenizers and derived
-    /// op/splittable tables. Language modules call this, then `with_tokenizers`.
+    /// Build a config from a grammar. Seeds the **C-style** `generic_tokenizers`
+    /// (backslash escaping) and the derived op/splittable tables; a language
+    /// module then refines the literal profile via `with_tokenizers`. The seeded
+    /// default is a convenience, *not* a guarantee — if the language escapes
+    /// strings differently it must override (see `generic_tokenizers`).
     pub fn from_grammar(language: Language) -> Self {
         let single_char = single_char_punct_tokens(&language);
         let splittable = detect_splittable(&language, &single_char);

--- a/rust/code_match/src/lang/bash.rs
+++ b/rust/code_match/src/lang/bash.rs
@@ -1,11 +1,20 @@
-//! Bash.
-use crate::config::LangConfig;
+//! Bash. Single-quoted strings have **no** escaping — a `'` always closes and
+//! `$`/`\` are literal (`'$x'` is the literal text `$x`). Double-quoted strings
+//! use backslash and `$`-expansion (matched opaquely via the node's text).
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn bash() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_bash::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),         // "..." backslash + $-expansion
+            sq_string_literal(), // '...' literal, no escaping
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_bash::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -20,5 +29,17 @@ mod tests {
         let src = "echo hello";
         let ms = matches(bash(), r"echo \MSG", src);
         assert_eq!(cap(&ms, "MSG").as_deref(), Some("hello"));
+    }
+
+    /// Conformance over Bash string forms (literal single quotes).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("'$HOME'", "x='$HOME'"), // literal, $ not expanded
+            ("'a b'", "x='a b'"),
+            ("\"hi\"", "x=\"hi\""),
+        ] {
+            assert!(!matches(bash(), lit, ctx).is_empty(), "Bash `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/cmake.rs
+++ b/rust/code_match/src/lang/cmake.rs
@@ -1,12 +1,57 @@
-//! cmake.
-use crate::config::LangConfig;
+//! CMake: bracket arguments `[[...]]` / `[=[...]=]` (matching `=` count) are
+//! single raw-text nodes the `regex` crate can't balance. Quoted args use the
+//! generic backslash escaping; `${VAR}` references match via the generic profile.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn cmake() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_cmake::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(TokenRule::new(CmakeBracket, TokKind::Str));
+        LangConfig::from_grammar(Language::new(tree_sitter_cmake::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
+}
+
+/// `[=*[ ... ]=*]` with a matching number of `=`.
+struct CmakeBracket;
+
+impl Tokenizer for CmakeBracket {
+    fn match_len(&self, input: &str) -> Option<usize> {
+        let b = input.as_bytes();
+        if b.first() != Some(&b'[') {
+            return None;
+        }
+        let mut p = 1;
+        let eq_start = p;
+        while b.get(p) == Some(&b'=') {
+            p += 1;
+        }
+        let n = p - eq_start;
+        if b.get(p) != Some(&b'[') {
+            return None;
+        }
+        p += 1;
+        loop {
+            while p < b.len() && b[p] != b']' {
+                p += 1;
+            }
+            if p >= b.len() {
+                return None;
+            }
+            let mut q = p + 1;
+            let mut e = 0;
+            while e < n && b.get(q) == Some(&b'=') {
+                e += 1;
+                q += 1;
+            }
+            if e == n && b.get(q) == Some(&b']') {
+                return Some(q + 1);
+            }
+            p += 1;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -19,5 +64,18 @@ mod tests {
         // CMake command arguments are space-separated.
         let ms = matches(cmake(), r"set(\(A*))", "set(x 1)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("x 1"));
+    }
+
+    /// Conformance over CMake argument forms (quoted, bracket, variable ref).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "set(x \"hi\")"),
+            ("${VAR}", "set(x ${VAR})"),
+            ("[[raw]]", "set(x [[raw]])"),
+            ("[=[ra]]w]=]", "set(x [=[ra]]w]=])"),
+        ] {
+            assert!(!matches(cmake(), lit, ctx).is_empty(), "CMake `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/csharp.rs
+++ b/rust/code_match/src/lang/csharp.rs
@@ -1,11 +1,17 @@
-//! csharp.
-use crate::config::LangConfig;
+//! C#: verbatim strings `@"a""b"` use doubled-quote escaping (and `\` is
+//! literal), and raw strings `"""..."""` (C# 11) are one node. Normal/interpolated
+//! `"..."` use the generic backslash form.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn csharp() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_c_sharp::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(triple_dq_string()); // raw string """..."""
+        toks.push(regex_rule(r#"(?s)^@"(?:""|[^"])*""#, TokKind::Str)); // verbatim @"a""b"
+        LangConfig::from_grammar(Language::new(tree_sitter_c_sharp::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +25,20 @@ mod tests {
         let src = "class C { void M() { foo(a, b); } }";
         let ms = matches(csharp(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over C# literal forms (verbatim/raw strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "class C { string s = \"hi\"; }"),
+            ("@\"a\"\"b\"", "class C { string s = @\"a\"\"b\"; }"),
+            ("\"\"\"hi\"\"\"", "class C { string s = \"\"\"hi\"\"\"; }"),
+            ("'c'", "class C { char c = 'c'; }"),
+            ("0xFF", "class C { int x = 0xFF; }"),
+            ("1_000L", "class C { long x = 1_000L; }"),
+        ] {
+            assert!(!matches(csharp(), lit, ctx).is_empty(), "C# `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/css.rs
+++ b/rust/code_match/src/lang/css.rs
@@ -1,11 +1,30 @@
-//! css.
-use crate::config::LangConfig;
+//! CSS: identifiers are kebab-case (`font-size`, `--var`, `-webkit-x`), and the
+//! grammar fuses several lexical forms into one node while hiding the lead:
+//! dimensions `10px`/`1.5em`/`100%` (leaf is just the unit) and hex colors
+//! `#fff` (leaf is just `#`) must be matched as whole nodes (Str). At-keywords
+//! `@media` and `!important` are single tokens (Token).
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn css() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_css::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            // kebab-case names incl. custom props `--x` and vendor `-webkit-x`.
+            regex_rule(r"^-{0,2}[A-Za-z_][A-Za-z0-9_-]*", TokKind::Token),
+            // dimensions / percentages / numbers — whole node by text.
+            regex_rule(r"^(?:[0-9]|\.[0-9])[0-9A-Za-z_.%]*", TokKind::Str),
+            dq_string(),
+            sq_string(),
+            // hex colors `#fff` and id selectors `#id` — whole node by text.
+            regex_rule(r"^#[0-9A-Za-z_-]+", TokKind::Str),
+            // at-keywords `@media`, `@import` — one token.
+            regex_rule(r"^@[0-9A-Za-z_-]+", TokKind::Token),
+            // `!important` / `!default` — one token.
+            regex_rule(r"^![A-Za-z]+", TokKind::Token),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_css::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +37,24 @@ mod tests {
     fn declaration_value() {
         let ms = matches(css(), r"color: \V", "a { color: red; }");
         assert_eq!(cap(&ms, "V").as_deref(), Some("red"));
+    }
+
+    /// Conformance over CSS forms: kebab names, dimensions, colors, at-rules.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("font-size", "a { font-size: 10px; }"),
+            ("--main-color", "a { --main-color: blue; }"),
+            (".foo-bar", ".foo-bar { color: red; }"),
+            ("#fff", "a { color: #fff; }"),
+            ("#id", "#id { color: red; }"),
+            ("10px", "a { width: 10px; }"),
+            ("1.5em", "a { width: 1.5em; }"),
+            ("100%", "a { width: 100%; }"),
+            ("@media screen", "@media screen {}"),
+            ("!important", "a { color: red !important; }"),
+        ] {
+            assert!(!matches(css(), lit, ctx).is_empty(), "CSS `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/elm.rs
+++ b/rust/code_match/src/lang/elm.rs
@@ -1,11 +1,15 @@
-//! elm.
-use crate::config::LangConfig;
+//! Elm: triple-quoted strings `"""..."""` (backslash escaping like the generic
+//! `"..."`/`'c'`).
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn elm() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_elm::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(triple_dq_string());
+        LangConfig::from_grammar(Language::new(tree_sitter_elm::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +22,20 @@ mod tests {
     fn declaration() {
         let ms = matches(elm(), r"x = \V", "x = 1");
         assert_eq!(cap(&ms, "V").as_deref(), Some("1"));
+    }
+
+    /// Conformance over Elm literal forms.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "x = \"hi\""),
+            ("\"\"\"hi\"\"\"", "x = \"\"\"hi\"\"\""),
+            ("'c'", "x = 'c'"),
+            ("0xFF", "x = 0xFF"),
+            ("1.5e10", "x = 1.5e10"),
+            ("42", "x = 42"),
+        ] {
+            assert!(!matches(elm(), lit, ctx).is_empty(), "Elm `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/fortran.rs
+++ b/rust/code_match/src/lang/fortran.rs
@@ -1,11 +1,24 @@
-//! fortran.
-use crate::config::LangConfig;
+//! Fortran: string literals use doubled-quote escaping (`'it''s'`, `"a""b"`) —
+//! the generic `'...'`/`"..."` would stop at the first inner quote. Plus BOZ
+//! literals `Z'FF'` / `B'1010'` / `O'17'`.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn fortran() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_fortran::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""), // 1.0d0, 1.5e10, 1.0_dp all covered by the alnum tail
+            // doubled-quote escaping: `''`/`""` is a literal quote, not a close.
+            sq_string_doubled(),
+            dq_string_doubled(),
+            // BOZ literals (binary/octal/hex), e.g. Z'FF', b'1010'.
+            regex_rule(r"^[BOZboz]'[0-9A-Fa-f]*'", TokKind::Str),
+            regex_rule(r#"^[BOZboz]"[0-9A-Fa-f]*""#, TokKind::Str),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_fortran::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +31,20 @@ mod tests {
     fn assignment() {
         let ms = matches(fortran(), r"\V = 1", "program p\nx = 1\nend program p\n");
         assert_eq!(cap(&ms, "V").as_deref(), Some("x"));
+    }
+
+    /// Conformance over Fortran literal forms (doubled-quote strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("'hi'", "program p\nx = 'hi'\nend program p\n"),
+            ("\"hi\"", "program p\nx = \"hi\"\nend program p\n"),
+            ("'it''s'", "program p\nx = 'it''s'\nend program p\n"),
+            ("\"a\"\"b\"", "program p\nx = \"a\"\"b\"\nend program p\n"),
+            ("1.0d0", "program p\nx = 1.0d0\nend program p\n"),
+            ("1.5e10", "program p\nx = 1.5e10\nend program p\n"),
+        ] {
+            assert!(!matches(fortran(), lit, ctx).is_empty(), "Fortran `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/go.rs
+++ b/rust/code_match/src/lang/go.rs
@@ -1,11 +1,22 @@
-//! go.
-use crate::config::LangConfig;
+//! Go: raw string literals use backticks with **no** escaping (`` `a\b` `` is
+//! the literal text `a\b`) — the generic backtick form treats `\` as an escape
+//! and would miss a `` `...\` ``. Interpreted strings `"..."` and runes `'r'`
+//! use the generic backslash forms.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn go() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_go::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),
+            sq_string(),               // rune 'r'
+            backtick_string_literal(), // `raw, no escapes`
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_go::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +30,20 @@ mod tests {
         let src = "package main\nfunc m() { foo(a, b) }";
         let ms = matches(go(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Go literal forms (raw backtick strings, runes, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "package m\nvar x = \"hi\""),
+            ("`raw`", "package m\nvar x = `raw`"),
+            ("`a\\b`", "package m\nvar x = `a\\b`"), // backslash is literal
+            ("'r'", "package m\nvar x = 'r'"),
+            ("0xFF", "package m\nvar x = 0xFF"),
+            ("1_000", "package m\nvar x = 1_000"),
+        ] {
+            assert!(!matches(go(), lit, ctx).is_empty(), "Go `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/hcl.rs
+++ b/rust/code_match/src/lang/hcl.rs
@@ -1,4 +1,7 @@
-//! hcl (HashiCorp Configuration Language / Terraform).
+//! hcl (HashiCorp Configuration Language / Terraform). The generic profile fits:
+//! strings use backslash escaping and `${...}` interpolation is matched opaquely
+//! via the whole string node. Heredocs (`<<EOF ... EOF`) are one node — match
+//! them with a metavar rather than an exact literal.
 use crate::config::LangConfig;
 use std::sync::LazyLock;
 use tree_sitter::Language;
@@ -18,5 +21,26 @@ mod tests {
     fn attribute() {
         let ms = matches(hcl(), r"a = \V", "a = \"b\"");
         assert_eq!(cap(&ms, "V").as_deref(), Some("\"b\""));
+    }
+
+    #[test]
+    fn heredoc_via_metavar() {
+        // Heredocs are one node — capturable with a metavar.
+        let ms = matches(hcl(), r"a = \V", "a = <<EOF\nhello\nEOF\n");
+        assert_eq!(cap(&ms, "V").as_deref(), Some("<<EOF\nhello\nEOF"));
+    }
+
+    /// Conformance over HCL literal forms (strings, interpolation, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "a = \"hi\""),
+            ("\"a${b}c\"", "a = \"a${b}c\""),
+            ("1.5", "a = 1.5"),
+            ("42", "a = 42"),
+            ("true", "a = true"),
+        ] {
+            assert!(!matches(hcl(), lit, ctx).is_empty(), "HCL `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/java.rs
+++ b/rust/code_match/src/lang/java.rs
@@ -1,11 +1,15 @@
-//! java.
-use crate::config::LangConfig;
+//! Java: text blocks `"""..."""` (Java 15+). Normal strings/chars use the
+//! generic backslash forms.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn java() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_java::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(triple_dq_string());
+        LangConfig::from_grammar(Language::new(tree_sitter_java::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +23,23 @@ mod tests {
         let src = "class C { void m() { foo(a, b); } }";
         let ms = matches(java(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Java literal forms (text blocks, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "class C { String s = \"hi\"; }"),
+            (
+                "\"\"\"\nhi\"\"\"",
+                "class C { String s = \"\"\"\nhi\"\"\"; }",
+            ),
+            ("'c'", "class C { char c = 'c'; }"),
+            ("0xFF", "class C { int x = 0xFF; }"),
+            ("1_000_000L", "class C { long x = 1_000_000L; }"),
+            ("1.5e-10", "class C { double x = 1.5e-10; }"),
+        ] {
+            assert!(!matches(java(), lit, ctx).is_empty(), "Java `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/javascript.rs
+++ b/rust/code_match/src/lang/javascript.rs
@@ -20,4 +20,21 @@ mod tests {
         let ms = matches(javascript(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
+
+    /// Conformance over JS literal forms — the generic profile (backslash
+    /// escaping, backtick template strings) is correct here.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "var x = \"hi\""),
+            ("'hi'", "var x = 'hi'"),
+            ("`tmpl`", "var x = `tmpl`"),
+            ("`a${b}c`", "var x = `a${b}c`"),
+            ("0xFF", "var x = 0xFF"),
+            ("1_000", "var x = 1_000"),
+            ("1.5e-10", "var x = 1.5e-10"),
+        ] {
+            assert!(!matches(javascript(), lit, ctx).is_empty(), "JS `{lit}`");
+        }
+    }
 }

--- a/rust/code_match/src/lang/json.rs
+++ b/rust/code_match/src/lang/json.rs
@@ -1,11 +1,21 @@
-//! json.
-use crate::config::LangConfig;
+//! JSON: numbers may be negative (`-1`, `-1.5e3`) — one node including the sign,
+//! which the generic (unsigned) number tokenizer would split off as an operator.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn json() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_json::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(), // true / false / null
+            regex_rule(
+                r"^-?(?:[0-9]|\.[0-9])(?:[eEpP][-+]|[0-9A-Za-z_.])*",
+                TokKind::Token,
+            ),
+            dq_string(),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_json::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +29,20 @@ mod tests {
         // Match over the value with a metavar.
         let ms = matches(json(), r#""a": \V"#, r#"{"a": 1}"#);
         assert_eq!(cap(&ms, "V").as_deref(), Some("1"));
+    }
+
+    /// Conformance over JSON literal forms (signed numbers, keywords).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "{\"k\": \"hi\"}"),
+            ("42", "{\"k\": 42}"),
+            ("-1", "{\"k\": -1}"),
+            ("1.5e-10", "{\"k\": 1.5e-10}"),
+            ("true", "{\"k\": true}"),
+            ("null", "{\"k\": null}"),
+        ] {
+            assert!(!matches(json(), lit, ctx).is_empty(), "JSON `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/julia.rs
+++ b/rust/code_match/src/lang/julia.rs
@@ -1,11 +1,33 @@
-//! julia.
-use crate::config::LangConfig;
+//! Julia: triple-quoted strings and non-standard (prefixed) string literals
+//! `r"..."`, `b"..."`, `raw"""..."""i` — `<prefix>"..."<flags>`, one node each.
+//! `$`-interpolation is matched opaquely via the whole node's text.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn julia() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_julia::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),
+            sq_string(),       // char literal 'c'
+            backtick_string(), // command `...`
+            triple_dq_string(),
+            // prefixed triple `r"""..."""flags` and single `r"..."flags`. The
+            // leading identifier + immediately-following quote is a macro string;
+            // longest-match beats the bare `identifier` / `"..."` tokenizers.
+            regex_rule(
+                r#"(?s)^[A-Za-z][A-Za-z0-9_]*""".*?"""[A-Za-z0-9_]*"#,
+                TokKind::Str,
+            ),
+            regex_rule(
+                r#"^[A-Za-z][A-Za-z0-9_]*"(?:\\.|[^"\\])*"[A-Za-z0-9_]*"#,
+                TokKind::Str,
+            ),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_julia::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +40,24 @@ mod tests {
     fn call() {
         let ms = matches(julia(), r"foo(\(A*))", "foo(a, b)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Julia literal forms (triple/prefixed strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "x = \"hi\""),
+            ("\"\"\"hi\"\"\"", "x = \"\"\"hi\"\"\""),
+            ("'c'", "x = 'c'"),
+            ("r\"reg\"", "x = r\"reg\""),
+            ("r\"reg\"i", "x = r\"reg\"i"),
+            ("b\"data\"", "x = b\"data\""),
+            ("0xFF", "x = 0xFF"),
+            ("1_000", "x = 1_000"),
+            ("1.5e10", "x = 1.5e10"),
+            ("1.5f0", "x = 1.5f0"),
+        ] {
+            assert!(!matches(julia(), lit, ctx).is_empty(), "Julia `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/kotlin.rs
+++ b/rust/code_match/src/lang/kotlin.rs
@@ -1,11 +1,15 @@
-//! kotlin.
-use crate::config::LangConfig;
+//! Kotlin: triple-quoted (raw) strings `"""..."""`.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn kotlin() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_kotlin_ng::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(triple_dq_string());
+        LangConfig::from_grammar(Language::new(tree_sitter_kotlin_ng::LANGUAGE))
+            .with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +22,30 @@ mod tests {
     fn call() {
         let ms = matches(kotlin(), r"foo(\(A*))", "fun m() { foo(a, b) }");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    #[test]
+    fn triple_string_literal() {
+        let src = "val x = \"\"\"a\nb\"\"\"";
+        assert!(!matches(kotlin(), src, src).is_empty());
+    }
+
+    /// Conformance over Kotlin literal forms (raw/interpolated strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"\"\"raw\"\"\"", "val x = \"\"\"raw\"\"\""),
+            ("\"hi\"", "val x = \"hi\""),
+            ("'c'", "val x = 'c'"),
+            ("0xFF", "val x = 0xFF"),
+            ("1_000", "val x = 1_000"),
+            ("1.5e10", "val x = 1.5e10"),
+            ("1L", "val x = 1L"),
+            ("1.0f", "val x = 1.0f"),
+            ("0b1010", "val x = 0b1010"),
+            ("\"a${b}c\"", "val x = \"a${b}c\""),
+        ] {
+            assert!(!matches(kotlin(), lit, ctx).is_empty(), "Kotlin `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/pascal.rs
+++ b/rust/code_match/src/lang/pascal.rs
@@ -1,11 +1,23 @@
-//! pascal.
-use crate::config::LangConfig;
+//! Pascal: string literals use doubled-quote escaping (`'it''s'`), and numbers
+//! have radix prefixes — `$FF` (hex), `&777` (octal), `%1010` (binary), `#65`
+//! (char code). Each is one `literalNumber`/`literalString` node, matched whole.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn pascal() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_pascal::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),                                     // decimal / real
+            sq_string_doubled(),                            // '' escape
+            regex_rule(r"^\$[0-9A-Fa-f]+", TokKind::Str),   // hex
+            regex_rule(r"^&[0-7]+", TokKind::Str),          // octal
+            regex_rule(r"^%[01]+", TokKind::Str),           // binary
+            regex_rule(r"^#\$?[0-9A-Fa-f]+", TokKind::Str), // char code #65 / #$41
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_pascal::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +30,19 @@ mod tests {
     fn call() {
         let ms = matches(pascal(), r"foo(\(A*))", "begin foo(a, b); end.");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Pascal literal forms (doubled-quote strings, radix nums).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("'hi'", "begin x := 'hi'; end."),
+            ("'it''s'", "begin x := 'it''s'; end."),
+            ("42", "begin x := 42; end."),
+            ("3.14", "begin x := 3.14; end."),
+            ("$FF", "begin x := $FF; end."),
+        ] {
+            assert!(!matches(pascal(), lit, ctx).is_empty(), "Pascal `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/php.rs
+++ b/rust/code_match/src/lang/php.rs
@@ -27,4 +27,19 @@ mod tests {
         let ms = matches(php(), r"$result = \VAL", src);
         assert_eq!(cap(&ms, "VAL").as_deref(), Some("compute()"));
     }
+
+    /// Conformance over PHP literal forms — the generic backslash profile fits.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "<?php $x = \"hi\"; ?>"),
+            ("'hi'", "<?php $x = 'hi'; ?>"),
+            ("42", "<?php $x = 42; ?>"),
+            ("0xFF", "<?php $x = 0xFF; ?>"),
+            ("1_000", "<?php $x = 1_000; ?>"),
+            ("1.5e-10", "<?php $x = 1.5e-10; ?>"),
+        ] {
+            assert!(!matches(php(), lit, ctx).is_empty(), "PHP `{lit}`");
+        }
+    }
 }

--- a/rust/code_match/src/lang/r.rs
+++ b/rust/code_match/src/lang/r.rs
@@ -1,11 +1,28 @@
-//! r.
-use crate::config::LangConfig;
+//! R: `%...%` special/infix operators (`%>%`, `%in%`, `%*%`) are single tokens,
+//! and numeric literals are matched as whole nodes — tree-sitter-r models the
+//! `L` suffix of `1L` as a child token and hides the digits, so the leaf frontier
+//! of `1L` is just `L`; matching the `integer` node by text (Str) handles it.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn r() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_r::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            // Str so suffixed integers (`1L`, `2i`) match the numeric node whole.
+            regex_rule(
+                r"^(?:[0-9]|\.[0-9])(?:[eEpP][-+]|[0-9A-Za-z_.])*",
+                TokKind::Str,
+            ),
+            dq_string(),
+            sq_string(),
+            backtick_string(), // non-syntactic names `` `x y` ``
+            // `%...%` infix/special operators, one token.
+            regex_rule(r"^%[^%]*%", TokKind::Token),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_r::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +35,29 @@ mod tests {
     fn call() {
         let ms = matches(r(), r"foo(\(A*))", "foo(a, b)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    #[test]
+    fn pipe_operator() {
+        let ms = matches(r(), r"x %>% \F(y)", "z <- x %>% filter(y)");
+        assert_eq!(cap(&ms, "F").as_deref(), Some("filter"));
+    }
+
+    /// Conformance over R literal/operator forms.
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "x <- \"hi\""),
+            ("'hi'", "x <- 'hi'"),
+            ("1L", "x <- 1L"),
+            ("42", "x <- 42"),
+            ("1e5", "x <- 1e5"),
+            ("0xFF", "x <- 0xFF"),
+            ("3.14", "x <- 3.14"),
+            ("x %>% y", "z <- x %>% y"),
+            ("x %in% y", "z <- x %in% y"),
+        ] {
+            assert!(!matches(r(), lit, ctx).is_empty(), "R `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/ruby.rs
+++ b/rust/code_match/src/lang/ruby.rs
@@ -20,4 +20,20 @@ mod tests {
         let ms = matches(ruby(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
+
+    /// Conformance over Ruby literal forms — the generic backslash profile fits
+    /// the common cases (`%w[...]`, heredocs are best matched with a metavar).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "x = \"hi\""),
+            ("'hi'", "x = 'hi'"),
+            ("42", "x = 42"),
+            ("0xFF", "x = 0xFF"),
+            ("1_000", "x = 1_000"),
+            ("3.14", "x = 3.14"),
+        ] {
+            assert!(!matches(ruby(), lit, ctx).is_empty(), "Ruby `{lit}`");
+        }
+    }
 }

--- a/rust/code_match/src/lang/scala.rs
+++ b/rust/code_match/src/lang/scala.rs
@@ -1,11 +1,16 @@
-//! scala.
-use crate::config::LangConfig;
+//! Scala: triple-quoted strings `"""..."""`. Interpolators (`s"..."`) and char
+//! literals (`'c'`) use the generic backslash forms; bare `'sym` (no closing
+//! quote) falls through to the operator table like a Rust lifetime.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn scala() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_scala::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let mut toks = generic_tokenizers();
+        toks.push(triple_dq_string());
+        LangConfig::from_grammar(Language::new(tree_sitter_scala::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +24,20 @@ mod tests {
         let src = "object O { def m = foo(a, b) }";
         let ms = matches(scala(), r"foo(\(ARGS*))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Scala literal forms (triple-quoted strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "object O { val x = \"hi\" }"),
+            ("\"\"\"hi\"\"\"", "object O { val x = \"\"\"hi\"\"\" }"),
+            ("'c'", "object O { val x = 'c' }"),
+            ("42", "object O { val x = 42 }"),
+            ("1.5e10", "object O { val x = 1.5e10 }"),
+            ("0xFF", "object O { val x = 0xFF }"),
+        ] {
+            assert!(!matches(scala(), lit, ctx).is_empty(), "Scala `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/solidity.rs
+++ b/rust/code_match/src/lang/solidity.rs
@@ -1,11 +1,26 @@
-//! solidity.
-use crate::config::LangConfig;
+//! Solidity: `hex"00ff"` and `unicode"..."` string literals (and `'`-quoted
+//! variants) are single nodes; the `hex`/`unicode` prefix would otherwise split
+//! off as an identifier. Normal strings use generic backslash escaping.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn solidity() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_solidity::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),
+            sq_string(),
+            // prefixed string literals (longest-match beats `identifier` + string)
+            regex_rule(r#"^hex"[0-9a-fA-F_]*""#, TokKind::Str),
+            regex_rule(r"^hex'[0-9a-fA-F_]*'", TokKind::Str),
+            regex_rule(r#"^unicode"(?:\\.|[^"\\])*""#, TokKind::Str),
+            regex_rule(r"^unicode'(?:\\.|[^'\\])*'", TokKind::Str),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_solidity::LANGUAGE))
+            .with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +34,23 @@ mod tests {
         let src = "contract C { function f() public { foo(a, b); } }";
         let ms = matches(solidity(), r"foo(\(A*))", src);
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Solidity literal forms (hex/unicode strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "contract C { string x = \"hi\"; }"),
+            ("'hi'", "contract C { string x = 'hi'; }"),
+            ("hex\"00ff\"", "contract C { bytes x = hex\"00ff\"; }"),
+            ("unicode\"hi\"", "contract C { string x = unicode\"hi\"; }"),
+            ("0x1234", "contract C { uint x = 0x1234; }"),
+            ("1000", "contract C { uint x = 1000; }"),
+        ] {
+            assert!(
+                !matches(solidity(), lit, ctx).is_empty(),
+                "Solidity `{lit}`"
+            );
+        }
     }
 }

--- a/rust/code_match/src/lang/sql.rs
+++ b/rust/code_match/src/lang/sql.rs
@@ -1,11 +1,22 @@
-//! SQL (tree-sitter-sequel).
-use crate::config::LangConfig;
+//! SQL (tree-sitter-sequel). String literals use **doubled-quote** escaping,
+//! not backslash: `'it''s'` is one literal, and `"a""b"` / delimited identifiers
+//! double the quote. The generic backslash profile would close at the wrong
+//! quote, so SQL picks the doubled-quote string builders.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn sql() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_sequel::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            sq_string_doubled(), // 'it''s'
+            dq_string_doubled(), // "delimited ""id"""
+            backtick_string(),   // `mysql_id`
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_sequel::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -19,5 +30,18 @@ mod tests {
         let src = "SELECT name FROM users";
         let ms = matches(sql(), r"SELECT \COL FROM \TBL", src);
         assert!(!ms.is_empty(), "expected SELECT pattern to match");
+    }
+
+    /// Conformance over SQL literal forms (doubled-quote escaping).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("'hi'", "SELECT 'hi'"),
+            ("'it''s'", "SELECT 'it''s'"),
+            ("42", "SELECT 42"),
+            ("3.14", "SELECT 3.14"),
+        ] {
+            assert!(!matches(sql(), lit, ctx).is_empty(), "SQL `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/swift.rs
+++ b/rust/code_match/src/lang/swift.rs
@@ -1,12 +1,76 @@
-//! swift.
-use crate::config::LangConfig;
+//! Swift: multiline strings `"""..."""` and raw strings `#"..."#` (any `#`
+//! count, single or triple quote). Interpolation `\(expr)` is matched opaquely
+//! via the whole string node's text.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn swift() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_swift::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),
+            triple_dq_string(),
+            TokenRule::new(SwiftRawString, TokKind::Str),
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_swift::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
+}
+
+/// `#*"..."#*` / `#*"""..."""#*` with a matching `#` count (≥1) — the balance
+/// the `regex` crate can't express, so it's a hand scanner. A normal (`#`-less)
+/// string is left to `dq_string` / `triple_dq_string`.
+struct SwiftRawString;
+
+impl Tokenizer for SwiftRawString {
+    fn match_len(&self, input: &str) -> Option<usize> {
+        let b = input.as_bytes();
+        let mut p = 0;
+        while b.get(p) == Some(&b'#') {
+            p += 1;
+        }
+        let hashes = p;
+        if hashes == 0 {
+            return None;
+        }
+        let triple =
+            b.get(p) == Some(&b'"') && b.get(p + 1) == Some(&b'"') && b.get(p + 2) == Some(&b'"');
+        let quotes = if triple {
+            3
+        } else if b.get(p) == Some(&b'"') {
+            1
+        } else {
+            return None;
+        };
+        p += quotes;
+        loop {
+            while p < b.len() && b[p] != b'"' {
+                p += 1;
+            }
+            if p >= b.len() {
+                return None; // unterminated
+            }
+            let mut q = p;
+            let mut got = 0;
+            while got < quotes && b.get(q) == Some(&b'"') {
+                got += 1;
+                q += 1;
+            }
+            if got == quotes {
+                let mut h = 0;
+                while h < hashes && b.get(q) == Some(&b'#') {
+                    h += 1;
+                    q += 1;
+                }
+                if h == hashes {
+                    return Some(q);
+                }
+            }
+            p += 1;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -18,5 +82,24 @@ mod tests {
     fn call() {
         let ms = matches(swift(), r"foo(\(A*))", "func m() { foo(a, b) }");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
+    }
+
+    /// Conformance over Swift literal forms (multiline/raw strings, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "let x = \"hi\""),
+            ("\"\"\"\nhi\n\"\"\"", "let x = \"\"\"\nhi\n\"\"\""),
+            ("#\"raw\"#", "let x = #\"raw\"#"),
+            ("##\"ra\"#w\"##", "let x = ##\"ra\"#w\"##"),
+            ("#\"\"\"\nr\n\"\"\"#", "let x = #\"\"\"\nr\n\"\"\"#"),
+            ("0xFF", "let x = 0xFF"),
+            ("0b1010", "let x = 0b1010"),
+            ("0o17", "let x = 0o17"),
+            ("1_000", "let x = 1_000"),
+            ("1.5e10", "let x = 1.5e10"),
+        ] {
+            assert!(!matches(swift(), lit, ctx).is_empty(), "Swift `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/toml.rs
+++ b/rust/code_match/src/lang/toml.rs
@@ -1,11 +1,33 @@
-//! toml.
-use crate::config::LangConfig;
+//! TOML: basic strings `"..."` use backslash escaping, but **literal** strings
+//! `'...'` have none (a `'` always closes); multiline `"""..."""` / `'''...'''`;
+//! integers may be signed; and date/time values (`1979-05-27`, `07:32:00`,
+//! `...T...Z`) are single nodes that the generic profile would split on `-`/`:`.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn toml() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_toml_ng::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(), // bare keys, true/false/inf/nan
+            // date-times before date/time before number (longest-match anyway).
+            regex_rule(
+                r"^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?",
+                TokKind::Str,
+            ),
+            regex_rule(r"^\d{4}-\d{2}-\d{2}", TokKind::Str),
+            regex_rule(r"^\d{2}:\d{2}:\d{2}(?:\.\d+)?", TokKind::Str),
+            regex_rule(
+                r"^[+-]?(?:[0-9]|\.[0-9])(?:[eEpP][-+]|[0-9A-Za-z_.])*",
+                TokKind::Token,
+            ),
+            dq_string(),         // basic "..."
+            sq_string_literal(), // literal '...'
+            triple_dq_string(),  // """..."""
+            triple_sq_string(),  // '''...'''
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_toml_ng::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +40,25 @@ mod tests {
     fn pair_value() {
         let ms = matches(toml(), r"a = \V", "a = 1");
         assert_eq!(cap(&ms, "V").as_deref(), Some("1"));
+    }
+
+    /// Conformance over TOML value forms (strings, multiline, dates, numbers).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("\"hi\"", "a = \"hi\""),
+            ("'literal'", "a = 'literal'"),
+            ("\"\"\"multi\"\"\"", "a = \"\"\"multi\"\"\""),
+            ("'''multi'''", "a = '''multi'''"),
+            ("1_000", "a = 1_000"),
+            ("0xFF", "a = 0xFF"),
+            ("-17", "a = -17"),
+            ("3.14", "a = 3.14"),
+            ("1979-05-27", "a = 1979-05-27"),
+            ("07:32:00", "a = 07:32:00"),
+            ("1979-05-27T07:32:00Z", "a = 1979-05-27T07:32:00Z"),
+        ] {
+            assert!(!matches(toml(), lit, ctx).is_empty(), "TOML `{lit}`");
+        }
     }
 }

--- a/rust/code_match/src/lang/yaml.rs
+++ b/rust/code_match/src/lang/yaml.rs
@@ -1,11 +1,22 @@
-//! yaml.
-use crate::config::LangConfig;
+//! YAML: single-quoted scalars escape a quote by **doubling** it (`'it''s'`),
+//! not with a backslash; double-quoted scalars use backslash. Note: a *plain*
+//! (unquoted) multi-word scalar like `hello world` is a single node with no
+//! delimiters, so it can't be written as an exact literal pattern (the lexer
+//! would see two identifiers) — match it with a metavar (`key: \V`) instead.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn yaml() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_yaml::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        let toks = vec![
+            identifier(),
+            number(""),
+            dq_string(),         // "..." backslash escaping
+            sq_string_doubled(), // '...' with '' escaping
+        ];
+        LangConfig::from_grammar(Language::new(tree_sitter_yaml::LANGUAGE)).with_tokenizers(toks)
+    });
     CFG.clone()
 }
 
@@ -18,5 +29,26 @@ mod tests {
     fn mapping_value() {
         let ms = matches(yaml(), r"a: \V", "a: 1");
         assert_eq!(cap(&ms, "V").as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn multiword_plain_scalar_via_metavar() {
+        // A plain multi-word scalar is one node — capture it with a metavar.
+        let ms = matches(yaml(), r"a: \V", "a: hello world");
+        assert_eq!(cap(&ms, "V").as_deref(), Some("hello world"));
+    }
+
+    /// Conformance over YAML scalar forms (single-word/quoted).
+    #[test]
+    fn literal_forms() {
+        for (lit, ctx) in [
+            ("1", "a: 1"),
+            ("hello", "a: hello"),
+            ("\"hi\"", "a: \"hi\""),
+            ("'hi'", "a: 'hi'"),
+            ("'it''s'", "a: 'it''s'"),
+        ] {
+            assert!(!matches(yaml(), lit, ctx).is_empty(), "YAML `{lit}`");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Hardens per-language literal tokenizers (the new languages had leaned on the generic C-style default + thin smoke tests). Each language now has a `literal_forms` conformance test, built from a systematic empirical audit of how every form actually nodeifies.

- **Triple-quoted / raw / prefixed strings**: Kotlin/Julia/Elm/Scala/Java (text blocks)/C# (raw) `"""..."""`; Swift multiline + `#"..."#` raw (hand scanner); Julia `r"..."i` macro strings; C# `@"a""b"` verbatim.
- **Correct string escaping** (per your reminder — the generic backslash default closes at the wrong quote for these): SQL / Fortran / Pascal `'it''s'` doubling; Bash / TOML literal `'...'` (no escape); Go raw backticks `` `a\b` ``; YAML `'it''s'`. SQL and Scala/Java/C# were *functionally* broken before (0 matches).
- **Fused / hidden-lead nodes matched whole** (Str): CSS dimensions `10px` / colors `#fff` / kebab `font-size`; R `1L` (tree-sitter-r hides the digit) and `%>%`/`%in%`; TOML dates `1979-05-27`; signed numbers (JSON `-1`, TOML `-17`); Pascal `$FF`/`&777`/`%1010`; Solidity `hex"..."`/`unicode"..."`; CMake bracket args `[[...]]`/`[=[...]=]` (hand scanner); CSS `@media`/`!important`.

Adds escape-aware string builders (`sq_string_doubled`, `dq_string_doubled`, `sq_string_literal`, `backtick_string_literal`, `triple_dq_string`, `triple_sq_string`) and documents that `generic_tokenizers` encodes a C-style convention that other languages must override.

**Known limitations** (documented; a metavar still matches): YAML multi-word *plain* scalars (`a: hello world` has no delimiters — use `a: \V`); a bare CSS `@media` with nothing after it (anonymous leaf, no candidate node).

## Test plan
- `cargo test -p cocoindex_code_match` — 130 tests (88 lib incl. 27 new `literal_forms`/conformance cases + 42 features).
- `cargo clippy` / `cargo fmt` clean.
