### PR TITLE
docs: consume @cocoindex/brand v0.2.0 shared UI layer

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,59 +8,9 @@ import remarkCodeTitles from './scripts/remark-code-titles.mjs';
 import remarkMermaid from './scripts/remark-mermaid.mjs';
 import remarkLinkChecker from './scripts/remark-link-checker.mjs';
 import { redirects } from './src/data/docs-sidebar.ts';
-
-// Shiki theme — canonical token palette from
-// design_guidelines/ui/color.html §04 (.code-showcase .tk-*). Saturated brand
-// accents are softened for ten-line snippets: pink→salmon for fn names,
-// gold→muted-amber for numbers/booleans. Background is maroon-ink.
-const cocoindexCodeTheme = {
-  name: 'cocoindex-dark',
-  type: 'dark',
-  colors: {
-    'editor.background': '#2A121B',
-    'editor.foreground': '#FCF3D8',
-  },
-  tokenColors: [
-    {
-      scope: ['comment', 'punctuation.definition.comment', 'string.comment'],
-      settings: { foreground: '#978A74', fontStyle: 'italic' }
-    },
-    {
-      scope: ['keyword', 'keyword.control', 'keyword.operator.new',
-        'storage', 'storage.type', 'storage.modifier'],
-      settings: { foreground: '#E59A63' }
-    },
-    {
-      scope: ['entity.name.function', 'meta.function-call', 'support.function',
-        'variable.function'],
-      settings: { foreground: '#FF9B8A' }
-    },
-    {
-      scope: ['string', 'string.quoted', 'string.template',
-        'punctuation.definition.string'],
-      settings: { foreground: '#8EF09E' }
-    },
-    {
-      scope: ['constant.numeric', 'constant.language',
-        'constant.language.boolean', 'constant.language.null'],
-      settings: { foreground: '#D4B86A' }
-    },
-    {
-      scope: ['entity.name.type', 'entity.name.class', 'support.type',
-        'support.class', 'meta.type.annotation'],
-      settings: { foreground: '#C9A0FF' }
-    },
-    {
-      scope: ['meta.decorator', 'variable.other.decorator', 'entity.name.decorator',
-        'punctuation.definition.decorator'],
-      settings: { foreground: '#E59A63' }
-    },
-    {
-      scope: ['variable', 'variable.other', 'variable.parameter'],
-      settings: { foreground: '#FCF3D8' }
-    },
-  ],
-};
+// One shared Shiki theme (the readability-tuned --code-* palette) so docs and
+// blog highlight code identically — single source of truth (GUIDELINE §5.5).
+import { cocoindexCodeTheme } from '@cocoindex/brand/code-theme';
 
 // V1 docs are served from https://cocoindex.io/docs/, matching the
 // Docusaurus URLs on the v1 branch (`baseUrl: '/docs/'` in

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.1.0",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.0",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -23,6 +23,9 @@
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/source-serif-4": "^5.2.9",
         "node-addon-api": "^8.7.0",
         "node-gyp": "^12.2.0"
       },
@@ -247,8 +250,9 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#ba3eaec139521e8a5ac189d3230c7bc20664b441"
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#30c7a00a637c00a0b4fe9c3b49feeb5f82c8bf60",
+      "license": "UNLICENSED"
     },
     "node_modules/@docsearch/css": {
       "version": "4.6.2",
@@ -686,6 +690,36 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@gar/promise-retry": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.1.0",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.0",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
@@ -28,6 +28,9 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/source-serif-4": "^5.2.9",
     "node-addon-api": "^8.7.0",
     "node-gyp": "^12.2.0"
   }

--- a/docs/scripts/remark-admonitions.mjs
+++ b/docs/scripts/remark-admonitions.mjs
@@ -1,5 +1,6 @@
-// Turn Docusaurus-style admonition blocks into the design system's `.co`
-// layout (see design_guidelines/ui/admonitions.html). Shape:
+// Turn Docusaurus-style admonition blocks into the shared `.callout` layout
+// (the four-variant callout from @cocoindex/brand/base.css, identical to the
+// blog). Shape:
 //
 //   :::info Prerequisite
 //   Make sure your Postgres server is running.
@@ -7,15 +8,15 @@
 //
 // …becomes:
 //
