### PR TITLE
docs: source design tokens from @cocoindex/brand

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.1.0",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -244,6 +245,10 @@
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@cocoindex/brand": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#ba3eaec139521e8a5ac189d3230c7bc20664b441"
     },
     "node_modules/@docsearch/css": {
       "version": "4.6.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.1.0",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1,33 +1,9 @@
-/* Palette + scales lifted verbatim from design_guidelines/CocoIndex Docs.html
-   so the rendered site matches the mock 1:1. When you tweak a value, keep
-   it in sync with the brand guidelines sheet next door. */
+/* Shared design tokens (:root) — from @cocoindex/brand (packages/brand/tokens.json),
+   the single source of truth across home, blog, and docs. */
+@import '@cocoindex/brand/tokens.css';
+
+/* Docs-specific layout tokens (3-pane shell). Brand tokens come from the import above. */
 :root {
-  --maroon: #532638;
-  --maroon-deep: #401E2B;
-  --maroon-ink: #2A121B;
-  --coral: #BE5133;
-  --peach: #E59A63;
-  --cream: #FCF3D8;
-  --cream-soft: #F6F4E9;
-  --pink: #FB6A76;
-  --palm: #27E62B;      /* live signal · dark bg only */
-  --palm-ink: #16A534;  /* live signal · light bg (a11y) */
-  --berry: #6A1E23;
-  --paper: #FBF6E8;
-  --rule: rgba(42, 18, 27, 0.14);
-  --rule-strong: rgba(42, 18, 27, 0.35);
-  --muted: rgba(42, 18, 27, 0.58);
-  /* Code-block exceptions — only valid inside fenced code on maroon-ink.
-     Single source of truth: design_guidelines/ui/color.html § 04 — Code. */
-  --gold:     #F5D76E;  /* numbers + True/False/None */
-  --lavender: #C9B8F5;  /* types + classes */
-  --taupe:    #978A74;  /* comments (italic) */
-  --stone:    #C5B7A0;  /* punctuation */
-
-  --serif: "Source Serif 4", ui-serif, Georgia, serif;
-  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
-
   --side: 280px;
   --toc: 240px;
 }


### PR DESCRIPTION
Replaces the hand-copied `:root` token block in `docs/src/styles/globals.css` with an `@import` of `@cocoindex/brand/tokens.css` — the single source of truth for design tokens shared with the homepage/blog. Keeps the docs-only `--side`/`--toc` layout tokens.

- **Zero visual change** — token values are identical; verified by a clean build with all tokens present in output.
- Consumed as a **public git dependency**: `github:cocoindex-io/cocoindex-brand#v0.1.0` (https://github.com/cocoindex-io/cocoindex-brand). Builds in CI with no sibling checkout; npm runs the package's `prepare` to regenerate `tokens.css` on install.

Part of factoring the CocoIndex design layer into one shared source (home/blog already on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)