### PR TITLE
fix(core): propagate logic deps across the mount boundary

### DIFF
--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -407,6 +407,156 @@ def test_transitive_component_mounts_bar_comp_memo() -> None:
 
 
 # ============================================================================
+# Memoized parent across the mount boundary — child's change must invalidate
+# the parent (its persisted logic_deps must include the mounted subtree).
+#
+# The memoized parent is defined here at module level (never reloaded), so its
+# own logic fingerprint stays stably registered across the v1->v2 transition.
+# This isolates the case "only the mounted child's code changed" — unlike the
+# tests above where the parent is a plain (non-memoized) component that always
+# re-runs and relies on the *child's* own memo to catch the change.
+# ============================================================================
+
+
+_mount_parent_metrics: list[Any] = []
+_mount_parent_child: list[Any] = []
+
+
+@coco.fn(memo=True)
+async def _memo_parent_mounts_child(key: str, value: str) -> None:
+    _mount_parent_metrics[0].increment("memo_parent")
+    await coco.mount(coco.component_subpath(key), _mount_parent_child[0], key, value)
+
+
+def test_memo_parent_invalidated_when_mounted_child_changes() -> None:
+    """A memoized parent that mounts a child must invalidate when only the
+    child's code changes — regression for the dropped mount-boundary deps."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+    _mount_parent_metrics.clear()
+    _mount_parent_metrics.append(metrics)
+
+    @coco.fn
+    async def app_main() -> None:
+        await coco.mount(
+            coco.component_subpath("A"), _memo_parent_mounts_child, "A", "value1"
+        )
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_memo_parent_invalidated_when_mounted_child_changes",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    # v1: first run — memoized parent and child both execute
+    mod = _load_module(_V1_PATH, metrics, current_module)
+    _mount_parent_child.clear()
+    _mount_parent_child.append(mod.bar_comp_plain)
+    app.update_blocking()
+    assert metrics.collect() == {"memo_parent": 1, "bar_comp_plain": 1}
+    assert GlobalDictTarget.store.data["A"].data == "bar_v1: value1"
+
+    # v1: second run — parent memo hit, nothing runs
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # v2: ONLY the mounted child's body changed. The memoized parent's stored
+    # logic_deps must include the child's fingerprint, so the parent invalidates,
+    # re-runs, and re-mounts the child — refreshing the output.
+    mod = _load_module(_V2_PATH, metrics, current_module, old_module=mod)
+    _mount_parent_child.clear()
+    _mount_parent_child.append(mod.bar_comp_plain)
+    app.update_blocking()
+    assert metrics.collect() == {"memo_parent": 1, "bar_comp_plain": 1}
+    assert GlobalDictTarget.store.data["A"].data == "bar_v2: value1"
+
+    # v2: second run — parent memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+# ============================================================================
+# Cache-hit propagation across the mount boundary — a memoized child that is a
+# cache *hit* (while its parent rebuilds for an unrelated reason) must still
+# report its dependency set to the rebuilt parent. Otherwise the parent's
+# refreshed memo loses the child's subtree, and a later change to the child
+# would wrongly leave the parent a memo hit.
+# ============================================================================
+
+
+_cachehit_metrics: list[Any] = []
+_cachehit_child: list[Any] = []
+_cachehit_value: list[str] = []
+
+
+@coco.fn(memo=True)
+async def _memo_parent_mounts_memo_child(key: str, value: str) -> None:
+    # `value` is part of this memo'd parent's key, so changing it forces a
+    # rebuild — but the child below is always mounted with FIXED args, so it
+    # stays a cache hit across that rebuild.
+    _cachehit_metrics[0].increment("cachehit_parent")
+    await coco.mount(coco.component_subpath("C"), _cachehit_child[0], "C", "fixed")
+
+
+def test_memo_child_cache_hit_still_propagates_deps_to_rebuilt_parent() -> None:
+    """When a memoized parent rebuilds (unrelated reason) and its memo child is
+    a cache hit, the child's deps must still flow into the parent's refreshed
+    memo — so a later change to the child invalidates the parent."""
+    GlobalDictTarget.store.clear()
+    metrics = Metrics()
+    current_module: list[Any] = []
+    _cachehit_metrics.clear()
+    _cachehit_metrics.append(metrics)
+    _cachehit_value.clear()
+    _cachehit_value.append("x1")
+
+    @coco.fn
+    async def app_main() -> None:
+        await coco.mount(
+            coco.component_subpath("P"),
+            _memo_parent_mounts_memo_child,
+            "P",
+            _cachehit_value[0],
+        )
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_memo_child_cache_hit_still_propagates_deps_to_rebuilt_parent",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    # Run 1 (child v1, value x1): parent + child both build.
+    mod = _load_module(_V1_PATH, metrics, current_module)
+    _cachehit_child.clear()
+    _cachehit_child.append(mod.bar_comp_memo)
+    app.update_blocking()
+    assert metrics.collect() == {"cachehit_parent": 1, "bar_comp_memo": 1}
+    assert GlobalDictTarget.store.data["C"].data == "bar_v1: fixed"
+
+    # Run 2 (child still v1, value x2): parent's key changed → parent rebuilds;
+    # child is unchanged → cache HIT. The child must still propagate its deps to
+    # the rebuilt parent (the `reused` outcome path).
+    _cachehit_value[0] = "x2"
+    app.update_blocking()
+    assert metrics.collect() == {"cachehit_parent": 1}  # child cached, didn't run
+
+    # Run 3 (child v2, value x2): only the child's code changed. Parent's key
+    # matches run 2, but its stored deps must include the child's (v1) fp, so the
+    # parent invalidates, rebuilds, and re-mounts the now-changed child.
+    mod = _load_module(_V2_PATH, metrics, current_module, old_module=mod)
+    _cachehit_child.clear()
+    _cachehit_child.append(mod.bar_comp_memo)
+    app.update_blocking()
+    assert metrics.collect() == {"cachehit_parent": 1, "bar_comp_memo": 1}
+    assert GlobalDictTarget.store.data["C"].data == "bar_v2: fixed"
+
+
+# ============================================================================
 # Explicit version bump invalidates memo (identical function body)
 # ============================================================================
 

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -207,6 +207,16 @@ impl ComponentRunOutcome {
         }
     }
 
+    /// Outcome for a component that hit its memo cache: no exception, but it
+    /// still reports the stored logic dependency set so a mounting parent's
+    /// memo depends on this subtree.
+    fn reused(logic_deps: Vec<Fingerprint>) -> Self {
+        Self {
+            has_exception: false,
+            logic_deps: logic_deps.into_iter().collect(),
+        }
+    }
+
     fn merge(&mut self, other: Self) {
         self.has_exception |= other.has_exception;
         self.logic_deps.extend(other.logic_deps);
@@ -869,7 +879,7 @@ impl<Prof: EngineProfile> Component<Prof> {
 
             match use_or_invalidate_component_memoization(processor_context, memo_fp_to_store).await
             {
-                Ok(Some((ret, memo_states))) => {
+                Ok(Some((ret, memo_states, stored_logic_deps))) => {
                     // If processor has state handler and there are stored states, validate them.
                     if processor.has_memo_state_handler() && !memo_states.is_empty() {
                         let fut = processor.handle_memo_states(
@@ -888,8 +898,11 @@ impl<Prof: EngineProfile> Component<Prof> {
                                 stats.num_execution_starts += 1;
                                 stats.num_unchanged += 1;
                             });
+                            // Report the stored dependency set upward even on a
+                            // memo hit, so a mounting parent's memo depends on
+                            // this whole subtree (see `merge_logic_deps` below).
                             return Ok((
-                                ComponentRunOutcome::default(),
+                                ComponentRunOutcome::reused(stored_logic_deps),
                                 Some(ComponentBuildOutput {
                                     ret,
                                     built_target_states_providers: Default::default(),
@@ -905,7 +918,7 @@ impl<Prof: EngineProfile> Component<Prof> {
                             stats.num_unchanged += 1;
                         });
                         return Ok((
-                            ComponentRunOutcome::default(),
+                            ComponentRunOutcome::reused(stored_logic_deps),
                             Some(ComponentBuildOutput {
                                 ret,
                                 built_target_states_providers: Default::default(),
@@ -932,7 +945,7 @@ impl<Prof: EngineProfile> Component<Prof> {
             async move {
                 // Acquire the semaphore to ensure `process()` and `submit()` cannot overlap
                 // with another execution of the same component.
-                let (ret, submit_output, children_outcome) = {
+                let (ret, submit_output, mut children_outcome) = {
                     let _permit = self.inner.build_semaphore.acquire().await?;
 
                     // Build mode only: write the component's own existence bit
@@ -983,8 +996,10 @@ impl<Prof: EngineProfile> Component<Prof> {
                         .clone()
                         .into_result()?;
 
-                    // Merge children's logic deps into this component's context before
-                    // post-submit memoization stores this component's dependency set.
+                    // Merge children's logic deps into this component's context. The
+                    // full set (own fp ∪ all descendants) is taken once after
+                    // memo-state collection below and used for both this component's
+                    // own memo and the outcome reported to its parent.
                     processor_context
                         .merge_logic_deps(std::mem::take(&mut children_outcome.logic_deps));
 
@@ -1038,7 +1053,18 @@ impl<Prof: EngineProfile> Component<Prof> {
                             } else {
                                 None
                             };
-                            post_submit_for_build(processor_context, comp_memo).await?;
+                            // Take the full dependency set once (O(1) move). It
+                            // must run after the memo-state collection above, which
+                            // reads the set via `collect_context_initial_states`.
+                            // Serves both this component's own memo (sorted inside
+                            // `post_submit_for_build`, only when memoizing) and the
+                            // outcome reported to the parent across the mount
+                            // boundary — so the parent's memo depends on this whole
+                            // subtree's logic.
+                            let logic_deps = processor_context.take_logic_deps();
+                            post_submit_for_build(processor_context, comp_memo, &logic_deps)
+                                .await?;
+                            children_outcome.logic_deps = logic_deps;
                         }
                         Some(ComponentBuildOutput {
                             ret,

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -914,12 +914,16 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         self.inner.logic_deps.lock().unwrap().extend(deps);
     }
 
-    /// Take the accumulated logic deps as a sorted Vec for deterministic storage.
-    pub(crate) fn take_logic_deps(&self) -> Vec<Fingerprint> {
-        let deps = std::mem::take(&mut *self.inner.logic_deps.lock().unwrap());
-        let mut v: Vec<_> = deps.into_iter().collect();
-        v.sort();
-        v
+    /// Take the accumulated logic deps (own fp ∪ all descendants merged so far)
+    /// out of this context. This is an O(1) move — the single full set serves
+    /// both consumers in `execute_once`: this component's own memo (sorted for
+    /// deterministic storage at the call site) and the `ComponentRunOutcome`
+    /// reported to the parent across the mount boundary (so the parent's memo
+    /// depends on this whole subtree's logic). Callers must invoke this only
+    /// after everything that reads the set (e.g. `collect_context_initial_states`
+    /// during cache-miss memo-state collection) has run.
+    pub(crate) fn take_logic_deps(&self) -> HashSet<Fingerprint> {
+        std::mem::take(&mut *self.inner.logic_deps.lock().unwrap())
     }
 
     /// Collect initial memo states for the change-detection context fingerprints

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -82,7 +82,13 @@ pub(crate) fn serialize_context_memo_states<Prof: EngineProfile>(
 pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     processor_fp: Option<Fingerprint>,
-) -> Result<Option<(Prof::FunctionData, MemoStatesPayload<Prof>)>> {
+) -> Result<
+    Option<(
+        Prof::FunctionData,
+        MemoStatesPayload<Prof>,
+        Vec<Fingerprint>,
+    )>,
+> {
     // Short-circuit to miss under full_reprocess
     if comp_ctx.full_reprocess() {
         return Ok(None);
@@ -112,12 +118,18 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
                         let context_memo_states = deserialize_context_memo_states::<Prof>(
                             &memo_info.context_memo_states,
                         )?;
+                        // Carry the stored logic deps out so the cache-hit path
+                        // can still report this subtree's dependency set to the
+                        // parent — otherwise a parent that mounts this component
+                        // would not depend on it (or its descendants) and would
+                        // wrongly stay a memo hit when their code changes.
                         return Ok(Some((
                             ret,
                             MemoStatesPayload {
                                 positional: memo_states,
                                 by_context_fp: context_memo_states,
                             },
+                            memo_info.logic_deps.to_vec(),
                         )));
                     }
                     Err(e) => {
@@ -1712,6 +1724,7 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
         &'_ Prof::FunctionData,
         &'_ MemoStatesPayload<Prof>,
     )>,
+    logic_deps: &HashSet<Fingerprint>,
 ) -> Result<()> {
     let Some((fp, ret, memo_states)) = comp_memo else {
         return Ok(());
@@ -1721,10 +1734,14 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
     let memo_states_serialized = serialize_memo_values::<Prof>(&memo_states.positional)?;
     let context_memo_states_serialized =
         serialize_context_memo_states::<Prof>(&memo_states.by_context_fp)?;
+    // Sorted for deterministic storage. Only reached when actually memoizing
+    // (after the early return above), so non-memoized builds pay no sort.
+    let mut logic_deps_sorted: Vec<Fingerprint> = logic_deps.iter().copied().collect();
+    logic_deps_sorted.sort();
     let memo_info = db_schema::ComponentMemoizationInfo {
         processor_fp: fp,
         return_value: db_schema::MemoizedValue::Inlined(Cow::Borrowed(ret_bytes.as_ref())),
-        logic_deps: comp_ctx.take_logic_deps(),
+        logic_deps: logic_deps_sorted,
         memo_states: memo_states_serialized,
         context_memo_states: context_memo_states_serialized,
     };


### PR DESCRIPTION
## Summary
- Fix logic-change detection across the `mount()` boundary (#2124): a memoized component's persisted `logic_deps` did not include the fingerprints of components it mounts, so editing only a mounted child's body left the parent a memo hit and its output went stale.
- In `execute_once`, a component now reports its *full* dependency set (own fp ∪ all descendants) to its parent — on both the cache-miss (build) path and the memo cache-hit path (which previously reported an empty set).
- `take_logic_deps` is now a single O(1) move; the sorted `Vec` for deterministic storage is built only when actually memoizing.
- Adds regression tests for both the build-path and cache-hit propagation. The existing mount tests used a non-memoized parent, so they never exercised this.

## Test plan
- `cargo test -p cocoindex_core` (61 passed)
- `python/tests/core/` (416 passed, incl. 2 new tests in `test_logic_change_detection.py`)
- Both new tests verified to fail without the fix and pass with it; stable across repeated runs.
- CI
