### PR TITLE
fix(code_match): bare keywords, anchored regex matchers, fragment ranges

### DIFF
--- a/rust/code_match/src/lang/rust.rs
+++ b/rust/code_match/src/lang/rust.rs
@@ -123,11 +123,12 @@ mod tests {
             "fn clone(self) {}",
         ] {
             let ms = matches(rust(), r"fn clone(self)", src);
-            // exactly one match — the function_item, reported with its full
-            // range; no enclosing-level (source_file) noise.
+            // exactly one match — the function_item (kind), no enclosing-level
+            // (source_file) noise. The reported range is the matched *fragment*
+            // (`fn clone(self)`), not the whole node incl. the body.
             assert_eq!(ms.len(), 1, "one match for `{src}`");
             assert_eq!(ms[0].kind, "function_item");
-            assert_eq!(ms[0].text, src);
+            assert_eq!(ms[0].text, "fn clone(self)");
         }
     }
 

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -22,8 +22,11 @@
 //! collides with bare-`\` escapes (Bash `\n`) / Haskell lambdas.
 //!
 //! Regex matcher `:/re/` constrains a **single-node** metavar: the captured
-//! source text must `is_match` (unanchored) the regex (use `^…$` for whole-node).
-//! The name is optional — `S(:/re/)` constrains a node without capturing it.
+//! source text must match the regex **anchored to the whole node** (compiled as
+//! `^(?:re)$`). So `:/set_/` means "text is exactly `set_`", `:/set_.*/` means
+//! "starts with `set_`"; add `.*` explicitly for prefix/suffix/substring. (This is
+//! less surprising than unanchored `is_match`, where a bare `set_.*` would match
+//! inside `unset_…`.) The name is optional — `S(:/re/)` constrains without capturing.
 //! Applies to `One`/`Optional`; ignored on `Many` (sibling runs, out of scope).
 //! The closing `/` is optional (`:/re`): a `/` at the matcher's top paren level
 //! closes (delimited), else the matcher's `)` closes (shorthand). Balanced `()`