-//   <div class="co info">
+//   <div class="callout info">
 //     <div class="ico">i</div>
 //     <div class="body"><b>Prerequisite</b> Make sure your …</div>
 //   </div>
 //
 // Pair with `remark-directive` (it's what parses the `:::name [label]`
-// block into a containerDirective node). The CSS for `.co` + variants
-// lives in src/styles/globals.css and matches
-// design_guidelines/ui/admonitions.html verbatim.
+// block into a containerDirective node). The CSS for `.callout` + variants
+// lives in @cocoindex/brand/base.css (imported via components.css), shared
+// pixel-for-pixel with the blog and home.
 import { visit } from 'unist-util-visit';
 import { toString } from 'mdast-util-to-string';
 
@@ -25,15 +26,15 @@ import { toString } from 'mdast-util-to-string';
 //   info    — important context (coral i, peach-tinted cream)
 //   tip     — helpful suggestion (palm ✓, green-tinted cream)
 //   warning — heads up (pink !, pink-tinted cream)
-//   caution — alias for warning
-//   danger  — critical (coral !, deeper pink-tinted cream)
+//   caution — alias for warning (GUIDELINE §3: not a separate variant)
+//   danger  — alias for warning (GUIDELINE §3: not a separate variant)
 const SPECS = {
   note: { defaultLabel: 'Note', cls: 'note', icon: 'i' },
   info: { defaultLabel: 'Info', cls: 'info', icon: 'i' },
   tip: { defaultLabel: 'Tip', cls: 'tip', icon: '\u2713' },
   warning: { defaultLabel: 'Warning', cls: 'warn', icon: '!' },
   caution: { defaultLabel: 'Caution', cls: 'warn', icon: '!' },
-  danger: { defaultLabel: 'Danger', cls: 'danger', icon: '!' },
+  danger: { defaultLabel: 'Warning', cls: 'warn', icon: '!' },
 };
 
 export default function remarkAdmonitions() {
@@ -57,7 +58,7 @@ export default function remarkAdmonitions() {
       const body = node.children;
       const data = node.data || (node.data = {});
       data.hName = 'div';
-      data.hProperties = { className: ['co', spec.cls] };
+      data.hProperties = { className: ['callout', spec.cls] };
 
       node.children = [
         {

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -132,38 +132,8 @@ const ENTERPRISE = `${SITE_MAIN}/enterprise`;
       })
       .catch(() => { /* offline / rate-limited — leave the em-dash. */ });
   })();
-
-  // Copy-to-clipboard for every .code-figure .copy button — one delegated
-  // listener per document. Emitted markup lives in scripts/remark-code-titles.mjs.
-  (() => {
-    document.addEventListener('click', (ev) => {
-      const btn = (ev.target as HTMLElement | null)?.closest('.code-figure .copy') as HTMLButtonElement | null;
-      if (!btn) return;
-      const fig = btn.closest<HTMLElement>('.code-figure');
-      const code = fig?.querySelector<HTMLElement>('pre code, pre');
-      if (!code) return;
-      const text = code.innerText.replace(/\n$/, '');
-      const label = btn.querySelector<HTMLElement>('.copy-lbl');
-      const done = () => {
-        btn.classList.add('copied');
-        if (label) label.textContent = 'Copied';
-        window.setTimeout(() => {
-          btn.classList.remove('copied');
-          if (label) label.textContent = 'Copy';
-        }, 1500);
-      };
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(text).then(done).catch(() => { /* fall through */ });
-      } else {
-        // Legacy fallback — create an offscreen textarea, select, execCommand.
-        const ta = document.createElement('textarea');
-        ta.value = text; ta.setAttribute('readonly', '');
-        ta.style.position = 'fixed'; ta.style.left = '-9999px';
-        document.body.appendChild(ta);
-        ta.select();
-        try { document.execCommand('copy'); done(); } catch { /* ignore */ }
-        ta.remove();
-      }
-    });
-  })();
 </script>
