### PR TITLE
refactor(code_match): migrate to locked symmetric pattern syntax

### DIFF
--- a/python/cocoindex/ops/code.py
+++ b/python/cocoindex/ops/code.py
@@ -2,7 +2,7 @@ r"""Structural code matching over a reusable parsed AST.
 
 Parse source once into a :class:`CodeAst`, then match by-example structural
 patterns and/or split it into chunks without re-parsing. Metavariables in a
-pattern use the ``\`` sigil (e.g. ``\NAME``, ``\(ARGS*)``).
+pattern use the ``\`` sigil (e.g. ``\NAME``, ``\(ARGS*\)``).
 """
 
 __all__ = [
@@ -54,7 +54,7 @@ class CodePattern:
         min_len: Prefilter tuning — required terms shorter than this are dropped.
 
     Examples:
-        >>> cp = CodePattern(r"def \NAME(\(A*)):", language="python")
+        >>> cp = CodePattern(r"def \NAME(\(A*\)):", language="python")
         >>> cp.might_match("x = 1")          # cheap, parse-free pre-check
         False
         >>> [m.captures["NAME"][0].text for m in cp.match_source("def f(): pass")]
@@ -112,7 +112,7 @@ class CodeAst:
 
     Examples:
         >>> ast = CodeAst("def f(a, b): return a + b", language="python")
-        >>> [m.captures["NAME"] for m in ast.matches(r"def \NAME(\(ARGS*)):")]
+        >>> [m.captures["NAME"] for m in ast.matches(r"def \NAME(\(ARGS*\)):")]
         ['f']
         >>> chunks = ast.split(chunk_size=1000)
     """

--- a/python/tests/ops/test_code.py
+++ b/python/tests/ops/test_code.py
@@ -30,7 +30,7 @@ def test_codeast_properties() -> None:
 
 def test_matches_returns_dataclasses_with_captures() -> None:
     ast = CodeAst(_PY_SRC, language="python")
-    matches = ast.matches(r"def \NAME(\(ARGS*)):")
+    matches = ast.matches(r"def \NAME(\(ARGS*\)):")
     assert all(isinstance(m, CodeMatch) for m in matches)
     by_name = {_cap(m, "NAME"): m for m in matches}
     assert set(by_name) == {"foo", "bar"}
@@ -50,7 +50,7 @@ def test_matches_returns_dataclasses_with_captures() -> None:
 def test_one_parse_many_patterns() -> None:
     """A single CodeAst can be matched against multiple patterns (reused parse)."""
     ast = CodeAst(_PY_SRC, language="python")
-    assert {_cap(m, "NAME") for m in ast.matches(r"def \NAME(\(ARGS*)):")} == {
+    assert {_cap(m, "NAME") for m in ast.matches(r"def \NAME(\(ARGS*\)):")} == {
         "foo",
         "bar",
     }
@@ -68,7 +68,7 @@ def test_split_returns_chunks() -> None:
 
 
 def test_match_code_one_shot() -> None:
-    matches = match_code(r"def \NAME(\(ARGS*)):", _PY_SRC, "python")
+    matches = match_code(r"def \NAME(\(ARGS*\)):", _PY_SRC, "python")
     assert {_cap(m, "NAME") for m in matches} == {"foo", "bar"}
 
 
@@ -94,16 +94,16 @@ def test_matching_unsupported_language_raises() -> None:
 def test_malformed_pattern_raises() -> None:
     ast = CodeAst(_PY_SRC, language="python")
     with pytest.raises(ValueError):
-        ast.matches(r"\(:/[/)")  # unterminated regex matcher
+        ast.matches(r"\(/[/\)")  # invalid regex matcher (unterminated char class)
 
 
 def test_code_pattern_reused_across_asts() -> None:
     # Compile once, match against many ASTs — same results as passing the string.
-    cp = CodePattern(r"def \NAME(\(ARGS*)):", language="python")
+    cp = CodePattern(r"def \NAME(\(ARGS*\)):", language="python")
     assert cp.language == "python"
     ast = CodeAst(_PY_SRC, language="python")
     via_obj = {_cap(m, "NAME") for m in ast.matches(cp)}
-    via_str = {_cap(m, "NAME") for m in ast.matches(r"def \NAME(\(ARGS*)):")}
+    via_str = {_cap(m, "NAME") for m in ast.matches(r"def \NAME(\(ARGS*\)):")}
     assert via_obj == via_str == {"foo", "bar"}
 
 
@@ -126,7 +126,7 @@ def test_code_pattern_language_mismatch_raises() -> None:
 
 
 def test_code_pattern_match_file(tmp_path: Path) -> None:
-    cp = CodePattern(r"def \NAME(\(A*)):", language="python")
+    cp = CodePattern(r"def \NAME(\(A*\)):", language="python")
 
     hit = tmp_path / "hit.py"
     # newline="" so the bytes round-trip verbatim (no `\n`→`\r\n` on Windows).

--- a/rust/code_match/README.md
+++ b/rust/code_match/README.md
@@ -2,7 +2,7 @@
 
 Match **by-example code patterns** against **tree-sitter ASTs**, with metavariables.
 
-The bet: parse the *source* with a full tree-sitter grammar, but keep the *pattern* a flat token + metavar skeleton, and match it against the AST with metavariables snapping to node boundaries. This gives Comby-style pattern ergonomics (fragments like `else { \(*) }` need not parse as a node) together with tree-sitter's correctness — balanced/context-sensitive nesting (`>>`, `<>`), AST-resolved precedence, and matches that are integral subtrees.
+The bet: parse the *source* with a full tree-sitter grammar, but keep the *pattern* a flat token + metavar skeleton, and match it against the AST with metavariables snapping to node boundaries. This gives Comby-style pattern ergonomics (fragments like `else { \(*\) }` need not parse as a node) together with tree-sitter's correctness — balanced/context-sensitive nesting (`>>`, `<>`), AST-resolved precedence, and matches that are integral subtrees.
 
 ## Example
 
@@ -10,7 +10,7 @@ The bet: parse the *source* with a full tree-sitter grammar, but keep the *patte
 use cocoindex_code_match::{lang, Pattern};
 
 let cfg = lang::typescript();
-let pat = Pattern::compile(r"console.log(\(ARGS*))", &cfg).unwrap();
+let pat = Pattern::compile(r"console.log(\(ARGS*\))", &cfg).unwrap();
 
 let src = r#"console.log("hi", x);"#;
 for m in pat.matches(src) {
@@ -23,10 +23,12 @@ for m in pat.matches(src) {
 
 The sigil is `\` by default (shell-safe; configurable to `$` via `LangConfig::with_meta_char('$')`). Names are `[A-Za-z0-9_]+` (uppercase by convention; lowercase/digits allowed).
 
+Metavar delimiters are **symmetric** — a metavar is `\( … \)` (the `\` marks both ends).
+
 - `\NAME` — one node (named); `\_` — one node, anonymous.
-- `\(NAME*)` — a run of **same-level** sibling nodes (many); `\*` — anonymous. A cross-level skip is written as multiple `\*`, one per grammar level.
-- `\(NAME?)` — optional (zero or one node); `\?` — anonymous.
-- `\(NAME:/regex/)` — the captured source text must match the regex (unanchored; `^…$` for whole-node). The name is optional: `\(:/regex/)` constrains a node without capturing it.
+- `\(NAME*\)` — a run of **same-level** sibling nodes (many); `\*` — anonymous. A cross-level skip is written as multiple `\*`, one per grammar level.
+- `\(NAME?\)` — optional (zero or one node); `\?` — anonymous.
+- `\(NAME:/regex/\)` — the captured source text must match the regex, **anchored to the whole node** (`/set_/` is exactly `set_`; add `.*` for prefix/suffix/substring). Anonymous: `\(/regex/\)` or the short form `\/regex/`.
 - A repeated name must capture equal text: `\X == \X` matches `a == a`, not `a == b`.
 
 Use raw strings (`r"..."`) when writing patterns in Rust so the backslashes stay literal.
@@ -43,4 +45,4 @@ For data/markup, match over content with a metavar (`<p>\X</p>`, `{"key": \V}`) 
 
 ## Status
 
-Matching + captures (same-level runs, leading/trailing tolerance, regex matchers); no rewriting yet. Planned: descendant containment (`\{{ … \}}`), node-kind matchers, rewriting, a rule DSL, prefiltering/indexing.
+Matching + captures (same-level runs, leading/trailing tolerance, regex matchers, descendant containment `\{{ … \}}`, prefiltering/indexing); no rewriting yet. Planned: sub-patterns with alternation/quantifiers (`\{ … \}`, `|`, `*`/`+`/`?` on terms), node-kind matchers, rewriting, a rule DSL.

--- a/rust/code_match/src/lang/c.rs
+++ b/rust/code_match/src/lang/c.rs
@@ -24,14 +24,14 @@ mod tests {
     #[test]
     fn call_multi_args() {
         let src = "void g(){ foo(a, b); }";
-        let ms = matches(c(), r"foo(\(ARGS*))", src);
+        let ms = matches(c(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 
     #[test]
     fn balanced_nested() {
         let src = "void g(){ foo(bar(x), baz); }";
-        let ms = matches(c(), r"foo(\(ARGS*))", src);
+        let ms = matches(c(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("bar(x), baz"));
     }
 

--- a/rust/code_match/src/lang/cmake.rs
+++ b/rust/code_match/src/lang/cmake.rs
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn command() {
         // CMake command arguments are space-separated.
-        let ms = matches(cmake(), r"set(\(A*))", "set(x 1)");
+        let ms = matches(cmake(), r"set(\(A*\))", "set(x 1)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("x 1"));
     }
 

--- a/rust/code_match/src/lang/csharp.rs
+++ b/rust/code_match/src/lang/csharp.rs
@@ -23,7 +23,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "class C { void M() { foo(a, b); } }";
-        let ms = matches(csharp(), r"foo(\(ARGS*))", src);
+        let ms = matches(csharp(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/go.rs
+++ b/rust/code_match/src/lang/go.rs
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "package main\nfunc m() { foo(a, b) }";
-        let ms = matches(go(), r"foo(\(ARGS*))", src);
+        let ms = matches(go(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/java.rs
+++ b/rust/code_match/src/lang/java.rs
@@ -21,7 +21,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "class C { void m() { foo(a, b); } }";
-        let ms = matches(java(), r"foo(\(ARGS*))", src);
+        let ms = matches(java(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/javascript.rs
+++ b/rust/code_match/src/lang/javascript.rs
@@ -21,7 +21,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "foo(a, b);";
-        let ms = matches(javascript(), r"foo(\(ARGS*))", src);
+        let ms = matches(javascript(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/julia.rs
+++ b/rust/code_match/src/lang/julia.rs
@@ -38,7 +38,7 @@ mod tests {
 
     #[test]
     fn call() {
-        let ms = matches(julia(), r"foo(\(A*))", "foo(a, b)");
+        let ms = matches(julia(), r"foo(\(A*\))", "foo(a, b)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/kotlin.rs
+++ b/rust/code_match/src/lang/kotlin.rs
@@ -19,7 +19,7 @@ mod tests {
 
     #[test]
     fn call() {
-        let ms = matches(kotlin(), r"foo(\(A*))", "fun m() { foo(a, b) }");
+        let ms = matches(kotlin(), r"foo(\(A*\))", "fun m() { foo(a, b) }");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/pascal.rs
+++ b/rust/code_match/src/lang/pascal.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn call() {
-        let ms = matches(pascal(), r"foo(\(A*))", "begin foo(a, b); end.");
+        let ms = matches(pascal(), r"foo(\(A*\))", "begin foo(a, b); end.");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/php.rs
+++ b/rust/code_match/src/lang/php.rs
@@ -21,7 +21,7 @@ mod tests {
     #[test]
     fn call_captures_dollar_vars() {
         let src = "<?php foo($a, $b); ?>";
-        let ms = matches(php(), r"foo(\(ARGS*))", src);
+        let ms = matches(php(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("$a, $b"));
     }
 

--- a/rust/code_match/src/lang/python.rs
+++ b/rust/code_match/src/lang/python.rs
@@ -32,21 +32,21 @@ mod tests {
     #[test]
     fn call_multi_args() {
         let src = "foo(a, b, c)";
-        let ms = matches(python(), r"foo(\(ARGS*))", src);
+        let ms = matches(python(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b, c"));
     }
 
     #[test]
     fn string_atomic() {
         let src = r#"print("a)b")"#;
-        let ms = matches(python(), r"print(\(ARGS*))", src);
+        let ms = matches(python(), r"print(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a)b""#));
     }
 
     #[test]
     fn keyword_args() {
         let src = "f(x=1, y=2)";
-        let ms = matches(python(), r"f(\(KW*))", src);
+        let ms = matches(python(), r"f(\(KW*\))", src);
         assert_eq!(cap(&ms, "KW").as_deref(), Some("x=1, y=2"));
     }
 

--- a/rust/code_match/src/lang/r.rs
+++ b/rust/code_match/src/lang/r.rs
@@ -33,7 +33,7 @@ mod tests {
 
     #[test]
     fn call() {
-        let ms = matches(r(), r"foo(\(A*))", "foo(a, b)");
+        let ms = matches(r(), r"foo(\(A*\))", "foo(a, b)");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/ruby.rs
+++ b/rust/code_match/src/lang/ruby.rs
@@ -21,7 +21,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "foo(a, b)";
-        let ms = matches(ruby(), r"foo(\(ARGS*))", src);
+        let ms = matches(ruby(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/rust.rs
+++ b/rust/code_match/src/lang/rust.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn call_multi_args() {
         let src = "fn m(){ foo(a, b); }";
-        let ms = matches(rust(), r"foo(\(ARGS*))", src);
+        let ms = matches(rust(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/scala.rs
+++ b/rust/code_match/src/lang/scala.rs
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "object O { def m = foo(a, b) }";
-        let ms = matches(scala(), r"foo(\(ARGS*))", src);
+        let ms = matches(scala(), r"foo(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/solidity.rs
+++ b/rust/code_match/src/lang/solidity.rs
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn call() {
         let src = "contract C { function f() public { foo(a, b); } }";
-        let ms = matches(solidity(), r"foo(\(A*))", src);
+        let ms = matches(solidity(), r"foo(\(A*\))", src);
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/swift.rs
+++ b/rust/code_match/src/lang/swift.rs
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn call() {
-        let ms = matches(swift(), r"foo(\(A*))", "func m() { foo(a, b) }");
+        let ms = matches(swift(), r"foo(\(A*\))", "func m() { foo(a, b) }");
         assert_eq!(cap(&ms, "A").as_deref(), Some("a, b"));
     }
 

--- a/rust/code_match/src/lang/typescript.rs
+++ b/rust/code_match/src/lang/typescript.rs
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn call_multi_args() {
         let src = r#"console.log("a", b);"#;
-        let ms = matches(typescript(), r"console.log(\(ARGS*))", src);
+        let ms = matches(typescript(), r"console.log(\(ARGS*\))", src);
         assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a", b"#));
     }
 

--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -3,17 +3,18 @@
 //! Metavariables are first-class tokens. Everything else is lexed with a small
 //! hand engine + the per-language op-token table.
 //!
-//! Metavar syntax (sigil `S` is configurable, default `\`):
-//!   `S NAME`        single, named (sugar for `S(NAME)`)
-//!   `S(NAME)`       single, named
-//!   `S(NAME*)`      many   (zero or more **same-level** sibling nodes)
-//!   `S(NAME?)`      optional (zero or one node)
-//!   `S_` / `S(_)`   anonymous single        `S*` / `S(*)`  anonymous many
-//!   `S?` / `S(?)`   anonymous optional
-//!   `S(NAME:/re/)`  single, regex-constrained — see below
-//!   `S(:/re/)`      regex-constrained, **anonymous** (filter without capturing)
-//!   `S{{ INNER S}}` containment: INNER must match some descendant within a
-//!                   same-level region here (DESIGN §12). Paired; may nest.
+//! Metavar syntax (sigil `S` is configurable, default `\`; delimiters are
+//! **symmetric** — a metavar is `S( … S)`, see DESIGN §0). Currently implemented:
+//!   `S NAME`        single, named (sugar for `S(NAME S)`)
+//!   `S(NAME S)`     single, named
+//!   `S(NAME* S)`    many   (zero or more **same-level** sibling nodes)
+//!   `S(NAME? S)`    optional (zero or one node)
+//!   `S_` / `S(_ S)` anonymous single        `S*` / `S(* S)`  anonymous many
+//!   `S?` / `S(? S)` anonymous optional
+//!   `S(NAME:/re/ S)` single, regex-constrained — see below
+//!   `S(/re/ S)` / `S/re/`  regex-constrained, **anonymous** (filter, don't capture)
+//!   `S{{ INNER S}}` containment: INNER must match some descendant of one node
+//!                   here (DESIGN §12). Paired; may nest.
 //!   `SS`            a doubled sigil is one **literal** sigil (e.g. `\\` → `\`)
 //! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
 //! written as multiple `*`, one per grammar level.
@@ -21,18 +22,17 @@
 //! readability convention, not a rule. With the `\` sigil, lowercase `\foo` only
 //! collides with bare-`\` escapes (Bash `\n`) / Haskell lambdas.
 //!
-//! Regex matcher `:/re/` constrains a **single-node** metavar: the captured
-//! source text must match the regex **anchored to the whole node** (compiled as
-//! `^(?:re)$`). So `:/set_/` means "text is exactly `set_`", `:/set_.*/` means
+//! Regex matcher `/re/` constrains a **single-node** metavar: the captured source
+//! text must match the regex **anchored to the whole node** (compiled as
+//! `^(?:re)$`). So `/set_/` means "text is exactly `set_`", `/set_.*/` means
 //! "starts with `set_`"; add `.*` explicitly for prefix/suffix/substring. (This is
 //! less surprising than unanchored `is_match`, where a bare `set_.*` would match
-//! inside `unset_…`.) The name is optional — `S(:/re/)` constrains without capturing.
-//! Applies to `One`/`Optional`; ignored on `Many` (sibling runs, out of scope).
-//! The closing `/` is optional (`:/re`): a `/` at the matcher's top paren level
-//! closes (delimited), else the matcher's `)` closes (shorthand). Balanced `()`
-//! inside the regex (alternations) need no escaping; escape a literal `/` or an
-//! unbalanced `)` as `\/` / `\)`. An unparseable (or unterminated) regex is a
-//! `client` error from `lex` / `Pattern::compile`.
+//! inside `unset_…`.) Named is `S(NAME:/re/ S)` (the `:` only follows a NAME);
+//! anonymous is `S(/re/ S)` or the short form `S/re/`. Applies to `One`/`Optional`;
+//! ignored on `Many` (sibling runs, out of scope). The regex is **delimited** —
+//! it closes at the first unescaped `/`; *balanced* `()` inside (alternations) need
+//! no escaping, escape a literal `/` as `\/`. An unparseable (or unterminated)
+//! regex is a `client` error from `lex` / `Pattern::compile`.
 
 use crate::config::{LangConfig, TokKind};
 use cocoindex_utils::error::{Error, Result};
@@ -42,9 +42,9 @@ use regex::Regex;
 pub enum Cardinality {
     /// `\X` — exactly one node
     One,
-    /// `\(X*)` — zero or more sibling nodes
+    /// `\(X*\)` — zero or more sibling nodes
     Many,
-    /// `\(X?)` — zero or one node
+    /// `\(X?\)` — zero or one node
     Optional,
 }
 
@@ -81,13 +81,13 @@ pub enum PatternItem {
         card: Cardinality,
         regex: Option<Regex>,
     },
-    /// `\{{` — opens a containment group `\{{ INNER \}}` (DESIGN §12). `close` is
+    /// `\{{` — opens a containment `\{{ INNER \}}` (DESIGN §12). `close` is
     /// the index of the matching `ContainsClose` in the flat items vec
     /// (back-patched by `lex`); `INNER` is `items[self_index+1 .. close]`. Kept
     /// flat (not a nested `Vec`) so the DP runs in one `pi` space with one memo,
     /// and nesting falls out of the back-patched indices.
     ContainsOpen { close: usize },
-    /// `\}}` — closes the containment group opened by the matching `ContainsOpen`.
+    /// `\}}` — closes the containment opened by the matching `ContainsOpen`.
     ContainsClose,
 }
 
@@ -139,7 +139,7 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
                 i = after + 2;
                 continue;
             }
-            if let Some((item, next)) = lex_metavar(pattern, bytes, after)? {
+            if let Some((item, next)) = lex_metavar(pattern, bytes, after, cfg.meta_char)? {
                 out.push(item);
                 i = next;
                 continue;
@@ -241,14 +241,24 @@ fn resolve_contains(items: &mut [PatternItem]) -> Result<()> {
 /// matcher (e.g. a bad regex). The metavar syntax is ASCII, so byte reads from
 /// `s` are safe even if a non-ASCII char follows the sigil (ASCII checks just
 /// fail → `Ok(None)`).
-fn lex_metavar(pattern: &str, bytes: &[u8], s: usize) -> Result<Option<(PatternItem, usize)>> {
+fn lex_metavar(
+    pattern: &str,
+    bytes: &[u8],
+    s: usize,
+    meta_char: char,
+) -> Result<Option<(PatternItem, usize)>> {
     Ok(match bytes.get(s).copied() {
-        // qualified form: S( ... )
-        Some(b'(') => return lex_qualified(pattern, bytes, s + 1),
-        // anonymous shorthands: S*  S?
+        // qualified form: \( ... \)
+        Some(b'(') => return lex_qualified(pattern, bytes, s + 1, meta_char),
+        // anonymous short forms: \*  \?
         Some(b'*') => Some((meta(None, Cardinality::Many, None), s + 1)),
         Some(b'?') => Some((meta(None, Cardinality::Optional, None), s + 1)),
-        // sugar: S NAME  /  S_  (single). Names may start with any alnum/`_`
+        // anonymous regex short form: \/re/  (≡ \(/re/\))
+        Some(b'/') => {
+            let (re, next) = lex_regex(pattern, bytes, s)?;
+            Some((meta(None, Cardinality::One, Some(re)), next))
+        }
+        // sugar: \NAME / \_  (single). Names may start with any alnum/`_`
         // (lowercase + digit allowed; the `\` sigil makes collisions rare).
         Some(c) if c.is_ascii_alphanumeric() || c == b'_' => {
             let (name, end) = read_name(pattern, bytes, s);
@@ -258,10 +268,17 @@ fn lex_metavar(pattern: &str, bytes: &[u8], s: usize) -> Result<Option<(PatternI
     })
 }
 
-/// Parse the inside of `S( ... )` given `j` pointing just after `(`:
-/// `NAME [*|?] [ : /regex/ ] )`. A `:` commits to a regex matcher (a bad regex
-/// is an `Err`); a missing closing `)` is lenient (`Ok(None)` → literal sigil).
-fn lex_qualified(pattern: &str, bytes: &[u8], j: usize) -> Result<Option<(PatternItem, usize)>> {
+/// Parse the inside of a metavar `\( ... \)` given `j` pointing just after `\(`.
+/// Forms (existing functionality): `NAME [*|?] \)`, named regex `NAME : /re/ \)`,
+/// anonymous regex `/re/ \)` (no colon — `:` separates a NAME from its body). The
+/// close is the **sigil + `)`** (`\)`); a bad regex is an `Err`, a missing/garbled
+/// close is lenient (`Ok(None)` → treat the sigil as literal).
+fn lex_qualified(
+    pattern: &str,
+    bytes: &[u8],
+    j: usize,
+    meta_char: char,
+) -> Result<Option<(PatternItem, usize)>> {
     let (name, mut k) = read_name(pattern, bytes, j);
     let card = match bytes.get(k).copied() {
         Some(b'*') => {
@@ -274,73 +291,65 @@ fn lex_qualified(pattern: &str, bytes: &[u8], j: usize) -> Result<Option<(Patter
         }
         _ => Cardinality::One,
     };
-    // optional `: /regex/` matcher
     k = skip_spaces(bytes, k);
-    let regex = if bytes.get(k) == Some(&b':') {
-        let (re, nk) = lex_regex(pattern, bytes, skip_spaces(bytes, k + 1))?;
-        k = nk;
-        Some(re)
-    } else {
-        None
+    // regex matcher: named `NAME:/re/` (a `:` only ever follows a NAME) or
+    // anonymous `/re/` (regex directly, no colon).
+    let regex = match bytes.get(k) {
+        Some(&b':') if !name.is_empty() => {
+            let (re, nk) = lex_regex(pattern, bytes, skip_spaces(bytes, k + 1))?;
+            k = nk;
+            Some(re)
+        }
+        Some(&b'/') if name.is_empty() => {
+            let (re, nk) = lex_regex(pattern, bytes, k)?;
+            k = nk;
+            Some(re)
+        }
+        _ => None,
     };
     k = skip_spaces(bytes, k);
-    if bytes.get(k) != Some(&b')') {
-        return Ok(None); // unterminated / malformed `S(` — treat the sigil as literal
+    // close: the sigil followed by `)` (`\)`). Sigil-agnostic + UTF-8-safe.
+    if !pattern[k..].starts_with(meta_char) || bytes.get(k + meta_char.len_utf8()) != Some(&b')') {
+        return Ok(None); // unterminated / malformed `\(` — treat the sigil as literal
     }
-    Ok(Some((meta(name_binding(name), card, regex), k + 1)))
+    let end = k + meta_char.len_utf8() + 1;
+    Ok(Some((meta(name_binding(name), card, regex), end)))
 }
 
-/// Parse `/regex/` (or shorthand `/regex`) starting at `k` (which must point at
-/// the opening `/`). Returns `(compiled_regex, index_past_the_regex)`. A missing
-/// `/`, an unterminated regex, or one that fails to compile is a `client` error.
-///
-/// Delimiting uses **paren depth** (the matcher's `\(` is depth 1): a `/` at
-/// depth 1 closes (delimited form); a `)` that drops depth to 0 closes (shorthand
-/// form). So *balanced* `()` inside the regex — alternations like `(foo|bar)` —
-/// are free, no escaping. Escape a literal `/` (or an unbalanced `)`) as `\/` /
-/// `\)`; the `regex` crate accepts `\<punct>` as the literal, so the slice is
-/// passed through verbatim. Scanning for these ASCII bytes is UTF-8-safe (they
-/// never occur mid multi-byte char).
+/// Parse a **delimited** `/regex/` starting at `k` (which must point at the
+/// opening `/`). Returns `(compiled_regex, index_past_the_closing_/)`. The regex
+/// closes at the first **unescaped** `/`; a literal `/` inside is escaped `\/`
+/// (the `regex` crate accepts `\<punct>` as the literal, so the slice is passed
+/// through verbatim, and *balanced* `()` need no escaping). A missing `/`, an
+/// unterminated regex, or one that fails to compile is a `client` error.
+/// Scanning for these ASCII bytes is UTF-8-safe (they never occur mid char).
 fn lex_regex(pattern: &str, bytes: &[u8], k: usize) -> Result<(Regex, usize)> {
     if bytes.get(k) != Some(&b'/') {
         return Err(Error::client(
-            "metavar matcher must be a regex: expected `/` after `:`",
+            "metavar matcher must be a regex: expected `/`",
         ));
     }
     let start = k + 1;
     let mut p = start;
-    let mut depth = 1usize; // the matcher's `\(` is open
-    let (close, delimited) = loop {
+    let close = loop {
         match bytes.get(p) {
             None => return Err(Error::client("unterminated regex in metavar matcher")),
-            Some(b'\\') => p += 2, // skip the escaped char (\/ \) \( …)
-            Some(b'(') => {
-                depth += 1;
-                p += 1;
-            }
-            Some(b')') => {
-                depth -= 1;
-                if depth == 0 {
-                    break (p, false); // matcher close → shorthand
-                }
-                p += 1;
-            }
-            Some(b'/') if depth == 1 => break (p, true), // top-level `/` → delimited
+            Some(b'\\') => p += 2, // skip the escaped char (\/ \( \) …)
+            Some(b'/') => break p, // delimiter close
             Some(_) => p += 1,
         }
     };
-    // `start`/`close` land on ASCII (`/`, `)`) → char boundaries; safe slice.
+    // `start`/`close` land on ASCII (`/`) → char boundaries; safe slice.
     let raw = &pattern[start..close];
-    // Anchor the matcher to the **whole** node text: `\(:/set_/)` means "text is
-    // exactly `set_`", `\(:/set_.*/)` means "starts with `set_`". Users add `.*`
+    // Anchor the matcher to the **whole** node text: `\(/set_/\)` means "text is
+    // exactly `set_`", `\(/set_.*/\)` means "starts with `set_`". Users add `.*`
     // explicitly for prefix/suffix/substring — far less surprising than unanchored
     // `is_match`, where a bare `set_.*` would match inside `unset_…`. Wrapping in a
     // non-capturing group keeps the user's alternations/anchors valid (a redundant
     // `^…$` they wrote still compiles).
     let regex = Regex::new(&format!("^(?:{raw})$"))
         .map_err(|e| Error::client(format!("invalid regex `/{raw}/`: {e}")))?;
-    let next = if delimited { close + 1 } else { close };
-    Ok((regex, next))
+    Ok((regex, close + 1))
 }
 
 fn skip_spaces(bytes: &[u8], mut k: usize) -> usize {

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -119,7 +119,7 @@ pub struct Pattern {
     cfg: LangConfig,
     /// Whether the `(pi, li)` fail-memo is sound. It isn't when forward-threaded
     /// bindings can change whether a `(pi, li)` matches: a repeated metavar name,
-    /// or a containment group (`\{{ \}}`), whose INNER binds names per descendant.
+    /// or a containment (`\{{ \}}`), whose INNER binds names per descendant.
     use_memo: bool,
 }
 
@@ -443,7 +443,7 @@ struct Ctx<'a, 's> {
 impl<'s> Ctx<'_, 's> {
     /// Match `items[pi..end]` against leaves `[li, hi)`. On success, `bound` holds
     /// the captures. `end` is the exclusive item bound: `items.len()` at the top
-    /// level, or a containment group's `close` index for an INNER sub-match — so
+    /// level, or a containment's `close` index for an INNER sub-match — so
     /// the same `dp` engine matches a bracketed sub-pattern without it running
     /// past its `\}}`. (`end` is a structural function of `pi` — each item sits in
     /// exactly one bracket level — so the `(pi, li)` fail-memo stays well-keyed.)
@@ -554,7 +554,7 @@ impl<'s> Ctx<'_, 's> {
         false
     }
 
-    /// `\(X*)` — match a run of sibling subtrees, restricted to a contiguous run
+    /// `\(X*\)` — match a run of sibling subtrees, restricted to a contiguous run
     /// of *one parent's* direct children (same-level), so a `*` run can't
     /// silently leak out of the subtree the pattern entered. A cross-level skip
     /// is written as multiple `*`, one per grammar level.
@@ -627,7 +627,7 @@ impl<'s> Ctx<'_, 's> {
     /// For a fixed region `[reg_lo, reg_hi)`: try to match `INNER` (`items[inner..
     /// inner_end]`) against some descendant inside it, and on a hit continue the
     /// outer match (`items[cont..cont_end]`) from `reg_hi`. INNER bindings thread
-    /// forward (visible after the group); a `bound` snapshot/restore around each
+    /// forward (visible after the containment); a `bound` snapshot/restore around each
     /// attempt undoes them when that attempt doesn't pan out.
     #[allow(clippy::too_many_arguments)]
     fn contains_then_continue(
@@ -649,7 +649,7 @@ impl<'s> Ctx<'_, 's> {
             if cand.start_leaf < reg_lo || cand.end_leaf >= reg_hi {
                 continue;
             }
-            // Snapshot is the *pre-group* bindings (captures inside INNER haven't
+            // Snapshot is the *pre-containment* bindings (captures inside INNER haven't
             // happened yet) — usually empty or tiny, so the clone is cheap.
             let snapshot = self.bound.clone();
             if self.dp(inner, inner_end, cand.start_leaf, cand.end_leaf + 1)
@@ -669,7 +669,7 @@ impl<'s> Ctx<'_, 's> {
         false
     }
 
-    /// `\(X?)` — match zero or one node. Greedy: try one node first, then none
+    /// `\(X?\)` — match zero or one node. Greedy: try one node first, then none
     /// (binding an empty capture at `li`). A regex constrains the node *when
     /// present*; absence is always allowed (the `?` keeps its meaning).
     fn match_optional(
@@ -818,7 +818,7 @@ mod tests {
         parser.set_language(&cfg.language).unwrap();
         let tree = parser.parse(src, None).unwrap();
 
-        let p1 = Pattern::compile(r"def \NAME(\(A*)):", &cfg).unwrap();
+        let p1 = Pattern::compile(r"def \NAME(\(A*\)):", &cfg).unwrap();
         let m1 = p1.matches_in_tree(&tree, src);
         assert_eq!(m1.iter().find_map(|m| m.capture_text("NAME")), Some("foo"));
 

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -10,7 +10,7 @@
 //!
 //! Terms come from three places in a pattern: identifiers (whole-word), string
 //! literal content (whole-word over each alphanumeric run), and the required
-//! literals of a regex matcher `\(:/re/)` (substring, via `regex-syntax`).
+//! literals of a regex matcher `\(/re/\)` (substring, via `regex-syntax`).
 //! Keywords, punctuation, numbers, and bare metavars contribute nothing.
 
 use std::collections::{HashMap, HashSet};
@@ -41,7 +41,7 @@ pub struct FilterTerm {
 }
 
 /// One CNF clause: satisfied if **any** of its terms occurs. More than one term
-/// only arises from a regex alternation (`\(:/get|set/)`); a plain identifier or
+/// only arises from a regex alternation (`\(/get|set/\)`); a plain identifier or
 /// string run is a singleton.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilterClause {
@@ -97,7 +97,7 @@ impl Prefilter {
                 }
                 // A regex literal is required only on a `One` metavar: an `Optional`
                 // node may be absent (so its regex isn't required — extracting it
-                // would be a false negative, e.g. `f(\(A?:/^x/))` matching `f()`),
+                // would be a false negative, e.g. `f(\(A?:/^x/\))` matching `f()`),
                 // and `Many` ignores the regex entirely.
                 PatternItem::Meta {
                     regex: Some(re),

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -13,7 +13,7 @@ use cocoindex_code_match::{Pattern, lang};
 fn string_is_atomic() {
     // The `)` inside the string literal must be invisible — strings are one node.
     let src = r#"foo("a)b");"#;
-    let ms = matches(lang::typescript(), r"foo(\(ARGS*))", src);
+    let ms = matches(lang::typescript(), r"foo(\(ARGS*\))", src);
     assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""a)b""#));
 }
 
@@ -118,7 +118,7 @@ fn partial_match_dedup() {
 fn multiple_gaps_dp() {
     // Two `\(*)` gaps around an anchor — exercises the wildcard DP / backtracking.
     let src = "function f() { a(); foo(); b(); }";
-    let ms = matches(lang::typescript(), r"{ \(A*) foo(); \(B*) }", src);
+    let ms = matches(lang::typescript(), r"{ \(A*\) foo(); \(B*\) }", src);
     let m = ms
         .iter()
         .find(|m| m.kind == "statement_block")
@@ -130,9 +130,9 @@ fn multiple_gaps_dp() {
 #[test]
 fn optional_metavar() {
     // `\(ARG?)` matches calls with zero or one argument.
-    let ms = matches(lang::typescript(), r"f(\(ARG?))", "f(x);");
+    let ms = matches(lang::typescript(), r"f(\(ARG?\))", "f(x);");
     assert_eq!(cap(&ms, "ARG").as_deref(), Some("x"));
-    let ms = matches(lang::typescript(), r"f(\(ARG?))", "f();");
+    let ms = matches(lang::typescript(), r"f(\(ARG?\))", "f();");
     assert!(has_kind(&ms, "call_expression"), "no-arg call should match");
 }
 
@@ -198,16 +198,34 @@ fn regex_constrains_identifier() {
     // Matchers are whole-node anchored, so `get.*` filters callees *starting* with
     // `get` (the trailing `.*` is the explicit "prefix").
     let src = "getUser(1); setName(2); getId(3);";
-    let ms = matches(lang::typescript(), r"\(F:/get.*/)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(F:/get.*/\)(\*)", src);
     assert_eq!(caps_all(&ms, "F"), vec!["getId", "getUser"]);
 }
 
 #[test]
 fn anonymous_regex_matcher() {
-    // `\(:/re/)` — a regex constraint with no name: filter a node without
+    // `\(/re/\)` — a regex constraint with no name: filter a node without
     // capturing it. Here the callee must start with `get` (`get.*`), but isn't bound.
     let src = "getUser(1); setName(2); getId(3);";
-    let ms = matches(lang::typescript(), r"\(:/get.*/)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(/get.*/\)(\*)", src);
+    let callees: Vec<&str> = ms
+        .iter()
+        .filter(|m| m.kind == "call_expression")
+        .map(|m| m.text)
+        .collect();
+    assert!(callees.contains(&"getUser(1)") && callees.contains(&"getId(3)"));
+    assert!(
+        !callees.iter().any(|t| t.contains("setName")),
+        "the `^get` constraint must exclude setName, got {callees:?}",
+    );
+}
+
+#[test]
+fn anonymous_regex_short_form() {
+    // `\/re/` is the short form of `\(/re/\)` — an anonymous regex-constrained node
+    // (filter, don't capture). Mirrors `anonymous_regex_matcher`.
+    let src = "getUser(1); setName(2); getId(3);";
+    let ms = matches(lang::typescript(), r"\/get.*/(\*)", src);
     let callees: Vec<&str> = ms
         .iter()
         .filter(|m| m.kind == "call_expression")
@@ -225,7 +243,7 @@ fn regex_pins_nesting_level() {
     // Larger spans (`foo.bar`, `foo.bar(x)`) all start at `foo`; `^foo$` filters
     // the candidates down to the leaf. Exercises "every sub-layer is a candidate".
     let src = "foo.bar(x);";
-    let ms = matches(lang::typescript(), r"\(OBJ:/^foo$/).bar(\*)", src);
+    let ms = matches(lang::typescript(), r"\(OBJ:/^foo$/\).bar(\*)", src);
     assert_eq!(cap(&ms, "OBJ").as_deref(), Some("foo"));
 }
 
@@ -233,32 +251,34 @@ fn regex_pins_nesting_level() {
 fn regex_on_subtree() {
     // The metavar binds a whole expression; the regex tests its source text.
     // Anchored, so `.*\+.*` is the explicit "contains `+`".
-    let yes = matches(lang::typescript(), r"f(\(A:/.*\+.*/))", "f(a + b);");
+    let yes = matches(lang::typescript(), r"f(\(A:/.*\+.*/\))", "f(a + b);");
     assert_eq!(cap(&yes, "A").as_deref(), Some("a + b"));
-    let no = matches(lang::typescript(), r"f(\(A:/.*\+.*/))", "f(ab);");
+    let no = matches(lang::typescript(), r"f(\(A:/.*\+.*/\))", "f(ab);");
     assert!(no.iter().all(|m| m.kind != "call_expression"));
 }
 
 #[test]
 fn regex_alternation_parens_free() {
-    // Balanced `()` inside a delimited regex need no escaping (paren-depth close).
+    // Balanced `()` inside a delimited regex need no escaping (the regex closes at
+    // its delimiting `/`, not at a paren).
     let src = "foo; bar; baz;";
-    let ms = matches(lang::typescript(), r"\(N:/^(foo|bar)$/)", src);
+    let ms = matches(lang::typescript(), r"\(N:/^(foo|bar)$/\)", src);
     assert_eq!(caps_all(&ms, "N"), vec!["bar", "foo"]);
 }
 
 #[test]
-fn regex_shorthand_no_closing_slash() {
-    // Shorthand (no closing `/`): the `)` closes the matcher. Anchored, so `get.*`.
+fn regex_named_then_call_group() {
+    // A named regex metavar `\(F:/get.*/\)` followed by a literal `(\*)` call group:
+    // F captures the callee (anchored, so `get.*`).
     let src = "getUser(1); setName(2);";
-    let ms = matches(lang::typescript(), r"\(F:/get.*)(\*)", src);
+    let ms = matches(lang::typescript(), r"\(F:/get.*/\)(\*)", src);
     assert_eq!(cap(&ms, "F").as_deref(), Some("getUser"));
 }
 
 #[test]
 fn regex_escaped_slash() {
     // `\/` is a literal slash (the `regex` crate accepts `\<punct>`).
-    let ms = matches(lang::typescript(), r"f(\(P:/a\/b/))", "f(a/b); f(ab);");
+    let ms = matches(lang::typescript(), r"f(\(P:/a\/b/\))", "f(a/b); f(ab);");
     assert_eq!(cap(&ms, "P").as_deref(), Some("a/b"));
 }
 
@@ -267,7 +287,7 @@ fn regex_dotstar_equals_bare() {
     // `/.*/ ` is a pure pass-through filter, so it must behave exactly like `\X`.
     let src = "a = b = c;";
     let bare = matches(lang::typescript(), r"\X = \Y", src);
-    let dotstar = matches(lang::typescript(), r"\(X:/.*/) = \Y", src);
+    let dotstar = matches(lang::typescript(), r"\(X:/.*/\) = \Y", src);
     assert_eq!(bare.len(), dotstar.len());
     assert_eq!(caps_all(&bare, "X"), caps_all(&dotstar, "X"));
 }
@@ -277,15 +297,15 @@ fn regex_optional_constrains_when_present() {
     // Present must match the regex; absence is still allowed (the `?` is kept).
     let ts = lang::typescript();
     assert_eq!(
-        cap(&matches(ts.clone(), r"f(\(A?:/^x/))", "f(x);"), "A").as_deref(),
+        cap(&matches(ts.clone(), r"f(\(A?:/^x/\))", "f(x);"), "A").as_deref(),
         Some("x")
     );
     assert!(has_kind(
-        &matches(ts.clone(), r"f(\(A?:/^x/))", "f();"),
+        &matches(ts.clone(), r"f(\(A?:/^x/\))", "f();"),
         "call_expression"
     ));
     assert!(
-        matches(ts, r"f(\(A?:/^x/))", "f(y);")
+        matches(ts, r"f(\(A?:/^x/\))", "f(y);")
             .iter()
             .all(|m| m.kind != "call_expression")
     );
@@ -295,7 +315,7 @@ fn regex_optional_constrains_when_present() {
 fn regex_invalid_errors() {
     // An unparseable regex surfaces as a `client` compile error (not a panic,
     // not a silently-dropped constraint).
-    let res = Pattern::compile(r"\(Z:/[/) = \Y", &lang::typescript());
+    let res = Pattern::compile(r"\(Z:/[/\) = \Y", &lang::typescript());
     assert!(
         matches!(res, Err(cocoindex_code_match::Error::Client { .. })),
         "expected a client error"
@@ -326,7 +346,7 @@ fn metavar_lowercase_name() {
 fn configurable_dollar_sigil() {
     let cfg = lang::typescript().with_meta_char('$');
     let src = "foo(a, b);";
-    let ms = Pattern::compile("foo($(ARGS*))", &cfg)
+    let ms = Pattern::compile("foo($(ARGS*$))", &cfg)
         .unwrap()
         .matches(src);
     assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
@@ -466,7 +486,7 @@ fn cjk_identifier() {
 #[test]
 fn emoji_in_string_and_as_arg() {
     let src = r#"f("😀", 你好)"#;
-    let ms = matches(lang::typescript(), r"f(\(ARGS*))", src);
+    let ms = matches(lang::typescript(), r"f(\(ARGS*\))", src);
     assert_eq!(cap(&ms, "ARGS").as_deref(), Some(r#""😀", 你好"#));
 }
 
@@ -606,7 +626,7 @@ fn fragment_match_reports_the_fragment_span_not_the_whole_node() {
     // The pattern covers the signature but not the body: the reported range is the
     // signature *fragment*, with `kind` still the enclosing function node.
     let src = "def foo(a, b):\n    return a + b\n";
-    let ms = matches(lang::python(), r"def \NAME(\(A*)):", src);
+    let ms = matches(lang::python(), r"def \NAME(\(A*\)):", src);
     let m = by_text(&ms, "def foo(a, b):").expect("fragment span, not whole node");
     assert_eq!(m.kind, "function_definition");
     assert_eq!(m.capture_text("NAME"), Some("foo"));
@@ -617,15 +637,15 @@ fn regex_matcher_is_whole_node_anchored() {
     // Matchers anchor to the whole node text, so a bare `set_.*` is a *prefix*
     // (no false positive on `test_unset_is`, where `set_` is only a substring).
     let src = "def set_value(): pass\ndef test_unset_is(): pass\n";
-    let prefix = matches(lang::python(), r"def \(N:/set_.*/)(\*):", src);
+    let prefix = matches(lang::python(), r"def \(N:/set_.*/\)(\*):", src);
     assert_eq!(caps_all(&prefix, "N"), vec!["set_value"]);
 
     // exact (no `.*`): the text must equal the regex
-    let exact = matches(lang::python(), r"def \(N:/set_value/)(\*):", src);
+    let exact = matches(lang::python(), r"def \(N:/set_value/\)(\*):", src);
     assert_eq!(caps_all(&exact, "N"), vec!["set_value"]);
 
     // substring needs explicit `.*…*.`
-    let substring = matches(lang::python(), r"def \(N:/.*set_.*/)(\*):", src);
+    let substring = matches(lang::python(), r"def \(N:/.*set_.*/\)(\*):", src);
     assert_eq!(
         caps_all(&substring, "N"),
         vec!["set_value", "test_unset_is"]
@@ -741,7 +761,7 @@ fn star_run_does_not_absorb_a_comment_into_its_capture() {
     // A `\*` sibling run skips comment nodes — the captured text is the args only.
     let ms = matches(
         lang::rust(),
-        r"foo(\(ARGS*))",
+        r"foo(\(ARGS*\))",
         "fn m() { foo(a, /* c */ b); }",
     );
     assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, /* c */ b"));

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -46,14 +46,14 @@ fn string_content_runs_required() {
 #[test]
 fn regex_substring_literal() {
     // `.*foobar.*` → required substring `foobar`, NOT word-bounded.
-    let pf = prefilter(r"\(:/.*foobar.*/)", 3);
+    let pf = prefilter(r"\(/.*foobar.*/\)", 3);
     assert!(pf.might_match("name = xfoobary")); // mid-token substring is fine
     assert!(!pf.might_match("name = foo_bar")); // no contiguous `foobar`
 }
 
 #[test]
 fn regex_alternation_is_a_disjunction() {
-    let pf = prefilter(r"\(:/get|set/)", 3);
+    let pf = prefilter(r"\(/get|set/\)", 3);
     assert!(pf.might_match("o.getValue()")); // get
     assert!(pf.might_match("o.setValue()")); // set
     assert!(!pf.might_match("o.value()")); // neither
@@ -141,7 +141,7 @@ fn extracted_terms_match_literally_not_as_regex() {
     // A regex matcher's extracted literal contains a `.` (escaped in the regex).
     // `might_match` uses aho-corasick *literal* search, so the `.` matches only a
     // literal dot — no re-interpretation of the term as a regex.
-    let pf = prefilter(r"\(:/foo\.bar/)", 3);
+    let pf = prefilter(r"\(/foo\.bar/\)", 3);
     assert!(pf.might_match("x = foo.bar")); // literal `foo.bar`
     assert!(!pf.might_match("x = fooXbar")); // `.` is literal, not "any char"
 }
@@ -185,14 +185,14 @@ fn index_terms_in_tree_matches_the_parsing_variant() {
 #[test]
 fn regex_on_optional_metavar_is_not_required() {
     // An optional metavar's regex must NOT become a required term — the node may be
-    // absent, so requiring its literal would falsely reject (e.g. `f(\(A?:/x.*/))`
+    // absent, so requiring its literal would falsely reject (e.g. `f(\(A?:/x.*/\))`
     // matching `f()`). A `One`-cardinality regex *is* still required.
-    let opt = Pattern::compile(r"f(\(A?:/x.*/))", &lang::python())
+    let opt = Pattern::compile(r"f(\(A?:/x.*/\))", &lang::python())
         .unwrap()
         .prefilter(1);
     assert!(opt.might_match("f()"), "optional-absent call must pass");
 
-    let one = Pattern::compile(r"f(\(A:/x.*/))", &lang::python())
+    let one = Pattern::compile(r"f(\(A:/x.*/\))", &lang::python())
         .unwrap()
         .prefilter(1);
     assert!(!one.might_match("f()"), "a One-metavar regex is required");


### PR DESCRIPTION
## Summary
- Migrate `cocoindex_code_match` to the **locked symmetric metavar syntax** (DESIGN §0): a metavar is now `\( … \)` (the `\` marks both ends) under the rule "`\`+bracket = a pattern construct; a bare bracket is literal code". This revises existing functionality to the locked grammar; no new features (sub-patterns / alternation / quantified groups stay reserved).
- **Lexer**: metavar close is `\)` (sigil + `)`, threaded via `meta_char` so it's sigil-agnostic + UTF-8-safe, e.g. a `§` sigil closes with `§)`); anonymous regex drops its colon (`\(/re/\)`, since `:` now only follows a NAME) and gains the short form `\/re/`; regex matchers are **delimited-only** (close at the first unescaped `/` — the old undelimited shorthand collided with `\)` as an escaped paren, so it's removed along with the paren-depth scan).
- **Docs/terminology**: migrated every pattern in the Rust tests, per-language test configs, Python tests, the README, and all doc-comments; unified terminology on **metavar / capture / sub-pattern / grouping / containment** (e.g. "containment group" → "containment").

Behavior is otherwise unchanged (the migration is a re-spelling of existing forms). Added a regression test for the new `\/re/` short form.

## Test plan
- CI. All 170 Rust + 15 Python `test_code` tests and `mypy` (244 files) pass locally.
