### PR TITLE
perf(code_ast): memoize byte→position index, drop per-query full scan

### DIFF
--- a/rust/ops_text/src/output_positions.rs
+++ b/rust/ops_text/src/output_positions.rs
@@ -55,24 +55,51 @@ impl Position {
     }
 }
 
-/// Compute the [`OutputPosition`] (char offset, 1-based line/column) for each
-/// byte offset in `byte_offsets`, returned in the same order. Single pass over
-/// `text`. Offsets must lie on char boundaries; an offset at the end of the text
-/// is allowed. Lets callers attach positions to arbitrary ranges (e.g. pattern
-/// match ranges) exactly the way the chunk splitter does.
-pub fn output_positions_for(text: &str, byte_offsets: &[usize]) -> Vec<OutputPosition> {
-    let mut positions: Vec<Position> = byte_offsets.iter().map(|&b| Position::new(b)).collect();
-    set_output_positions(text, positions.iter_mut());
-    positions
-        .into_iter()
-        .map(|p| {
-            p.output.unwrap_or(OutputPosition {
-                char_offset: 0,
-                line: 1,
-                column: 1,
-            })
-        })
-        .collect()
+/// A reusable per-file index from byte offset to [`OutputPosition`]. Built once
+/// in a single O(file) pass, then each lookup is a binary search over line starts
+/// plus a short char count within the target line. A long-lived parse (e.g. a
+/// `CodeAst` matched against many patterns) builds this once and reuses it, rather
+/// than re-scanning the whole file per query (a one-shot batch is O(file) *every*
+/// call, so N queries cost O(file·N)).
+pub struct LineIndex {
+    /// Byte offset of each line start (`[0]` is byte 0), ascending.
+    line_start_byte: Vec<usize>,
+    /// Char offset of each line start, parallel to `line_start_byte`.
+    line_start_char: Vec<usize>,
+}
+
+impl LineIndex {
+    /// Build the index from `text` in a single pass.
+    pub fn build(text: &str) -> Self {
+        let mut line_start_byte = vec![0usize];
+        let mut line_start_char = vec![0usize];
+        let mut char_count = 0usize;
+        for (b, ch) in text.char_indices() {
+            char_count += 1;
+            if ch == '\n' {
+                line_start_byte.push(b + 1); // the next line starts after the '\n'
+                line_start_char.push(char_count);
+            }
+        }
+        Self {
+            line_start_byte,
+            line_start_char,
+        }
+    }
+
+    /// Resolve `byte_offset` to its char offset + 1-based line/column. The offset
+    /// must lie on a char boundary of `text`; the end of the text is allowed.
+    /// `text` must be the same string the index was built from.
+    pub fn position(&self, text: &str, byte_offset: usize) -> OutputPosition {
+        // `line_start_byte[0]` is 0 ≤ byte_offset, so `partition_point` ≥ 1.
+        let idx = self.line_start_byte.partition_point(|&s| s <= byte_offset) - 1;
+        let chars_in_line = text[self.line_start_byte[idx]..byte_offset].chars().count();
+        OutputPosition {
+            char_offset: self.line_start_char[idx] + chars_in_line,
+            line: (idx + 1) as u32,
+            column: (chars_in_line + 1) as u32,
+        }
+    }
 }
 
 /// Fill OutputPosition for the requested byte offsets.
@@ -326,6 +353,51 @@ mod tests {
                 line: 1,
                 column: 8,
             })
+        );
+    }
+
+    #[test]
+    fn line_index_matches_single_pass() {
+        // LineIndex.position must agree with set_output_positions for the same
+        // offsets, including newlines and multibyte chars.
+        let text = "ab\ncd\nef";
+        let li = LineIndex::build(text);
+        for &b in &[0usize, 3, 6, 8] {
+            let mut p = Position::new(b);
+            set_output_positions(text, std::iter::once(&mut p));
+            assert_eq!(Some(li.position(text, b)), p.output, "byte {b}");
+        }
+
+        let emoji = "abc\u{1F604}def"; // emoji is 4 bytes at byte 3..7
+        let eli = LineIndex::build(emoji);
+        for &b in &[0usize, 3, 7, 10] {
+            let mut p = Position::new(b);
+            set_output_positions(emoji, std::iter::once(&mut p));
+            assert_eq!(Some(eli.position(emoji, b)), p.output, "emoji byte {b}");
+        }
+    }
+
+    #[test]
+    fn line_index_end_of_text_and_line_starts() {
+        let text = "x\n\ny"; // line starts at bytes 0, 2, 3
+        let li = LineIndex::build(text);
+        // start of line 3 (the 'y')
+        assert_eq!(
+            li.position(text, 3),
+            OutputPosition {
+                char_offset: 3,
+                line: 3,
+                column: 1,
+            }
+        );
+        // end of text
+        assert_eq!(
+            li.position(text, text.len()),
+            OutputPosition {
+                char_offset: 4,
+                line: 3,
+                column: 2,
+            }
         );
     }
 

--- a/rust/ops_text/src/split/mod.rs
+++ b/rust/ops_text/src/split/mod.rs
@@ -7,7 +7,7 @@
 mod by_separators;
 mod recursive;
 
