### PR TITLE
feat(code_match): support `+` (one-or-more) quantifier and `\+` short form

### DIFF
--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -8,15 +8,16 @@
 //!   `S NAME`        single, named (sugar for `S(NAME S)`)
 //!   `S(NAME S)`     single, named
 //!   `S(NAME* S)`    many   (zero or more **same-level** sibling nodes)
+//!   `S(NAME+ S)`    one-or-more (one or more **same-level** sibling nodes)
 //!   `S(NAME? S)`    optional (zero or one node)
 //!   `S_` / `S(_ S)` anonymous single        `S*` / `S(* S)`  anonymous many
-//!   `S?` / `S(? S)` anonymous optional
+//!   `S+` / `S(+ S)` anonymous one-or-more   `S?` / `S(? S)`  anonymous optional
 //!   `S(NAME:/re/ S)` single, regex-constrained — see below
 //!   `S(/re/ S)` / `S/re/`  regex-constrained, **anonymous** (filter, don't capture)
 //!   `S{{ INNER S}}` containment: INNER must match some descendant of one node
 //!                   here (DESIGN §12). Paired; may nest.
 //!   `SS`            a doubled sigil is one **literal** sigil (e.g. `\\` → `\`)
-//! `*` is **same-level** (one parent's direct siblings); a cross-level skip is
+//! `*`/`+` are **same-level** (one parent's direct siblings); a cross-level skip is
 //! written as multiple `*`, one per grammar level.
 //! Names are `[A-Za-z0-9_]+` (upper/lower/digit, sed-like `\1`); UPPERCASE is a
 //! readability convention, not a rule. With the `\` sigil, lowercase `\foo` only
@@ -44,6 +45,8 @@ pub enum Cardinality {
     One,
     /// `\(X*\)` — zero or more sibling nodes
     Many,
+    /// `\(X+\)` — one or more sibling nodes (like `Many`, but non-empty)
+    OneOrMore,
     /// `\(X?\)` — zero or one node
     Optional,
 }
@@ -250,8 +253,9 @@ fn lex_metavar(
     Ok(match bytes.get(s).copied() {
         // qualified form: \( ... \)
         Some(b'(') => return lex_qualified(pattern, bytes, s + 1, meta_char),
-        // anonymous short forms: \*  \?
+        // anonymous short forms: \*  \+  \?
         Some(b'*') => Some((meta(None, Cardinality::Many, None), s + 1)),
+        Some(b'+') => Some((meta(None, Cardinality::OneOrMore, None), s + 1)),
         Some(b'?') => Some((meta(None, Cardinality::Optional, None), s + 1)),
         // anonymous regex short form: \/re/  (≡ \(/re/\))
         Some(b'/') => {
@@ -284,6 +288,10 @@ fn lex_qualified(
         Some(b'*') => {
             k += 1;
             Cardinality::Many
+        }
+        Some(b'+') => {
+            k += 1;
+            Cardinality::OneOrMore
         }
         Some(b'?') => {
             k += 1;

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -480,8 +480,10 @@ impl<'s> Ctx<'_, 's> {
                 Cardinality::One => {
                     self.match_single(pi, end, li, hi, name.as_deref(), regex.as_ref())
                 }
-                // Many ignores the regex (sibling runs are out of the single-node scope).
-                Cardinality::Many => self.match_multi(pi, end, li, hi, name.as_deref()),
+                // Many/OneOrMore ignore the regex (sibling runs are out of the
+                // single-node scope). `OneOrMore` is `Many` with a non-empty run.
+                Cardinality::Many => self.match_multi(pi, end, li, hi, name.as_deref(), false),
+                Cardinality::OneOrMore => self.match_multi(pi, end, li, hi, name.as_deref(), true),
                 Cardinality::Optional => {
                     self.match_optional(pi, end, li, hi, name.as_deref(), regex.as_ref())
                 }
@@ -565,11 +567,16 @@ impl<'s> Ctx<'_, 's> {
         li: usize,
         hi: usize,
         name: Option<&str>,
+        nonempty: bool,
     ) -> bool {
         let idx = self.idx;
         let reach = reachable(li, hi, idx); // descending => greedy longest first
         for next in reach {
-            // a same-level `*` run must be a single parent's sibling slice
+            // `\+` (one-or-more) requires at least one node; `\*` allows the empty run
+            if nonempty && next == li {
+                continue;
+            }
+            // a same-level `*`/`+` run must be a single parent's sibling slice
             if !idx.same_level(li, next) {
                 continue;
             }

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -137,6 +137,33 @@ fn optional_metavar() {
 }
 
 #[test]
+fn one_or_more_metavar() {
+    // `\(NAME+\)` / `\+` — one or more same-level siblings; like `\*` but non-empty.
+    let src = "f(a, b); g();";
+    // named: captures the (non-empty) argument run
+    let ms = matches(lang::typescript(), r"f(\(ARGS+\))", src);
+    assert_eq!(cap(&ms, "ARGS").as_deref(), Some("a, b"));
+    // anonymous short form `\+` matches the multi-arg call
+    assert!(has_kind(
+        &matches(lang::typescript(), r"f(\+)", src),
+        "call_expression"
+    ));
+    // `+` must REJECT the zero-arg call `g()` (the run is empty)…
+    assert!(
+        !has_kind(
+            &matches(lang::typescript(), r"g(\(A+\))", src),
+            "call_expression"
+        ),
+        "`+` must require at least one node",
+    );
+    // …whereas `*` accepts it — the difference between the two.
+    assert!(has_kind(
+        &matches(lang::typescript(), r"g(\(A*\))", src),
+        "call_expression"
+    ));
+}
+
+#[test]
 fn anonymous_metavars() {
     // `\_` single + `\*` anonymous many: matches but captures nothing.
     let src = "obj.method(1, 2, 3);";


### PR DESCRIPTION
## Summary
- Add the `+` (one-or-more) quantifier and its `\+` short form: `\(NAME+\)` (named) / `\+` (anonymous) match **one or more** same-level sibling nodes — like `\*`, but the run must be non-empty.
- Lexer: `+` in `lex_qualified`'s cardinality match + a `\+` arm in `lex_metavar`; new `Cardinality::OneOrMore`.
- Matcher: `match_multi` gains a `nonempty` flag that skips the empty run; `OneOrMore` routes through it (`Many` shares the path with `nonempty = false`).
- Prefilter: no change needed — regex extraction is gated on `Cardinality::One`, so a `+` run contributes no required term (sound).

## Test plan
- CI. New `one_or_more_metavar` test: `f(\(ARGS+\))` captures the run, `\+` matches, and `g(\(A+\))` rejects the zero-arg `g()` that `g(\(A*\))` accepts. 172 Rust + 15 Python tests pass.
