### PR TITLE
test(code_match): cross-check the prefilter on every match test (+ fix it caught)

### DIFF
--- a/rust/code_match/src/lang/mod.rs
+++ b/rust/code_match/src/lang/mod.rs
@@ -111,10 +111,25 @@ pub(crate) mod testutil {
     use crate::config::LangConfig;
     use crate::{Match, Pattern};
 
+    /// Run the pattern against `src`. Every call also cross-checks the **prefilter**:
+    /// it must never reject a source that actually matches (soundness — no false
+    /// negatives), and `matches_prefiltered` must agree with the plain run. So every
+    /// feature / per-language test doubles as a prefilter soundness test for free.
+    /// `min_len = 1` keeps even short terms, exercising the most prefilter logic.
     pub fn matches<'s>(cfg: LangConfig, pat: &str, src: &'s str) -> Vec<Match<'s>> {
-        Pattern::compile(pat, &cfg)
-            .expect("valid test pattern")
-            .matches(src)
+        let compiled = Pattern::compile(pat, &cfg).expect("valid test pattern");
+        let out = compiled.matches(src);
+        let pf = compiled.prefilter(1);
+        assert!(
+            out.is_empty() || pf.might_match(src),
+            "prefilter wrongly rejected a matching source\n  pattern: {pat:?}\n  source:  {src:?}",
+        );
+        assert_eq!(
+            compiled.matches_prefiltered(src, &pf).len(),
+            out.len(),
+            "matches_prefiltered disagrees with matches\n  pattern: {pat:?}\n  source:  {src:?}",
+        );
+        out
     }
 
     pub fn cap(ms: &[Match], name: &str) -> Option<String> {

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -19,7 +19,7 @@ use aho_corasick::{AhoCorasick, MatchKind};
 use tree_sitter::{Node, Parser, Tree};
 
 use crate::config::LangConfig;
-use crate::lexer::PatternItem;
+use crate::lexer::{Cardinality, PatternItem};
 
 /// How a required term must occur in the source text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,8 +95,14 @@ impl Prefilter {
                         }
                     }
                 }
+                // A regex literal is required only on a `One` metavar: an `Optional`
+                // node may be absent (so its regex isn't required — extracting it
+                // would be a false negative, e.g. `f(\(A?:/^x/))` matching `f()`),
+                // and `Many` ignores the regex entirely.
                 PatternItem::Meta {
-                    regex: Some(re), ..
+                    regex: Some(re),
+                    card: Cardinality::One,
+                    ..
                 } => {
                     for alts in regex_required_literals(re.as_str()) {
                         // Disjunction: keep only if every alternative survives.

--- a/rust/code_match/tests/common/mod.rs
+++ b/rust/code_match/tests/common/mod.rs
@@ -3,11 +3,25 @@
 
 use cocoindex_code_match::{LangConfig, Match, Pattern};
 
-/// Compile `pat` for `cfg` and match it against `src`.
+/// Compile `pat` for `cfg` and match it against `src`. Also cross-checks the
+/// **prefilter** on every call: it must never reject a source that actually matches
+/// (soundness — no false negatives), and `matches_prefiltered` must agree with the
+/// plain run. So every feature test doubles as a prefilter soundness test for free.
+/// `min_len = 1` keeps even short terms, exercising the most prefilter logic.
 pub fn matches<'s>(cfg: LangConfig, pat: &str, src: &'s str) -> Vec<Match<'s>> {
-    Pattern::compile(pat, &cfg)
-        .expect("valid test pattern")
-        .matches(src)
+    let compiled = Pattern::compile(pat, &cfg).expect("valid test pattern");
+    let out = compiled.matches(src);
+    let pf = compiled.prefilter(1);
+    assert!(
+        out.is_empty() || pf.might_match(src),
+        "prefilter wrongly rejected a matching source\n  pattern: {pat:?}\n  source:  {src:?}",
+    );
+    assert_eq!(
+        compiled.matches_prefiltered(src, &pf).len(),
+        out.len(),
+        "matches_prefiltered disagrees with matches\n  pattern: {pat:?}\n  source:  {src:?}",
+    );
+    out
 }
 
 /// First captured value for `name` across the matches, as an owned String.

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -183,6 +183,23 @@ fn index_terms_in_tree_matches_the_parsing_variant() {
 }
 
 #[test]
+fn regex_on_optional_metavar_is_not_required() {
+    // An optional metavar's regex must NOT become a required term — the node may be
+    // absent, so requiring its literal would falsely reject (e.g. `f(\(A?:/x.*/))`
+    // matching `f()`). A `One`-cardinality regex *is* still required.
+    let opt = Pattern::compile(r"f(\(A?:/x.*/))", &lang::python())
+        .unwrap()
+        .prefilter(1);
+    assert!(opt.might_match("f()"), "optional-absent call must pass");
+
+    let one = Pattern::compile(r"f(\(A:/x.*/))", &lang::python())
+        .unwrap()
+        .prefilter(1);
+    assert!(!one.might_match("f()"), "a One-metavar regex is required");
+    assert!(one.might_match("f(xyz)"));
+}
+
+#[test]
 fn clause_structure_is_exposed() {
     let pf = prefilter(r"foobar", 3);
     let clauses = pf.clauses();


### PR DESCRIPTION
## Summary
Make the shared `matches(cfg, pat, src)` test helpers (`tests/common` for feature tests, `lang::testutil` for per-language tests) **also** run the prefilter on every call: assert it never rejects a source that actually matches (soundness — no false negatives) and that `matches_prefiltered` agrees with the plain run. `min_len = 1` keeps short terms, exercising the most prefilter logic. So every feature + per-language test now doubles as a prefilter soundness test, with no boilerplate.

This immediately **caught a real false-negative bug**: a regex on an **optional** metavar (`f(\(A?:/^x/))`) was extracted as a *required* prefilter term, so `f()` (the optional arg absent) was wrongly rejected. Fix: only extract regex literals for `Cardinality::One` — an `Optional` node may be absent, and `Many` ignores the regex anyway. Added a dedicated prefilter test for the optional/one distinction.

## Test plan
Full suite green with the cross-check active: 91 lib + 58 feature + 16 prefilter. The optional-regex case now passes the prefilter; the `One` case still correctly requires it.