-pub use crate::output_positions::{OutputPosition, TextRange, output_positions_for};
+pub use crate::output_positions::{LineIndex, OutputPosition, TextRange};
 pub use by_separators::{KeepSeparator, SeparatorSplitConfig, SeparatorSplitter};
 pub use recursive::{
     CustomLanguageConfig, RecursiveChunkConfig, RecursiveChunker, RecursiveSplitConfig,

--- a/rust/py/src/code_ast.rs
+++ b/rust/py/src/code_ast.rs
@@ -11,8 +11,7 @@ use cocoindex_code_match::lang;
 use cocoindex_code_match::{Match, Pattern};
 use cocoindex_ops_text::prog_langs;
 use cocoindex_ops_text::split::{
-    OutputPosition, RecursiveChunkConfig, RecursiveChunker, RecursiveSplitConfig,
-    output_positions_for,
+    LineIndex, OutputPosition, RecursiveChunkConfig, RecursiveChunker, RecursiveSplitConfig,
 };
 use pyo3::prelude::*;
 use tree_sitter::{Parser, Tree};
@@ -69,46 +68,29 @@ fn chunk_from(range: &Range<usize>, s: OutputPosition, e: OutputPosition) -> PyC
     }
 }
 
-/// Convert raw matches to `PyCodeMatch`, computing line/column positions for
-/// every match and capture endpoint in a *single* pass over `source` (the way
-/// the splitter does). Capture names are sorted so the offset read-back aligns.
-fn build_matches(source: &str, raw: Vec<Match<'_>>) -> Vec<PyCodeMatch> {
-    let mut offsets = Vec::new();
-    let mut per_match_caps: Vec<Vec<(String, Range<usize>)>> = Vec::with_capacity(raw.len());
-    for m in &raw {
-        offsets.push(m.range.start);
-        offsets.push(m.range.end);
-        let mut caps: Vec<(String, Range<usize>)> = m
-            .captures
-            .iter()
-            .map(|(k, c)| (k.clone(), c.range.clone()))
-            .collect();
-        caps.sort_by(|a, b| a.0.cmp(&b.0));
-        for (_, r) in &caps {
-            offsets.push(r.start);
-            offsets.push(r.end);
-        }
-        per_match_caps.push(caps);
-    }
-
-    let pos = output_positions_for(source, &offsets);
-    let mut idx = 0usize;
-    let mut out = Vec::with_capacity(raw.len());
-    for (m, caps) in raw.into_iter().zip(per_match_caps) {
-        let chunk = chunk_from(&m.range, pos[idx], pos[idx + 1]);
-        idx += 2;
-        let mut captures: HashMap<String, Vec<PyChunk>> = HashMap::with_capacity(caps.len());
-        for (name, range) in caps {
-            captures.insert(name, vec![chunk_from(&range, pos[idx], pos[idx + 1])]);
-            idx += 2;
-        }
-        out.push(PyCodeMatch {
-            kind: m.kind,
-            chunks: vec![chunk],
-            captures,
-        });
-    }
-    out
+/// Convert raw matches to `PyCodeMatch`, resolving line/column positions for
+/// every match and capture endpoint through the AST's reusable [`LineIndex`]
+/// (each offset is an independent lookup, so no per-call full-file scan).
+fn build_matches(source: &str, line_index: &LineIndex, raw: Vec<Match<'_>>) -> Vec<PyCodeMatch> {
+    let pos = |b: usize| line_index.position(source, b);
+    raw.into_iter()
+        .map(|m| {
+            let chunk = chunk_from(&m.range, pos(m.range.start), pos(m.range.end));
+            let captures = m
+                .captures
+                .iter()
+                .map(|(name, c)| {
+                    let ch = chunk_from(&c.range, pos(c.range.start), pos(c.range.end));
+                    (name.clone(), vec![ch])
+                })
+                .collect();
+            PyCodeMatch {
+                kind: m.kind,
+                chunks: vec![chunk],
+                captures,
+            }
+        })
+        .collect()
 }
 
 /// A parsed code AST. Parse once, then `matches()` structural patterns and/or
@@ -119,6 +101,9 @@ pub struct PyCodeAst {
     source: String,
     language: String,
     tree: Tree,
+    /// Byte→position index over `source`, built on first `matches()` and reused
+    /// across subsequent pattern queries (the "one parse, many patterns" case).
+    line_index: std::sync::OnceLock<LineIndex>,
 }
 
 #[pymethods]
@@ -146,6 +131,7 @@ impl PyCodeAst {
             source,
             language,
             tree,
+            line_index: std::sync::OnceLock::new(),
         })
     }
 
@@ -174,8 +160,11 @@ impl PyCodeAst {
         let compiled = Pattern::compile(pattern, &cfg)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?;
         Ok(py.detach(|| {
+            let line_index = self
+                .line_index
+                .get_or_init(|| LineIndex::build(&self.source));
             let raw = compiled.matches_in_tree(&self.tree, &self.source);
-            build_matches(&self.source, raw)
+            build_matches(&self.source, line_index, raw)
         }))
     }
 


### PR DESCRIPTION
## Summary
`CodeAst.matches()` resolved each match's line/column via `output_positions_for` — a single O(file) pass over the source, but run on **every** `matches()` call. The `CodeAst` is built for "one parse, many patterns", so N pattern queries cost **O(file·N)**.

- Add a reusable `LineIndex` (in `ops_text/output_positions.rs`): built once (line-start byte + char offsets); each lookup is a binary search over line starts plus a short in-line char count.
- `PyCodeAst` holds it in a `OnceLock`, built on the first `matches()` and reused across subsequent queries. `build_matches` resolves each offset through it instead of batching a full scan per call.
- `output_positions_for` (now unused) removed; `set_output_positions` kept — the splitter's batched per-call positions are a separate path, untouched.

## Test plan
- 2 new parity unit tests asserting `LineIndex::position` agrees with `set_output_positions` (newlines, multibyte, line starts, end-of-text).
- Existing 9 Python `test_code.py` tests pass — identical positions end to end.
- `cargo test -p cocoindex_ops_text` (45) green; `cocoindex_py` builds; clippy clean on changed files.

Out of scope (noted in code): `CodeAst.split()` still uses the chunker's own per-call scan — positions there are computed deep inside recursive splitting, a different path from this O(file·N) issue.
