### PR TITLE
feat(code_match): honor a regex on a run (`\(NAME:/re/*\)`)

### DIFF
--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -29,8 +29,10 @@
 //! "starts with `set_`"; add `.*` explicitly for prefix/suffix/substring. (This is
 //! less surprising than unanchored `is_match`, where a bare `set_.*` would match
 //! inside `unset_…`.) Named is `S(NAME:/re/ S)` (the `:` only follows a NAME);
-//! anonymous is `S(/re/ S)` or the short form `S/re/`. Applies to `One`/`Optional`;
-//! ignored on `Many` (sibling runs, out of scope). The regex is **delimited** —
+//! anonymous is `S(/re/ S)` or the short form `S/re/`. On a **run** (`S(NAME:/re/* S)`
+//! / `+`) the regex constrains *every* node — literal per-node: a non-matching node
+//! ends the run. The quantifier sits after the regex term (the after-NAME position
+//! `S(NAME*:/re/ S)` is also accepted). The regex is **delimited** —
 //! it closes at the first unescaped `/`; *balanced* `()` inside (alternations) need
 //! no escaping, escape a literal `/` as `\/`. An unparseable (or unterminated)
 //! regex is a `client` error from `lex` / `Pattern::compile`.
@@ -272,11 +274,27 @@ fn lex_metavar(
     })
 }
 
+/// Read a cardinality quantifier (`*`/`+`/`?`) at `k`, advancing past it.
+/// `None` (and `k` unchanged) if there's no quantifier there.
+fn read_card(bytes: &[u8], k: &mut usize) -> Option<Cardinality> {
+    let card = match bytes.get(*k).copied() {
+        Some(b'*') => Cardinality::Many,
+        Some(b'+') => Cardinality::OneOrMore,
+        Some(b'?') => Cardinality::Optional,
+        _ => return None,
+    };
+    *k += 1;
+    Some(card)
+}
+
 /// Parse the inside of a metavar `\( ... \)` given `j` pointing just after `\(`.
