### PR TITLE
feat(code_match): index_terms — source-side extraction for prefilter indexes

### DIFF
--- a/rust/code_match/src/lib.rs
+++ b/rust/code_match/src/lib.rs
@@ -15,7 +15,7 @@ mod prefilter;
 pub use config::{LangConfig, RegexTokenizer, TokKind, TokenRule, Tokenizer};
 pub use lexer::{Cardinality, PatternItem};
 pub use matcher::{Capture, Match, Pattern};
-pub use prefilter::{Boundary, FilterClause, FilterTerm, Prefilter};
+pub use prefilter::{Boundary, FilterClause, FilterTerm, Prefilter, index_terms};
 
 // The crate's fallible surface uses the workspace-standard error type.
 pub use cocoindex_utils::error::{Error, Result};

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -13,9 +13,10 @@
 //! literals of a regex matcher `\(:/re/)` (substring, via `regex-syntax`).
 //! Keywords, punctuation, numbers, and bare metavars contribute nothing.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use aho_corasick::{AhoCorasick, MatchKind};
+use tree_sitter::{Node, Parser};
 
 use crate::config::LangConfig;
 use crate::lexer::PatternItem;
@@ -194,6 +195,77 @@ impl Prefilter {
     pub fn clauses(&self) -> &[FilterClause] {
         &self.clauses
     }
+}
+
+/// Extract the indexable terms of a **source** file — the same content the
+/// pattern side requires (identifiers and string-literal content), as deduped
+/// word-runs (≥ `min_len`). The caller feeds these into its index (FTS tokens, or
+/// n-grams for substring/regex queries) and later queries it with the clauses from
+/// [`Pattern::prefilter`](crate::Pattern::prefilter). Use the **same `min_len`** on
+/// both sides so the index is a superset of what any pattern can ask for.
+///
+/// AST traversal (not a text scan): at index-build time you're parsing anyway, so
+/// this is category-precise — identifiers (named leaves) and string contents, with
+/// comments skipped (the matcher skips them too). Over-collecting would only ever
+/// add false positives, never false negatives.
+pub fn index_terms(source: &str, cfg: &LangConfig, min_len: usize) -> Vec<String> {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&cfg.language)
+        .expect("load language for index_terms");
+    let Some(tree) = parser.parse(source, None) else {
+        return Vec::new();
+    };
+    let mut out = HashSet::new();
+    collect_index_terms(tree.root_node(), source.as_bytes(), min_len, &mut out);
+    out.into_iter().collect()
+}
+
+fn collect_index_terms(node: Node, src: &[u8], min_len: usize, out: &mut HashSet<String>) {
+    let kind = node.kind();
+    if kind.contains("comment") {
+        return; // patterns never match comment text (matcher skips them)
+    }
+    let keep = |s: &str, out: &mut HashSet<String>| {
+        if s.chars().count() >= min_len {
+            out.insert(s.to_string());
+        }
+    };
+    if is_string_like(kind) {
+        // The whole literal's word-runs (its content); don't descend into the
+        // quote/content children.
+        if let Ok(text) = node.utf8_text(src) {
+            for run in word_runs(text) {
+                keep(run, out);
+            }
+        }
+        return;
+    }
+    if node.child_count() == 0 {
+        // A named leaf that is word-shaped is an identifier (keywords are
+        // anonymous; numbers start with a digit) — the source counterpart of a
+        // pattern identifier term.
+        if node.is_named()
+            && let Ok(text) = node.utf8_text(src)
+            && text
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphabetic() || c == '_')
+        {
+            keep(text, out);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_index_terms(child, src, min_len, out);
+    }
+}
+
+/// A string/char literal node kind. Liberal on purpose: over-collecting source
+/// content into the index is sound (only adds false positives).
+fn is_string_like(kind: &str) -> bool {
+    kind.contains("string") || kind.contains("char")
 }
 
 /// A pattern `Token` is an identifier term iff it starts with an identifier char

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -2,12 +2,20 @@
 //! scan. The load-bearing property is **no false negatives** — anything that
 //! actually matches must pass the prefilter.
 
