### PR TITLE
feat(code_match): prefilter — required-content extraction + index-free scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,8 +2035,10 @@ dependencies = [
 name = "cocoindex_code_match"
 version = "999.0.0"
 dependencies = [
+ "aho-corasick",
  "cocoindex_utils",
  "regex",
+ "regex-syntax",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.89"
 license = "Apache-2.0"
 
 [workspace.dependencies]
+aho-corasick = "1.1.4"
 anyhow = { version = "1.0.100", features = ["std"] }
 async-stream = "0.3.6"
 async-trait = "0.1.89"
@@ -54,6 +55,7 @@ pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }
 pythonize = "0.27.0"
 rand = "0.9.2"
 regex = "1.12.2"
+regex-syntax = "0.8.10"
 reqwest = { version = "0.12.24", default-features = false, features = [
     "json",
     "rustls-tls",

--- a/rust/code_match/Cargo.toml
+++ b/rust/code_match/Cargo.toml
@@ -8,6 +8,8 @@ license = { workspace = true }
 [dependencies]
 cocoindex_utils = { path = "../utils" }
 regex = { workspace = true }
+regex-syntax = { workspace = true }
+aho-corasick = { workspace = true }
 
 # tree-sitter + grammars are pinned to the SAME versions as `cocoindex_ops_text`.
 # `tree-sitter` uses `links = "tree-sitter"`, so the whole workspace must resolve

--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -209,6 +209,10 @@ pub struct LangConfig {
     /// Compound operators normalized to single chars on both sides (e.g. `>>` ->
     /// `>` `>`). Auto-detected from the grammar.
     pub splittable: HashSet<String>,
+    /// The grammar's word-shaped anonymous symbols — its keywords (`if`, `return`,
+    /// contextual ones like TS `type`). Complement of `op_tokens` among anonymous
+    /// symbols. Used by the prefilter to exclude keywords from identifier terms.
+    pub keywords: HashSet<String>,
     /// Metavariable sigil. Default `\` (shell-safe).
     pub meta_char: char,
     /// Tokenizers for literal/identifier classes, tried at each position; the
@@ -236,10 +240,12 @@ impl LangConfig {
         let single_char = single_char_punct_tokens(&language);
         let splittable = detect_splittable(&language, &single_char);
         let op_tokens = derive_op_tokens(&language, &splittable);
+        let keywords = derive_keywords(&language);
         LangConfig {
             language,
             op_tokens,
             splittable,
+            keywords,
             meta_char: '\\',
             tokenizers,
             transitions: Vec::new(),
@@ -356,4 +362,26 @@ fn derive_op_tokens(lang: &Language, splittable: &HashSet<String>) -> Vec<String
     toks.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
     toks.dedup();
     toks
+}
+
+/// The grammar's word-shaped anonymous symbols — its keywords. These are the
+/// anonymous symbols `derive_op_tokens` *excludes* (they fail `is_punct_token`),
+/// e.g. `if`, `return`, `async`, contextual keywords like TS `type`. A pattern
+/// word in this set is a keyword, not a selective identifier, so the prefilter
+/// skips it.
+fn derive_keywords(lang: &Language) -> HashSet<String> {
+    let mut set = HashSet::new();
+    for id in 0..lang.node_kind_count() as u16 {
+        if lang.node_kind_is_named(id) {
+            continue;
+        }
+        let Some(s) = lang.node_kind_for_id(id) else {
+            continue;
+        };
+        if s.is_empty() || s == "ERROR" || is_punct_token(s) {
+            continue;
+        }
+        set.insert(s.to_string());
+    }
+    set
 }

--- a/rust/code_match/src/lib.rs
+++ b/rust/code_match/src/lib.rs
@@ -10,10 +10,12 @@ mod config;
 pub mod lang;
 mod lexer;
 mod matcher;
+mod prefilter;
 
 pub use config::{LangConfig, RegexTokenizer, TokKind, TokenRule, Tokenizer};
 pub use lexer::{Cardinality, PatternItem};
 pub use matcher::{Capture, Match, Pattern};
+pub use prefilter::{Boundary, FilterClause, FilterTerm, Prefilter};
 
 // The crate's fallible surface uses the workspace-standard error type.
 pub use cocoindex_utils::error::{Error, Result};

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -122,6 +122,13 @@ impl Pattern {
         })
     }
 
+    /// Build a [`Prefilter`](crate::Prefilter) — the pattern's required literal
+    /// content, for cheaply rejecting sources that can't match before parsing.
+    /// `min_len` drops terms shorter than this many chars (default sensibly 3).
+    pub fn prefilter(&self, min_len: usize) -> crate::Prefilter {
+        crate::Prefilter::build(&self.items, &self.cfg, min_len)
+    }
+
     pub fn matches<'s>(&self, source: &'s str) -> Vec<Match<'s>> {
         let mut parser = Parser::new();
         parser

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -1,0 +1,267 @@
+//! Prefiltering: extract a pattern's **required literal content** so callers can
+//! cheaply reject sources that can't possibly match, before the expensive parse +
+//! precise match. See `specs/code_match/prefilter_design.md`.
+//!
+//! Build one with [`Pattern::prefilter`]. The result is a conjunction of clauses
+//! (CNF): a source can match only if it satisfies **every** clause, and a clause
+//! holds if **any** of its terms occurs. This is *sound* — it may pass a source
+//! that doesn't actually match (false positive), but never rejects one that would
+//! (no false negatives), because we only ever *drop* constraints we can't extract.
+//!
+//! Terms come from three places in a pattern: identifiers (whole-word), string
+//! literal content (whole-word over each alphanumeric run), and the required
+//! literals of a regex matcher `\(:/re/)` (substring, via `regex-syntax`).
+//! Keywords, punctuation, numbers, and bare metavars contribute nothing.
+
+use std::collections::HashMap;
+
+use aho_corasick::{AhoCorasick, MatchKind};
+
+use crate::config::LangConfig;
+use crate::lexer::PatternItem;
+
+/// How a required term must occur in the source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Boundary {
+    /// Whole word (`\bterm\b`). A pattern identifier or string-content run: the
+    /// precise matcher needs an exact token, so a word-bounded occurrence is
+    /// necessary and more selective.
+    Word,
+    /// Anywhere (substring). A regex-extracted literal, which the regex may match
+    /// mid-token.
+    Substring,
+}
+
+/// A required literal and how it must occur.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterTerm {
+    pub text: String,
+    pub boundary: Boundary,
+}
+
+/// One CNF clause: satisfied if **any** of its terms occurs. More than one term
+/// only arises from a regex alternation (`\(:/get|set/)`); a plain identifier or
+/// string run is a singleton.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterClause {
+    pub any_of: Vec<FilterTerm>,
+}
+
+/// A required-content prefilter compiled from a pattern. A source can match only
+/// if [`might_match`](Prefilter::might_match) returns true. Sound: false positives
+/// are possible, false negatives are not.
+pub struct Prefilter {
+    clauses: Vec<FilterClause>,
+    /// Automaton over the distinct term texts (`None` when there are no terms —
+    /// the pattern can't be prefiltered, so everything is a "maybe").
+    ac: Option<AhoCorasick>,
+    /// Per automaton pattern id, the `(clause index, boundary)` of each term with
+    /// that text. A text can belong to several clauses / boundaries.
+    membership: Vec<Vec<(usize, Boundary)>>,
+}
+
+impl Prefilter {
+    /// Build from a pattern's items + language config. `min_len`: terms shorter
+    /// than this (in chars) are dropped — too short to be selective or to index as
+    /// n-grams. A clause is kept only if *all* its alternatives survive (dropping a
+    /// disjunction alternative would be unsound), so a too-short alternative drops
+    /// the whole clause.
+    pub(crate) fn build(items: &[PatternItem], cfg: &LangConfig, min_len: usize) -> Prefilter {
+        let mut clauses: Vec<Vec<FilterTerm>> = Vec::new();
+        let keep = |s: &str| s.chars().count() >= min_len;
+
+        for item in items {
+            match item {
+                PatternItem::Token(text) => {
+                    if is_identifier_term(text, cfg) && keep(text) {
+                        clauses.push(vec![FilterTerm {
+                            text: text.clone(),
+                            boundary: Boundary::Word,
+                        }]);
+                    }
+                }
+                PatternItem::Str(text) => {
+                    // Each maximal alphanumeric run of the raw string text is a
+                    // whole-word requirement (runs are bounded by quotes/punct in
+                    // both pattern and source raw text). Independent AND clauses,
+                    // so a too-short run is dropped on its own.
+                    for run in word_runs(text) {
+                        if keep(run) {
+                            clauses.push(vec![FilterTerm {
+                                text: run.to_string(),
+                                boundary: Boundary::Word,
+                            }]);
+                        }
+                    }
+                }
+                PatternItem::Meta {
+                    regex: Some(re), ..
+                } => {
+                    for alts in regex_required_literals(re.as_str()) {
+                        // Disjunction: keep only if every alternative survives.
+                        if !alts.is_empty() && alts.iter().all(|s| keep(s)) {
+                            clauses.push(
+                                alts.into_iter()
+                                    .map(|text| FilterTerm {
+                                        text,
+                                        boundary: Boundary::Substring,
+                                    })
+                                    .collect(),
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Prefilter::compile(clauses)
+    }
+
+    fn compile(clause_terms: Vec<Vec<FilterTerm>>) -> Prefilter {
+        let mut patterns: Vec<String> = Vec::new();
+        let mut id_of: HashMap<String, usize> = HashMap::new();
+        let mut membership: Vec<Vec<(usize, Boundary)>> = Vec::new();
+
+        for (ci, terms) in clause_terms.iter().enumerate() {
+            for t in terms {
+                let pid = *id_of.entry(t.text.clone()).or_insert_with(|| {
+                    patterns.push(t.text.clone());
+                    membership.push(Vec::new());
+                    patterns.len() - 1
+                });
+                membership[pid].push((ci, t.boundary));
+            }
+        }
+
+        let ac = (!patterns.is_empty()).then(|| {
+            AhoCorasick::builder()
+                .match_kind(MatchKind::Standard) // Standard supports overlapping search
+                .build(&patterns)
+                .expect("aho-corasick build over literal terms")
+        });
+
+        let clauses = clause_terms
+            .into_iter()
+            .map(|any_of| FilterClause { any_of })
+            .collect();
+
+        Prefilter {
+            clauses,
+            ac,
+            membership,
+        }
+    }
+
+    /// True if `source` **might** contain a match — a cheap, parse-free gate. The
+    /// caller runs the precise matcher only when this is true. Conservative: a
+    /// pattern with no extractable terms always returns true.
+    pub fn might_match(&self, source: &str) -> bool {
+        if self.clauses.is_empty() {
+            return true;
+        }
+        let Some(ac) = &self.ac else {
+            return true;
+        };
+
+        let mut satisfied = vec![false; self.clauses.len()];
+        let mut remaining = self.clauses.len();
+        // Overlapping search so two distinct terms that overlap in the text are
+        // both seen (e.g. `abc`/`bcd` in `abcd`).
+        for m in ac.find_overlapping_iter(source) {
+            for &(ci, boundary) in &self.membership[m.pattern().as_usize()] {
+                if satisfied[ci] {
+                    continue;
+                }
+                let ok = match boundary {
+                    Boundary::Substring => true,
+                    Boundary::Word => word_bounded(source, m.start(), m.end()),
+                };
+                if ok {
+                    satisfied[ci] = true;
+                    remaining -= 1;
+                    if remaining == 0 {
+                        return true;
+                    }
+                }
+            }
+        }
+        remaining == 0
+    }
+
+    /// The required-term clauses (CNF). Exposed for index-query construction and
+    /// tests; a caller turns each clause into an index lookup.
+    pub fn clauses(&self) -> &[FilterClause] {
+        &self.clauses
+    }
+}
+
+/// A pattern `Token` is an identifier term iff it starts with an identifier char
+/// (letter/`_` — excludes punctuation and numbers) and isn't a grammar keyword.
+fn is_identifier_term(text: &str, cfg: &LangConfig) -> bool {
+    let Some(first) = text.chars().next() else {
+        return false;
+    };
+    (first.is_alphabetic() || first == '_') && !cfg.keywords.contains(text)
+}
+
+/// Maximal `[A-Za-z0-9_]` runs of `s`, in order.
+fn word_runs(s: &str) -> impl Iterator<Item = &str> {
+    s.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .filter(|r| !r.is_empty())
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Whether the byte range `[start, end)` of `s` sits on word boundaries both sides.
+fn word_bounded(s: &str, start: usize, end: usize) -> bool {
+    let before = start == 0 || !s[..start].chars().next_back().is_some_and(is_word_char);
+    let after = end == s.len() || !s[end..].chars().next().is_some_and(is_word_char);
+    before && after
+}
+
+/// Required literals of a regex, as CNF: a `Vec` of clauses, each a disjunction of
+/// alternative literal strings. Every clause must hold (a literal in it appears);
+/// an empty result means the regex imposes no extractable requirement. Sound: we
+/// only emit literals that must appear in *every* match of the regex.
+fn regex_required_literals(pattern: &str) -> Vec<Vec<String>> {
+    match regex_syntax::parse(pattern) {
+        Ok(hir) => required_lits(&hir),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn required_lits(hir: &regex_syntax::hir::Hir) -> Vec<Vec<String>> {
+    use regex_syntax::hir::HirKind;
+    match hir.kind() {
+        HirKind::Literal(lit) => match std::str::from_utf8(&lit.0) {
+            Ok(s) if !s.is_empty() => vec![vec![s.to_string()]],
+            _ => Vec::new(),
+        },
+        // The sub appears at least once => its literals are required.
+        HirKind::Repetition(rep) if rep.min >= 1 => required_lits(&rep.sub),
+        HirKind::Capture(cap) => required_lits(&cap.sub),
+        // Concatenation: every part's requirements hold (AND).
+        HirKind::Concat(subs) => subs.iter().flat_map(required_lits).collect(),
+        // Alternation: one representative literal per branch (disjunction). If any
+        // branch has no required literal, the whole alternation is unconstrained.
+        HirKind::Alternation(subs) => {
+            let mut alts = Vec::with_capacity(subs.len());
+            for sub in subs {
+                match required_lits(sub).first().and_then(|c| c.first()) {
+                    Some(rep) => alts.push(rep.clone()),
+                    None => return Vec::new(),
+                }
+            }
+            if alts.is_empty() {
+                Vec::new()
+            } else {
+                vec![alts]
+            }
+        }
+        // Empty, Look (anchors), Class, optional Repetition: no required literal.
+        _ => Vec::new(),
+    }
+}

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -1,0 +1,94 @@
+//! Prefilter tests: required-content extraction + the index-free `might_match`
+//! scan. The load-bearing property is **no false negatives** — anything that
+//! actually matches must pass the prefilter.
+
+use cocoindex_code_match::{Boundary, Pattern, Prefilter, lang};
+
+fn prefilter(pat: &str, min_len: usize) -> Prefilter {
+    Pattern::compile(pat, &lang::python())
+        .expect("valid pattern")
+        .prefilter(min_len)
+}
+
+#[test]
+fn identifier_terms_are_word_bounded() {
+    let pf = prefilter(r"foobar(\X)", 3);
+    assert!(pf.might_match("y = foobar(z)"));
+    assert!(!pf.might_match("y = other(z)")); // foobar absent
+    assert!(!pf.might_match("y = foobarbaz(z)")); // word boundary: foobar not a whole token
+}
+
+#[test]
+fn keywords_and_punct_are_not_required() {
+    // `if`/`return` are keywords, `(`/`)`/`:` punctuation → not extracted. Only the
+    // identifiers `cond` and `val` are required, so a structurally different file
+    // with both still passes.
+    let pf = prefilter(r"if cond: return val", 3);
+    assert!(pf.might_match("while cond:\n    yield val"));
+    assert!(!pf.might_match("if cond: pass")); // `val` missing
+}
+
+#[test]
+fn string_content_runs_required() {
+    let pf = prefilter(r#""hello world""#, 3);
+    assert!(pf.might_match(r#"msg = "say hello to the world""#)); // both runs present
+    assert!(!pf.might_match(r#"msg = "hello there""#)); // `world` missing
+}
+
+#[test]
+fn regex_substring_literal() {
+    // `.*foobar.*` → required substring `foobar`, NOT word-bounded.
+    let pf = prefilter(r"\(:/.*foobar.*/)", 3);
+    assert!(pf.might_match("name = xfoobary")); // mid-token substring is fine
+    assert!(!pf.might_match("name = foo_bar")); // no contiguous `foobar`
+}
+
+#[test]
+fn regex_alternation_is_a_disjunction() {
+    let pf = prefilter(r"\(:/get|set/)", 3);
+    assert!(pf.might_match("o.getValue()")); // get
+    assert!(pf.might_match("o.setValue()")); // set
+    assert!(!pf.might_match("o.value()")); // neither
+}
+
+#[test]
+fn min_len_drops_short_terms() {
+    // `io` (2 chars) is dropped at min_len 3 → not required; `read` (4) stays.
+    let pf = prefilter(r"io.read(\X)", 3);
+    assert!(pf.might_match("xyz.read(q)")); // io not required
+    assert!(!pf.might_match("io.write(q)")); // read missing
+}
+
+#[test]
+fn empty_prefilter_passes_everything() {
+    // Pure metavars + punctuation → no extractable terms → always "maybe".
+    let pf = prefilter(r"\A = \B", 3);
+    assert!(pf.clauses().is_empty());
+    assert!(pf.might_match("literally anything"));
+}
+
+#[test]
+fn no_false_negative_on_a_real_match() {
+    // The core soundness property: a source the precise matcher accepts must pass
+    // the prefilter.
+    let src = "def handler(req):\n    return process(req)\n";
+    let pat = Pattern::compile(r"return process(\X)", &lang::python()).unwrap();
+    assert!(
+        !pat.matches(src).is_empty(),
+        "sanity: pattern really matches"
+    );
+    assert!(
+        pat.prefilter(3).might_match(src),
+        "prefilter must never reject a real match",
+    );
+}
+
+#[test]
+fn clause_structure_is_exposed() {
+    let pf = prefilter(r"foobar", 3);
+    let clauses = pf.clauses();
+    assert_eq!(clauses.len(), 1);
+    assert_eq!(clauses[0].any_of.len(), 1);
+    assert_eq!(clauses[0].any_of[0].text, "foobar");
+    assert_eq!(clauses[0].any_of[0].boundary, Boundary::Word);
+}


### PR DESCRIPTION
## Summary
Adds the **index-free half** of pattern prefiltering (DESIGN §10): extract a pattern's required literal content so a caller can cheaply reject sources that can't possibly match — *before* the expensive parse + precise match.

- `Pattern::prefilter(min_len) -> Prefilter`. A **CNF** of clauses: a source can match only if it satisfies every clause; a clause holds if any of its terms occurs. **Sound by construction** — false positives allowed, false negatives never (we only ever *drop* constraints we can't extract).
- **Terms**: identifiers (whole-word), string-literal content (whole-word per alphanumeric run), and a regex matcher's required literals (substring, via `regex-syntax` HIR — handles `.*foo.*` inner literals and `a|b` disjunctions). Keywords/punct/numbers/bare metavars contribute nothing. `min_len` drops short terms (a too-short disjunction alternative drops its whole clause, to stay sound).
- `Prefilter::might_match(source)`: a **parse-free** raw-text scan (`aho-corasick` + word-boundary check) — the whole point is to reject without parsing. `clauses()` exposes the CNF for index-query construction (next PR) and tests.
- Pattern words are classified at extraction time via a new grammar-derived `keywords` set on `LangConfig` (anonymous, non-punct symbols) — no lexer change.

Design rationale (text-scan vs AST-traversal, the term model, the open-question decisions) is in `specs/code_match/prefilter_design.md`.

Deps `regex-syntax` + `aho-corasick` (already transitive via `regex`) promoted to direct — no new crates in the tree.

## Test plan
9 new e2e tests in `tests/prefilter.rs`: identifier word-boundary, keyword/punct exclusion, string-content runs, regex substring + alternation, `min_len`, empty prefilter, clause structure, and the **no-false-negative** property. Full suite green (91 lib + 50 features + 9 prefilter); `cocoindex_py` builds; clippy clean on changed files.