@@ -70,9 +73,9 @@ pub enum PatternItem {
     /// source *node* span by text, atomically (advance past the whole span).
     Str(String),
     /// Metavariable. `name` == None for anonymous (`\_`, `\*`, `\?`). `regex`, if
-    /// present, constrains the captured text (unanchored `is_match`); honored for
-    /// single-node cardinalities (`One`/`Optional`) only. `Many` (`*`) is always
-    /// same-level; cross-level skips use multiple `*`.
+    /// present, constrains the captured text (whole-node anchored — compiled
+    /// `^(?:re)$`); honored for single-node cardinalities (`One`/`Optional`) only.
+    /// `Many` (`*`) is always same-level; cross-level skips use multiple `*`.
     Meta {
         name: Option<String>,
         card: Cardinality,
@@ -328,8 +331,14 @@ fn lex_regex(pattern: &str, bytes: &[u8], k: usize) -> Result<(Regex, usize)> {
     };
     // `start`/`close` land on ASCII (`/`, `)`) → char boundaries; safe slice.
     let raw = &pattern[start..close];
-    let regex =
-        Regex::new(raw).map_err(|e| Error::client(format!("invalid regex `/{raw}/`: {e}")))?;
+    // Anchor the matcher to the **whole** node text: `\(:/set_/)` means "text is
+    // exactly `set_`", `\(:/set_.*/)` means "starts with `set_`". Users add `.*`
+    // explicitly for prefix/suffix/substring — far less surprising than unanchored
+    // `is_match`, where a bare `set_.*` would match inside `unset_…`. Wrapping in a
+    // non-capturing group keeps the user's alternations/anchors valid (a redundant
+    // `^…$` they wrote still compiles).
+    let regex = Regex::new(&format!("^(?:{raw})$"))
+        .map_err(|e| Error::client(format!("invalid regex `/{raw}/`: {e}")))?;
     let next = if delimited { close + 1 } else { close };
     Ok((regex, next))
 }

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -179,42 +179,61 @@ impl Pattern {
 
         let mut out = Vec::new();
         for cand in &idx.candidates {
-            // 1) Whole-node coverage (the pattern spans the entire candidate).
-            let captures = run(cand.start_leaf, cand.end_leaf + 1).or_else(|| {
-                // 2) Leading/trailing tolerance: the pattern may instead cover a
-                // contiguous run of the candidate's *direct children* that spans
-                // **≥2** children (`j > i`). Leading/trailing siblings — e.g. a
-                // Rust `pub` and the fn body around `fn clone(self)` — are free
-                // context. The ≥2 rule means a single-child run isn't matched
-                // here; that child is the integral match on its own iteration
-                // (so `\A = \B` matches the assignment, not the `expr;` around it).
-                let kids = &cand.child_bounds;
-                (0..kids.len()).find_map(|i| {
-                    // Cheap prune: if the pattern starts with a literal token, the
-                    // run must start at a child whose first leaf is that token —
-                    // skip hopeless starts without allocating a match context.
-                    // (Keeps the O(children²) partial scan from churning on the
-                    // common no-match candidates during a search.)
-                    if let Some(PatternItem::Token(t)) = self.items.first()
-                        && &idx.leaves[kids[i].0].text != t
-                    {
-                        return None;
-                    }
-                    (i + 1..kids.len()).find_map(|j| {
-                        let (a, hi) = (kids[i].0, kids[j].1 + 1);
-                        // skip the whole-node run — already tried in (1)
-                        if a == cand.start_leaf && hi == cand.end_leaf + 1 {
+            // 1) Whole-node coverage (the pattern spans the entire candidate) →
+            //    the match is the whole node. 2) Otherwise a contiguous run of the
+            //    candidate's direct children (leading/trailing tolerance) → the
+            //    match is that *fragment's* span, with `kind` still the node's.
+            let hit = run(cand.start_leaf, cand.end_leaf + 1)
+                .map(|caps| (caps, cand.start_byte, cand.end_byte))
+                .or_else(|| {
+                    // A child-run covers children `[i, j]`. It must span **≥2**
+                    // children, *except* a single child that is one **anonymous**
+                    // leaf (a keyword/punct like `if`): the ≥2 rule exists only to
+                    // defer to a *named* child candidate matched on its own
+                    // iteration (so `\A = \B` matches the assignment, not the
+                    // `expr;`), and an anonymous leaf is never a candidate — so
+                    // there is nothing to defer to, and `if` should match
+                    // `if_statement`. The reported range is the fragment, not the
+                    // whole node.
+                    let kids = &cand.child_bounds;
+                    (0..kids.len()).find_map(|i| {
+                        // Cheap prune: if the pattern starts with a literal token,
+                        // the run must start at a child whose first leaf is that
+                        // token — skip hopeless starts without allocating a context.
+                        if let Some(PatternItem::Token(t)) = self.items.first()
+                            && &idx.leaves[kids[i].0].text != t
+                        {
                             return None;
                         }
-                        run(a, hi)
+                        (i..kids.len()).find_map(|j| {
+                            let (first, last) = (kids[i].0, kids[j].1);
+                            let hi = last + 1;
+                            // skip the whole-node run — already tried in (1)
+                            if first == cand.start_leaf && hi == cand.end_leaf + 1 {
+                                return None;
+                            }
+                            // single-child run only for one anonymous leaf
+                            if j == i {
+                                let (s, e) = kids[i];
+                                if !(s == e && idx.leaves[s].anon) {
+                                    return None;
+                                }
+                            }
+                            run(first, hi).map(|caps| {
+                                (
+                                    caps,
+                                    idx.leaves[first].start_byte,
+                                    idx.leaves[last].end_byte,
+                                )
+                            })
+                        })
                     })
-                })
-            });
-            if let Some(captures) = captures {
+                });
+            if let Some((captures, start_byte, end_byte)) = hit {
                 out.push(Match {
                     kind: cand.node_kind,
-                    range: cand.start_byte..cand.end_byte,
-                    text: &source[cand.start_byte..cand.end_byte],
+                    range: start_byte..end_byte,
+                    text: &source[start_byte..end_byte],
                     captures,
                 });
             }
@@ -688,8 +707,10 @@ enum BindResult {
     Inconsistent,
 }
 
-/// A metavar's regex constraint (if any) against a candidate's source text.
-/// Unanchored (`is_match`): `/get/` is a substring test, `^…$` pins the whole node.
+/// A metavar's regex constraint (if any) against a candidate's source text. The
+/// regex is whole-node anchored at compile time (`^(?:re)$`, see `lexer::lex_regex`),
+/// so `is_match` here means "the *whole* text matches": `/get/` ≡ exactly `get`,
+/// `/get.*/` ≡ starts with `get`.
 fn regex_ok(regex: Option<&Regex>, text: &str) -> bool {
     regex.is_none_or(|re| re.is_match(text))
 }

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -195,18 +195,19 @@ fn caps_all<'a>(ms: &'a [cocoindex_code_match::Match], name: &str) -> Vec<&'a st
 
 #[test]
 fn regex_constrains_identifier() {
-    // `\(F:/^get/)` filters the callee to names starting with `get`.
+    // Matchers are whole-node anchored, so `get.*` filters callees *starting* with
+    // `get` (the trailing `.*` is the explicit "prefix").
     let src = "getUser(1); setName(2); getId(3);";
-    let ms = matches(lang::typescript(), r"\(F:/^get/)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(F:/get.*/)(\*)", src);
     assert_eq!(caps_all(&ms, "F"), vec!["getId", "getUser"]);
 }
 
 #[test]
 fn anonymous_regex_matcher() {
     // `\(:/re/)` — a regex constraint with no name: filter a node without
-    // capturing it. Here the callee must match `^get`, but isn't bound.
+    // capturing it. Here the callee must start with `get` (`get.*`), but isn't bound.
     let src = "getUser(1); setName(2); getId(3);";
-    let ms = matches(lang::typescript(), r"\(:/^get/)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(:/get.*/)(\*)", src);
     let callees: Vec<&str> = ms
         .iter()
         .filter(|m| m.kind == "call_expression")
@@ -231,9 +232,10 @@ fn regex_pins_nesting_level() {
 #[test]
 fn regex_on_subtree() {
     // The metavar binds a whole expression; the regex tests its source text.
-    let yes = matches(lang::typescript(), r"f(\(A:/\+/))", "f(a + b);");
+    // Anchored, so `.*\+.*` is the explicit "contains `+`".
+    let yes = matches(lang::typescript(), r"f(\(A:/.*\+.*/))", "f(a + b);");
     assert_eq!(cap(&yes, "A").as_deref(), Some("a + b"));
-    let no = matches(lang::typescript(), r"f(\(A:/\+/))", "f(ab);");
+    let no = matches(lang::typescript(), r"f(\(A:/.*\+.*/))", "f(ab);");
     assert!(no.iter().all(|m| m.kind != "call_expression"));
 }
 
@@ -247,8 +249,9 @@ fn regex_alternation_parens_free() {
 
 #[test]
 fn regex_shorthand_no_closing_slash() {
+    // Shorthand (no closing `/`): the `)` closes the matcher. Anchored, so `get.*`.
     let src = "getUser(1); setName(2);";
-    let ms = matches(lang::typescript(), r"\(F:/^get)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(F:/get.*)(\*)", src);
     assert_eq!(cap(&ms, "F").as_deref(), Some("getUser"));
 }
 
@@ -574,6 +577,59 @@ fn contains_nested() {
 fn contains_unbalanced_markers_error() {
     assert!(Pattern::compile(r"def foo(): \{{ return \X", &lang::python()).is_err());
     assert!(Pattern::compile(r"return \X \}}", &lang::python()).is_err());
+}
+
+// ---------------- single bare keyword / fragment range / anchored regex ----------------
+
+#[test]
+fn bare_keyword_matches_its_enclosing_node() {
+    // A single anonymous-leaf token (a keyword) matches the node it's a direct
+    // child of — `if` → `if_statement` — reported as the keyword fragment.
+    let ms = matches(lang::python(), r"if", "if x:\n    pass\n");
+    let m = by_text(&ms, "if").expect("`if` should match");
+    assert_eq!(m.kind, "if_statement");
+
+    let src = "if x:\n    pass\nelse:\n    pass\n";
+    assert!(has_kind(
+        &matches(lang::python(), r"else", src),
+        "else_clause"
+    ));
+    // a single *identifier* already matched (it's a named leaf node) — unchanged
+    assert!(has_kind(
+        &matches(lang::python(), r"foo", "y = foo + 1"),
+        "identifier"
+    ));
+}
+
+#[test]
+fn fragment_match_reports_the_fragment_span_not_the_whole_node() {
+    // The pattern covers the signature but not the body: the reported range is the
+    // signature *fragment*, with `kind` still the enclosing function node.
+    let src = "def foo(a, b):\n    return a + b\n";
+    let ms = matches(lang::python(), r"def \NAME(\(A*)):", src);
+    let m = by_text(&ms, "def foo(a, b):").expect("fragment span, not whole node");
+    assert_eq!(m.kind, "function_definition");
+    assert_eq!(m.capture_text("NAME"), Some("foo"));
+}
+
+#[test]
+fn regex_matcher_is_whole_node_anchored() {
+    // Matchers anchor to the whole node text, so a bare `set_.*` is a *prefix*
+    // (no false positive on `test_unset_is`, where `set_` is only a substring).
+    let src = "def set_value(): pass\ndef test_unset_is(): pass\n";
+    let prefix = matches(lang::python(), r"def \(N:/set_.*/)(\*):", src);
+    assert_eq!(caps_all(&prefix, "N"), vec!["set_value"]);
+
+    // exact (no `.*`): the text must equal the regex
+    let exact = matches(lang::python(), r"def \(N:/set_value/)(\*):", src);
+    assert_eq!(caps_all(&exact, "N"), vec!["set_value"]);
+
+    // substring needs explicit `.*…*.`
+    let substring = matches(lang::python(), r"def \(N:/.*set_.*/)(\*):", src);
+    assert_eq!(
+        caps_all(&substring, "N"),
+        vec!["set_value", "test_unset_is"]
+    );
 }
 
 // ---------------- comments are transparent ----------------


### PR DESCRIPTION
## Summary
Three fixes from searching cocoindex-code's own codebase:

1. **Bare keyword `if`/`else` matched nothing.** A single-token pattern can match only via whole-node coverage (no named node *is* just a keyword leaf) or a child-run (gated ≥2 children). Now a single-child run is allowed when that child is **one anonymous leaf** — the ≥2 rule exists only to defer to a *named* child candidate matched on its own, and an anonymous leaf (keyword/punct) is never a candidate. `if`→`if_statement`, `else`→`else_clause`. (A single identifier already matched its `identifier` node.)

2. **Regex matchers were unanchored** (`is_match`), so `\(:/set_.*/)` matched `test_env_unset_is_noop` (the substring `set_`). Now **anchored to the whole node** (`^(?:re)$`): `/set_/` is exact, `/set_.*/` is "starts with set_"; add `.*` explicitly for prefix/suffix/substring.

3. **Fragment match reported the whole parent range.** A child-run match (e.g. a signature over a function with a body) now reports the **matched fragment's** byte span (`fn clone(self)`), with `kind` still the enclosing node. Whole-node coverage still reports the full node.

DESIGN §0/§4 + doc comments updated.

## Test plan
3 new feature tests (bare keyword → enclosing node; fragment span; anchored regex prefix/exact/substring); updated the existing regex tests to anchored semantics and the Rust signature test to the fragment range. Full suite green: 91 lib + 58 feature + 15 prefilter; 15 Python `test_code.py`.

> Note: this is a behavior change for regex matchers (now anchored) and for fragment-match ranges — both deliberate, per discussion.
