### PR TITLE
refactor(code_match): require an explicit tokenizer profile per language

### DIFF
--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -176,13 +176,13 @@ pub fn triple_sq_string() -> TokenRule {
     regex_rule(r"(?s)^'''.*?'''", TokKind::Str)
 }
 
-/// A convenience tokenizer set for **C-style** languages: identifier, number,
-/// and the three quote styles with *backslash* escaping. Correct for the large
-/// family (C/C++/Rust/Java/JS/TS/C#/Go/…), but **not** universal — languages
-/// that escape differently (SQL/Fortran/Pascal `''` doubling, shells/TOML
-/// literal `'...'`, Go raw backticks) must build their own set from the
+/// The tokenizer profile for **C-style** languages: identifier, number, and the
+/// three quote styles with *backslash* escaping. Passed explicitly by the large
+/// family (C/C++/Rust/Java/JS/TS/C#/Go/…) to [`LangConfig::from_grammar`].
+/// Languages that escape differently (SQL/Fortran/Pascal `''` doubling,
+/// shells/TOML literal `'...'`, Go raw backticks) compose their own set from the
 /// `*_doubled` / `*_literal` builders above. Verify with a `literal_forms` test.
-pub fn generic_tokenizers() -> Vec<TokenRule> {
+pub fn c_like_tokenizers() -> Vec<TokenRule> {
     vec![
         identifier(),
         number(""),
@@ -221,12 +221,14 @@ pub struct LangConfig {
 }
 
 impl LangConfig {
-    /// Build a config from a grammar. Seeds the **C-style** `generic_tokenizers`
-    /// (backslash escaping) and the derived op/splittable tables; a language
-    /// module then refines the literal profile via `with_tokenizers`. The seeded
-    /// default is a convenience, *not* a guarantee — if the language escapes
-    /// strings differently it must override (see `generic_tokenizers`).
-    pub fn from_grammar(language: Language) -> Self {
+    /// Build a config from a grammar and an **explicit** tokenizer profile.
+    /// There is deliberately no default: every language must state how its
+    /// literals tokenize, because string-escaping conventions differ (a `"a\"b"`
+    /// that is one string in C is two in a doubled-quote language). C-style
+    /// languages pass [`c_like_tokenizers`]; others compose the `*_doubled` /
+    /// `*_literal` / `triple_*` builders. Op/splittable tables are derived from
+    /// the grammar.
+    pub fn from_grammar(language: Language, tokenizers: Vec<TokenRule>) -> Self {
         let single_char = single_char_punct_tokens(&language);
         let splittable = detect_splittable(&language, &single_char);
         let op_tokens = derive_op_tokens(&language, &splittable);
@@ -235,16 +237,10 @@ impl LangConfig {
             op_tokens,
             splittable,
             meta_char: '\\',
-            tokenizers: generic_tokenizers(),
+            tokenizers,
             transitions: Vec::new(),
             ws_preserve: 0,
         }
-    }
-
-    /// Replace the tokenizer set (per-language literal profiles).
-    pub fn with_tokenizers(mut self, tokenizers: Vec<TokenRule>) -> Self {
-        self.tokenizers = tokenizers;
-        self
     }
 
     /// Configure a context-sensitive (multi-mode) lexer: `transitions` flip the

--- a/rust/code_match/src/lang/bash.rs
+++ b/rust/code_match/src/lang/bash.rs
@@ -13,7 +13,7 @@ pub fn bash() -> LangConfig {
             dq_string(),         // "..." backslash + $-expansion
             sq_string_literal(), // '...' literal, no escaping
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_bash::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_bash::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/c.rs
+++ b/rust/code_match/src/lang/c.rs
@@ -11,8 +11,7 @@ pub(crate) fn c_tokenizers() -> Vec<TokenRule> {
 
 pub fn c() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        LangConfig::from_grammar(Language::new(tree_sitter_c::LANGUAGE))
-            .with_tokenizers(c_tokenizers())
+        LangConfig::from_grammar(Language::new(tree_sitter_c::LANGUAGE), c_tokenizers())
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/cmake.rs
+++ b/rust/code_match/src/lang/cmake.rs
@@ -7,9 +7,9 @@ use tree_sitter::Language;
 
 pub fn cmake() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(TokenRule::new(CmakeBracket, TokKind::Str));
-        LangConfig::from_grammar(Language::new(tree_sitter_cmake::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_cmake::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/cpp.rs
+++ b/rust/code_match/src/lang/cpp.rs
@@ -9,7 +9,7 @@ pub fn cpp() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
         let mut toks = c_tokenizers();
         toks.push(TokenRule::new(CppRawString, TokKind::Str));
-        LangConfig::from_grammar(Language::new(tree_sitter_cpp::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_cpp::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/csharp.rs
+++ b/rust/code_match/src/lang/csharp.rs
@@ -7,10 +7,10 @@ use tree_sitter::Language;
 
 pub fn csharp() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(triple_dq_string()); // raw string """..."""
         toks.push(regex_rule(r#"(?s)^@"(?:""|[^"])*""#, TokKind::Str)); // verbatim @"a""b"
-        LangConfig::from_grammar(Language::new(tree_sitter_c_sharp::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_c_sharp::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/css.rs
+++ b/rust/code_match/src/lang/css.rs
@@ -23,7 +23,7 @@ pub fn css() -> LangConfig {
             // `!important` / `!default` — one token.
             regex_rule(r"^![A-Za-z]+", TokKind::Token),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_css::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_css::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/elm.rs
+++ b/rust/code_match/src/lang/elm.rs
@@ -6,9 +6,9 @@ use tree_sitter::Language;
 
 pub fn elm() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(triple_dq_string());
-        LangConfig::from_grammar(Language::new(tree_sitter_elm::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_elm::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/fortran.rs
+++ b/rust/code_match/src/lang/fortran.rs
@@ -17,7 +17,7 @@ pub fn fortran() -> LangConfig {
             regex_rule(r"^[BOZboz]'[0-9A-Fa-f]*'", TokKind::Str),
             regex_rule(r#"^[BOZboz]"[0-9A-Fa-f]*""#, TokKind::Str),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_fortran::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_fortran::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/go.rs
+++ b/rust/code_match/src/lang/go.rs
@@ -15,7 +15,7 @@ pub fn go() -> LangConfig {
             sq_string(),               // rune 'r'
             backtick_string_literal(), // `raw, no escapes`
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_go::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_go::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/hcl.rs
+++ b/rust/code_match/src/lang/hcl.rs
@@ -1,14 +1,18 @@
-//! hcl (HashiCorp Configuration Language / Terraform). The generic profile fits:
+//! hcl (HashiCorp Configuration Language / Terraform). The C-style profile fits:
 //! strings use backslash escaping and `${...}` interpolation is matched opaquely
 //! via the whole string node. Heredocs (`<<EOF ... EOF`) are one node — match
 //! them with a metavar rather than an exact literal.
-use crate::config::LangConfig;
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn hcl() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_hcl::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_hcl::LANGUAGE),
+            c_like_tokenizers(),
+        )
+    });
     CFG.clone()
 }
 

--- a/rust/code_match/src/lang/html.rs
+++ b/rust/code_match/src/lang/html.rs
@@ -27,8 +27,7 @@ pub fn html() -> LangConfig {
             dq_string().in_modes(1 << TAG),
             sq_string().in_modes(1 << TAG),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_html::LANGUAGE))
-            .with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_html::LANGUAGE), toks)
             .with_modes(vec![(TEXT, '<', TAG), (TAG, '>', TEXT)], 1 << TEXT)
     });
     CFG.clone()

--- a/rust/code_match/src/lang/java.rs
+++ b/rust/code_match/src/lang/java.rs
@@ -6,9 +6,9 @@ use tree_sitter::Language;
 
 pub fn java() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(triple_dq_string());
-        LangConfig::from_grammar(Language::new(tree_sitter_java::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_java::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/javascript.rs
+++ b/rust/code_match/src/lang/javascript.rs
@@ -1,11 +1,15 @@
-//! javascript.
-use crate::config::LangConfig;
+//! JavaScript: C-style escaping + backtick template strings.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn javascript() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_javascript::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_javascript::LANGUAGE),
+            c_like_tokenizers(),
+        )
+    });
     CFG.clone()
 }
 

--- a/rust/code_match/src/lang/json.rs
+++ b/rust/code_match/src/lang/json.rs
@@ -14,7 +14,7 @@ pub fn json() -> LangConfig {
             ),
             dq_string(),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_json::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_json::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/julia.rs
+++ b/rust/code_match/src/lang/julia.rs
@@ -26,7 +26,7 @@ pub fn julia() -> LangConfig {
                 TokKind::Str,
             ),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_julia::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_julia::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/kotlin.rs
+++ b/rust/code_match/src/lang/kotlin.rs
@@ -5,10 +5,9 @@ use tree_sitter::Language;
 
 pub fn kotlin() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(triple_dq_string());
-        LangConfig::from_grammar(Language::new(tree_sitter_kotlin_ng::LANGUAGE))
-            .with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_kotlin_ng::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/pascal.rs
+++ b/rust/code_match/src/lang/pascal.rs
@@ -16,7 +16,7 @@ pub fn pascal() -> LangConfig {
             regex_rule(r"^%[01]+", TokKind::Str),           // binary
             regex_rule(r"^#\$?[0-9A-Fa-f]+", TokKind::Str), // char code #65 / #$41
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_pascal::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_pascal::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/php.rs
+++ b/rust/code_match/src/lang/php.rs
@@ -1,11 +1,15 @@
-//! PHP. Config-wise generic; `$` is ordinary source (the sigil is `\`).
-use crate::config::LangConfig;
+//! PHP: C-style escaping; `$` is ordinary source (the sigil is `\`).
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn php() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_php::LANGUAGE_PHP)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_php::LANGUAGE_PHP),
+            c_like_tokenizers(),
+        )
+    });
     CFG.clone()
 }
 

--- a/rust/code_match/src/lang/python.rs
+++ b/rust/code_match/src/lang/python.rs
@@ -6,7 +6,7 @@ use tree_sitter::Language;
 
 pub fn python() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         // triple-quoted (with optional r/b/f/u prefixes), then prefixed single
         // line strings. Interpolation inside f-strings is treated opaquely.
         toks.push(regex_rule(r#"(?s)^[rbfuRBFU]{0,2}""".*?""""#, TokKind::Str));
@@ -19,7 +19,7 @@ pub fn python() -> LangConfig {
             r"^[rbfuRBFU]{1,2}'(?:\\.|[^'\\])*'",
             TokKind::Str,
         ));
-        LangConfig::from_grammar(Language::new(tree_sitter_python::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_python::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/r.rs
+++ b/rust/code_match/src/lang/r.rs
@@ -21,7 +21,7 @@ pub fn r() -> LangConfig {
             // `%...%` infix/special operators, one token.
             regex_rule(r"^%[^%]*%", TokKind::Token),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_r::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_r::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/ruby.rs
+++ b/rust/code_match/src/lang/ruby.rs
@@ -1,11 +1,15 @@
-//! ruby.
-use crate::config::LangConfig;
+//! Ruby: C-style escaping (the common case; `%w[...]`, heredocs use a metavar).
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn ruby() -> LangConfig {
-    static CFG: LazyLock<LangConfig> =
-        LazyLock::new(|| LangConfig::from_grammar(Language::new(tree_sitter_ruby::LANGUAGE)));
+    static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_ruby::LANGUAGE),
+            c_like_tokenizers(),
+        )
+    });
     CFG.clone()
 }
 

--- a/rust/code_match/src/lang/rust.rs
+++ b/rust/code_match/src/lang/rust.rs
@@ -14,7 +14,7 @@ pub fn rust() -> LangConfig {
             TokenRule::new(RustRawString, TokKind::Str),
             regex_rule(r#"(?s)^b"(?:\\.|[^"\\])*""#, TokKind::Str), // byte string b"..."
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_rust::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_rust::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/scala.rs
+++ b/rust/code_match/src/lang/scala.rs
@@ -7,9 +7,9 @@ use tree_sitter::Language;
 
 pub fn scala() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        let mut toks = generic_tokenizers();
+        let mut toks = c_like_tokenizers();
         toks.push(triple_dq_string());
-        LangConfig::from_grammar(Language::new(tree_sitter_scala::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_scala::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/solidity.rs
+++ b/rust/code_match/src/lang/solidity.rs
@@ -18,8 +18,7 @@ pub fn solidity() -> LangConfig {
             regex_rule(r#"^unicode"(?:\\.|[^"\\])*""#, TokKind::Str),
             regex_rule(r"^unicode'(?:\\.|[^'\\])*'", TokKind::Str),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_solidity::LANGUAGE))
-            .with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_solidity::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/sql.rs
+++ b/rust/code_match/src/lang/sql.rs
@@ -15,7 +15,7 @@ pub fn sql() -> LangConfig {
             dq_string_doubled(), // "delimited ""id"""
             backtick_string(),   // `mysql_id`
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_sequel::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_sequel::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/swift.rs
+++ b/rust/code_match/src/lang/swift.rs
@@ -14,7 +14,7 @@ pub fn swift() -> LangConfig {
             triple_dq_string(),
             TokenRule::new(SwiftRawString, TokKind::Str),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_swift::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_swift::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/toml.rs
+++ b/rust/code_match/src/lang/toml.rs
@@ -26,7 +26,7 @@ pub fn toml() -> LangConfig {
             triple_dq_string(),  // """..."""
             triple_sq_string(),  // '''...'''
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_toml_ng::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_toml_ng::LANGUAGE), toks)
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/typescript.rs
+++ b/rust/code_match/src/lang/typescript.rs
@@ -1,18 +1,24 @@
-//! TypeScript / TSX.
-use crate::config::LangConfig;
+//! TypeScript / TSX: C-style escaping + backtick template strings.
+use crate::config::*;
 use std::sync::LazyLock;
 use tree_sitter::Language;
 
 pub fn typescript() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        LangConfig::from_grammar(Language::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT))
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT),
+            c_like_tokenizers(),
+        )
     });
     CFG.clone()
 }
 
 pub fn tsx() -> LangConfig {
     static CFG: LazyLock<LangConfig> = LazyLock::new(|| {
-        LangConfig::from_grammar(Language::new(tree_sitter_typescript::LANGUAGE_TSX))
+        LangConfig::from_grammar(
+            Language::new(tree_sitter_typescript::LANGUAGE_TSX),
+            c_like_tokenizers(),
+        )
     });
     CFG.clone()
 }

--- a/rust/code_match/src/lang/xml.rs
+++ b/rust/code_match/src/lang/xml.rs
@@ -19,8 +19,7 @@ pub fn xml() -> LangConfig {
             dq_string().in_modes(1 << TAG),
             sq_string().in_modes(1 << TAG),
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_xml::LANGUAGE_XML))
-            .with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_xml::LANGUAGE_XML), toks)
             .with_modes(vec![(TEXT, '<', TAG), (TAG, '>', TEXT)], 1 << TEXT)
     });
     CFG.clone()