+
+<!-- Copy-to-clipboard for every `.code-figure .copy` button — shared behavior
+     from @cocoindex/brand/copy-code (identical to home + blog). -->
+<script>import '@cocoindex/brand/copy-code';</script>

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -178,15 +178,8 @@ const breadcrumbLd = {
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
 
     <link rel="icon" href={`${base}/img/favicon.ico`} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Trimmed Inter weights: the site uses 400/500/600 only (no 300/700 in CSS).
-         Source Serif 4 is italic-only, used exclusively for the H1 italic-coral
-         accent. JetBrains Mono weights reduced to the two we actually render. -->
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
-    />
+    <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2) —
+         no Google CDN, identical rendering to home + blog. -->
   </head>
   <body>
     <Topbar mobileSheetId="mobileSheet" />

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -21,12 +21,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
     <title>404 · Page not found · Coconut rolled away</title>
     <meta name="description" content="That page wandered off. Let's get you back to something that exists." />
     <link rel="icon" href={`${base}/img/favicon.ico`} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
-    />
+    <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2). -->
   </head>
   <body>
     <Topbar mobileSheetId="mobileSheet" />

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -139,12 +139,7 @@ const introItems = [
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
 
     <link rel="icon" href={`${base}/img/favicon.ico`} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
-    />
+    <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2). -->
   </head>
   <body class="ex-detail">
     <Topbar mobileSheetId="mobileSheet" />
