### PR TITLE
feat(code_match): containment matcher `\{{ INNER \}}`

### DIFF
--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -12,6 +12,8 @@
 //!   `S?` / `S(?)`   anonymous optional
 //!   `S(NAME:/re/)`  single, regex-constrained — see below
 //!   `S(:/re/)`      regex-constrained, **anonymous** (filter without capturing)
+//!   `S{{ INNER S}}` containment: INNER must match some descendant within a
+//!                   same-level region here (DESIGN §12). Paired; may nest.
 //!   `SS`            a doubled sigil is one **literal** sigil (e.g. `\\` → `\`)
 //! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
 //! written as multiple `*`, one per grammar level.
@@ -76,6 +78,14 @@ pub enum PatternItem {
         card: Cardinality,
         regex: Option<Regex>,
     },
+    /// `\{{` — opens a containment group `\{{ INNER \}}` (DESIGN §12). `close` is
+    /// the index of the matching `ContainsClose` in the flat items vec
+    /// (back-patched by `lex`); `INNER` is `items[self_index+1 .. close]`. Kept
+    /// flat (not a nested `Vec`) so the DP runs in one `pi` space with one memo,
+    /// and nesting falls out of the back-patched indices.
+    ContainsOpen { close: usize },
+    /// `\}}` — closes the containment group opened by the matching `ContainsOpen`.
+    ContainsClose,
 }
 
 pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
@@ -112,6 +122,18 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
             if pattern[after..].starts_with(cfg.meta_char) {
                 out.push(PatternItem::Token(cfg.meta_char.to_string()));
                 i = after + cfg.meta_char.len_utf8();
+                continue;
+            }
+            // containment markers `\{{` / `\}}` (sigil-agnostic: the `{{`/`}}`
+            // sits right after the sigil). `close` is back-patched after lexing.
+            if pattern[after..].starts_with("{{") {
+                out.push(PatternItem::ContainsOpen { close: 0 });
+                i = after + 2;
+                continue;
+            }
+            if pattern[after..].starts_with("}}") {
+                out.push(PatternItem::ContainsClose);
+                i = after + 2;
                 continue;
             }
             if let Some((item, next)) = lex_metavar(pattern, bytes, after)? {
@@ -181,7 +203,33 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         i += clen;
     }
 
+    resolve_contains(&mut out)?;
     Ok(out)
