### PR TITLE
feat(code_match): matches_prefiltered + index_terms_in_tree

### DIFF
--- a/rust/code_match/src/lib.rs
+++ b/rust/code_match/src/lib.rs
@@ -15,7 +15,9 @@ mod prefilter;
 pub use config::{LangConfig, RegexTokenizer, TokKind, TokenRule, Tokenizer};
 pub use lexer::{Cardinality, PatternItem};
 pub use matcher::{Capture, Match, Pattern};
-pub use prefilter::{Boundary, FilterClause, FilterTerm, Prefilter, index_terms};
+pub use prefilter::{
+    Boundary, FilterClause, FilterTerm, Prefilter, index_terms, index_terms_in_tree,
+};
 
 // The crate's fallible surface uses the workspace-standard error type.
 pub use cocoindex_utils::error::{Error, Result};

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -129,6 +129,22 @@ impl Pattern {
         crate::Prefilter::build(&self.items, &self.cfg, min_len)
     }
 
+    /// Match `source`, skipping the parse entirely when `prefilter` rejects it —
+    /// the point of prefiltering (the parse dominates cost at scale). `prefilter`
+    /// should be one this pattern produced; a mismatched one stays *sound* (it can
+    /// only over-accept) but may parse needlessly.
+    pub fn matches_prefiltered<'s>(
+        &self,
+        source: &'s str,
+        prefilter: &crate::Prefilter,
+    ) -> Vec<Match<'s>> {
+        if prefilter.might_match(source) {
+            self.matches(source)
+        } else {
+            Vec::new()
+        }
+    }
+
     pub fn matches<'s>(&self, source: &'s str) -> Vec<Match<'s>> {
         let mut parser = Parser::new();
         parser

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -16,7 +16,7 @@
 use std::collections::{HashMap, HashSet};
 
 use aho_corasick::{AhoCorasick, MatchKind};
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Node, Parser, Tree};
 
 use crate::config::LangConfig;
 use crate::lexer::PatternItem;
@@ -216,6 +216,13 @@ pub fn index_terms(source: &str, cfg: &LangConfig, min_len: usize) -> Vec<String
     let Some(tree) = parser.parse(source, None) else {
         return Vec::new();
     };
+    index_terms_in_tree(&tree, source, min_len)
+}
+
+/// [`index_terms`] reusing an already-parsed `tree` (which encodes the language,
+/// so no `LangConfig` is needed). `tree` must be `source`'s parse. Use this when
+/// the caller already has the AST (e.g. a `CodeAst`) to avoid re-parsing.
+pub fn index_terms_in_tree(tree: &Tree, source: &str, min_len: usize) -> Vec<String> {
     let mut out = HashSet::new();
     collect_index_terms(tree.root_node(), source.as_bytes(), min_len, &mut out);
     out.into_iter().collect()

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -137,6 +137,52 @@ fn index_terms_supply_every_required_term_of_a_match() {
 }
 
 #[test]
+fn extracted_terms_match_literally_not_as_regex() {
+    // A regex matcher's extracted literal contains a `.` (escaped in the regex).
+    // `might_match` uses aho-corasick *literal* search, so the `.` matches only a
+    // literal dot — no re-interpretation of the term as a regex.
+    let pf = prefilter(r"\(:/foo\.bar/)", 3);
+    assert!(pf.might_match("x = foo.bar")); // literal `foo.bar`
+    assert!(!pf.might_match("x = fooXbar")); // `.` is literal, not "any char"
+}
+
+#[test]
+fn matches_prefiltered_skips_on_reject_and_agrees_on_accept() {
+    let pat = Pattern::compile(r"return process(\X)", &lang::python()).unwrap();
+    let pf = pat.prefilter(3);
+
+    // Accept: identical to a plain match.
+    let hit = "def f():\n    return process(x)\n";
+    assert_eq!(
+        pat.matches_prefiltered(hit, &pf).len(),
+        pat.matches(hit).len(),
+    );
+    assert_eq!(pat.matches_prefiltered(hit, &pf).len(), 1);
+
+    // Reject: `process` absent → prefilter short-circuits → empty (no parse needed).
+    let miss = "def f():\n    return other(x)\n";
+    assert!(!pf.might_match(miss));
+    assert!(pat.matches_prefiltered(miss, &pf).is_empty());
+}
+
+#[test]
+fn index_terms_in_tree_matches_the_parsing_variant() {
+    use tree_sitter::Parser;
+    let src = "def f():\n    return process(item, \"payload\")\n";
+    let cfg = lang::python();
+    let mut parser = Parser::new();
+    parser.set_language(&cfg.language).unwrap();
+    let tree = parser.parse(src, None).unwrap();
+
+    let mut a = cocoindex_code_match::index_terms_in_tree(&tree, src, 3);
+    let mut b = cocoindex_code_match::index_terms(src, &cfg, 3);
+    a.sort();
+    b.sort();
+    assert_eq!(a, b);
+    assert!(a.contains(&"process".to_string()));
+}
+
+#[test]
 fn clause_structure_is_exposed() {
     let pf = prefilter(r"foobar", 3);
     let clauses = pf.clauses();


### PR DESCRIPTION
## Summary
Two small Rust-core additions toward wiring the prefilter into real scans. `code_match` stays pure — file I/O will live in the PyO3 layer (a follow-up).

- `Pattern::matches_prefiltered(source, prefilter) -> Vec<Match>`: match while **skipping the parse** when the prefilter rejects the source (the whole point — the parse dominates cost at scale). Sound even with a mismatched prefilter (it can only over-accept).
- `index_terms_in_tree(tree, source, min_len)`: source-side extractor reusing an already-parsed tree, so a caller that already has the AST (e.g. `CodeAst`) doesn't re-parse. `index_terms` now delegates to it.

Also a test pinning that extracted terms match **literally** — a regex matcher's `foo\.bar` literal matches only a literal dot (via aho-corasick), never re-interpreted as a regex. (Answers "do we need escaping?" — no.)

## Test plan
3 new tests (literal-term matching, `matches_prefiltered` accept/reject, `index_terms_in_tree` ≡ parsing variant). Full suite green (91 + 50 + 15); clippy clean on changed files.