-use cocoindex_code_match::{Boundary, Pattern, Prefilter, lang};
+use std::collections::HashSet;
+
+use cocoindex_code_match::{Boundary, Pattern, Prefilter, index_terms, lang};
 
 fn prefilter(pat: &str, min_len: usize) -> Prefilter {
     Pattern::compile(pat, &lang::python())
         .expect("valid pattern")
         .prefilter(min_len)
+}
+
+fn terms(src: &str, min_len: usize) -> HashSet<String> {
+    index_terms(src, &lang::python(), min_len)
+        .into_iter()
+        .collect()
 }
 
 #[test]
@@ -81,6 +89,51 @@ fn no_false_negative_on_a_real_match() {
         pat.prefilter(3).might_match(src),
         "prefilter must never reject a real match",
     );
+}
+
+#[test]
+fn index_terms_extracts_identifiers_and_string_content() {
+    let t = terms(
+        "def handler(req):\n    return process(req, \"hello world\")\n",
+        3,
+    );
+    for want in ["handler", "req", "process", "hello", "world"] {
+        assert!(t.contains(want), "expected {want:?} in {t:?}");
+    }
+    assert!(!t.contains("def"), "keyword must be excluded");
+    assert!(!t.contains("return"), "keyword must be excluded");
+}
+
+#[test]
+fn index_terms_skips_comments_and_short_terms() {
+    let t = terms("x = 1  # secret note\nvalue = compute()\n", 3);
+    assert!(t.contains("value"));
+    assert!(t.contains("compute"));
+    assert!(!t.contains("secret"), "comment text must be skipped");
+    assert!(!t.contains("note"));
+    assert!(!t.contains("x"), "below min_len");
+}
+
+#[test]
+fn index_terms_supply_every_required_term_of_a_match() {
+    // Index-path soundness: every clause a matching pattern requires is satisfiable
+    // from the source's index terms (Word => token present; Substring => substring
+    // of some indexed token, as an n-gram index would resolve).
+    let src = "def f():\n    return process(item, \"payload data\")\n";
+    let pat = Pattern::compile(r#"process(\X, "payload data")"#, &lang::python()).unwrap();
+    assert!(!pat.matches(src).is_empty(), "sanity: pattern matches");
+
+    let idx = terms(src, 3);
+    for clause in pat.prefilter(3).clauses() {
+        let ok = clause.any_of.iter().any(|t| match t.boundary {
+            Boundary::Word => idx.contains(&t.text),
+            Boundary::Substring => idx.iter().any(|term| term.contains(&t.text)),
+        });
+        assert!(
+            ok,
+            "index terms miss a required clause {clause:?} (have {idx:?})"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Completes pattern prefiltering (DESIGN §10) with the index-building half.

`index_terms(source, cfg, min_len) -> Vec<String>` extracts the same content the pattern side requires — **identifiers** and **string-literal content** — from a source file, as deduped word-runs (≥ `min_len`). The caller feeds these into an external index (FTS tokens, or n-grams for substring/regex queries) and later queries it with the clauses from `Pattern::prefilter` (PR #2147).

Unlike the index-free `might_match` (a pre-parse raw-text scan), this **traverses the AST** — at index-build time you're parsing anyway, so it's category-precise: named identifier leaves (keywords are anonymous; numbers are digit-led) and string-node contents, with comments skipped (the matcher skips them too). Over-collecting would only ever add false positives, never false negatives.

The asymmetry is intentional and documented in `specs/code_match/prefilter_design.md`: cheap-and-loose raw-text scan before the parse; precise-and-amortized AST traversal at index-build time.

## Test plan
3 new e2e tests: identifier + string-content extraction, comment/short-term exclusion, and an **index-round-trip soundness** check (every clause a matching pattern requires is satisfiable from the source's index terms). Full suite green (91 lib + 50 features + 12 prefilter); clippy clean on changed files.
