### PR TITLE
perf(code_match): prune the child-run scan by the trailing literal token

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -177,6 +177,21 @@ impl Pattern {
             ctx.dp(0, self.items.len(), start, hi).then_some(ctx.bound)
         };
 
+        // A child-run match must begin at a child whose first leaf is the pattern's
+        // leading literal token (if any), and end at a child whose last leaf is the
+        // trailing literal token (if any). Precompute both so the O(children²) scan
+        // skips hopeless starts/ends in O(1) without ever building a match context —
+        // this is what keeps a wildcard-led pattern like `\*: Path` from running the
+        // DP against every (i, j) over a huge node's thousands of children.
+        let first_tok = match self.items.first() {
+            Some(PatternItem::Token(t)) => Some(t.as_str()),
+            _ => None,
+        };
+        let last_tok = match self.items.last() {
+            Some(PatternItem::Token(t)) => Some(t.as_str()),
+            _ => None,
+        };
+
         let mut out = Vec::new();
         for cand in &idx.candidates {
             // 1) Whole-node coverage (the pattern spans the entire candidate) →
@@ -197,15 +212,19 @@ impl Pattern {
                     // whole node.
                     let kids = &cand.child_bounds;
                     (0..kids.len()).find_map(|i| {
-                        // Cheap prune: if the pattern starts with a literal token,
-                        // the run must start at a child whose first leaf is that
-                        // token — skip hopeless starts without allocating a context.
-                        if let Some(PatternItem::Token(t)) = self.items.first()
-                            && &idx.leaves[kids[i].0].text != t
+                        // Leading-token prune: the run must start at this child.
+                        if let Some(t) = first_tok
+                            && idx.leaves[kids[i].0].text != t
                         {
                             return None;
                         }
                         (i..kids.len()).find_map(|j| {
+                            // Trailing-token prune: the run must end at this child.
+                            if let Some(t) = last_tok
+                                && idx.leaves[kids[j].1].text != t
+                            {
+                                return None;
+                            }
                             let (first, last) = (kids[i].0, kids[j].1);
                             let hi = last + 1;
                             // skip the whole-node run — already tried in (1)

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -632,6 +632,17 @@ fn regex_matcher_is_whole_node_anchored() {
     );
 }
 
+#[test]
+fn leading_wildcard_trailing_token_still_matches() {
+    // `\*: Path` — leading wildcard, trailing literal token. The trailing-token
+    // prune (which makes this fast on huge nodes) must not drop the real match.
+    let ms = matches(lang::python(), r"\*: Path", "def f(x: Path):\n    pass\n");
+    assert!(
+        ms.iter().any(|m| m.text == "x: Path"),
+        "should match the annotated `x: Path`, got {ms:?}",
+    );
+}
+
 // ---------------- comments are transparent ----------------
 
 #[test]


### PR DESCRIPTION
## Summary
A pattern led by a wildcard (`\*: Path`) made the leading/trailing-tolerance child-run scan run the DP for **every** (i, j) sub-run over a node's children — the existing leading-token prune didn't apply (the pattern starts with `\*`), so a 302 KB JSON object with thousands of `key: value` siblings went super-linear (60 KB: 1.23s; full file didn't finish in 45s).

Add a **trailing-token prune** symmetric to the leading one: a child-run must end at a child whose last leaf is the pattern's trailing literal token. Precompute `first_tok`/`last_tok` once. For `\*: Path` no JSON child ends in a bare `Path` token → **zero** DP runs.

**Result: 60 KB 1.23s → 0.010s; full 302 KB >45s → 0.043s (now linear).**

Correct by construction: when the pattern's last item is a `Token`, the DP can only finish by consuming it as the run's last leaf, so a run ending elsewhere can never match.

> Note: this fixes *token-bounded* patterns; **metavar-bounded** ones (`\X \* \Y`) still hit O(children²) — that needs a single-DP-run refactor of the leading/trailing tolerance, tracked separately.

## Test plan
All 165 tests pass (incl. the `>>`-split alignment) + a new leading-wildcard/trailing-token correctness test. Manually measured the JSON file 15→300 KB: linear.