--- a/rust/code_match/src/lang/yaml.rs
+++ b/rust/code_match/src/lang/yaml.rs
@@ -15,7 +15,7 @@ pub fn yaml() -> LangConfig {
             dq_string(),         // "..." backslash escaping
             sq_string_doubled(), // '...' with '' escaping
         ];
-        LangConfig::from_grammar(Language::new(tree_sitter_yaml::LANGUAGE)).with_tokenizers(toks)
+        LangConfig::from_grammar(Language::new(tree_sitter_yaml::LANGUAGE), toks)
     });
     CFG.clone()
 }


### PR DESCRIPTION
## Summary
Removes the implicit C-style default from `LangConfig::from_grammar` — it now takes the tokenizer profile as a **required argument**, so a language can't be constructed without stating how its literals tokenize. This turns the string-escaping choice into a compile-time decision instead of a silent default (which, before the escaping fixes, was functionally wrong for SQL/Scala/Java/C# and subtly wrong for Bash/Go).

- `generic_tokenizers()` → `c_like_tokenizers()` — clearly named; the C-style backslash profile the large family (C/C++/Rust/Java/JS/TS/C#/Go/…) now passes explicitly.
- `from_grammar(lang)` → `from_grammar(lang, tokenizers)`; `with_tokenizers` removed (folded into the constructor).
- The five languages that relied on the default (HCL/JS/PHP/Ruby/TS) now pass `c_like_tokenizers()` explicitly.

No behavior change — every language keeps its existing profile; this is purely making the choice explicit and unforgettable.

## Test plan
- `cargo test -p cocoindex_code_match` — 130 tests (88 lib + 42 features).
- `cargo clippy` / `cargo fmt` clean.
