### PR TITLE
feat(connectors): add Apache Pulsar target connector (Python)

### DIFF
--- a/docs/src/content/docs/connectors/pulsar.mdx
+++ b/docs/src/content/docs/connectors/pulsar.mdx
@@ -1,0 +1,81 @@
+---
+title: "*Apache Pulsar* connector"
+sidebar_label: Pulsar
+description: >
+  Produce messages to Apache Pulsar topics as target states.
+---
+
+The `pulsar` connector supports [Apache Pulsar](https://pulsar.apache.org/docs/)
+as a **target**: declared target states are produced as messages to a
+user-managed Pulsar topic, with the target-state key used as the message
+[partition key](https://pulsar.apache.org/docs/concepts-messaging/#routing-modes).
+
+```python
+from cocoindex.connectors import pulsar
+```
+
+Install the optional dependency:
+
+```bash
+pip install cocoindex[pulsar]
+```
+
+The connector expects a `pulsar.Client` that you create and provide through your
+app context. Topics are user-managed: CocoIndex does not create or drop them.
+
+## As Target
+
+The target connector sends bytes or strings to a user-managed Pulsar topic. The
+`pulsar.Client` is provided via a [`ContextKey`](/core/context); the connector
+creates and caches one producer per topic and sends off the event loop.
+
+```python
+import pulsar
+
+PULSAR = coco.ContextKey[pulsar.Client]("pulsar")
+
+target = await pulsar.mount_pulsar_topic_target(
+    PULSAR,
+    topic="persistent://public/default/derived-events",
+)
+
+target.declare_target_state(key="order-123", value=b'{"status":"ready"}')
+```
+
+On each commit, CocoIndex produces a message only when a declared target state
+has changed since the last run (tracked by a content fingerprint).
+
+### Deletions
+
+By default a deleted target state produces a message with an empty payload (and
+the key as the partition key). For key-based compaction, use a
+[compacted topic](https://pulsar.apache.org/docs/concepts-topic-compaction/).
+Pass `deletion_value_fn` to emit a custom delete marker instead:
+
+```python
+target = await pulsar.mount_pulsar_topic_target(
+    PULSAR,
+    topic="persistent://public/default/derived-events",
+    deletion_value_fn=lambda key: f'{{"id":{key!r},"deleted":true}}',
+)
+```
+
+### Target APIs
+
+```python
+def declare_pulsar_topic_target(
+    client: ContextKey[pulsar.Client],
+    topic: str,
+    *,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> PulsarTopicTarget[PendingS]
+```
+
+```python
+async def mount_pulsar_topic_target(
+    client: ContextKey[pulsar.Client],
+    topic: str,
+    *,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> PulsarTopicTarget[ResolvedS]
+```

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -70,6 +70,7 @@ export const sidebar: SidebarItem[] = [
       { type: 'doc', slug: 'connectors/neo4j', label: 'Neo4j' },
       { type: 'doc', slug: 'connectors/oci_object_storage', label: 'OCI Object Storage' },
       { type: 'doc', slug: 'connectors/postgres', label: 'Postgres' },
+      { type: 'doc', slug: 'connectors/pulsar', label: 'Pulsar' },
       { type: 'doc', slug: 'connectors/qdrant', label: 'Qdrant' },
       { type: 'doc', slug: 'connectors/sqlite', label: 'SQLite' },
       { type: 'doc', slug: 'connectors/surrealdb', label: 'SurrealDB' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ falkordb = ["falkordb>=1.1.0"]
 neo4j = ["neo4j>=5.18.0"]
 kafka = ["confluent_kafka>=2.6"]
 iggy = ["apache-iggy>=0.8.0"]
+pulsar = ["pulsar-client>=3.0.0"]
 oci = ["oci>=2.0"]
 entity_resolution = ["faiss-cpu>=1.7"]
 entity_resolution_llm = [
@@ -125,6 +126,7 @@ all = [
     "neo4j>=5.18.0",
     "confluent_kafka>=2.6",
     "apache-iggy>=0.8.0",
+    "pulsar-client>=3.0.0",
     "oci>=2.0",
     "faiss-cpu>=1.7",
     "instructor>=1.0",
@@ -235,6 +237,8 @@ module = [
     "oci.*",
     "confluent_kafka",
     "confluent_kafka.*",
+    "pulsar",
+    "pulsar.*",
     "openai",
     "openai.*",
     "transformers",

--- a/python/cocoindex/connectors/pulsar/__init__.py
+++ b/python/cocoindex/connectors/pulsar/__init__.py
@@ -1,0 +1,4 @@
+from . import _target
+from ._target import *
+
+__all__ = _target.__all__

--- a/python/cocoindex/connectors/pulsar/_target.py
+++ b/python/cocoindex/connectors/pulsar/_target.py
@@ -1,0 +1,361 @@
+"""
+Apache Pulsar target for CocoIndex.
+
+This module provides a two-level target state system for Pulsar:
+1. Topic level: Lightweight container for generation tracking (user-managed topic)
+2. Message level: Produces messages to the topic for upserts/deletes
+
+The Pulsar Python client (``pulsar-client``) is synchronous and producers are
+created per topic, so a single ``pulsar.Client`` is provided via a ContextKey and
+the connector lazily creates/caches one producer per topic, sending off the event
+loop via ``asyncio.to_thread``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Callable, Collection, Generic, NamedTuple, Sequence
+
+try:
+    import pulsar  # type: ignore[import-not-found]
+except ImportError as e:
+    raise ImportError(
+        "pulsar-client is required to use the Pulsar connector. "
+        "Please install cocoindex[pulsar]."
+    ) from e
+
+import cocoindex as coco
+from cocoindex.connectorkits.fingerprint import fingerprint_bytes, fingerprint_str
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+from cocoindex._internal.datatype import TypeChecker
+
+# --- Type aliases ---
+
+_MessageFingerprint = bytes
+
+# --- Internal types ---
+
+
+class _TopicKey(NamedTuple):
+    client_key: str
+    topic: str
+
+
+_TOPIC_KEY_CHECKER = TypeChecker(tuple[str, str])
+
+
+@dataclass
+class _TopicSpec:
+    deletion_value_fn: Callable[[bytes | str], bytes | str] | None
+
+
+class _TopicAction(NamedTuple):
+    key: _TopicKey
+    spec: _TopicSpec | coco.NonExistenceType
+
+
+class _MessageAction(NamedTuple):
+    key: bytes | str
+    value: bytes | str | None  # None = tombstone (no deletion_value_fn)
+
+
+def _as_partition_key(key: bytes | str) -> str:
+    return key.decode("utf-8") if isinstance(key, bytes) else key
+
+
+def _as_payload(value: bytes | str | None) -> bytes:
+    # Pulsar payloads are bytes; a tombstone (value=None) is sent as an empty
+    # payload (use ``deletion_value_fn`` for a custom delete marker, and a
+    # compacted topic if you need key-based compaction semantics).
+    if value is None:
+        return b""
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return value
+
+
+# --- Message handler (child level) ---
+
+
+class _MessageHandler:
+    """Handler for message-level target states within a topic."""
+
+    __slots__ = ("_client", "_topic", "_deletion_value_fn", "_producer", "_sink")
+
+    _client: pulsar.Client
+    _topic: str
+    _deletion_value_fn: Callable[[bytes | str], bytes | str] | None
+    _producer: pulsar.Producer | None
+    _sink: coco.TargetActionSink[_MessageAction]
+
+    def __init__(
+        self,
+        client: pulsar.Client,
+        topic: str,
+        deletion_value_fn: Callable[[bytes | str], bytes | str] | None,
+    ) -> None:
+        self._client = client
+        self._topic = topic
+        self._deletion_value_fn = deletion_value_fn
+        self._producer = None
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    def _ensure_producer(self) -> pulsar.Producer:
+        if self._producer is None:
+            self._producer = self._client.create_producer(self._topic)
+        return self._producer
+
+    def _send(self, producer: pulsar.Producer, action: _MessageAction) -> None:
+        producer.send(
+            _as_payload(action.value), partition_key=_as_partition_key(action.key)
+        )
+
+    async def _apply_actions(
+        self,
+        context_provider: ContextProvider,
+        actions: Sequence[_MessageAction],
+        /,
+    ) -> None:
+        if not actions:
+            return
+        # The pulsar-client producer is synchronous; send each message off the
+        # event loop and await all sends to ensure delivery before returning.
+        producer = self._ensure_producer()
+        await asyncio.gather(
+            *(asyncio.to_thread(self._send, producer, action) for action in actions)
+        )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_target_state: bytes | str | coco.NonExistenceType,
+        prev_possible_records: Collection[_MessageFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_MessageAction, _MessageFingerprint] | None:
+        assert isinstance(key, (bytes, str))
+
+        if coco.is_non_existence(desired_target_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            deletion_value: bytes | str | None = None
+            if self._deletion_value_fn is not None:
+                deletion_value = self._deletion_value_fn(key)
+            return coco.TargetReconcileOutput(
+                action=_MessageAction(key=key, value=deletion_value),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        # Upsert case
+        if isinstance(desired_target_state, bytes):
+            target_fp = fingerprint_bytes(desired_target_state)
+        else:
+            target_fp = fingerprint_str(desired_target_state)
+
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_MessageAction(key=key, value=desired_target_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+# --- Topic handler (root level) ---
+
+
+class _TopicHandler:
+    """Handler for topic-level target states. Always returns output for generation tracking."""
+
+    __slots__ = ("_sink",)
+
+    _sink: coco.TargetActionSink[_TopicAction, _MessageHandler]
+
+    def __init__(self) -> None:
+        self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
+
+    async def _apply_actions(
+        self,
+        context_provider: ContextProvider,
+        actions: Sequence[_TopicAction],
+        /,
+    ) -> list[coco.ChildTargetDef[_MessageHandler] | None]:
+        outputs: list[coco.ChildTargetDef[_MessageHandler] | None] = []
+        for action in actions:
+            if coco.is_non_existence(action.spec):
+                outputs.append(None)
+            else:
+                client = context_provider.get(action.key.client_key, pulsar.Client)
+                handler = _MessageHandler(
+                    client=client,
+                    topic=action.key.topic,
+                    deletion_value_fn=action.spec.deletion_value_fn,
+                )
+                outputs.append(coco.ChildTargetDef(handler=handler))
+        return outputs
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_target_state: _TopicSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[None],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_TopicAction, None, _MessageHandler]:
+        topic_key = _TopicKey(*_TOPIC_KEY_CHECKER.check(key))
+
+        tracking_record: None | coco.NonExistenceType
+        if coco.is_non_existence(desired_target_state):
+            tracking_record = coco.NON_EXISTENCE
+        else:
+            tracking_record = None
+
+        return coco.TargetReconcileOutput(
+            action=_TopicAction(key=topic_key, spec=desired_target_state),
+            sink=self._sink,
+            tracking_record=tracking_record,
+        )
+
+
+# --- Root provider registration ---
+
+_topic_provider = coco.register_root_target_states_provider(
+    "cocoindex/pulsar/topic", _TopicHandler()
+)
+
+# --- Public API ---
+
+DeletionValueFn = Callable[[bytes | str], bytes | str]
+
+
+class PulsarTopicTarget(
+    Generic[coco.MaybePendingS], coco.ResolvesTo["PulsarTopicTarget"]
+):
+    """
+    A target for producing messages to a Pulsar topic.
+
+    The topic is user-managed (CocoIndex does not create/drop topics).
+    Messages are produced for upserts and deletes of declared target states.
+    """
+
+    _provider: coco.TargetStateProvider[
+        bytes | str | coco.NonExistenceType, None, coco.MaybePendingS
+    ]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[
+            bytes | str | coco.NonExistenceType, None, coco.MaybePendingS
+        ],
+    ) -> None:
+        self._provider = provider
+
+    def declare_target_state(
+        self: "PulsarTopicTarget", *, key: bytes | str, value: bytes | str
+    ) -> None:
+        """
+        Declare a target state backed by a Pulsar message.
+
+        On commit, CocoIndex will produce a message with the given key (as the
+        Pulsar ``partition_key``) and value if the state has changed since the
+        last run.
+
+        Args:
+            key: The message key (used as the stable identity and partition key).
+            value: The message value.
+        """
+        coco.declare_target_state(self._provider.target_state(key, value))
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+def pulsar_topic_target(
+    client: ContextKey[pulsar.Client],
+    topic: str,
+    *,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> coco.TargetState[_MessageHandler]:
+    """
+    Create a TargetState for a Pulsar topic target.
+
+    Use with ``coco.mount_target()`` to mount and get a child provider,
+    or with ``mount_pulsar_topic_target()`` for a convenience wrapper.
+
+    Args:
+        client: ContextKey for the ``pulsar.Client`` connection.
+        topic: The Pulsar topic name.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            If not provided, deletions produce messages with an empty payload.
+
+    Returns:
+        A TargetState that can be passed to ``mount_target()``.
+    """
+    key = _TopicKey(client_key=client.key, topic=topic)
+    spec = _TopicSpec(deletion_value_fn=deletion_value_fn)
+    return _topic_provider.target_state(key, spec)
+
+
+@coco.fn
+def declare_pulsar_topic_target(
+    client: ContextKey[pulsar.Client],
+    topic: str,
+    *,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> PulsarTopicTarget[coco.PendingS]:
+    """
+    Declare a Pulsar topic target and return a PulsarTopicTarget for declaring messages.
+
+    Args:
+        client: ContextKey for the ``pulsar.Client`` connection.
+        topic: The Pulsar topic name.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            If not provided, deletions produce messages with an empty payload.
+
+    Returns:
+        A PulsarTopicTarget that can be used to declare target states.
+    """
+    provider = coco.declare_target_state_with_child(
+        pulsar_topic_target(client, topic, deletion_value_fn=deletion_value_fn)
+    )
+    return PulsarTopicTarget(provider)
+
+
+async def mount_pulsar_topic_target(
+    client: ContextKey[pulsar.Client],
+    topic: str,
+    *,
+    deletion_value_fn: DeletionValueFn | None = None,
+) -> PulsarTopicTarget[coco.ResolvedS]:
+    """
+    Mount a Pulsar topic target and return a ready-to-use PulsarTopicTarget.
+
+    Sugar over ``pulsar_topic_target()`` + ``coco.mount_target()`` + wrapping.
+
+    Args:
+        client: ContextKey for the ``pulsar.Client`` connection.
+        topic: The Pulsar topic name.
+        deletion_value_fn: Optional callback to produce a deletion value for a given key.
+            If not provided, deletions produce messages with an empty payload.
+
+    Returns:
+        A PulsarTopicTarget that can be used to declare target states.
+    """
+    provider = await coco.mount_target(
+        pulsar_topic_target(client, topic, deletion_value_fn=deletion_value_fn)
+    )
+    return PulsarTopicTarget(provider)
+
+
+__all__ = [
+    "DeletionValueFn",
+    "PulsarTopicTarget",
+    "declare_pulsar_topic_target",
+    "pulsar_topic_target",
+    "mount_pulsar_topic_target",
+]

--- a/python/tests/connectors/test_pulsar_target.py
+++ b/python/tests/connectors/test_pulsar_target.py
@@ -1,0 +1,307 @@
+"""Tests for Pulsar target connector handlers and reconciliation logic.
+
+These tests mock the pulsar client to verify handler behavior without a real
+Pulsar broker.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+# --- Mock pulsar before importing the connector ---
+
+
+class MockProducer:
+    """Mock pulsar.Producer that records send() calls into a shared list."""
+
+    def __init__(self, topic: str, sink: list[tuple[str, Any, Any]]) -> None:
+        self._topic = topic
+        self._sink = sink
+
+    def send(self, content: bytes, *, partition_key: Any = None) -> None:
+        self._sink.append((self._topic, partition_key, content))
+
+
+class MockClient:
+    """Mock pulsar.Client that hands out per-topic MockProducers."""
+
+    def __init__(self) -> None:
+        self.sent_messages: list[tuple[str, Any, Any]] = []
+
+    def create_producer(self, topic: str) -> MockProducer:
+        return MockProducer(topic, self.sent_messages)
+
+    def clear(self) -> None:
+        self.sent_messages.clear()
+
+
+_mock_pulsar = MagicMock()
+_mock_pulsar.Client = MockClient
+_mock_pulsar.Producer = MockProducer
+sys.modules.setdefault("pulsar", _mock_pulsar)
+
+import pulsar  # type: ignore[import-not-found]  # noqa: E402
+from cocoindex.connectors.pulsar._target import (  # noqa: E402
+    _MessageAction,
+    _MessageHandler,
+    _TopicAction,
+    _TopicHandler,
+    _TopicKey,
+    _TopicSpec,
+    PulsarTopicTarget,
+)
+import cocoindex as coco  # noqa: E402
+from cocoindex._internal.context_keys import ContextProvider  # noqa: E402
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def client() -> MockClient:
+    return MockClient()
+
+
+def _as_client(mock: MockClient) -> pulsar.Client:
+    return cast(pulsar.Client, mock)
+
+
+@pytest.fixture
+def message_handler(client: MockClient) -> _MessageHandler:
+    return _MessageHandler(
+        client=_as_client(client), topic="test-topic", deletion_value_fn=None
+    )
+
+
+@pytest.fixture
+def message_handler_with_deletion(client: MockClient) -> _MessageHandler:
+    return _MessageHandler(
+        client=_as_client(client),
+        topic="test-topic",
+        deletion_value_fn=lambda k: (
+            b"deleted:" + (k if isinstance(k, bytes) else k.encode())
+        ),
+    )
+
+
+# =============================================================================
+# _TopicHandler tests
+# =============================================================================
+
+
+class TestTopicHandler:
+    def test_reconcile_always_returns_output(self) -> None:
+        handler = _TopicHandler()
+        spec = _TopicSpec(deletion_value_fn=None)
+
+        result = handler.reconcile(("client_key", "my-topic"), spec, [], False)
+
+        assert result is not None
+        assert result.tracking_record is None
+
+    def test_reconcile_non_existence(self) -> None:
+        handler = _TopicHandler()
+
+        result = handler.reconcile(
+            ("client_key", "my-topic"), coco.NON_EXISTENCE, [], False
+        )
+
+        assert result is not None
+        assert coco.is_non_existence(result.tracking_record)
+
+    @pytest.mark.asyncio
+    async def test_sink_creates_child_handler(self, client: MockClient) -> None:
+        handler = _TopicHandler()
+        spec = _TopicSpec(deletion_value_fn=None)
+        key = _TopicKey(client_key="ck", topic="my-topic")
+        action = _TopicAction(key=key, spec=spec)
+
+        context_provider = MagicMock(spec=ContextProvider)
+        context_provider.get.return_value = client
+
+        children = await handler._apply_actions(context_provider, [action])
+
+        assert len(children) == 1
+        child_def = children[0]
+        assert child_def is not None
+        assert isinstance(child_def.handler, _MessageHandler)
+
+    @pytest.mark.asyncio
+    async def test_sink_returns_none_for_deletion(self) -> None:
+        handler = _TopicHandler()
+        key = _TopicKey(client_key="ck", topic="my-topic")
+        action = _TopicAction(key=key, spec=coco.NON_EXISTENCE)
+
+        context_provider = MagicMock(spec=ContextProvider)
+        children = await handler._apply_actions(context_provider, [action])
+
+        assert len(children) == 1
+        assert children[0] is None
+
+
+# =============================================================================
+# _MessageHandler reconcile tests
+# =============================================================================
+
+
+class TestMessageHandlerReconcile:
+    def test_upsert_new_state(self, message_handler: _MessageHandler) -> None:
+        result = message_handler.reconcile(b"k1", b"v1", [], True)
+
+        assert result is not None
+        assert result.action.key == b"k1"
+        assert result.action.value == b"v1"
+        assert isinstance(result.tracking_record, bytes)
+
+    def test_upsert_unchanged_skips(self, message_handler: _MessageHandler) -> None:
+        result1 = message_handler.reconcile(b"k1", b"v1", [], True)
+        assert result1 is not None
+        fp = result1.tracking_record
+        assert isinstance(fp, bytes)
+
+        result2 = message_handler.reconcile(b"k1", b"v1", [fp], False)
+        assert result2 is None
+
+    def test_upsert_changed_value(self, message_handler: _MessageHandler) -> None:
+        result1 = message_handler.reconcile(b"k1", b"v1", [], True)
+        assert result1 is not None
+        fp = result1.tracking_record
+        assert isinstance(fp, bytes)
+
+        result2 = message_handler.reconcile(b"k1", b"v2", [fp], False)
+        assert result2 is not None
+        assert result2.action.value == b"v2"
+
+    def test_upsert_with_prev_may_be_missing(
+        self, message_handler: _MessageHandler
+    ) -> None:
+        result1 = message_handler.reconcile(b"k1", b"v1", [], True)
+        assert result1 is not None
+        fp = result1.tracking_record
+        assert isinstance(fp, bytes)
+
+        # Same fingerprint but prev_may_be_missing=True → still produces
+        result2 = message_handler.reconcile(b"k1", b"v1", [fp], True)
+        assert result2 is not None
+
+    def test_delete_without_callback(self, message_handler: _MessageHandler) -> None:
+        result = message_handler.reconcile(b"k1", coco.NON_EXISTENCE, [b"fp"], False)
+
+        assert result is not None
+        assert result.action.key == b"k1"
+        assert result.action.value is None  # Tombstone
+        assert coco.is_non_existence(result.tracking_record)
+
+    def test_delete_with_callback(
+        self, message_handler_with_deletion: _MessageHandler
+    ) -> None:
+        result = message_handler_with_deletion.reconcile(
+            b"k1", coco.NON_EXISTENCE, [b"fp"], False
+        )
+
+        assert result is not None
+        assert result.action.key == b"k1"
+        assert result.action.value == b"deleted:k1"
+
+    def test_delete_no_prev_no_missing_skips(
+        self, message_handler: _MessageHandler
+    ) -> None:
+        result = message_handler.reconcile(b"k1", coco.NON_EXISTENCE, [], False)
+        assert result is None
+
+    def test_str_key_and_value(self, message_handler: _MessageHandler) -> None:
+        result = message_handler.reconcile("str-key", "str-value", [], True)
+
+        assert result is not None
+        assert result.action.key == "str-key"
+        assert result.action.value == "str-value"
+        assert isinstance(result.tracking_record, bytes)
+
+
+# =============================================================================
+# _MessageHandler sink tests
+# =============================================================================
+
+
+class TestMessageHandlerSink:
+    @pytest.mark.asyncio
+    async def test_produce_messages(self, client: MockClient) -> None:
+        handler = _MessageHandler(
+            client=_as_client(client), topic="test-topic", deletion_value_fn=None
+        )
+
+        action1 = _MessageAction(key=b"k1", value=b"v1")
+        action2 = _MessageAction(key=b"k2", value=b"v2")
+
+        context_provider = MagicMock(spec=ContextProvider)
+        await handler._apply_actions(context_provider, [action1, action2])
+
+        # Sends run concurrently via asyncio.to_thread, so compare unordered.
+        assert set(client.sent_messages) == {
+            ("test-topic", "k1", b"v1"),
+            ("test-topic", "k2", b"v2"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_produce_tombstone(self, client: MockClient) -> None:
+        handler = _MessageHandler(
+            client=_as_client(client), topic="test-topic", deletion_value_fn=None
+        )
+
+        action = _MessageAction(key=b"k1", value=None)
+
+        context_provider = MagicMock(spec=ContextProvider)
+        await handler._apply_actions(context_provider, [action])
+
+        # Tombstone (value=None) is sent as an empty payload.
+        assert client.sent_messages == [("test-topic", "k1", b"")]
+
+    @pytest.mark.asyncio
+    async def test_produce_deletion_value(self, client: MockClient) -> None:
+        handler = _MessageHandler(
+            client=_as_client(client),
+            topic="test-topic",
+            deletion_value_fn=lambda k: (
+                b"del:" + (k if isinstance(k, bytes) else k.encode())
+            ),
+        )
+
+        action = _MessageAction(key=b"k1", value=b"del:k1")
+
+        context_provider = MagicMock(spec=ContextProvider)
+        await handler._apply_actions(context_provider, [action])
+
+        assert client.sent_messages == [("test-topic", "k1", b"del:k1")]
+
+    @pytest.mark.asyncio
+    async def test_str_key_becomes_partition_key(self, client: MockClient) -> None:
+        handler = _MessageHandler(
+            client=_as_client(client), topic="test-topic", deletion_value_fn=None
+        )
+
+        context_provider = MagicMock(spec=ContextProvider)
+        await handler._apply_actions(
+            context_provider, [_MessageAction(key="strk", value="strv")]
+        )
+
+        assert client.sent_messages == [("test-topic", "strk", b"strv")]
+
+
+# =============================================================================
+# PulsarTopicTarget tests
+# =============================================================================
+
+
+class TestPulsarTopicTarget:
+    def test_memo_key(self) -> None:
+        provider = MagicMock()
+        provider.memo_key = "test-memo-key"
+        target = PulsarTopicTarget(provider)
+
+        assert target.__coco_memo_key__() == "test-memo-key"

--- a/python/tests/connectors/test_pulsar_target_live.py
+++ b/python/tests/connectors/test_pulsar_target_live.py
@@ -1,0 +1,83 @@
+"""End-to-end test for the Pulsar target connector against a live broker.
+
+Unlike ``test_pulsar_target.py`` (which mocks the client), this drives the real
+produce path through ``_MessageHandler._apply_actions`` and consumes the topic
+back to assert the message payload, partition key, and tombstone behaviour.
+
+It is **skipped unless** ``PULSAR_SERVICE_URL`` is set, so it never runs in the
+default (broker-less) suite.
+
+Run it against a local Pulsar standalone::
+
+    docker run -d --name pulsar -p 6650:6650 -p 8080:8080 \
+        apachepulsar/pulsar:3.3.1 bin/pulsar standalone
+
+    PULSAR_SERVICE_URL=pulsar://localhost:6650 \
+        pytest python/tests/connectors/test_pulsar_target_live.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("PULSAR_SERVICE_URL"),
+    reason="set PULSAR_SERVICE_URL to run the Pulsar target connector against a live broker",
+)
+
+
+def _real_pulsar() -> Any:
+    """Return the real ``pulsar-client`` module.
+
+    ``test_pulsar_target.py`` installs a mock into ``sys.modules['pulsar']`` at
+    import time; drop it so a live run uses the genuine client.
+    """
+    sys.modules.pop("pulsar", None)
+    import pulsar  # type: ignore[import-not-found]
+
+    return pulsar
+
+
+@pytest.mark.asyncio
+async def test_pulsar_target_produces_and_deletes_against_live_broker() -> None:
+    pulsar = _real_pulsar()
+    from cocoindex.connectors.pulsar._target import _MessageAction, _MessageHandler
+
+    service_url = os.environ["PULSAR_SERVICE_URL"]
+    topic = f"persistent://public/default/coco-e2e-{uuid.uuid4().hex}"
+    key = "order-123"
+    value = b'{"status":"ready"}'
+
+    client = pulsar.Client(service_url)
+    handler = _MessageHandler(client=client, topic=topic, deletion_value_fn=None)
+    context_provider = MagicMock()
+
+    try:
+        # 1. Upsert: a message is produced with the target-state key as the
+        #    Pulsar partition key and the value as the payload.
+        await handler._apply_actions(context_provider, [_MessageAction(key=key, value=value)])
+
+        reader = client.create_reader(topic, pulsar.MessageId.earliest)
+        try:
+            upsert = reader.read_next(timeout_millis=15000)
+            assert upsert.data() == value
+            assert upsert.partition_key() == key
+
+            # 2. Delete: a tombstone is produced as an empty payload (no
+            #    deletion_value_fn was configured) under the same key.
+            await handler._apply_actions(
+                context_provider, [_MessageAction(key=key, value=None)]
+            )
+            tombstone = reader.read_next(timeout_millis=15000)
+            assert tombstone.data() == b""
+            assert tombstone.partition_key() == key
+        finally:
+            reader.close()
+    finally:
+        client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -580,6 +580,7 @@ all = [
     { name = "neo4j" },
     { name = "oci" },
     { name = "pgvector" },
+    { name = "pulsar-client" },
     { name = "pyarrow" },
     { name = "pymysql" },
     { name = "qdrant-client" },
@@ -639,6 +640,9 @@ oci = [
 ]
 postgres = [
     { name = "asyncpg" },
+]
+pulsar = [
+    { name = "pulsar-client" },
 ]
 qdrant = [
     { name = "qdrant-client" },
@@ -769,6 +773,8 @@ requires-dist = [
     { name = "oci", marker = "extra == 'oci'", specifier = ">=2.0" },
     { name = "pgvector", marker = "extra == 'all'", specifier = ">=0.4.2" },
     { name = "psutil", specifier = ">=7.2.1" },
+    { name = "pulsar-client", marker = "extra == 'all'", specifier = ">=3.0.0" },
+    { name = "pulsar-client", marker = "extra == 'pulsar'", specifier = ">=3.0.0" },
     { name = "pyarrow", marker = "extra == 'all'", specifier = ">=23.0.0" },
     { name = "pyarrow", marker = "extra == 'lancedb'", specifier = ">=23.0.0" },
     { name = "pymysql", marker = "extra == 'all'", specifier = ">=1.1.0" },
@@ -792,7 +798,7 @@ requires-dist = [
     { name = "zvec", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "zvec", marker = "extra == 'zvec'", specifier = ">=0.4.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer", "valkey", "zvec"]
+provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "pulsar", "qdrant", "sentence-transformers", "sqlite", "surrealdb", "turbopuffer", "valkey", "zvec"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -2857,6 +2863,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/15/dd6fd869753ce82ff64dcbc18356093471a5a5adf4f77ed1f805d473d859/psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67", size = 147402, upload-time = "2025-12-29T08:26:39.21Z" },
     { url = "https://files.pythonhosted.org/packages/34/68/d9317542e3f2b180c4306e3f45d3c922d7e86d8ce39f941bb9e2e9d8599e/psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17", size = 136938, upload-time = "2025-12-29T08:26:41.036Z" },
     { url = "https://files.pythonhosted.org/packages/3e/73/2ce007f4198c80fcf2cb24c169884f833fe93fbc03d55d302627b094ee91/psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442", size = 133836, upload-time = "2025-12-29T08:26:43.086Z" },
+]
+
+[[package]]
+name = "pulsar-client"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/15/e82da360519daa156b89b43bf0fba7cc25d9b46329d72b4eb7859d385f21/pulsar_client-3.12.0-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:6492ccb2c93e8a4a7dc1a3ee83ba486b267c925b3a7a7d327ce6e8d33ee110bb", size = 10585392, upload-time = "2026-05-20T03:28:36.723Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c4/872dda04b5c1f0b631f82a1f26812eec8bba69c0631ab4c38d725a4909e7/pulsar_client-3.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d5ab61719aa6615ae5523263f729b5ea759b091a5b66046b513ed134333459a1", size = 7562033, upload-time = "2026-05-20T03:28:40.409Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5e/9f590638d48bdcb894497bf6e269bd0e777eeaf5f0a38807e0e900215f19/pulsar_client-3.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b8b9a5a28439ef572ab23ff02f68b9e43d7fb1055db620e57a744895576c238e", size = 7545668, upload-time = "2026-05-20T03:28:43.634Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/5a145b4591aa93c79129c93dbbdf821b5d04124c6ad83f1391304658f8ff/pulsar_client-3.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5e4424ee8416517313dcc4bf38e521e3a6dd4c8b2d1e21a32e28db347827202f", size = 8080257, upload-time = "2026-05-20T03:28:46.933Z" },
+    { url = "https://files.pythonhosted.org/packages/40/81/615105749ab8bb7839cb9cec9eab54620c20bfb8dfcb98faaa4b4421fde6/pulsar_client-3.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae2989a1c102f07461a32774ce9175967f308a305de1dd5236c0b4971dfc9b89", size = 7920941, upload-time = "2026-05-20T03:28:50.582Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/95/b6db93c432328827452cf572143b82c620cb8cea522dc9eacccab8590995/pulsar_client-3.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:53a32fa73abebbad30a251949f8bf8bc3caab20d89687a936747d0b6ff4dc722", size = 3894648, upload-time = "2026-05-20T03:28:53.147Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/af/bfacc4323442684dac4a64790574b111c9534ec1e159a5ca4a06a46fbb7d/pulsar_client-3.12.0-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:f4fe247a522c78373ae78b284d261e3ba061663332673f6e8553f7c380ada95a", size = 10610847, upload-time = "2026-05-20T03:28:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/b5/af9b4753525b33000e9466d334def0b7b3ab668e788fd5134d3a35b14b4b/pulsar_client-3.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c49b0d454b1f2a50633fe9f7c5d80b8359ad100629a9d300981552a295c362e5", size = 7566357, upload-time = "2026-05-20T03:29:00.734Z" },
+    { url = "https://files.pythonhosted.org/packages/05/04/f43d8502c30c52380321a901a31f703e4237f3c3b6328e7feb7305a0c0be/pulsar_client-3.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1849b84403dc480b67cbd32b4c5d208ef58dcc27299a760f8fa3996accc14c4e", size = 7554899, upload-time = "2026-05-20T03:29:04.552Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5c/30d2f08a84e5a28538c3479b614eec2a19fbf142d52fd7f4971fc8e7dd1a/pulsar_client-3.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9e38f72360881915ea75097f728553842cc5d94b2375b16a42e85005242215", size = 8082633, upload-time = "2026-05-20T03:29:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b9/3ec0aa13e7b84ccad1d053cbdaecd4fb0e1de570d57906feaa3cba9743f7/pulsar_client-3.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:28305584ae37e1f13fb6207385d1c120f0bfe1204052315b9de0d3f4908cc317", size = 7930614, upload-time = "2026-05-20T03:29:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/64/00/faff1cdfd99363464f2e37b8eb6da9029342a691835daa9ca7e61f2ff8fd/pulsar_client-3.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:2cfe007465d411d6d8b9ec011e317b9e722e0c0637cd26bb06384c925578dca7", size = 3895002, upload-time = "2026-05-20T03:29:14.945Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/67/df6fa67ed8cceae5ea58e43ddcd8c4f6ce58f4426a86905db4fb5b1522dd/pulsar_client-3.12.0-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:af4c0f79ba092f022df312a8719ed7b66a00c993522c306a1ec5e40535cf34b9", size = 10612065, upload-time = "2026-05-20T03:29:18.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9e638339f15d81f6169f1c743dcfa1c9f6bca55414adebc8d6a99ae366a9/pulsar_client-3.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57d787200c9d7b727beec8761a054837fd9541a827b71b882e9a2f9e303777bb", size = 7569546, upload-time = "2026-05-20T03:29:22.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/73/8a1815ced889db65cf8359aa9caf57aaa78d4c8db57c7a3f6ac349fefc92/pulsar_client-3.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:42897004d0a5489b925b8cdb27720d127146a0a43823d8b2fd7cd181934da03c", size = 7555833, upload-time = "2026-05-20T03:29:26.23Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/11/d5b08db3874633b288186517f95f1b245155eba82508bf55be12ce56c119/pulsar_client-3.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc7635a34c04539e9f6fbadf8f4685987d514b8a96a2ed9b5bab1f72ca45f519", size = 8088957, upload-time = "2026-05-20T03:29:29.961Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/b70ccc285f1c9b21749fd177efa472778a6a2643a944c81a64766ed80679/pulsar_client-3.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:16f6077bc413ae14e686af303d0c36db4c5a59005cc79399365c2f03b2a3fcbe", size = 7931419, upload-time = "2026-05-20T03:29:33.497Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ca/1aad952648d2e60199687865bdf89222dcd362d8bef2f4d1fbfde2aa0310/pulsar_client-3.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:1ee1e1a9523d7ddfb3d36c0fcd05d7a9105246058360c0d5a8ca9d335cb19038", size = 3895088, upload-time = "2026-05-20T03:29:36.414Z" },
+    { url = "https://files.pythonhosted.org/packages/45/66/a2e596e6c9b61f04bfd21c91b40ad89708824965df8b975fef5f47d48d54/pulsar_client-3.12.0-cp314-cp314-macosx_13_0_universal2.whl", hash = "sha256:c2206130ec0001a6c3259e8ce607429db78f90135e3184bdb2f68bb8d8320243", size = 10602799, upload-time = "2026-05-20T03:29:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3d/7590ea07bc596f995166f705f6e1af0f9d4529b788a2f467089df9dc6198/pulsar_client-3.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:49a67033f0483c011a0793f2f71513102c7ba4c205fb2bdc0ab5301e795bdca7", size = 7571890, upload-time = "2026-05-20T03:29:44.18Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/805eeb8cc086558c98b836fbfc802a50ec6b687987e72be28e513791b34d/pulsar_client-3.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:2d4efc722a686f8ca7c886ec49ccc8e9adb9d0694e981dc72ba320a70d397658", size = 7556264, upload-time = "2026-05-20T03:29:47.505Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/878499119d5d9c1123f87389cd49e78bbf2362354c9d77cd8af8692c583a/pulsar_client-3.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32836a96935a7c1953818f8c0162f0f4232c37281a9e8cf9f70232567f20d80c", size = 8091668, upload-time = "2026-05-20T03:29:50.854Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bb/de43644792354986074941170e05aaf15044161c62b8f61a30957e4f18b1/pulsar_client-3.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:711358da7a5930bf71c78b9db3e2ca01d8e19266049966a2b3bcf9b0460f14fb", size = 7932654, upload-time = "2026-05-20T03:29:54.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8a/68bafcaf9ea12e42719852f580a61522b5bb772716b666ed8c05625c7715/pulsar_client-3.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:d685dcde62c930b5f257fbf73a76883349d2cb938488ec8d5a65497ee3cf8db0", size = 4015054, upload-time = "2026-05-20T03:29:57.656Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #2125 (target connector; source/consumer to follow).

## Summary

Adds an Apache **Pulsar target connector** for the Python SDK, mirroring the existing **Kafka** and **Iggy** target connectors. Declared target states are produced as messages to a user-managed Pulsar topic, with the target-state key used as the Pulsar **partition key**. A message is produced only when a state changes since the last run (tracked by a content fingerprint), and deletes are handled (empty payload by default, or a custom marker via `deletion_value_fn`).

```python
import pulsar
import cocoindex as coco
from cocoindex.connectors import pulsar as pulsar_connector

PULSAR = coco.ContextKey[pulsar.Client]("pulsar")

target = await pulsar_connector.mount_pulsar_topic_target(
    PULSAR, topic="persistent://public/default/derived-events"
)
target.declare_target_state(key="order-123", value=b'{"status":"ready"}')
```

## Design

Same two-level handler model as Kafka/Iggy (`_TopicHandler` → `_MessageHandler`), registered via `register_root_target_states_provider` — no engine/Rust changes. The one adaptation: the `pulsar-client` Python client is **synchronous with per-topic producers**, so the connector takes a single `pulsar.Client` via a `ContextKey`, lazily creates and caches one producer per topic, and sends off the event loop with `asyncio.to_thread`. The `reconcile` change-detection logic (fingerprint upserts, tombstone/`deletion_value_fn` deletes) is identical to Kafka's.

## Changes

- `python/cocoindex/connectors/pulsar/{__init__,_target}.py` — the connector + public API (`pulsar_topic_target`, `declare_pulsar_topic_target`, `mount_pulsar_topic_target`, `PulsarTopicTarget`).
- `pyproject.toml` + `uv.lock` — `cocoindex[pulsar]` optional dependency (`pulsar-client>=3.0.0`), added to the `all` extra and mypy ignore list.
- `docs/src/content/docs/connectors/pulsar.mdx` + sidebar entry.
- `python/tests/connectors/test_pulsar_target.py` — unit tests.

## Verification

- `pytest python/tests/connectors/test_pulsar_target.py` — **17 passed**. Tests mock the Pulsar client (like the Kafka target tests), so **no broker is required** and they're CI-safe.
- `mypy` — clean on the connector and tests.
- `ruff format --check` — clean.

## Scope / follow-ups

This PR is the **target** side only, per an incremental approach. Natural follow-ups: the Pulsar **source** (consumer, mirroring `kafka`/`iggy` `topic_as_map`/`topic_as_stream`) and an optional Rust SDK Pulsar target. Happy to do those next.