### PR TITLE
ci(build-test): fetch the to-ref commit for the prek diff

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -110,8 +110,14 @@ jobs:
 
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               echo "Running prek on PR diff against target branch: ${{ github.base_ref }}"
+              # Fetch both diff endpoints: origin/<base> and the to-ref commit.
+              # The shallow checkout only guarantees the to-ref's tree, not the
+              # commit as a named object; without fetching <sha> explicitly,
+              # prek's `git diff origin/<base>..<sha>` can fail with "bad
+              # revision" (e.g. when the PR merges while this run is in flight).
               git fetch --no-tags --prune --depth=1 origin \
-                "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+                "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+                "${{ github.sha }}"
 
               prek run \
                 --from-ref "origin/${{ github.base_ref }}" \


### PR DESCRIPTION
## Summary
- The build-test "changed files" step runs `git diff origin/<base>..<sha>` to scope prek hooks to the PR diff. With `fetch-depth: 1`, only `origin/<base>` was fetched, so `<sha>` (`github.sha`) wasn't guaranteed to exist locally as a named object — the diff could fail with `fatal: bad revision`.
- This notably happens when the PR merges while a `pull_request` run is in flight, making `github.sha` the merge commit; the run (and every retry, since re-runs replay the same frozen event) fails deterministically before any hook executes.
- Fix: fetch both diff endpoints in a single `git fetch` — the base refspec plus the bare `github.sha` as a want. A two-dot diff only needs both endpoints present, so two depth-1 fetches suffice; `--prune` is preserved for the base.

## Test plan
- CI: this PR's own build-test run exercises the `pull_request` path with a live `github.sha`.
