### PR TITLE
feat(code_match): report all non-overlapping fragment matches per node

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -204,42 +204,47 @@ impl Pattern {
             let end_idx: HashMap<usize, usize> =
                 kids.iter().enumerate().map(|(c, &(_, e))| (e, c)).collect();
 
-            let mut found: Option<(usize, usize)> = None; // (start_byte, end_byte)
+            // Collect the candidate's matches **leftmost-longest, non-overlapping**:
+            // after a match `[a, b)` resume at `b` (skip overlapped starts). Because
+            // `stops` is start-independent the fail-memo is shared across the whole
+            // loop, so finding *every* occurrence is still O(N·k) — no worse than
+            // finding the first; the old `break` was only an early exit. The DP is
+            // greedy (longest stop first), so each match is the longest from its start.
+            let mut next_start = 0; // earliest non-overlapping start (a leaf index)
             for a in starts {
+                if a < next_start {
+                    continue;
+                }
                 ctx.bound.clear();
                 if !ctx.dp(0, n_items, a, hi) {
                     continue;
                 }
                 let b = ctx.matched_end; // child-end-exclusive, or `hi`
-                // Whole-node coverage spans the entire candidate → report the whole
-                // node, no ≥2 gate.
-                if a == cand.start_leaf && b == hi {
-                    found = Some((cand.start_byte, cand.end_byte));
-                    break;
-                }
-                // Fragment: it must span **≥2** direct children, except a single
-                // child that is one anonymous leaf (a keyword/punct like `if` — never
-                // a candidate on its own; see §4). A single *named* child defers to
-                // that child's own candidate, so we skip it and try the next start.
-                let ci = start_idx[&a];
-                let cj = end_idx[&(b - 1)];
-                let ok = cj > ci || {
-                    let (s, e) = kids[ci];
-                    s == e && idx.leaves[s].anon
+                // Whole-node coverage spans the entire candidate → the whole node, no
+                // ≥2 gate. Otherwise a fragment: it must span **≥2** direct children,
+                // except a single child that is one anonymous leaf (a keyword/punct
+                // like `if` — never a candidate on its own; see §4). A single *named*
+                // child defers to its own candidate, so it isn't reported here.
+                let range = if a == cand.start_leaf && b == hi {
+                    Some((cand.start_byte, cand.end_byte))
+                } else {
+                    let ci = start_idx[&a];
+                    let cj = end_idx[&(b - 1)];
+                    let ok = cj > ci || {
+                        let (s, e) = kids[ci];
+                        s == e && idx.leaves[s].anon
+                    };
+                    ok.then(|| (idx.leaves[a].start_byte, idx.leaves[b - 1].end_byte))
                 };
-                if ok {
-                    found = Some((idx.leaves[a].start_byte, idx.leaves[b - 1].end_byte));
-                    break;
+                if let Some((start_byte, end_byte)) = range {
+                    out.push(Match {
+                        kind: cand.node_kind,
+                        range: start_byte..end_byte,
+                        text: &source[start_byte..end_byte],
+                        captures: std::mem::take(&mut ctx.bound),
+                    });
+                    next_start = b; // non-overlapping: resume past this match
                 }
-            }
-
-            if let Some((start_byte, end_byte)) = found {
-                out.push(Match {
-                    kind: cand.node_kind,
-                    range: start_byte..end_byte,
-                    text: &source[start_byte..end_byte],
-                    captures: std::mem::take(&mut ctx.bound),
-                });
             }
         }
         out

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -633,6 +633,28 @@ fn regex_matcher_is_whole_node_anchored() {
 }
 
 #[test]
+fn overlapping_fragments_are_leftmost_longest_non_overlapping() {
+    // `a b a b a b a` parses (bash) as one `command` with seven `word` siblings.
+    // A *fragment* pattern reports every non-overlapping occurrence within the node
+    // (leftmost-longest), not just the first.
+    let bash = || cocoindex_code_match::lang::by_name("bash").unwrap();
+    let src = "a b a b a b a\n";
+    let texts = |p: &str| -> Vec<String> {
+        matches(bash(), p, src)
+            .iter()
+            .map(|m| m.text.to_string())
+            .collect()
+    };
+    // whole-node matches — the four distinct `word` nodes spelled `a`
+    assert_eq!(texts("a").len(), 4);
+    // fragment matches — every non-overlapping `a b`
+    assert_eq!(texts("a b"), ["a b", "a b", "a b"]);
+    // and `a b a` at [0..5] and [8..13]; the overlapping [4..9] is skipped (resume
+    // past each match).
+    assert_eq!(texts("a b a"), ["a b a", "a b a"]);
+}
+
+#[test]
 fn metavar_bounded_pattern_matches_all_siblings() {
     // `\K: \V` has no literal-token boundary, so the leading/trailing-token prune
     // can't help — it relies on the single-DP-per-candidate path (shared memo +


### PR DESCRIPTION
## Summary
The child-run scan `break`-ed on the first match, so a node with several matching fragments reported only the leftmost — over a flat sibling list `a b a b a b a`, `a b a` gave **one** match instead of all occurrences.

Collect them **leftmost-longest, non-overlapping** instead: on a match `[a, b)` resume at `b` (skip overlapped starts), like a regex global scan.

| pattern (`a b a b a b a`) | before | after |
|---|---|---|
| `a` (whole-node `word`s) | 4 | 4 |
| `a b` (fragment) | 1 | **3** |
| `a b a` (fragment) | 1 | **2** — `[0..5]`, `[8..13]`; overlapping `[4..9]` skipped |

Distinct *nodes* matching the same pattern are unchanged (tree nodes never partially overlap).

**No complexity cost:** the fail-memo is shared across all starts of a candidate, so it already bounds the loop at O(N·k) no matter how many starts we examine — and we now *skip* starts overlapped by a match (≤ before). Verified on the 302 KB JSON: `\*: Path` 0.166s, `\A: \B` 0.044s, `\* \A \*` 0.047s — unchanged (and `\A: \B` now finds 4 *more* valid matches the `break` was dropping).

## Test plan
All 168 Rust + 15 Python tests pass + a new overlap regression test. DESIGN §4 documents the leftmost-longest-non-overlapping semantics.