### PR TITLE
docs(code_match): explain why PatternItem Token vs Str stay distinct

### DIFF
--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -18,12 +18,16 @@ use tree_sitter::Language;
 // Tokenizer interface
 // ---------------------------------------------------------------------------
 
-/// How a matched pattern token aligns against the source.
+/// How a matched pattern token aligns against the source. This is the strong
+/// type the lexer carries into `PatternItem::{Token, Str}` — the two are distinct
+/// match operations (single leaf vs whole node), not a redundant split; see the
+/// note on `PatternItem` in `lexer.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokKind {
-    /// Word / number / operator — matched against a single source *leaf* by text.
+    /// Word / number / operator — always a single source *leaf*, matched by text.
     Token,
-    /// String / char / raw literal — matched against a source *node* by text.
+    /// String / char / raw literal (or any atomic whole-node class) — matched
+    /// against a source *node* by text, spanning all its leaves at once.
     Str,
 }
 

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -45,12 +45,27 @@ pub enum Cardinality {
 
 // `Regex` is not `PartialEq`/`Eq`, so `PatternItem` isn't either (it's only ever
 // pattern-matched, never compared for equality).
+//
+// `Token` vs `Str` are two **distinct match operations** (not a vestigial split):
+//   - `Token` → one source *leaf* by text, advancing exactly one leaf.
+//   - `Str`   → one whole *node* span by text, advancing past all its leaves.
+// They can't be unified without loss. An operator/punctuation leaf (`+`, `<`) is
+// *anonymous* — it never appears as a named span, so the whole-node path can't
+// reach it. A composite literal (`"foo"`, `'a'`, a raw string) spans ≥2 leaves
+// (quote + content + quote), so the single-leaf path can't reach it. The split
+// also lets the matcher do the minimal correct lookup in its hot path instead of
+// speculatively trying both. Critically, the lexer already knows which one a
+// token is — for free, from the tokenizer's `TokKind` (config.rs) — so encoding
+// it in the variant here is the "exchange to the strong type early" rule: a
+// unified variant would discard that and re-derive it per compare at match time.
 #[derive(Debug, Clone)]
 pub enum PatternItem {
-    /// Word (identifier / keyword / number) or operator/punctuation token.
-    /// Matched against a single source *leaf* by text.
+    /// Operator / punctuation / word (identifier / keyword / number) — always a
+    /// single source *leaf*. Matched against `leaves[li]` by text (advance 1 leaf).
     Token(String),
-    /// String literal (with quotes). Matched against a source string *node* by text.
+    /// Atomic whole-node literal: string / char / raw string, and any other
+    /// `TokKind::Str` class (e.g. TOML dates, CSS hex colors). Matched against a
+    /// source *node* span by text, atomically (advance past the whole span).
     Str(String),
     /// Metavariable. `name` == None for anonymous (`\_`, `\*`, `\?`). `regex`, if
     /// present, constrains the captured text (unanchored `is_match`); honored for


### PR DESCRIPTION
## Summary
- Resolves the `specs/code_match/TODOs.md` cleanup question "why distinguish `PatternItem::Token` vs `Str`, can they be unified?" — answer: **no, the split is load-bearing**, now documented in code.
- An operator/punctuation leaf is *anonymous* (never a named span, so the whole-node match path can't reach it); a composite literal (string/char/raw) spans ≥2 leaves (so the single-leaf path can't reach it). The two variants are two distinct match operations, not a redundant split.
- The lexer already knows which one a token is for free from the tokenizer's `TokKind`, so encoding it in the variant is the "exchange to the strong type early" rule — a unified "try leaf then spans" variant would discard that and re-derive it speculatively per-compare in the matcher hot path.
- Doc-comment only at `PatternItem` (lexer.rs) and `TokKind` (config.rs). No behavior change.

## Test plan
CI (existing `cargo test` for `cocoindex_code_match` passes; no logic touched).