+}
+
+/// Pair up `\{{` / `\}}` markers and back-patch each `ContainsOpen.close` with the
+/// index of its matching `ContainsClose`. A `client` error on any unbalanced
+/// marker (the pattern is malformed). Nesting is handled by the stack.
+fn resolve_contains(items: &mut [PatternItem]) -> Result<()> {
+    let mut stack: Vec<usize> = Vec::new();
+    for idx in 0..items.len() {
+        match &items[idx] {
+            PatternItem::ContainsOpen { .. } => stack.push(idx),
+            PatternItem::ContainsClose => {
+                let open = stack
+                    .pop()
+                    .ok_or_else(|| Error::client("unmatched `\\}}` in pattern"))?;
+                if let PatternItem::ContainsOpen { close } = &mut items[open] {
+                    *close = idx;
+                }
+            }
+            _ => {}
+        }
+    }
+    if !stack.is_empty() {
+        return Err(Error::client("unmatched `\\{{` in pattern"));
+    }
+    Ok(())
 }
 
 /// Parse a metavar given `s` = the index just past the sigil. `Ok(Some(..))` is

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -100,20 +100,25 @@ impl Indexed {
 pub struct Pattern {
     items: Vec<PatternItem>,
     cfg: LangConfig,
-    /// true when some metavar name appears more than once (disables the fail-memo)
-    has_dup_names: bool,
+    /// Whether the `(pi, li)` fail-memo is sound. It isn't when forward-threaded
+    /// bindings can change whether a `(pi, li)` matches: a repeated metavar name,
+    /// or a containment group (`\{{ \}}`), whose INNER binds names per descendant.
+    use_memo: bool,
 }
 
 impl Pattern {
     /// Compile a pattern for `cfg`. Fails with a `client` error on a malformed
-    /// metavar matcher (e.g. an unparseable regex).
+    /// metavar matcher (e.g. an unparseable regex) or unbalanced `\{{` / `\}}`.
     pub fn compile(pattern: &str, cfg: &LangConfig) -> Result<Pattern> {
         let items = lex(pattern, cfg)?;
-        let has_dup_names = detect_dup_names(&items);
+        let has_contains = items
+            .iter()
+            .any(|it| matches!(it, PatternItem::ContainsOpen { .. }));
+        let use_memo = !detect_dup_names(&items) && !has_contains;
         Ok(Pattern {
             items,
             cfg: cfg.clone(),
-            has_dup_names,
+            use_memo,
         })
     }
 
@@ -142,11 +147,11 @@ impl Pattern {
                 items: &self.items,
                 idx: &idx,
                 source,
-                use_memo: !self.has_dup_names,
+                use_memo: self.use_memo,
                 bound: HashMap::new(),
                 fail: HashSet::new(),
             };
-            ctx.dp(0, start, hi).then_some(ctx.bound)
+            ctx.dp(0, self.items.len(), start, hi).then_some(ctx.bound)
         };
 
         let mut out = Vec::new();
@@ -355,10 +360,14 @@ struct Ctx<'a, 's> {
 }
 
 impl<'s> Ctx<'_, 's> {
-    /// Match `items[pi..]` against leaves `[li, hi)`. On success, `bound` holds
-    /// the captures.
-    fn dp(&mut self, pi: usize, li: usize, hi: usize) -> bool {
-        if pi == self.items.len() {
+    /// Match `items[pi..end]` against leaves `[li, hi)`. On success, `bound` holds
+    /// the captures. `end` is the exclusive item bound: `items.len()` at the top
+    /// level, or a containment group's `close` index for an INNER sub-match — so
+    /// the same `dp` engine matches a bracketed sub-pattern without it running
+    /// past its `\}}`. (`end` is a structural function of `pi` — each item sits in
+    /// exactly one bracket level — so the `(pi, li)` fail-memo stays well-keyed.)
+    fn dp(&mut self, pi: usize, end: usize, li: usize, hi: usize) -> bool {
+        if pi == end {
             return li == hi;
         }
         if self.use_memo && self.fail.contains(&(pi, li)) {
@@ -370,17 +379,23 @@ impl<'s> Ctx<'_, 's> {
         let items = self.items;
         let ok = match &items[pi] {
             PatternItem::Token(t) => {
-                li < hi && &self.idx.leaves[li].text == t && self.dp(pi + 1, li + 1, hi)
+                li < hi && &self.idx.leaves[li].text == t && self.dp(pi + 1, end, li + 1, hi)
             }
-            PatternItem::Str(s) => self.match_literal(pi, li, hi, s),
+            PatternItem::Str(s) => self.match_literal(pi, end, li, hi, s),
             PatternItem::Meta { name, card, regex } => match card {
-                Cardinality::One => self.match_single(pi, li, hi, name.as_deref(), regex.as_ref()),
+                Cardinality::One => {
+                    self.match_single(pi, end, li, hi, name.as_deref(), regex.as_ref())
+                }
                 // Many ignores the regex (sibling runs are out of the single-node scope).
-                Cardinality::Many => self.match_multi(pi, li, hi, name.as_deref()),
+                Cardinality::Many => self.match_multi(pi, end, li, hi, name.as_deref()),
                 Cardinality::Optional => {
-                    self.match_optional(pi, li, hi, name.as_deref(), regex.as_ref())
+                    self.match_optional(pi, end, li, hi, name.as_deref(), regex.as_ref())
                 }
             },
+            PatternItem::ContainsOpen { close } => self.match_contains(pi, *close, end, li, hi),
+            // Never landed on: the outer DP jumps over `[open+1, close]` to
+            // `close+1`, and an INNER sub-DP stops at `pi == end == close`.
+            PatternItem::ContainsClose => false,
         };
 
         if !ok && self.use_memo {
@@ -389,7 +404,7 @@ impl<'s> Ctx<'_, 's> {
         ok
     }
 
-    fn match_literal(&mut self, pi: usize, li: usize, hi: usize, s: &str) -> bool {
+    fn match_literal(&mut self, pi: usize, end: usize, li: usize, hi: usize, s: &str) -> bool {
         if li >= hi {
             return false;
         }
@@ -400,7 +415,7 @@ impl<'s> Ctx<'_, 's> {
         for sp in &idx.spans_by_start[li] {
             if sp.end_leaf < hi
                 && &source[sp.start_byte..sp.end_byte] == s
-                && self.dp(pi + 1, sp.end_leaf + 1, hi)
+                && self.dp(pi + 1, end, sp.end_leaf + 1, hi)
             {
                 return true;
             }
@@ -411,6 +426,7 @@ impl<'s> Ctx<'_, 's> {
     fn match_single(
         &mut self,
         pi: usize,
+        end: usize,
         li: usize,
         hi: usize,
         name: Option<&str>,
@@ -434,7 +450,7 @@ impl<'s> Ctx<'_, 's> {
             match self.bind(name, cap) {
                 BindResult::Inconsistent => continue,
                 bind => {
-                    if self.dp(pi + 1, sp.end_leaf + 1, hi) {
+                    if self.dp(pi + 1, end, sp.end_leaf + 1, hi) {
                         return true;
                     }
                     self.unbind(name, bind);
@@ -448,7 +464,14 @@ impl<'s> Ctx<'_, 's> {
     /// of *one parent's* direct children (same-level), so a `*` run can't
     /// silently leak out of the subtree the pattern entered. A cross-level skip
     /// is written as multiple `*`, one per grammar level.
-    fn match_multi(&mut self, pi: usize, li: usize, hi: usize, name: Option<&str>) -> bool {
+    fn match_multi(
+        &mut self,
+        pi: usize,
+        end: usize,
+        li: usize,
+        hi: usize,
+        name: Option<&str>,
+    ) -> bool {
         let idx = self.idx;
         let reach = reachable(li, hi, idx); // descending => greedy longest first
         for next in reach {
@@ -466,7 +489,7 @@ impl<'s> Ctx<'_, 's> {
             match self.bind(name, cap) {
                 BindResult::Inconsistent => continue,
                 bind => {
-                    if self.dp(pi + 1, next, hi) {
+                    if self.dp(pi + 1, end, next, hi) {
                         return true;
                     }
                     self.unbind(name, bind);
@@ -476,12 +499,86 @@ impl<'s> Ctx<'_, 's> {
         false
     }
 
+    /// `\{{ INNER \}}` — containment (DESIGN §12). Consume a same-level region
+    /// `[li, next)` (a child-aligned sibling slice, like `\*`, possibly empty),
+    /// require `INNER` (`items[pi+1..close]`) to match *some descendant node*
+    /// fully inside the region (any depth), then continue the outer match at
+    /// `items[close+1..end]` from `next`. The region grows greedily (longest
+    /// first) so whole-node coverage is preferred, same as `match_multi`.
+    fn match_contains(
+        &mut self,
+        pi: usize,
+        close: usize,
+        end: usize,
+        li: usize,
+        hi: usize,
+    ) -> bool {
+        let inner = pi + 1; // first INNER item
+        let cont = close + 1; // first outer item after `\}}`
+        let idx = self.idx;
+        for next in reachable(li, hi, idx) {
+            if !idx.same_level(li, next) {
+                continue; // region must be a clean sibling slice
+            }
+            if self.contains_then_continue(inner, close, cont, end, li, next, hi) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// For a fixed region `[reg_lo, reg_hi)`: try to match `INNER` (`items[inner..
+    /// inner_end]`) against some descendant inside it, and on a hit continue the
+    /// outer match (`items[cont..cont_end]`) from `reg_hi`. INNER bindings thread
+    /// forward (visible after the group); a `bound` snapshot/restore around each
+    /// attempt undoes them when that attempt doesn't pan out.
+    #[allow(clippy::too_many_arguments)]
+    fn contains_then_continue(
+        &mut self,
+        inner: usize,
+        inner_end: usize,
+        cont: usize,
+        cont_end: usize,
+        reg_lo: usize,
+        reg_hi: usize,
+        hi: usize,
+    ) -> bool {
+        let idx = self.idx;
+        // Descendant candidates fully inside the region, any depth. `candidates`
+        // is post-order (innermost first) and leaf-dedup'd — enough for existence.
+        // (MVP scans all candidates filtered by region; a region-indexed lookup is
+        // a perf follow-up, in line with §10 deferring indexing.)
+        for cand in &idx.candidates {
+            if cand.start_leaf < reg_lo || cand.end_leaf >= reg_hi {
+                continue;
+            }
+            // Snapshot is the *pre-group* bindings (captures inside INNER haven't
+            // happened yet) — usually empty or tiny, so the clone is cheap.
+            let snapshot = self.bound.clone();
+            if self.dp(inner, inner_end, cand.start_leaf, cand.end_leaf + 1)
+                && self.dp(cont, cont_end, reg_hi, hi)
+            {
+                return true;
+            }
+            self.bound = snapshot; // undo INNER bindings from a failed attempt
+        }
+        // INNER matches zero nodes (all-optional INNER, e.g. `\{{ \? \}}`): match
+        // the empty leaf range, then continue.
+        let snapshot = self.bound.clone();
+        if self.dp(inner, inner_end, reg_lo, reg_lo) && self.dp(cont, cont_end, reg_hi, hi) {
+            return true;
+        }
+        self.bound = snapshot;
+        false
+    }
+
     /// `\(X?)` — match zero or one node. Greedy: try one node first, then none
     /// (binding an empty capture at `li`). A regex constrains the node *when
     /// present*; absence is always allowed (the `?` keeps its meaning).
     fn match_optional(
         &mut self,
         pi: usize,
+        end: usize,
         li: usize,
         hi: usize,
         name: Option<&str>,
@@ -501,7 +598,7 @@ impl<'s> Ctx<'_, 's> {
                 match self.bind(name, cap) {
                     BindResult::Inconsistent => continue,
                     bind => {
-                        if self.dp(pi + 1, sp.end_leaf + 1, hi) {
+                        if self.dp(pi + 1, end, sp.end_leaf + 1, hi) {
                             return true;
                         }
                         self.unbind(name, bind);
@@ -521,7 +618,7 @@ impl<'s> Ctx<'_, 's> {
         match self.bind(name, cap) {
             BindResult::Inconsistent => false,
             bind => {
-                if self.dp(pi + 1, li, hi) {
+                if self.dp(pi + 1, end, li, hi) {
                     return true;
                 }
                 self.unbind(name, bind);

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -500,6 +500,82 @@ fn non_ascii_sigil() {
     );
 }
 
+// ---------------- containment `\{{ ... \}}` ----------------
+
+#[test]
+fn contains_basic() {
+    // `\{{ return \X \}}` asserts the function body *contains* `return \X` (any
+    // depth). The whole function_definition is reported; X binds inside the group
+    // and is exposed on the match.
+    let src = "def foo():\n    x = 1\n    return a + b\n";
+    let ms = matches(lang::python(), r"def foo(): \{{ return \X \}}", src);
+    let m = ms
+        .iter()
+        .find(|m| m.kind == "function_definition")
+        .unwrap_or_else(|| panic!("should match the function containing `return \\X`, got {ms:?}"));
+    assert_eq!(m.capture_text("X"), Some("a + b"));
+}
+
+#[test]
+fn contains_searches_any_depth() {
+    // The `return` is nested inside an `if` — the descendant search must descend.
+    let src = "def foo():\n    if c:\n        return a + b\n";
+    let ms = matches(lang::python(), r"def foo(): \{{ return \X \}}", src);
+    assert_eq!(cap(&ms, "X").as_deref(), Some("a + b"));
+}
+
+#[test]
+fn contains_negative_when_absent() {
+    // No `return` in the body → the containment predicate fails → no match.
+    let src = "def foo():\n    x = 1\n";
+    let ms = matches(lang::python(), r"def foo(): \{{ return \X \}}", src);
+    assert!(
+        !ms.iter().any(|m| m.kind == "function_definition"),
+        "must not match a function whose body has no `return`, got {ms:?}",
+    );
+}
+
+#[test]
+fn contains_binding_threads_across_the_group() {
+    // A name bound *before* the group constrains a use *inside* it (forward
+    // threading): `\P` is the parameter and must equal the returned name.
+    let pat = r"def foo(\P): \{{ return \P \}}";
+    let yes = matches(lang::python(), pat, "def foo(a):\n    return a\n");
+    assert!(
+        yes.iter().any(|m| m.kind == "function_definition"),
+        "param `a` and returned `a` are equal → match, got {yes:?}",
+    );
+    let no = matches(lang::python(), pat, "def foo(b):\n    return a\n");
+    assert!(
+        !no.iter().any(|m| m.kind == "function_definition"),
+        "param `b` ≠ returned `a` → no match, got {no:?}",
+    );
+}
+
+#[test]
+fn contains_nested() {
+    // Nested groups: foo's body contains an `if` whose body contains `return \X`.
+    // Exercises the back-patched close indices and recursive `match_contains`.
+    let src = "def foo():\n    if c:\n        return a + b\n";
+    let ms = matches(
+        lang::python(),
+        r"def foo(): \{{ if \C: \{{ return \X \}} \}}",
+        src,
+    );
+    let m = ms
+        .iter()
+        .find(|m| m.kind == "function_definition")
+        .unwrap_or_else(|| panic!("nested containment should match, got {ms:?}"));
+    assert_eq!(m.capture_text("C"), Some("c"));
+    assert_eq!(m.capture_text("X"), Some("a + b"));
+}
+
+#[test]
+fn contains_unbalanced_markers_error() {
+    assert!(Pattern::compile(r"def foo(): \{{ return \X", &lang::python()).is_err());
+    assert!(Pattern::compile(r"return \X \}}", &lang::python()).is_err());
+}
+
 // ---------------- operator/generics alignment ----------------
 
 #[test]


### PR DESCRIPTION
## Summary
Implements the containment / `has` primitive from DESIGN §0/§12 (milestone M2.9): a paired, nestable `\{{ INNER \}}` group asserts that `INNER` matches **some descendant** (any depth) within a same-level region of the candidate.

```
def foo(): \{{ return \X \}}    # matches a function whose body contains `return \X`
```

- **Lexer**: `\{{` / `\}}` lex to flat `ContainsOpen { close }` / `ContainsClose` markers in the single items vec; `close` is back-patched in `lex` (`resolve_contains`) — nesting for free, one `pi` space, one memo. Unbalanced markers → `client` error from `Pattern::compile`.
- **Matcher**: `dp` gains a bounded `end` so the same engine matches a bracketed sub-pattern without running past its `\}}`. The `ContainsOpen` arm consumes a same-level region (`reachable` + `same_level`, exactly like `match_multi`) and runs the candidate loop over descendants inside it. INNER bindings thread forward (so `\X` is visible after the group), with a `bound` snapshot/restore on backtrack. The `(pi, li)` fail-memo is disabled when a pattern contains any `\{{ \}}` (per-descendant binding makes it unsound, same reasoning as repeated names).

The region is a child-aligned sibling slice (possibly empty when INNER matches zero), so it stays bounded and can't leak — unlike the removed `\**`.

Follow-ups (noted in code + DESIGN): child-run tolerance for INNER (today whole-node descendant coverage); a region-indexed descendant lookup (today a filtered scan over all candidates).

## Test plan
6 new e2e tests in `tests/features.rs` (basic, any-depth descent, negative/absent, cross-boundary binding equality, nested groups, unbalanced-marker error). Full suite green locally: 91 lib + 50 feature tests; `cocoindex_py` builds.
