### PR TITLE
fix(code_match): containment INNER fragment match + end-position panic

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -117,10 +117,17 @@ impl Indexed {
 pub struct Pattern {
     items: Vec<PatternItem>,
     cfg: LangConfig,
-    /// Whether the `(pi, li)` fail-memo is sound. It isn't when forward-threaded
-    /// bindings can change whether a `(pi, li)` matches: a repeated metavar name,
-    /// or a containment (`\{{ \}}`), whose INNER binds names per descendant.
+    /// Whether the `(pi, li)` fail-memo is sound *globally*. It isn't when
+    /// forward-threaded bindings can change whether a `(pi, li)` matches: a repeated
+    /// metavar name, or a containment (`\{{ \}}`), whose INNER is matched against many
+    /// descendants with **different `stops`**.
     use_memo: bool,
+    /// No repeated metavar name → bindings never change whether a `(pi, li)` matches.
+    /// Lets the containment use a *fresh per-descendant* memo for INNER (the descendant's
+    /// `stops` are fixed, so it's sound there) even when `use_memo` is off for the whole
+    /// pattern — so INNER's leading-tolerance starts collapse to one pass, like the
+    /// top-level. (Repeated names — the "backreference" case — keep it off.)
+    no_dups: bool,
 }
 
 impl Pattern {
@@ -131,11 +138,13 @@ impl Pattern {
         let has_contains = items
             .iter()
             .any(|it| matches!(it, PatternItem::ContainsOpen { .. }));
-        let use_memo = !detect_dup_names(&items) && !has_contains;
+        let no_dups = !detect_dup_names(&items);
+        let use_memo = no_dups && !has_contains;
         Ok(Pattern {
             items,
             cfg: cfg.clone(),
             use_memo,
+            no_dups,
         })
     }
 
@@ -202,10 +211,12 @@ impl Pattern {
                 idx: &idx,
                 source,
                 use_memo: self.use_memo,
+                no_dups: self.no_dups,
                 bound: HashMap::new(),
                 fail: HashSet::new(),
                 stops,
                 matched_end: 0,
+                tolerant_end: None,
             };
 
             // Start positions: each child-start; a leaf candidate has none, so use
@@ -429,6 +440,9 @@ struct Ctx<'a, 's> {
     idx: &'a Indexed,
     source: &'s str,
     use_memo: bool,
+    /// No repeated names (see `Pattern::no_dups`) — lets `inner_matches_candidate`
+    /// turn on a fresh per-descendant memo while the global `use_memo` stays off.
+    no_dups: bool,
     bound: HashMap<String, Capture<'s>>,
     fail: HashSet<(usize, usize)>,
     /// Valid end positions for the **whole pattern** when matching against the
@@ -444,6 +458,12 @@ struct Ctx<'a, 's> {
     /// Set to the stop position when the top-level base case succeeds, so the caller
     /// learns where the (possibly partial) match ended.
     matched_end: usize,
+    /// While matching a containment's INNER against a descendant candidate, the INNER
+    /// end (`close`). The base case then applies the same whole-node/fragment trailing
+    /// tolerance (via `stops`) to INNER as to the whole pattern — so a bare keyword
+    /// `\{{ throw \}}` matches its `throw_statement`, just like a top-level `throw`.
+    /// `None` otherwise (every other sub-pattern end must land exactly on `hi`).
+    tolerant_end: Option<usize>,
 }
 
 impl<'s> Ctx<'_, 's> {
@@ -461,13 +481,17 @@ impl<'s> Ctx<'_, 's> {
             // so caching the states that lead here stays sound across start
             // positions. A containment-inner sub-pattern (`end < items.len()`) must
             // still land exactly on `hi`.
-            if end == self.items.len() {
+            if end == self.items.len() || self.tolerant_end == Some(end) {
+                // Whole pattern, or a containment INNER matched against a candidate
+                // (`tolerant_end`): the match may stop at any of the candidate's
+                // child-end boundaries (`stops`), not only at the very end.
                 if li == hi || self.stops.contains(&li) {
                     self.matched_end = li;
                     return true;
                 }
                 return false;
             }
+            // Any other sub-pattern end must land exactly on `hi`.
             return li == hi;
         }
         if self.use_memo && self.fail.contains(&(pi, li)) {
@@ -630,7 +654,13 @@ impl<'s> Ctx<'_, 's> {
         let inner = pi + 1; // first INNER item
         let cont = close + 1; // first outer item after `\}}`
         let idx = self.idx;
-        for sp in &idx.spans_by_start[li] {
+        // `li` can be the end-exclusive position (`== leaves.len()`, e.g. a preceding
+        // `\*` consumed everything up to the candidate end) — there's no node starting
+        // there to bracket, so nothing contains INNER.
+        let Some(spans) = idx.spans_by_start.get(li) else {
+            return false;
+        };
+        for sp in spans {
             let next = sp.end_leaf + 1;
             // the region must be exactly one direct-child node (not a multi-child
             // span like a root `module` covering all its statements)
@@ -672,7 +702,7 @@ impl<'s> Ctx<'_, 's> {
             // Snapshot is the *pre-containment* bindings (captures inside INNER haven't
             // happened yet) — usually empty or tiny, so the clone is cheap.
             let snapshot = self.bound.clone();
-            if self.dp(inner, inner_end, cand.start_leaf, cand.end_leaf + 1)
+            if self.inner_matches_candidate(inner, inner_end, cand)
                 && self.dp(cont, cont_end, reg_hi, hi)
             {
                 return true;
@@ -687,6 +717,59 @@ impl<'s> Ctx<'_, 's> {
         }
         self.bound = snapshot;
         false
+    }
+
+    /// Does INNER (`items[lo..hi_items]`) match the descendant candidate `cand` as a
+    /// **whole node or a valid (child-aligned) fragment** — the *same* whole-node /
+    /// leading+trailing tolerance a top-level match gives, so a bare keyword
+    /// `\{{ throw \}}` matches its `throw_statement`, and `\{{ fn clone(self) \}}`
+    /// matches a `pub fn clone(self){}`. `cand`'s child-end boundaries become the
+    /// trailing-tolerance `stops` and `tolerant_end` flags the INNER end so the base
+    /// case honors them; the leading-tolerance starts are `cand`'s child-starts. (Every
+    /// start/stop is a child boundary, so any match is child-aligned by construction —
+    /// no ≥2-vs-anon classification needed; a single-named-child fragment is redundantly
+    /// covered by that child's own candidate.)
+    ///
+    /// Cost: a **fresh per-descendant fail-memo** (sound because `cand`'s `stops` are
+    /// fixed; on only when `no_dups`) makes the leading-tolerance starts share work —
+    /// O(candidate leaves · INNER) total, the same as the old single whole-node DP. So
+    /// no complexity increase, *except* the repeated-name ("backreference") case, where
+    /// the memo is unsound and off → the starts cost an extra O(children) factor.
+    ///
+    /// On a hit INNER's bindings stay (threaded to the continuation); on a miss the DP
+    /// self-unwinds (and the caller's snapshot wraps INNER + cont anyway).
+    fn inner_matches_candidate(&mut self, lo: usize, hi_items: usize, cand: &Span) -> bool {
+        let cand_hi = cand.end_leaf + 1;
+        let stops: HashSet<usize> = cand
+            .child_bounds
+            .iter()
+            .map(|&(_, e)| e + 1)
+            .chain(std::iter::once(cand_hi))
+            .collect();
+        // leading-tolerance starts: the candidate's start + each child start.
+        let starts: Vec<usize> = std::iter::once(cand.start_leaf)
+            .chain(cand.child_bounds.iter().map(|&(s, _)| s))
+            .collect();
+        let saved_stops = std::mem::replace(&mut self.stops, stops);
+        let saved_tol = self.tolerant_end.replace(hi_items);
+        // A fresh memo for *this* descendant (its `stops` are fixed → sound); taken/
+        // restored so nesting is fine. Off when the pattern repeats a name.
+        let saved_fail = std::mem::take(&mut self.fail);
+        let saved_use_memo = std::mem::replace(&mut self.use_memo, self.no_dups);
+        let mut ok = false;
+        for a in starts {
+            let snap = self.bound.clone();
+            if self.dp(lo, hi_items, a, cand_hi) {
+                ok = true;
+                break;
+            }
+            self.bound = snap; // undo bindings before trying the next start
+        }
+        self.use_memo = saved_use_memo;
+        self.fail = saved_fail;
+        self.stops = saved_stops;
+        self.tolerant_end = saved_tol;
+        ok
     }
 
     /// `\(X?\)` — match zero or one node. Greedy: try one node first, then none

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -363,6 +363,16 @@ fn regex_on_a_run() {
 }
 
 #[test]
+fn containment_at_candidate_end_does_not_panic() {
+    // Regression: a `\*` before `\{{ … \}}` can consume up to the candidate end, so the
+    // containment is matched at the **end-exclusive** position (`li == leaves.len()`).
+    // `match_contains` indexed `spans_by_start[li]` there → out of bounds → panic. No
+    // node starts at the end, so nothing contains INNER — but it must not crash.
+    let src = "function f() { try { g(); } catch (e) { throw e; } }";
+    let _ = matches(lang::typescript(), r"catch \* \{{ throw \}}", src);
+}
+
+#[test]
 fn regex_run_empty_at_boundary_does_not_panic() {
     // Regression: a `*`-run forced to match **empty** at a child boundary (the regex
     // rejects the next node) is a zero-width match — it must be dropped, not reported
@@ -901,4 +911,60 @@ fn alignment_operators_and_generics() {
         "fn m(){ std::mem::swap(); }"
     ));
     assert!(ok(lang::typescript(), "a === b", "if (a === b) {}"));
+}
+
+#[test]
+fn containment_inner_matches_a_fragment() {
+    // A containment's INNER matches a descendant whole-node **or fragment**, the same
+    // tolerance a top-level match gives — so a bare keyword `\{{ throw \}}` matches the
+    // `throw_statement` it heads, not only the whole-node form `\{{ throw err ; \}}`.
+    // The second `catch` (no `throw`) is correctly excluded.
+    let src = "function g() {\n  try { x(); } catch (err: unknown) {\n    if ((err as any) !== \"EPIPE\") { throw err; }\n  }\n  try { y(); } catch (e2) { log(e2); }\n}\n";
+    let full = matches(
+        lang::typescript(),
+        r"catch (\_:\_) \{{ throw err ; \}}",
+        src,
+    );
+    assert_eq!(
+        full.len(),
+        1,
+        "whole-node INNER matches the catch with a throw"
+    );
+    let bare = matches(lang::typescript(), r"catch (\_:\_) \{{ throw \}}", src);
+    assert_eq!(
+        bare.len(),
+        1,
+        "bare-keyword INNER also matches it (fragment tolerance)"
+    );
+    assert_eq!(bare[0].kind, "catch_clause");
+}
+
+#[test]
+fn containment_inner_leading_fragment_at_any_depth() {
+    // INNER gets the FULL top-level tolerance — **leading** too: `fn clone(self)` is a
+    // leading-context fragment of `pub fn clone(self){}` (it skips the `pub`), and it
+    // matches as a containment INNER, nested arbitrarily deep (here inside `impl`
+    // inside `mod`). This is the case a single-start INNER match would miss.
+    let src = "mod m { impl Foo { pub fn clone(self) -> Foo { Foo } } }";
+    // sanity: the same fragment matches at the top level (leading tolerance there).
+    assert!(has_kind(
+        &matches(lang::rust(), r"fn clone(self)", src),
+        "function_item"
+    ));
+    // as INNER, it matches the enclosing impl (the fragment is found at depth).
+    let ms = matches(lang::rust(), r"impl \T \{{ fn clone(self) \}}", src);
+    assert!(
+        ms.iter().any(|m| m.kind == "impl_item"),
+        "the impl contains the leading-fragment fn, got {ms:?}",
+    );
+
+    // and a keyword INNER reaches arbitrary depth (the `throw` is 3 blocks deep):
+    let deep = "function f() { if (a) { while (b) { throw e; } } }";
+    assert!(
+        has_kind(
+            &matches(lang::typescript(), r"function f() \{{ throw \}}", deep),
+            "function_declaration",
+        ),
+        "INNER must reach a throw nested several levels deep",
+    );
 }


### PR DESCRIPTION
## Summary
Two bugs in `\{{ INNER \}}`, both surfaced by `ccc grep` on a real repo:

- **INNER fragment match.** INNER matched a descendant only by *whole-node* coverage, so a bare keyword `\{{ throw \}}` matched nothing while `\{{ throw err ; \}}` did (and top-level `throw` matches its `throw_statement`). INNER now matches each descendant the **same way a top-level pattern does** — whole node OR a valid (child-aligned) fragment, with leading + trailing tolerance, at any depth — so `\{{ throw \}}` matches its `throw_statement` and `\{{ fn clone(self) \}}` matches a `pub fn clone(self){}` (leading-context fragment).
- **No complexity increase.** A fresh *per-descendant* fail-memo (sound — the descendant's `stops` are fixed; on only when `no_dups`) collapses the leading-tolerance starts into one pass — `O(candidate leaves · INNER)`, same as the old single whole-node DP. Only the repeated-name ("backreference") case keeps the memo off → an extra `O(children)` factor there.
- **Panic fix.** `match_contains` indexed `spans_by_start[li]` unchecked; a preceding `\*` can consume to the candidate end, leaving `li == leaves.len()` → out-of-bounds panic (`catch \* \{{ throw \}}` crashed). Now bounds-checked.

## Test plan
- CI. 3 e2e tests (fragment INNER + no-over-match; leading-context fragment at depth; end-position panic). 178 Rust + 15 Python tests pass; a 118 KB source with 2000 containments matches in ~0.11s.