-/// Forms (existing functionality): `NAME [*|?] \)`, named regex `NAME : /re/ \)`,
-/// anonymous regex `/re/ \)` (no colon — `:` separates a NAME from its body). The
-/// close is the **sigil + `)`** (`\)`); a bad regex is an `Err`, a missing/garbled
-/// close is lenient (`Ok(None)` → treat the sigil as literal).
+/// Forms: `NAME [*+?] \)` (shorthand: quantifier on the implicit `.` body), named
+/// regex `NAME : /re/ [*+?] \)`, anonymous regex `/re/ [*+?] \)` (no colon — `:`
+/// separates a NAME from its body). The quantifier sits **after the body term**
+/// (`\(NAME:/re/*\)`, the locked grammar); the after-NAME position is the shorthand
+/// when there's no explicit body, and is also accepted with one for back-compat.
+/// The close is the **sigil + `)`** (`\)`); a bad regex is an `Err`, a
+/// missing/garbled close is lenient (`Ok(None)` → treat the sigil as literal).
 fn lex_qualified(
     pattern: &str,
     bytes: &[u8],
@@ -284,21 +302,8 @@ fn lex_qualified(
     meta_char: char,
 ) -> Result<Option<(PatternItem, usize)>> {
     let (name, mut k) = read_name(pattern, bytes, j);
-    let card = match bytes.get(k).copied() {
-        Some(b'*') => {
-            k += 1;
-            Cardinality::Many
-        }
-        Some(b'+') => {
-            k += 1;
-            Cardinality::OneOrMore
-        }
-        Some(b'?') => {
-            k += 1;
-            Cardinality::Optional
-        }
-        _ => Cardinality::One,
-    };
+    // quantifier after the NAME — the shorthand position (`\(NAME*\)`).
+    let card_after_name = read_card(bytes, &mut k);
     k = skip_spaces(bytes, k);
     // regex matcher: named `NAME:/re/` (a `:` only ever follows a NAME) or
     // anonymous `/re/` (regex directly, no colon).
@@ -315,6 +320,16 @@ fn lex_qualified(
         }
         _ => None,
     };
+    // quantifier after the body **term** — the locked position (`\(NAME:/re/*\)`).
+    // Wins over the after-NAME one when both are present.
+    let card_after_term = if regex.is_some() {
+        read_card(bytes, &mut k)
+    } else {
+        None
+    };
+    let card = card_after_term
+        .or(card_after_name)
+        .unwrap_or(Cardinality::One);
     k = skip_spaces(bytes, k);
     // close: the sigil followed by `)` (`\)`). Sigil-agnostic + UTF-8-safe.
     if !pattern[k..].starts_with(meta_char) || bytes.get(k + meta_char.len_utf8()) != Some(&b')') {

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -480,10 +480,14 @@ impl<'s> Ctx<'_, 's> {
                 Cardinality::One => {
                     self.match_single(pi, end, li, hi, name.as_deref(), regex.as_ref())
                 }
-                // Many/OneOrMore ignore the regex (sibling runs are out of the
-                // single-node scope). `OneOrMore` is `Many` with a non-empty run.
-                Cardinality::Many => self.match_multi(pi, end, li, hi, name.as_deref(), false),
-                Cardinality::OneOrMore => self.match_multi(pi, end, li, hi, name.as_deref(), true),
+                // A regex on a run constrains every node in it (literal per-node,
+                // §0). `OneOrMore` is `Many` with a non-empty run.
+                Cardinality::Many => {
+                    self.match_multi(pi, end, li, hi, name.as_deref(), false, regex.as_ref())
+                }
+                Cardinality::OneOrMore => {
+                    self.match_multi(pi, end, li, hi, name.as_deref(), true, regex.as_ref())
+                }
                 Cardinality::Optional => {
                     self.match_optional(pi, end, li, hi, name.as_deref(), regex.as_ref())
                 }
@@ -568,9 +572,12 @@ impl<'s> Ctx<'_, 's> {
         hi: usize,
         name: Option<&str>,
         nonempty: bool,
+        regex: Option<&Regex>,
     ) -> bool {
         let idx = self.idx;
-        let reach = reachable(li, hi, idx); // descending => greedy longest first
+        // a regex run extends only over nodes each matching `re` (literal per-node).
+        let re_filter = regex.map(|re| (self.source, re));
+        let reach = reachable(li, hi, idx, re_filter); // descending => greedy longest first
         for next in reach {
             // `\+` (one-or-more) requires at least one node; `\*` allows the empty run
             if nonempty && next == li {
@@ -780,7 +787,7 @@ fn regex_ok(regex: Option<&Regex>, text: &str) -> bool {
 /// Positions reachable from `li` (within `[li, hi]`) by consuming whole units:
 /// a complete named subtree span, or a single anonymous leaf. Returns them
 /// descending so the multi-metavar binds greedily (longest first).
-fn reachable(li: usize, hi: usize, idx: &Indexed) -> Vec<usize> {
+fn reachable(li: usize, hi: usize, idx: &Indexed, re_filter: Option<(&str, &Regex)>) -> Vec<usize> {
     let n = hi - li;
     let mut reach = vec![false; n + 1];
     reach[0] = true;
@@ -790,11 +797,15 @@ fn reachable(li: usize, hi: usize, idx: &Indexed) -> Vec<usize> {
         }
         let p = li + off;
         for sp in &idx.spans_by_start[p] {
-            if sp.end_leaf < hi {
+            // `\(/re/*\)` only extends a run over nodes whose whole text matches
+            // `re` (literal per-node — a non-matching node ends the run).
+            if sp.end_leaf < hi
+                && re_filter.is_none_or(|(src, re)| re.is_match(&src[sp.start_byte..sp.end_byte]))
+            {
                 reach[sp.end_leaf + 1 - li] = true;
             }
         }
-        if idx.leaves[p].anon {
+        if idx.leaves[p].anon && re_filter.is_none_or(|(_, re)| re.is_match(&idx.leaves[p].text)) {
             reach[p + 1 - li] = true;
         }
     }

--- a/rust/code_match/src/prefilter.rs
+++ b/rust/code_match/src/prefilter.rs
@@ -95,13 +95,13 @@ impl Prefilter {
                         }
                     }
                 }
-                // A regex literal is required only on a `One` metavar: an `Optional`
-                // node may be absent (so its regex isn't required — extracting it
-                // would be a false negative, e.g. `f(\(A?:/^x/\))` matching `f()`),
-                // and `Many` ignores the regex entirely.
+                // A regex literal is required on `One` and on `OneOrMore` (a `+` run
+                // is ≥1 node *each* matching `re`, so the literal must occur). It is
+                // NOT required on `Optional` or `Many`, which can be empty (extracting
+                // it would be a false negative, e.g. `f(\(A?:/^x/\))` matching `f()`).
                 PatternItem::Meta {
                     regex: Some(re),
-                    card: Cardinality::One,
+                    card: Cardinality::One | Cardinality::OneOrMore,
                     ..
                 } => {
                     for alts in regex_required_literals(re.as_str()) {

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -334,6 +334,35 @@ fn regex_matches_a_string_literal() {
 }
 
 #[test]
+fn regex_on_a_run() {
+    // `\(NAME:/re/*\)` — a run of nodes **each** matching `re` (literal per-node: a
+    // non-matching node, e.g. a separator, ends the run). Folding the separator
+    // into the regex matches the whole comma-separated list.
+    let src = "const x = [1, 2, 3];";
+    let ms = matches(lang::typescript(), r"[\(N:/[0-9]+|,/*\)]", src);
+    assert_eq!(cap(&ms, "N").as_deref(), Some("1, 2, 3"));
+    // Without the separator in `re`, the comma ends the run, so the `[ … ]` can't
+    // close → no array match.
+    assert!(
+        !has_kind(
+            &matches(lang::typescript(), r"[\(/[0-9]+/*\)]", src),
+            "array"
+        ),
+        "a non-matching separator must end the run",
+    );
+    // `+` requires at least one matching node: an empty `[]` matches with `*`, not `+`.
+    let empty = "const y = [];";
+    assert!(has_kind(
+        &matches(lang::typescript(), r"[\(/[0-9]+/*\)]", empty),
+        "array"
+    ));
+    assert!(!has_kind(
+        &matches(lang::typescript(), r"[\(/[0-9]+/+\)]", empty),
+        "array"
+    ));
+}
+
+#[test]
 fn regex_dotstar_equals_bare() {
     // `/.*/ ` is a pure pass-through filter, so it must behave exactly like `\X`.
     let src = "a = b = c;";

--- a/rust/code_match/tests/prefilter.rs
+++ b/rust/code_match/tests/prefilter.rs
@@ -200,6 +200,29 @@ fn regex_on_optional_metavar_is_not_required() {
 }
 
 #[test]
+fn regex_on_a_run_required_only_for_one_or_more() {
+    // A `+` run is ≥1 node *each* matching `re`, so `re`'s required literal IS
+    // required → can reject a source lacking it.
+    let plus = Pattern::compile(r"[\(/foo[0-9]/+\)]", &lang::typescript())
+        .unwrap()
+        .prefilter(1);
+    assert!(
+        !plus.might_match("[bar]"),
+        "`+` run regex literal is required"
+    );
+    assert!(plus.might_match("[foo1]"));
+    // A `*` run can be empty, so its regex literal must NOT be required (else `[]`
+    // would be a false negative).
+    let star = Pattern::compile(r"[\(/foo[0-9]/*\)]", &lang::typescript())
+        .unwrap()
+        .prefilter(1);
+    assert!(
+        star.might_match("[]"),
+        "`*` run can be empty — must not reject"
+    );
+}
+
+#[test]
 fn clause_structure_is_exposed() {
     let pf = prefilter(r"foobar", 3);
     let clauses = pf.clauses();


### PR DESCRIPTION
## Summary
- A regex on a **run** (`\(NAME:/re/*\)` / `+`) now constrains **every** node in it — *literal per-node*: a non-matching node (e.g. a separator) ends the run, so a comma-separated list folds the separator into `re` (`/[0-9]+|,/`). This is the engine-consistent reading (what a future `/re/*` NFA term does); previously the regex was ignored on `Many`.
- **Lexer**: a quantifier is accepted **after the regex term** (`\(NAME:/re/*\)`, the locked grammar position) via a shared `read_card`; the after-NAME position (`\(NAME*:/re/\)`) is still accepted — additive, no migration.
- **Matcher**: `reachable` gained an optional `(source, &Regex)` filter; a run extends only over nodes/leaves whose whole text matches `re`. Same-level + greedy-longest logic unchanged.
- **Prefilter**: regex-literal extraction extended from `One` to `One | OneOrMore` (a `+`-run guarantees ≥1 matching node → the literal is required; `*`/`?` can be empty → still excluded, sound).

## Test plan
- CI. 2 new tests (matcher: list with/without the separator folded in, `*` vs `+` on empty `[]`; prefilter: `+`-run literal required, `*`-run not). 174 Rust + 15 Python tests pass.
