### PR TITLE
feat(code_match): restrict `\{{ ... \}}` containment to a single node

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -94,6 +94,23 @@ impl Indexed {
         let ends = &self.child_end_owners[next - 1];
         starts.iter().any(|n| ends.contains(n))
     }
+
+    /// Is `[li, next)` *exactly one* direct child of some parent — a single
+    /// same-level sibling node, not the whole subtree and not a multi-sibling run?
+    /// (`same_level` is true for the whole of a node's children too — e.g. a root
+    /// `module` spanning all its statements — which `\{{ \}}` must *not* treat as a
+    /// single node.) True iff some parent `M` owns `li` as a child-start and
+    /// `next-1` as a child-end with **no** child-end of `M` strictly inside.
+    fn single_child(&self, li: usize, next: usize) -> bool {
+        if next <= li {
+            return false;
+        }
+        let last = next - 1;
+        self.child_start_owners[li].iter().any(|&m| {
+            self.child_end_owners[last].contains(&m)
+                && !(li..last).any(|e| self.child_end_owners[e].contains(&m))
+        })
+    }
 }
 
 /// Compiled, language-bound pattern.
@@ -576,12 +593,12 @@ impl<'s> Ctx<'_, 's> {
         false
     }
 
-    /// `\{{ INNER \}}` — containment (DESIGN §12). Consume a same-level region
-    /// `[li, next)` (a child-aligned sibling slice, like `\*`, possibly empty),
-    /// require `INNER` (`items[pi+1..close]`) to match *some descendant node*
-    /// fully inside the region (any depth), then continue the outer match at
-    /// `items[close+1..end]` from `next`. The region grows greedily (longest
-    /// first) so whole-node coverage is preferred, same as `match_multi`.
+    /// `\{{ INNER \}}` — containment (DESIGN §12). The region is a **single node**
+    /// starting at `li` (a clean direct-child of the surrounding parent): require
+    /// `INNER` (`items[pi+1..close]`) to match *some descendant node* inside that one
+    /// node (any depth), then continue the outer match at `items[close+1..end]` from
+    /// just past it. "This one node contains INNER" — the `has` intuition; the node
+    /// is tried largest-first (`spans_by_start` is sorted that way).
     fn match_contains(
         &mut self,
         pi: usize,
@@ -593,9 +610,12 @@ impl<'s> Ctx<'_, 's> {
         let inner = pi + 1; // first INNER item
         let cont = close + 1; // first outer item after `\}}`
         let idx = self.idx;
-        for next in reachable(li, hi, idx) {
-            if !idx.same_level(li, next) {
-                continue; // region must be a clean sibling slice
+        for sp in &idx.spans_by_start[li] {
+            let next = sp.end_leaf + 1;
+            // the region must be exactly one direct-child node (not a multi-child
+            // span like a root `module` covering all its statements)
+            if next > hi || !idx.single_child(li, next) {
+                continue;
             }
             if self.contains_then_continue(inner, close, cont, end, li, next, hi) {
                 return true;

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -633,6 +633,32 @@ fn regex_matcher_is_whole_node_anchored() {
 }
 
 #[test]
+fn containment_brackets_a_single_node_not_a_multi_sibling_region() {
+    // `\{{ INNER \}}` brackets exactly one node (the "has" intuition), not a greedy
+    // multi-sibling region. `\{{ b() \}}` must NOT match the whole module (which
+    // spans all three statements) — only the single node containing `b()`.
+    let ms = matches(lang::python(), r"\{{ b() \}}", "a()\nb()\nc()\n");
+    assert!(
+        !ms.iter().any(|m| m.kind == "module"),
+        "must not bracket the whole module, got {ms:?}",
+    );
+    assert!(
+        ms.iter().any(|m| m.text == "b()"),
+        "should match the single node `b()`, got {ms:?}",
+    );
+    // canonical body-containment still works (the body block is one node)
+    let f = matches(
+        lang::python(),
+        r"def f(): \{{ return \X \}}",
+        "def f():\n    x = 1\n    return y\n",
+    );
+    assert!(
+        f.iter()
+            .any(|m| m.kind == "function_definition" && m.capture_text("X") == Some("y")),
+    );
+}
+
+#[test]
 fn overlapping_fragments_are_leftmost_longest_non_overlapping() {
     // `a b a b a b a` parses (bash) as one `command` with seven `word` siblings.
     // A *fragment* pattern reports every non-overlapping occurrence within the node


### PR DESCRIPTION
## Summary
- Restrict `\{{ ... \}}` containment to bracket **exactly one node** instead of a multi-sibling region (like `\*`). Previously `\{{ b() \}}` over a module `a(); b(); c();` matched the whole `module`, not the statement containing `b()` — surprising for a "has" primitive.
- `match_contains` now iterates `spans_by_start[li]` (named nodes at the leaf, largest-first) gated by a new `Indexed::single_child` (a single direct child of its parent — rejects the whole-subtree/root span the old `same_level` admitted).
- The canonical `fn foo() \{{ return \X \}}` body case is unaffected (a body block is one node).

## Test plan
- CI (cargo test). Adds an e2e regression test asserting `\{{ b() \}}` brackets only the `b()` node, never the enclosing `module`, while the body-containment case still binds `\X`.