@@ -457,14 +452,14 @@ const introItems = [
       body.ex-detail .code-bar .name { margin-left: 8px; }
       body.ex-detail .code-bar .lang { margin-left: auto; opacity: 0.65; }
       body.ex-detail .code pre { margin: 0; padding: 16px 18px 20px; overflow-x: auto; white-space: pre; tab-size: 4; color: var(--cream); }
-      body.ex-detail .code .kw { color: #E59A63; }
-      body.ex-detail .code .dec { color: #E59A63; }
-      body.ex-detail .code .fn { color: #FF9B8A; }
-      body.ex-detail .code .str { color: #8EF09E; }
-      body.ex-detail .code .num { color: #D4B86A; }
-      body.ex-detail .code .tp { color: #C9A0FF; }
+      body.ex-detail .code .kw { color: var(--code-keyword); }
+      body.ex-detail .code .dec { color: var(--code-decorator); }
+      body.ex-detail .code .fn { color: var(--code-function); }
+      body.ex-detail .code .str { color: var(--code-string); }
+      body.ex-detail .code .num { color: var(--code-number); }
+      body.ex-detail .code .tp { color: var(--code-type); }
       body.ex-detail .code .dim { opacity: 0.48; }
-      body.ex-detail .code .comment { color: #978A74; font-style: italic; opacity: 0.75; }
+      body.ex-detail .code .comment { color: var(--code-comment); font-style: italic; opacity: 0.75; }
       body.ex-detail .code.terminal .prompt::before { content: "$ "; color: var(--peach); }
 
       body.ex-detail .callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -128,12 +128,7 @@ const breadcrumbLd = {
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
 
     <link rel="icon" href={`${base}/img/favicon.ico`} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
-    />
+    <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2). -->
   </head>
   <body class="ex-listing">
     <Topbar mobileSheetId="mobileSheet" />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -92,12 +92,7 @@ const ICONS: Record<string, string> = {
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />
     <link rel="icon" href={`${base}/img/favicon.ico`} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap"
-    />
+    <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2). -->
   </head>
   <body class="docs-home">
     <Topbar mobileSheetId="mobileSheet" />

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1,6 +1,17 @@
-/* Shared design tokens (:root) — from @cocoindex/brand (packages/brand/tokens.json),
-   the single source of truth across home, blog, and docs. */
+/* Shared design layer — from @cocoindex/brand, the single source of truth across
+   home, blog, and docs. tokens.css = :root tokens; components.css = the shared
+   primitives (callouts, .btn, .t-* tags, inline code + .code-figure, cards). */
 @import '@cocoindex/brand/tokens.css';
+@import '@cocoindex/brand/components.css';
+
+/* Self-hosted fonts (WOFF2) — identical to the blog; no Google CDN (GUIDELINE §5.2). */
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
+@import '@fontsource/jetbrains-mono/400.css';
+@import '@fontsource/jetbrains-mono/500.css';
+@import '@fontsource/source-serif-4/400.css';
+@import '@fontsource/source-serif-4/400-italic.css';
 
 /* Docs-specific layout tokens (3-pane shell). Brand tokens come from the import above. */
 :root {
@@ -20,73 +31,8 @@ body {
 a { color: var(--coral); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
-/* ─── Buttons ─── Single structural base + composable variants.
-   Ported verbatim from design_guidelines/ui/buttons.html — one `.btn` class
-   carries shape, padding, focus ring; variants colour it; sizes tune it.
-   Keep this block as the sole source of truth — per-page overrides have
-   been removed. */
-.btn {
-  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 10px 18px; border-radius: 999px;
-  font-family: var(--sans); font-size: 14px; font-weight: 500; line-height: 1.2;
-  text-decoration: none; white-space: nowrap; cursor: pointer;
-  border: 1px solid var(--maroon); color: var(--maroon); background: transparent;
-  transition: background .16s ease, color .16s ease, border-color .16s ease, transform .12s ease;
-}
-.btn:hover { text-decoration: none; }
-.btn:focus-visible, .btn.is-focus { outline: 2px solid var(--coral); outline-offset: 2px; }
-.btn[disabled], .btn.is-disabled { opacity: 0.45; pointer-events: none; }
-
-/* Variants */
-.btn-coral,
-.btn-coral:hover { color: var(--cream); }
-.btn-coral { background: var(--coral); border-color: var(--coral); }
-.btn-coral:hover, .btn-coral.is-hover { background: var(--maroon); border-color: var(--maroon); }
-
-.btn-primary,
-.btn-primary:hover { color: var(--cream); }
-.btn-primary { background: var(--maroon); border-color: var(--maroon); }
-.btn-primary:hover, .btn-primary.is-hover { background: var(--maroon-deep); border-color: var(--maroon-deep); }
-
-.btn-outline { border-color: var(--maroon); color: var(--maroon); background: transparent; }
-.btn-outline:hover, .btn-outline.is-hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
-
-.btn-outline-muted { border-color: var(--rule-strong); color: var(--maroon-ink); background: transparent; }
-.btn-outline-muted:hover, .btn-outline-muted.is-hover { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
-
-.btn-ghost { border-color: transparent; color: var(--maroon-ink); background: transparent; }
-.btn-ghost:hover, .btn-ghost.is-hover { color: var(--coral); }
-
-.btn-mono {
-  font-family: var(--mono); font-size: 12px; font-weight: 500;
-  letter-spacing: 0.14em; text-transform: uppercase;
-  border-color: var(--rule-strong); color: var(--maroon-ink);
-}
-.btn-mono:hover, .btn-mono.is-hover { border-color: var(--coral); color: var(--coral); }
-
-/* Sizes — default is medium. `btn-xl` is an alias of `btn-lg`. */
-.btn-sm { padding: 6px 12px; font-size: 13px; }
-.btn-lg, .btn-xl { padding: 13px 22px; font-size: 15px; }
-
-/* Shape — pill is default; `btn-rounded` is the rectangular variant. */
-.btn-rounded { border-radius: 8px; }
-
-/* Icon-only — square 36px at default, 28/44 at sm/lg. `btn-icon-circle`
-   keeps the pill radius; otherwise defaults to `btn-rounded`. */
-.btn-icon { padding: 0; width: 36px; height: 36px; border-radius: 8px; }
-.btn-icon.btn-sm { width: 28px; height: 28px; }
-.btn-icon.btn-lg, .btn-icon.btn-xl { width: 44px; height: 44px; }
-.btn-icon-circle { border-radius: 999px; }
-
-/* Social — 32px hairline square, maroon icon at rest, coral on hover.
-   Always compose as `btn btn-social` with an `aria-label`. */
-.btn-social {
-  width: 32px; height: 32px; padding: 0; border-radius: 6px;
-  border-color: var(--rule); color: var(--maroon);
-  background: transparent;
-}
-.btn-social:hover, .btn-social.is-hover { border-color: var(--coral); color: var(--coral); background: transparent; }
-
+/* Buttons (.btn + variants/sizes), inline code, .code-figure, and admonitions
+   (.callout) now come from @cocoindex/brand/components.css. */
 .caps { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
 .mono { font-family: var(--mono); }
 
@@ -886,113 +832,6 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
 .prose ul, .prose ol { max-width: 68ch; padding-left: 22px; }
 .prose li { margin: 6px 0; }
 
-/* Inline code in prose — coral-washed pill on cream background. */
-.prose :not(pre) > code {
-  font-family: var(--mono); font-size: 13px;
-  background: rgba(190, 81, 51, 0.12);
-  color: var(--berry);
-  padding: 1px 6px; border-radius: 3px;
-}
-
-/* Fenced code blocks. Chrome matches the blog's `article pre` exactly so
-   code looks consistent across docs + blog. Shiki paints the bg via the
-   inline style it generates, but we keep the `.prose pre` background as
-   a fallback for environments where Shiki hasn't rendered yet. */
-.prose pre {
-  margin: 20px 0;
-  border-radius: 8px;
-  overflow: hidden;
-  overflow-x: auto;
-  border: 1px solid rgba(42, 18, 27, 0.2);
-  background: var(--maroon-ink) !important;
-  padding: 18px 22px;
-  font-family: var(--mono); font-size: 13px; line-height: 1.7;
-  color: var(--cream);
-}
-.prose pre code { background: none; color: inherit; padding: 0; font-size: inherit; }
-
-/* Titled code blocks — wrapped by scripts/remark-code-titles.mjs with
-   <figure class="code-figure"><div class="bar">[dots][file]</div><pre>...</pre></figure>.
-   Matches the blog pattern at cocoindex-io.github.io/src/styles/globals.css:3115
-   (.blog-theme article .code-figure) so docs and blog code blocks look identical.
-   The .bar replaces the <pre>'s own top border/radius so the figure is one card. */
-.code-figure {
-  margin: 24px 0;
-  border-radius: 14px; overflow: hidden;
-  background: var(--maroon-ink);
-  border: 1px solid rgba(42, 18, 27, 0.2);
-}
-.code-figure .bar {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 16px;
-  border-bottom: 1px solid rgba(252, 243, 216, 0.06);
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em;
-  color: rgba(252, 243, 216, 0.6);
-}
-.code-figure .bar .dots { display: flex; gap: 6px; }
-.code-figure .bar .dots span {
-  width: 9px; height: 9px; border-radius: 50%;
-  background: rgba(252, 243, 216, 0.15);
-}
-.code-figure .bar .right {
-  display: flex; align-items: center; gap: 12px;
-}
-.code-figure .bar .file {
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em;
-  color: rgba(252, 243, 216, 0.72);
-  text-transform: none;
-}
-/* Copy button — hidden at rest, revealed on figure hover or keyboard focus.
-   After a successful copy the .copied class flips icon + label for 1.5s. */
-.code-figure .bar .copy {
-  display: inline-flex; align-items: center; gap: 6px;
-  margin: -3px 0;
-  padding: 3px 9px;
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(252, 243, 216, 0.7);
-  background: transparent;
-  border: 1px solid rgba(252, 243, 216, 0.16);
-  border-radius: 999px;
-  cursor: pointer;
-  opacity: 0; transform: translateY(-1px);
-  transition: opacity .18s ease, transform .18s ease, color .15s ease, border-color .15s ease, background .15s ease;
-}
-.code-figure:hover .bar .copy,
-.code-figure:focus-within .bar .copy,
-.code-figure .bar .copy.copied {
-  opacity: 1; transform: none;
-}
-.code-figure .bar .copy:hover {
-  color: var(--cream);
-  border-color: rgba(252, 243, 216, 0.42);
-  background: rgba(252, 243, 216, 0.06);
-}
-.code-figure .bar .copy:focus-visible {
-  outline: 2px solid var(--coral); outline-offset: 2px;
-}
-.code-figure .bar .copy .copy-ok { display: none; }
-.code-figure .bar .copy.copied {
-  color: #8EF09E; border-color: rgba(142, 240, 158, 0.45);
-}
-.code-figure .bar .copy.copied .copy-i { display: none; }
-.code-figure .bar .copy.copied .copy-ok { display: inline-block; }
-.code-figure .bar .copy .copy-lbl { line-height: 1; }
-@media (prefers-reduced-motion: reduce) {
-  .code-figure .bar .copy { transition: opacity .12s ease; transform: none; }
-}
-.code-figure pre {
-  margin: 0 !important;
-  padding: 18px 22px !important;
-  border: 0 !important; border-radius: 0 !important;
-  background: var(--maroon-ink) !important;
-  font-family: var(--mono); font-size: 13px; line-height: 1.7;
-  overflow-x: auto;
-}
-.code-figure pre code {
-  background: transparent; padding: 0; border: 0; color: inherit;
-  font-family: var(--mono); font-size: 13px;
-}
 
 /* Mermaid diagrams — rendered from ```mermaid fenced blocks by
    scripts/remark-mermaid.mjs and initialized in MermaidRenderer.astro. */
@@ -1026,70 +865,6 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
   .mermaid-figure .mermaid { min-width: 560px; }
 }
 
-/* Admonitions — rendered from Docusaurus-style `:::note`, `:::info`,
-   `:::tip`, `:::warning` blocks via scripts/remark-admonitions.mjs.
-   Ported verbatim from design_guidelines/ui/admonitions.html — four
-   semantic variants, single hairline border + cream fill + circular
-   icon badge. Colour carries semantics; the glyph is a single-character
-   mark (i / ✓ / !). */
-.prose .co {
-  display: flex;
-  gap: 14px;
-  padding: 14px 16px;
-  border: 1px solid var(--rule-strong);
-  border-radius: 8px;
-  background: var(--cream);
-  font-size: 13.5px;
-  color: var(--maroon-ink);
-  margin: 18px 0;
-}
-.prose .co .ico {
-  width: 24px; height: 24px; flex: none;
-  border-radius: 50%;
-  display: grid; place-items: center;
-  font-family: var(--mono); font-size: 12px; font-weight: 500;
-  color: var(--cream);
-  background: var(--coral);
-}
-.prose .co .body { flex: 1; line-height: 1.5; min-width: 0; font-size: inherit; margin: 0; max-width: none; }
-.prose .co .body > b {
-  display: block;
-  font-family: var(--sans); font-weight: 600;
-  font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase;
-  margin-bottom: 2px;
-}
-.prose .co .body > :is(p, ul, ol):first-of-type { margin-top: 0; }
-.prose .co .body > :last-child { margin-bottom: 0; }
-
-/* Note — quietest level: berry disc, no tint. */
-.prose .co.note .ico { background: var(--berry); }
-
-/* Info — prerequisite / setup: peach wash, coral hairline. */
-.prose .co.info {
-  border-color: color-mix(in oklab, var(--coral) 45%, transparent);
-  background: color-mix(in oklab, var(--peach) 16%, var(--cream));
-}
-
-/* Tip — non-blocking suggestion: palm wash + check glyph. */
-.prose .co.tip {
-  border-color: color-mix(in oklab, var(--palm) 50%, var(--rule-strong));
-  background: color-mix(in oklab, var(--palm) 7%, var(--cream));
-}
-.prose .co.tip .ico { background: var(--palm); color: var(--maroon-ink); }
-
-/* Warn — might break: pink wash + coral border. */
-.prose .co.warn {
-  border-color: var(--coral);
-  background: color-mix(in oklab, var(--pink) 10%, var(--cream));
-}
-.prose .co.warn .ico { background: var(--pink); color: var(--maroon-ink); }
-
-/* Danger — critical / breaking: deeper pink wash, coral icon. */
-.prose .co.danger {
-  border-color: var(--coral);
-  background: color-mix(in oklab, var(--pink) 20%, var(--cream));
-}
-.prose .co.danger .ico { background: var(--coral); color: var(--cream); }
 
 /* Block quotes — plain markdown `> …` surfaces that aren't admonitions. */
 .prose blockquote {


### PR DESCRIPTION
Docs + examples adopt the full shared design layer so they match home + blog exactly (one syntax palette, shared buttons/tags/code/callouts, self-hosted fonts).

- `astro.config.mjs`: drop the drifted hand-defined Shiki theme; import the shared `cocoindexCodeTheme` (GUIDELINE §5.5).
- `globals.css`: import the components barrel; delete the duplicated `.btn` / `.prose .co` / inline-code / `pre` / `.code-figure` blocks; self-host fonts via `@fontsource` and drop the Google-CDN `<link>`s (GUIDELINE §5.2).
- `remark-admonitions.mjs`: emit `.callout` (shared base.css), alias caution/danger → warn.
- `Topbar.astro`: shared `@cocoindex/brand/copy-code`.
- examples `[slug]`: repoint hand-authored `.code` syntax spans to `--code-*` tokens.

Verified: build green (62 pages); admonitions render as `.callout` (caution→warn), code palette matches the blog, fonts self-hosted (no Google CDN in output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)