### PR TITLE
fix(code_match): don't panic on a zero-width run match

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -244,7 +244,7 @@ impl Pattern {
                 // child defers to its own candidate, so it isn't reported here.
                 let range = if a == cand.start_leaf && b == hi {
                     Some((cand.start_byte, cand.end_byte))
-                } else {
+                } else if b > a {
                     let ci = start_idx[&a];
                     let cj = end_idx[&(b - 1)];
                     let ok = cj > ci || {
@@ -252,6 +252,12 @@ impl Pattern {
                         s == e && idx.leaves[s].anon
                     };
                     ok.then(|| (idx.leaves[a].start_byte, idx.leaves[b - 1].end_byte))
+                } else {
+                    // `b == a`: the pattern matched **empty** (e.g. an all-`\*` / `\?`
+                    // pattern landing on a child boundary). A zero-width match isn't a
+                    // fragment — drop it (and don't index `leaves[b - 1]`, which would
+                    // be the leaf *before* `a` → an inverted byte range).
+                    None
                 };
                 if let Some((start_byte, end_byte)) = range {
                     out.push(Match {

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -363,6 +363,25 @@ fn regex_on_a_run() {
 }
 
 #[test]
+fn regex_run_empty_at_boundary_does_not_panic() {
+    // Regression: a `*`-run forced to match **empty** at a child boundary (the regex
+    // rejects the next node) is a zero-width match — it must be dropped, not reported
+    // as a fragment (which would index `leaves[b-1]` = the leaf *before* the start →
+    // an inverted byte range → panic). `a + b + c` parses as `(a + b) + c`, so the
+    // `[a-z]` run keeps hitting `+`/`=` boundaries where it can only match empty.
+    let src = "x = a + b + c;";
+    let ms = matches(lang::typescript(), r"\(/[a-z]/*\)", src);
+    assert!(
+        ms.iter().all(|m| !m.text.is_empty()),
+        "no zero-width match may be reported, got {ms:?}",
+    );
+    assert!(
+        ms.iter().any(|m| m.text == "a"),
+        "the identifiers still match"
+    );
+}
+
+#[test]
 fn regex_dotstar_equals_bare() {
     // `/.*/ ` is a pure pass-through filter, so it must behave exactly like `\X`.
     let src = "a = b = c;";


### PR DESCRIPTION
## Summary
- **Panic fix.** A pattern that matches **empty** (an all-`\*`/`\?` pattern landing on a child boundary, so `matched_end == start`) hit the fragment-range branch, which indexed `leaves[b-1]` = the leaf *before* the start → an inverted byte range → `panic: byte range starts at N but ends at N-1`.
- Latent in the leading/trailing-tolerance classification, but #2168 (regex-on-run) made it reachable: the regex filter forces the run empty at non-matching positions, so `\(/[a-z]/*\)` over `x = a + b + c;` (parsed `(a + b) + c`) crashed.
- Fix: a zero-width match (`b == a`) isn't a fragment — drop it (guard the fragment branch with `b > a`). Whole-node matches are unaffected.

## Test plan
- CI. New regression test `regex_run_empty_at_boundary_does_not_panic`; full suite (175 Rust + 15 Python) passes.
