### PR TITLE
docs: consume @cocoindex/brand v0.2.1 (chrome + interactive system + shared components)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.1",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.2",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -250,8 +250,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#768d46979749f2d14c87cffe02f716c8c7cb2146",
+      "version": "0.2.2",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#231e9eb779260748f7786fe1b260453b27f85524",
       "license": "UNLICENSED"
     },
     "node_modules/@docsearch/css": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.2",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.3",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -23,9 +23,6 @@
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
-        "@fontsource/inter": "^5.2.8",
-        "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/source-serif-4": "^5.2.9",
         "node-addon-api": "^8.7.0",
         "node-gyp": "^12.2.0"
       },
@@ -250,9 +247,14 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#231e9eb779260748f7786fe1b260453b27f85524",
-      "license": "UNLICENSED"
+      "version": "0.2.3",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#3321e28617036d23e40ca6c52d5d999d0eb00b21",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/source-serif-4": "^5.2.9"
+      }
     },
     "node_modules/@docsearch/css": {
       "version": "4.6.2",
@@ -696,7 +698,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
-      "dev": true,
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -706,7 +707,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
-      "dev": true,
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -716,7 +716,6 @@
       "version": "5.2.9",
       "resolved": "https://registry.npmjs.org/@fontsource/source-serif-4/-/source-serif-4-5.2.9.tgz",
       "integrity": "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==",
-      "dev": true,
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.0",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.1",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -250,8 +250,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#30c7a00a637c00a0b4fe9c3b49feeb5f82c8bf60",
+      "version": "0.2.1",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#768d46979749f2d14c87cffe02f716c8c7cb2146",
       "license": "UNLICENSED"
     },
     "node_modules/@docsearch/css": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.0",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.1",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.2",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.3",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
@@ -28,9 +28,6 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "@fontsource/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/source-serif-4": "^5.2.9",
     "node-addon-api": "^8.7.0",
     "node-gyp": "^12.2.0"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.1",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.2",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",

--- a/docs/src/components/Foot.astro
+++ b/docs/src/components/Foot.astro
@@ -1,34 +1,6 @@
 ---
-// Footer — markup + styles from @cocoindex/brand (Footer.astro + footer.css).
-// This file only supplies the docs site's links/logo (absolute cocoindex.io
-// URLs since the docs live under /docs).
+// The one shared footer — identical links + logo on every CocoIndex surface.
+// Markup + styles live in @cocoindex/brand (Footer.astro + footer.css).
 import Footer from '@cocoindex/brand/Footer.astro';
-import { SITE_MAIN, SITE_BLOG, SITE_EXAMPLES, GITHUB_REPO, DISCORD_URL } from '../consts';
-
-const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
-
-<Footer
-  logoHref={SITE_MAIN}
-  logoSrc={`${base}/images/coconut.svg`}
-  resources={[
-    { label: 'Blog', href: SITE_BLOG },
-    { label: 'Documentation', href: `${base}/` },
-    { label: 'YouTube', href: 'https://www.youtube.com/@cocoindex-io' },
-    { label: 'Examples', href: SITE_EXAMPLES },
-  ]}
-  community={[
-    { label: 'GitHub', href: GITHUB_REPO },
-    { label: 'Discord', href: DISCORD_URL },
-    { label: 'Twitter', href: 'https://x.com/cocoindex_io' },
-    { label: 'LinkedIn', href: 'https://www.linkedin.com/company/cocoindex' },
-  ]}
-  company={[
-    { label: 'Enterprise', href: `${SITE_MAIN}/enterprise` },
-    { label: 'Careers', href: `${SITE_MAIN}/careers` },
-    { label: 'Brand & press kit', href: `${SITE_MAIN}/brand` },
-    { label: 'Privacy policy', href: `${SITE_MAIN}/privacy-policy` },
-    { label: 'Terms of use', href: `${SITE_MAIN}/terms-of-use` },
-    { label: 'hi@cocoindex.io', href: 'mailto:hi@cocoindex.io' },
-  ]}
-/>
+<Footer />

--- a/docs/src/components/Foot.astro
+++ b/docs/src/components/Foot.astro
@@ -1,90 +1,34 @@
 ---
-// Site footer — mirrors Foot.astro in cocoindex-io.github.io (markup, class
-// names, styles) so the docs share the same footer as the home page. Links
-// point at absolute cocoindex.io URLs since the docs live under /docs.
+// Footer — markup + styles from @cocoindex/brand (Footer.astro + footer.css).
+// This file only supplies the docs site's links/logo (absolute cocoindex.io
+// URLs since the docs live under /docs).
+import Footer from '@cocoindex/brand/Footer.astro';
 import { SITE_MAIN, SITE_BLOG, SITE_EXAMPLES, GITHUB_REPO, DISCORD_URL } from '../consts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const ENTERPRISE = `${SITE_MAIN}/enterprise`;
 ---
 
-<footer class="it-foot">
-  <div class="foot-grid">
-    <div class="foot-brand">
-      <a class="logo" href={SITE_MAIN} style="gap: 12px">
-        <img src={`${base}/images/coconut.svg`} alt="" width="36" height="36" style="width: 36px; height: auto" />
-        <span>CocoIndex</span>
-      </a>
-      <p>The open-source, incremental data framework that keeps your AI agents grounded in fresh, structured context.</p>
-    </div>
-    <div class="foot-col">
-      <h6>Resources</h6>
-      <a href={SITE_BLOG}>Blog</a>
-      <a href={`${base}/`}>Documentation</a>
-      <a href="https://www.youtube.com/@cocoindex-io">YouTube</a>
-      <a href={SITE_EXAMPLES}>Examples</a>
-    </div>
-    <div class="foot-col">
-      <h6>Community</h6>
-      <a href={GITHUB_REPO}>GitHub</a>
-      <a href={DISCORD_URL}>Discord</a>
-      <a href="https://x.com/cocoindex_io">Twitter</a>
-      <a href="https://www.linkedin.com/company/cocoindex">LinkedIn</a>
-    </div>
-    <div class="foot-col">
-      <h6>Company</h6>
-      <a href={ENTERPRISE}>Enterprise</a>
-      <a href={`${SITE_MAIN}/careers`}>Careers</a>
-      <a href={`${SITE_MAIN}/brand`}>Brand &amp; press kit</a>
-      <a href={`${SITE_MAIN}/privacy-policy`}>Privacy policy</a>
-      <a href={`${SITE_MAIN}/terms-of-use`}>Terms of use</a>
-      <a href="mailto:hi@cocoindex.io">hi@cocoindex.io</a>
-    </div>
-  </div>
-  <div class="colo">
-    <span>© 2026 CocoIndex</span>
-  </div>
-</footer>
-
-<style>
-  footer.it-foot {
-    padding: 72px 24px 36px;
-    border-top: 1px solid var(--rule);
-    max-width: 1480px;
-    margin: 0 auto;
-  }
-  .foot-grid {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr 1fr;
-    gap: 24px;
-    padding-bottom: 48px;
-  }
-  .foot-brand { display: flex; flex-direction: column; gap: 16px; max-width: 38ch; }
-  .foot-brand .logo { font-family: var(--sans); font-size: 18px; font-weight: 600; letter-spacing: -0.02em; }
-  .foot-brand p { color: var(--muted); margin: 0; font-size: 14px; }
-  .foot-col h6 {
-    font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
-    color: var(--muted); margin: 0 0 14px; font-weight: 500;
-  }
-  .foot-col a {
-    display: block; text-decoration: none; color: var(--maroon-ink);
-    padding: 5px 0; font-size: 14px;
-  }
-  .foot-col a:hover { color: var(--coral); }
-  .colo {
-    padding-top: 20px;
-    display: flex; justify-content: space-between; align-items: center;
-    font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
-    color: var(--muted);
-    flex-wrap: wrap; gap: 8px;
-  }
-
-  @media (max-width: 820px) {
-    footer.it-foot { padding: 56px 24px 32px; }
-    .foot-grid { grid-template-columns: 1fr 1fr; gap: 32px 24px; }
-    .foot-brand { grid-column: 1 / -1; }
-  }
-  @media (max-width: 520px) {
-    .foot-grid { grid-template-columns: 1fr; }
-  }
-</style>
+<Footer
+  logoHref={SITE_MAIN}
+  logoSrc={`${base}/images/coconut.svg`}
+  resources={[
+    { label: 'Blog', href: SITE_BLOG },
+    { label: 'Documentation', href: `${base}/` },
+    { label: 'YouTube', href: 'https://www.youtube.com/@cocoindex-io' },
+    { label: 'Examples', href: SITE_EXAMPLES },
+  ]}
+  community={[
+    { label: 'GitHub', href: GITHUB_REPO },
+    { label: 'Discord', href: DISCORD_URL },
+    { label: 'Twitter', href: 'https://x.com/cocoindex_io' },
+    { label: 'LinkedIn', href: 'https://www.linkedin.com/company/cocoindex' },
+  ]}
+  company={[
+    { label: 'Enterprise', href: `${SITE_MAIN}/enterprise` },
+    { label: 'Careers', href: `${SITE_MAIN}/careers` },
+    { label: 'Brand & press kit', href: `${SITE_MAIN}/brand` },
+    { label: 'Privacy policy', href: `${SITE_MAIN}/privacy-policy` },
+    { label: 'Terms of use', href: `${SITE_MAIN}/terms-of-use` },
+    { label: 'hi@cocoindex.io', href: 'mailto:hi@cocoindex.io' },
+  ]}
+/>

--- a/docs/src/components/MobileSheet.astro
+++ b/docs/src/components/MobileSheet.astro
@@ -1,20 +1,18 @@
 ---
-// Phone-only off-canvas drawer. Two segmented tabs:
-//   - On this page : the current doc's H2/H3 headings (numbered like Toc)
+// Phone-only off-canvas drawer. The shell (scrim + sliding panel + close
+// header) and the open/close behavior come from the shared
+// @cocoindex/brand/MobileSheet; this component fills its slot with the docs
+// content: a search box + two segmented tabs —
 //   - Pages        : the full sidebar tree (mirrors Sidebar.astro)
-//
-// Token discipline matches design_guidelines/ui/hamburger-toc.html:
-//   · ghost-at-rest burger + star pill in the topbar
-//   · scrim + hairline border for elevation (no drop shadows)
-//   · one coral accent at a time — the active row, or the burger glyph
-//     while open. Never both.
-//
-// Scoped via `@media (max-width: 820px)` in globals.css, so desktop is
-// unaffected — the sheet sits at `display: none` until phone width.
+//   - On this page : the current doc's H2/H3 headings (numbered like Toc)
+// and adds the tab-switch script (open/close, scrim, Esc, scroll-lock, and
+// close-on-link-tap all live in the shared controller). The tab/pane/group/
+// search styling stays in globals.css; the shell styling is brand nav.css.
 import type { MarkdownHeading } from 'astro';
 import { sidebar, type SidebarItem } from '../data/docs-sidebar';
 import { SITE_MAIN, SITE_BLOG } from '../consts';
 import Search from './Search.astro';
+import MobileSheet from '@cocoindex/brand/MobileSheet.astro';
 
 export interface Props {
   /** Slug of the currently-rendered doc. Drives the `aria-current` row in the Pages tab. */
@@ -38,9 +36,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 // Site-level nav — same set rendered inline in Topbar.astro at desktop
 // width. Surfaced here so phones still have a path to Examples / Docs /
-// Enterprise / Blog when `.nav-links` is hidden. Kept in this component
-// (rather than a shared module) because Topbar's links carry hover-
-// dropdown markup the drawer doesn't need; flat list reads better here.
+// Enterprise / Blog when `.nav-links` is hidden.
 const SITE_LINKS: Array<{ href: string; label: string }> = [
   { href: `${SITE_MAIN}/cocoindex-code`, label: 'CocoIndex Code' },
   { href: `${base}/examples`,            label: 'Examples'       },
@@ -65,60 +61,24 @@ function href(slug: string): string {
 }
 ---
 
-<div class="mobile-scrim" id="mobileScrim" aria-hidden="true"></div>
-
-<aside
-  class="mobile-sheet"
-  id="mobileSheet"
-  role="dialog"
-  aria-modal="true"
-  aria-labelledby="mobileSheetTtl"
-  hidden
->
-  <header class="mobile-sheet-head">
-    <span class="ttl" id="mobileSheetTtl">Menu</span>
-    <button class="mobile-close" id="mobileClose" type="button" aria-label="Close menu">
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
-        <path d="M3 3l10 10M13 3L3 13"/>
-      </svg>
-    </button>
-  </header>
-
+<MobileSheet id="mobileSheet" title="Menu" closeAbove={820}>
   <div class="mobile-search">
     <Search />
   </div>
 
   {tocRows.length > 0 && (
     <div class="mobile-tabs" role="tablist" aria-label="Menu sections">
-      <button
-        id="tabPages"
-        type="button"
-        role="tab"
-        aria-selected="true"
-        aria-controls="panePages"
-      >
+      <button id="tabPages" type="button" role="tab" aria-selected="true" aria-controls="panePages">
         Pages
       </button>
-      <button
-        id="tabToc"
-        type="button"
-        role="tab"
-        aria-selected="false"
-        aria-controls="paneToc"
-      >
+      <button id="tabToc" type="button" role="tab" aria-selected="false" aria-controls="paneToc">
         On this page
       </button>
     </div>
   )}
 
   {tocRows.length > 0 && (
-    <div
-      class="mobile-pane"
-      id="paneToc"
-      role="tabpanel"
-      aria-labelledby="tabToc"
-      hidden
-    >
+    <div class="mobile-pane" id="paneToc" role="tabpanel" aria-labelledby="tabToc" hidden>
       <nav class="mobile-list" aria-label="On this page">
         {tocRows.map((h) => (
           <a
@@ -134,12 +94,7 @@ function href(slug: string): string {
     </div>
   )}
 
-  <div
-    class="mobile-pane"
-    id="panePages"
-    role="tabpanel"
-    aria-labelledby="tabPages"
-  >
+  <div class="mobile-pane" id="panePages" role="tabpanel" aria-labelledby="tabPages">
     <div class="mobile-group">
       <h6><span>Site</span></h6>
       <nav class="mobile-list" aria-label="Site">
@@ -190,95 +145,41 @@ function href(slug: string): string {
       )
     ))}
   </div>
-</aside>
+</MobileSheet>
 
 <script>
-  // Phone drawer controller. Same logic shape as the design-system spec
-  // at design_guidelines/ui/hamburger-toc.html: open/close, tab switch,
-  // Esc, scrim-tap, body scroll-lock. The burger lives in Topbar; the
-  // sheet lives in this component; they connect by id via aria-controls.
+  // Tab switch only — open/close, scrim, Esc, scroll-lock, and close-on-link-tap
+  // are all handled by the shared MobileSheet controller (@cocoindex/brand).
+  // Tabs render only when the page has headings; bail cleanly otherwise.
   (() => {
-    const burger = document.getElementById('menuBtn') as HTMLButtonElement | null;
-    const sheet  = document.getElementById('mobileSheet') as HTMLElement | null;
-    const scrim  = document.getElementById('mobileScrim') as HTMLElement | null;
-    const close  = document.getElementById('mobileClose') as HTMLButtonElement | null;
-    // Tabs only render when the current page has headings; on pages
-    // without (e.g. the examples listing, 404), there's a single Pages
-    // pane with no segmented control, so these refs may be null.
     const tabToc   = document.getElementById('tabToc')   as HTMLButtonElement | null;
     const tabPages = document.getElementById('tabPages') as HTMLButtonElement | null;
     const paneToc   = document.getElementById('paneToc')   as HTMLElement | null;
     const panePages = document.getElementById('panePages') as HTMLElement | null;
-    if (!burger || !sheet || !scrim || !close || !panePages) return;
-    const hasTabs = !!(tabToc && tabPages && paneToc);
+    if (!tabToc || !tabPages || !paneToc || !panePages) return;
 
-    const setOpen = (open: boolean) => {
-      burger.classList.toggle('open', open);
-      sheet.classList.toggle('open', open);
-      scrim.classList.toggle('open', open);
-      sheet.hidden = !open;
-      scrim.setAttribute('aria-hidden', open ? 'false' : 'true');
-      burger.setAttribute('aria-expanded', open ? 'true' : 'false');
-      burger.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
-      // Prevent the page beneath from scrolling when the sheet is open;
-      // restoring `''` keeps any user-set inline overflow intact.
-      document.body.style.overflow = open ? 'hidden' : '';
-      if (open) {
-        const active = sheet.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
-        active?.focus();
-      }
+    const setTab = (which: 'toc' | 'pages') => {
+      const onToc = which === 'toc';
+      tabToc.setAttribute('aria-selected', onToc ? 'true' : 'false');
+      tabPages.setAttribute('aria-selected', onToc ? 'false' : 'true');
+      paneToc.hidden = !onToc;
+      panePages.hidden = onToc;
     };
 
-    burger.addEventListener('click', () => setOpen(!sheet.classList.contains('open')));
-    close .addEventListener('click', () => setOpen(false));
-    scrim .addEventListener('click', () => setOpen(false));
+    tabToc  .addEventListener('click', () => setTab('toc'));
+    tabPages.addEventListener('click', () => setTab('pages'));
 
-    if (hasTabs) {
-      const setTab = (which: 'toc' | 'pages') => {
-        const onToc = which === 'toc';
-        tabToc!.setAttribute('aria-selected', onToc ? 'true' : 'false');
-        tabPages!.setAttribute('aria-selected', onToc ? 'false' : 'true');
-        paneToc!.hidden = !onToc;
-        panePages.hidden = onToc;
-      };
-
-      tabToc!  .addEventListener('click', () => setTab('toc'));
-      tabPages!.addEventListener('click', () => setTab('pages'));
-
-      // Arrow-key tab navigation (a11y).
-      const tabsArr = [tabToc!, tabPages!];
-      tabsArr.forEach((t, i, arr) => {
-        t.addEventListener('keydown', (e) => {
-          if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-            e.preventDefault();
-            const target = arr[(i + (e.key === 'ArrowRight' ? 1 : -1) + arr.length) % arr.length];
-            target.focus();
-            setTab(target === tabToc ? 'toc' : 'pages');
-          }
-        });
+    // Arrow-key tab navigation (a11y).
+    const tabsArr = [tabToc, tabPages];
+    tabsArr.forEach((t, i, arr) => {
+      t.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const target = arr[(i + (e.key === 'ArrowRight' ? 1 : -1) + arr.length) % arr.length];
+          target.focus();
+          setTab(target === tabToc ? 'toc' : 'pages');
+        }
       });
-
-      // Tapping a TOC link closes the sheet so the user lands on the heading
-      // without an open drawer obscuring it.
-      paneToc!.addEventListener('click', (e) => {
-        const a = (e.target as HTMLElement | null)?.closest('a[data-mobile-toc-link]');
-        if (a) setOpen(false);
-      });
-    }
-
-    // Esc closes the sheet — only listen at the document level when open
-    // so we don't sit on every keystroke.
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && sheet.classList.contains('open')) setOpen(false);
     });
-
-    // If the viewport widens past phone breakpoint while the sheet is
-    // open, close it — the desktop rails take over the same job.
-    const mq = window.matchMedia('(min-width: 821px)');
-    const onMq = (ev: MediaQueryListEvent | MediaQueryList) => {
-      if ((ev as MediaQueryList).matches) setOpen(false);
-    };
-    if (mq.addEventListener) mq.addEventListener('change', onMq as (ev: MediaQueryListEvent) => void);
-    else mq.addListener(onMq as (ev: MediaQueryListEvent) => void);
   })();
 </script>

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -1,138 +1,45 @@
 ---
-// Mirrors Nav.astro in cocoindex-io.github.io (class names, markup, links)
-// so both sites share the exact same header. The stars island is a plain
-// inline script rather than a React component so we don't need to ship
-// React + a client bundle just to render one number.
-import { SITE_MAIN, SITE_BLOG, GITHUB_REPO } from '../consts';
+// Docs header: the shared <Nav> bar from @cocoindex/brand, fed this site's
+// links — including the v1/v0 version dropdowns on Examples + Documentation.
+// The phone drawer (tabbed sidebar + TOC) is MobileSheet.astro, opened by the
+// bar's hamburger; pass `mobileSheetId` to render that hamburger.
+import Nav from '@cocoindex/brand/Nav.astro';
+import { SITE_MAIN, SITE_BLOG } from '../consts';
 
 interface Props {
-  /** When set, renders the phone hamburger and wires `aria-controls` to
-   *  the given sheet id. Layouts that ship a phone drawer (DocsLayout)
-   *  set this; pages that have no off-canvas sheet (404, listing pages)
-   *  leave it off so no orphan burger appears on phones. */
+  /** When set, renders the phone hamburger wired (aria-controls) to that sheet id. */
   mobileSheetId?: string;
 }
-
 const { mobileSheetId } = Astro.props as Props;
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
-const CODE = `${SITE_MAIN}/cocoindex-code`;
 const DOCS = base;
-const DOCS_V0 = `${SITE_MAIN}/docs-v0`;
 const EXAMPLES_V1 = `${base}/examples`;
+const DOCS_V0 = `${SITE_MAIN}/docs-v0`;
 const EXAMPLES_V0 = `${SITE_MAIN}/docs-v0/examples/`;
-const ENTERPRISE = `${SITE_MAIN}/enterprise`;
+
+const links = [
+  { href: `${SITE_MAIN}/cocoindex-code`, label: 'CocoIndex Code' },
+  {
+    href: EXAMPLES_V1, label: 'Examples',
+    versions: [
+      { href: EXAMPLES_V1, label: 'v1', current: true },
+      { href: EXAMPLES_V0, label: 'v0', tag: 'legacy' },
+    ],
+  },
+  {
+    href: DOCS, label: 'Documentation',
+    versions: [
+      { href: DOCS, label: 'v1', current: true },
+      { href: DOCS_V0, label: 'v0', tag: 'legacy' },
+    ],
+  },
+  { href: `${SITE_MAIN}/enterprise`, label: 'Enterprise' },
+  { href: SITE_BLOG, label: 'Blog' },
+];
 ---
 
-<nav class="top">
-  <div class="nav-in">
-    <a class="logo" href={SITE_MAIN}>
-      <img src={`${base === '/' ? '' : base}/images/coconut.svg`} alt="CocoIndex logo" width="28" height="28" />
-      <span>CocoIndex</span>
-    </a>
-    <div class="nav-links">
-      <a href={CODE}>CocoIndex Code</a>
-      <div class="nav-dd">
-        <a href={EXAMPLES_V1} class="nav-dd-trigger" aria-haspopup="menu">
-          Examples
-          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden>
-            <path d="m2.5 4.5 3.5 3.5 3.5-3.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </a>
-        <div class="nav-dd-menu" role="menu">
-          <a class="on" href={EXAMPLES_V1} role="menuitem">
-            <span class="ver">v1</span>
-          </a>
-          <a href={EXAMPLES_V0} role="menuitem">
-            <span class="ver">v0</span>
-            <span class="tag legacy">legacy</span>
-          </a>
-        </div>
-      </div>
-      <div class="nav-dd">
-        <a href={DOCS} class="nav-dd-trigger" aria-haspopup="menu">
-          Documentation
-          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden>
-            <path d="m2.5 4.5 3.5 3.5 3.5-3.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </a>
-        <div class="nav-dd-menu" role="menu">
-          <a class="on" href={DOCS} role="menuitem">
-            <span class="ver">v1</span>
-          </a>
-          <a href={DOCS_V0} role="menuitem">
-            <span class="ver">v0</span>
-            <span class="tag legacy">legacy</span>
-          </a>
-        </div>
-      </div>
-      <a href={ENTERPRISE}>Enterprise</a>
-      <a href={SITE_BLOG}>Blog</a>
-    </div>
-    <div class="nav-cta">
-      <a class="stars" href={GITHUB_REPO} target="_blank" rel="noopener" data-repo="cocoindex-io/cocoindex">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
-        <span class="count" aria-label="GitHub stars">—</span>
-      </a>
-      {mobileSheetId && (
-        <button
-          class="menu-btn"
-          id="menuBtn"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls={mobileSheetId}
-          data-mobile-toggle={mobileSheetId}
-        >
-          <span class="bar"></span>
-        </button>
-      )}
-    </div>
-  </div>
-</nav>
-
-<script>
-  // Tiny islandless GitHub-stars counter. sessionStorage cache + a single
-  // fetch per tab. Matches the formatting used by IconThemeStars on the
-  // sister site (`1.2k` under 10k, `48k` above).
-  (() => {
-    const el = document.querySelector<HTMLElement>('.stars .count');
-    if (!el) return;
-    const a = el.closest('a[data-repo]') as HTMLAnchorElement | null;
-    const repo = a?.dataset.repo;
-    if (!repo) return;
-
-    const KEY = `gh-stars:${repo}`;
-    const TTL = 60 * 60 * 1000;
-
-    const fmt = (n: number) =>
-      n < 1000 ? n.toLocaleString() :
-      n < 10000 ? `${(Math.round(n / 100) / 10).toFixed(1)}k` :
-      `${Math.round(n / 1000)}k`;
-
-    try {
-      const raw = sessionStorage.getItem(KEY);
-      if (raw) {
-        const { count, ts } = JSON.parse(raw) as { count: number; ts: number };
-        if (Date.now() - ts < TTL && typeof count === 'number') {
-          el.textContent = fmt(count);
-          return;
-        }
-      }
-    } catch { /* ignore quota / JSON errors */ }
-
-    fetch(`https://api.github.com/repos/${repo}`)
-      .then((r) => r.json())
-      .then((d: { stargazers_count?: number }) => {
-        if (typeof d.stargazers_count !== 'number') return;
-        el.textContent = fmt(d.stargazers_count);
-        try { sessionStorage.setItem(KEY, JSON.stringify({ count: d.stargazers_count, ts: Date.now() })); } catch { /* ignore */ }
-      })
-      .catch(() => { /* offline / rate-limited — leave the em-dash. */ });
-  })();
-</script>
+<Nav links={links} mobileSheetId={mobileSheetId} />
 
 <!-- Copy-to-clipboard for every `.code-figure .copy` button — shared behavior
      from @cocoindex/brand/copy-code (identical to home + blog). -->

--- a/docs/src/components/examples/ExampleCard.astro
+++ b/docs/src/components/examples/ExampleCard.astro
@@ -1,0 +1,33 @@
+---
+// One card in the examples listing grid. Markup extracted from
+// examples/index.astro's per-category loop; styling stays in that page's
+// `body.ex-listing .ex-card` block (tags use the shared .t-pill + --dt).
+import { titleMarkup } from '../../consts';
+import { CATEGORY_META, type ExampleCard } from '../../data/examples';
+
+interface Props {
+  ex: ExampleCard;
+  href: string;
+}
+const { ex, href } = Astro.props;
+---
+<a class="ex-card" href={href}>
+  <div class={`ex-thumb ${ex.thumbClass ?? CATEGORY_META[ex.category].thumbClass}`}>
+    <span class="tl">{ex.thumbLabel}</span>
+    <span class="tr">{ex.index}</span>
+    <div class="motif" set:html={ex.motif ?? ''} />
+  </div>
+  <div class="ex-body">
+    <h3 set:html={titleMarkup(ex.title)} />
+    <p>{ex.description}</p>
+    <div class="ex-tags">
+      {ex.tags.map((t) => (
+        <span class={`t-pill ${t.kind}`}><span class="dt"></span>{t.label}</span>
+      ))}
+    </div>
+    <div class="ex-foot">
+      <span>{ex.footMeta}</span>
+      <span class="go">Open →</span>
+    </div>
+  </div>
+</a>

--- a/docs/src/components/examples/FeaturedCard.astro
+++ b/docs/src/components/examples/FeaturedCard.astro
@@ -1,0 +1,30 @@
+---
+// The large featured card at the top of the examples listing. Markup extracted
+// from examples/index.astro; styling stays in that page's `body.ex-listing
+// .feat-card` block.
+import { titleMarkup } from '../../consts';
+import { type ExampleCard } from '../../data/examples';
+
+interface Props {
+  ex: ExampleCard;
+  href: string;
+}
+const { ex, href } = Astro.props;
+---
+<a class="feat-card" href={href}>
+  <div class="feat-body">
+    <span class="ribbon"><span class="tick"></span>{ex.thumbLabel} · <span class="idx">{ex.index}</span></span>
+    <h3 set:html={titleMarkup(ex.title + '.')} />
+    <p>{ex.description}</p>
+    <div class="chips">
+      {ex.tags.map((t) => <span class="chip">{t.label}</span>)}
+    </div>
+    <div class="foot">
+      <span>{ex.footMeta}</span>
+      <span class="go">Open example
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </span>
+    </div>
+  </div>
+  <div class="feat-viz" aria-hidden="true" set:html={ex.motif ?? ''} />
+</a>

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -236,7 +236,7 @@ const introItems = [
               The step-by-step walkthrough for this example is still being written. The code itself is live on GitHub — clone it to try it today.
             </p>
           </div>
-          <div class="callout" style="max-width:780px;">
+          <div class="ex-callout" style="max-width:780px;">
             <div class="hd tip"><span class="dt"></span>What this example shows</div>
             <p>{ex.description}</p>
           </div>
@@ -430,7 +430,7 @@ const introItems = [
       body.ex-detail .step-head p { margin: 0 0 14px; color: var(--maroon-ink); max-width: 64ch; font-size: 15px; line-height: 1.55; }
       body.ex-detail .step-head code,
       body.ex-detail .step-head p code,
-      body.ex-detail .callout code,
+      body.ex-detail .ex-callout code,
       body.ex-detail .step-bullets code { font-family: var(--mono); font-size: 13px; background: rgba(190, 81, 51, 0.12); color: var(--berry); padding: 1px 6px; border-radius: 3px; }
       body.ex-detail .step-bullets { list-style: none; padding: 0; margin: 0 0 6px; display: flex; flex-direction: column; gap: 4px; }
       body.ex-detail .step-bullets li { display: flex; gap: 10px; align-items: flex-start; font-size: 13.5px; color: var(--muted); padding: 6px 0; border-top: 1px solid var(--rule); }
@@ -462,13 +462,17 @@ const introItems = [
       body.ex-detail .code .comment { color: var(--code-comment); font-style: italic; opacity: 0.75; }
       body.ex-detail .code.terminal .prompt::before { content: "$ "; color: var(--peach); }
 
-      body.ex-detail .callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }
-      body.ex-detail .callout .hd { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
-      body.ex-detail .callout .hd .dt { width: 8px; height: 8px; border-radius: 50%; background: var(--coral); }
-      body.ex-detail .callout .hd.tip .dt { background: var(--palm-ink); }
-      body.ex-detail .callout .hd.note .dt { background: var(--peach); }
-      body.ex-detail .callout .hd.warn .dt { background: var(--pink); }
-      body.ex-detail .callout p { margin: 0; color: var(--maroon-ink); }
+      /* `.ex-callout` (not `.callout`) so this example-specific highlight box —
+         column layout, .hd dot header — never collides with the shared
+         admonition `.callout` (@cocoindex/brand/base.css) that `:::note` blocks
+         in example content render as. */
+      body.ex-detail .ex-callout { border: 1px solid var(--rule-strong); border-radius: 8px; padding: 14px 18px; background: var(--cream); display: flex; flex-direction: column; gap: 6px; font-size: 13px; line-height: 1.5; }
+      body.ex-detail .ex-callout .hd { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+      body.ex-detail .ex-callout .hd .dt { width: 8px; height: 8px; border-radius: 50%; background: var(--coral); }
+      body.ex-detail .ex-callout .hd.tip .dt { background: var(--palm-ink); }
+      body.ex-detail .ex-callout .hd.note .dt { background: var(--peach); }
+      body.ex-detail .ex-callout .hd.warn .dt { background: var(--pink); }
+      body.ex-detail .ex-callout p { margin: 0; color: var(--maroon-ink); }
 
       /* Variations */
       body.ex-detail .var-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -155,9 +155,9 @@ const breadcrumbLd = {
             </p>
 
             <div class="hero-filters" id="filters">
-              <button class="filter-chip on" data-filter="all">All <span class="cnt">{total}</span></button>
+              <button class="t-filter on" data-filter="all">All <span class="cnt">{total}</span></button>
               {activeCats.map((c) => (
-                <button class="filter-chip" data-filter={c}>
+                <button class="t-filter" data-filter={c}>
                   {CATEGORY_META[c].label}{CATEGORY_META[c].em ?? ''} <span class="cnt">{catCount(c)}</span>
                 </button>
               ))}
@@ -189,17 +189,17 @@ const breadcrumbLd = {
 
           <div class="side-group">
             <h6>By target</h6>
-            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <span class="t-pill">{t}</span>)}</div>
           </div>
 
           <div class="side-group">
             <h6>By source</h6>
-            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <span class="mini-tag">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <span class="t-pill">{t}</span>)}</div>
           </div>
 
           <div class="side-group">
             <h6>By LLM</h6>
-            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <span class="mini-tag">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <span class="t-pill">{t}</span>)}</div>
           </div>
 
           <div class="side-group">
@@ -271,7 +271,7 @@ const breadcrumbLd = {
                         <p>{ex.description}</p>
                         <div class="ex-tags">
                           {ex.tags.map((t) => (
-                            <span class={`tag ${t.kind}`}><span class="dt"></span>{t.label}</span>
+                            <span class={`t-pill ${t.kind}`}><span class="dt"></span>{t.label}</span>
                           ))}
                         </div>
                         <div class="ex-foot">
@@ -305,7 +305,7 @@ const breadcrumbLd = {
     <script is:inline>
       // Category filter chips — toggle visibility of category sections.
       (function(){
-        const chips = document.querySelectorAll('#filters .filter-chip');
+        const chips = document.querySelectorAll('#filters .t-filter');
         const sections = document.querySelectorAll('section.cat[data-cat]');
         const feat = document.querySelector('section.feat');
 
@@ -383,18 +383,7 @@ const breadcrumbLd = {
       body.ex-listing .hero-sub b { font-weight: 600; color: var(--maroon); }
 
       body.ex-listing .hero-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
-      body.ex-listing .filter-chip {
-        font-family: var(--sans); font-size: 13px; font-weight: 500;
-        padding: 8px 14px; border-radius: 999px;
-        background: var(--cream); color: var(--maroon-ink);
-        border: 1px solid var(--rule); cursor: pointer;
-        transition: background .15s, color .15s, border-color .15s;
-        display: inline-flex; gap: 6px; align-items: center;
-      }
-      body.ex-listing .filter-chip:hover { background: var(--paper); border-color: var(--rule-strong); }
-      body.ex-listing .filter-chip.on { background: var(--maroon); color: var(--cream); border-color: var(--maroon); }
-      body.ex-listing .filter-chip .cnt { font-family: var(--mono); font-size: 11px; opacity: 0.6; letter-spacing: 0; }
-      body.ex-listing .filter-chip.on .cnt { opacity: 0.8; }
+      /* .t-filter comes from @cocoindex/brand/tags.css (consistent coral hover). */
 
       body.ex-listing .hero-viz { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; aspect-ratio: 3/2; }
       body.ex-listing .hero-viz .t {
@@ -469,12 +458,7 @@ const breadcrumbLd = {
         color: var(--muted); margin: 0 0 10px;
       }
       body.ex-listing .side-group .tags-row { display: flex; flex-wrap: wrap; gap: 5px; }
-      body.ex-listing .side-group .mini-tag {
-        font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
-        color: var(--maroon-ink);
-        padding: 4px 9px; border-radius: 999px;
-        background: var(--cream); border: 1px solid var(--rule);
-      }
+      /* Sidebar mini-tags use @cocoindex/brand .t-pill. */
       body.ex-listing .side-group .links { display: flex; flex-direction: column; gap: 4px; }
       body.ex-listing .side-group .links a {
         text-decoration: none; color: var(--maroon-ink);
@@ -599,8 +583,8 @@ const breadcrumbLd = {
         transition: background-image .18s ease;
       }
       body.ex-listing .ex-card:hover {
-        background-image: radial-gradient(circle, rgba(42, 18, 27, 0.1) 1.2px, transparent 1.6px);
-        background-size: 14px 14px;
+        background-image: var(--dot-reveal);
+        background-size: var(--dot-reveal-size) var(--dot-reveal-size);
       }
       body.ex-listing .ex-thumb {
         aspect-ratio: 16/7;
@@ -657,19 +641,13 @@ const breadcrumbLd = {
       body.ex-listing .ex-body p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; flex: 1; }
 
       body.ex-listing .ex-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
-      body.ex-listing .ex-tags .tag {
-        font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
-        padding: 4px 10px; border-radius: 999px;
-        background: var(--paper); color: var(--maroon);
-        border: 1px solid var(--rule);
-        display: inline-flex; gap: 6px; align-items: center;
-      }
-      body.ex-listing .ex-tags .tag .dt { width: 5px; height: 5px; border-radius: 50%; background: var(--coral); }
-      body.ex-listing .ex-tags .tag.src .dt { background: var(--peach); }
-      body.ex-listing .ex-tags .tag.tgt .dt { background: var(--pink); }
-      body.ex-listing .ex-tags .tag.llm .dt { background: var(--palm-ink); }
-      body.ex-listing .ex-tags .tag.ops .dt { background: var(--coral); }
-      body.ex-listing .ex-tags .tag.lvl .dt { background: var(--maroon); }
+      /* Tags use @cocoindex/brand .t-pill; the leading dot's colour is the
+         example category, set via the --dt custom property (default coral). */
+      body.ex-listing .ex-tags .t-pill.src { --dt: var(--peach); }
+      body.ex-listing .ex-tags .t-pill.tgt { --dt: var(--pink); }
+      body.ex-listing .ex-tags .t-pill.llm { --dt: var(--palm-ink); }
+      body.ex-listing .ex-tags .t-pill.ops { --dt: var(--coral); }
+      body.ex-listing .ex-tags .t-pill.lvl { --dt: var(--maroon); }
 
       body.ex-listing .ex-foot {
         display: flex; justify-content: space-between; align-items: center;

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -10,6 +10,8 @@ import MobileSheet from '../../components/MobileSheet.astro';
 import Analytics from '../../components/Analytics.astro';
 import ScarfPixel from '../../components/ScarfPixel.astro';
 import Foot from '../../components/Foot.astro';
+import ExampleCard from '../../components/examples/ExampleCard.astro';
+import FeaturedCard from '../../components/examples/FeaturedCard.astro';
 import { GITHUB_REPO, DISCORD_URL, SITE_URL, titleMarkup, SCARF_PIXEL_ID, OG_IMAGE_EXAMPLES, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT, OG_IMAGE_EXAMPLES_ALT } from '../../consts';
 import {
   examples,
@@ -225,24 +227,7 @@ const breadcrumbLd = {
           <!-- ═══════════ FEATURED ═══════════ -->
           <section class="feat" id="feat-scroll">
             <div class="feat-eyebrow">★ Featured</div>
-            <a class="feat-card" href={exampleHref(featured.slug)}>
-              <div class="feat-body">
-                <span class="ribbon"><span class="tick"></span>{featured.thumbLabel} · <span class="idx">{featured.index}</span></span>
-                <h3 set:html={titleMarkup(featured.title + '.')} />
-                <p>{featured.description}</p>
-                <div class="chips">
-                  {featured.tags.map((t) => <span class="chip">{t.label}</span>)}
-                </div>
-                <div class="foot">
-                  <span>{featured.footMeta}</span>
-                  <span class="go">Open example
-                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 6h8m-3-3 3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </div>
-              </div>
-
-              <div class="feat-viz" aria-hidden="true" set:html={featured.motif ?? ''} />
-            </a>
+            <FeaturedCard ex={featured} href={exampleHref(featured.slug)} />
           </section>
 
           <!-- ═══════════ CATEGORY SECTIONS ═══════════ -->
@@ -259,28 +244,7 @@ const breadcrumbLd = {
                 </div>
 
                 <div class="cat-grid">
-                  {items.map((ex) => (
-                    <a class="ex-card" href={exampleHref(ex.slug)}>
-                      <div class={`ex-thumb ${ex.thumbClass ?? CATEGORY_META[ex.category].thumbClass}`}>
-                        <span class="tl">{ex.thumbLabel}</span>
-                        <span class="tr">{ex.index}</span>
-                        <div class="motif" set:html={ex.motif ?? ''} />
-                      </div>
-                      <div class="ex-body">
-                        <h3 set:html={titleMarkup(ex.title)} />
-                        <p>{ex.description}</p>
-                        <div class="ex-tags">
-                          {ex.tags.map((t) => (
-                            <span class={`t-pill ${t.kind}`}><span class="dt"></span>{t.label}</span>
-                          ))}
-                        </div>
-                        <div class="ex-foot">
-                          <span>{ex.footMeta}</span>
-                          <span class="go">Open →</span>
-                        </div>
-                      </div>
-                    </a>
-                  ))}
+                  {items.map((ex) => <ExampleCard ex={ex} href={exampleHref(ex.slug)} />)}
                 </div>
               </section>
             );

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -54,45 +54,6 @@ a:hover { text-decoration: underline; }
    Hidden on desktop; phone-mode rules quiet both this and `.stars` so
    the topbar doesn't read as three competing controls (logo + stars +
    burger). See @media (max-width: 820px) below for the ghost treatment. */
-.menu-btn {
-  display: none; /* desktop default; flipped on at phone width */
-  width: 32px; height: 32px; flex: none;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--muted);
-  align-items: center; justify-content: center;
-  cursor: pointer;
-  position: relative;
-  padding: 0;
-  transition: background .16s ease, border-color .16s ease, color .16s ease;
-}
-.menu-btn:hover {
-  border-color: var(--rule);
-  background: color-mix(in oklab, var(--peach) 10%, transparent);
-  color: var(--maroon-ink);
-}
-.menu-btn:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
-.menu-btn .bar,
-.menu-btn::before,
-.menu-btn::after {
-  content: "";
-  position: absolute; left: 8px; right: 8px;
-  height: 1.4px; border-radius: 1px;
-  background: currentColor;
-  transition: transform .22s cubic-bezier(.2,.8,.2,1), opacity .14s ease, top .22s cubic-bezier(.2,.8,.2,1);
-}
-.menu-btn::before { top: 10px; }
-.menu-btn .bar    { top: 15px; }
-.menu-btn::after  { top: 20px; }
-.menu-btn.open {
-  color: var(--coral);
-  border-color: var(--rule);
-  background: color-mix(in oklab, var(--peach) 10%, transparent);
-}
-.menu-btn.open::before { top: 15px; transform: rotate(45deg); }
-.menu-btn.open::after  { top: 15px; transform: rotate(-45deg); }
-.menu-btn.open .bar    { opacity: 0; }
 
 /* ─── phone drawer (scrim + sheet + tabs + lists) ───
    Lives at `display: none` on desktop and only materializes at phone

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -3,6 +3,9 @@
    primitives (callouts, .btn, .t-* tags, inline code + .code-figure, cards). */
 @import '@cocoindex/brand/tokens.css';
 @import '@cocoindex/brand/components.css';
+/* Docs-only chrome (sidebar groups, TOC, pager, breadcrumb, search button,
+   version dropdown, doc footer). Not in components.css — home/blog don't need it. */
+@import '@cocoindex/brand/docs-chrome.css';
 
 /* Self-hosted fonts (WOFF2) — identical to the blog; no Google CDN (GUIDELINE §5.2). */
 @import '@fontsource/inter/400.css';
@@ -13,10 +16,12 @@
 @import '@fontsource/source-serif-4/400.css';
 @import '@fontsource/source-serif-4/400-italic.css';
 
-/* Docs-specific layout tokens (3-pane shell). Brand tokens come from the import above. */
+/* Docs-specific layout tokens (3-pane shell). Brand tokens come from the import above.
+   --chrome-maxw widens the shared nav + footer to the docs content column (1480). */
 :root {
   --side: 280px;
   --toc: 240px;
+  --chrome-maxw: var(--maxw-docs);
 }
 
 * { box-sizing: border-box; }
@@ -39,123 +44,11 @@ a:hover { text-decoration: underline; }
 /* ─── top nav ─── */
 /* Lifted from cocoindex-io.github.io globals.css so both sites share the
    exact same header — class names, spacing, hover colors all match 1:1. */
-nav.top {
-  position: sticky; top: 0; z-index: 50;
-  background: color-mix(in oklab, var(--paper) 92%, transparent);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--rule);
-}
-.nav-in {
-  max-width: 1480px; margin: 0 auto;
-  padding: 14px 32px;
-  display: flex; align-items: center; gap: 28px;
-}
-.logo { display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--maroon-ink); line-height: 1; }
-.logo:hover, .logo:hover span { text-decoration: none; }
-.logo img { width: 28px; height: 28px; display: block; transform: translateY(-3px); }
-.logo span { font-family: var(--sans); font-size: 18px; font-weight: 600; letter-spacing: -0.02em; line-height: 1; display: inline-block; }
-.nav-links { display: flex; gap: 28px; margin-left: 24px; }
-.nav-links a { font-size: 14px; color: var(--maroon-ink); text-decoration: none; padding: 6px 0; position: relative; }
-.nav-links a:hover { color: var(--coral); }
+/* Desktop nav bar (nav.top / .logo / .nav-links) comes from
+   @cocoindex/brand/nav.css. The docs-only version dropdown (.nav-dd) stays below. */
 
-/* Docs version switcher — hover-revealed dropdown on the Documentation
-   nav link. Matches the brand palette: cream panel, maroon ink text,
-   coral `current` pill, muted `legacy` pill. */
-.nav-dd { position: relative; }
-.nav-dd-trigger {
-  display: inline-flex !important; align-items: center; gap: 6px;
-}
-.nav-dd-trigger svg {
-  color: var(--muted);
-  transition: transform .15s ease;
-}
-.nav-dd:hover .nav-dd-trigger svg,
-.nav-dd:focus-within .nav-dd-trigger svg {
-  color: var(--coral);
-  transform: rotate(180deg);
-}
-.nav-dd-menu {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  min-width: 180px;
-  padding: 6px;
-  background: var(--paper);
-  border: 1px solid var(--rule-strong);
-  border-radius: 10px;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(-4px);
-  transition: opacity .15s ease, transform .15s ease, visibility 0s linear .15s;
-  display: flex; flex-direction: column; gap: 2px;
-  z-index: 60;
-}
-.nav-dd:hover .nav-dd-menu,
-.nav-dd:focus-within .nav-dd-menu {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-  transition-delay: 0s;
-}
-/* Invisible bridge so the menu doesn't close when the cursor moves
-   from the trigger to the panel. */
-.nav-dd-menu::before {
-  content: "";
-  position: absolute;
-  top: -10px; left: 0; right: 0; height: 10px;
-}
-.nav-dd-menu a {
-  display: flex !important; align-items: center; justify-content: space-between;
-  gap: 12px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--maroon-ink);
-  text-decoration: none;
-}
-.nav-dd-menu a:hover { color: var(--coral); }
-.nav-dd-menu a.on { color: var(--coral); }
-.nav-dd-menu .ver {
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 500;
-}
-.nav-dd-menu .tag {
-  font-family: var(--mono);
-  font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
-  padding: 2px 7px; border-radius: 999px;
-  background: color-mix(in oklab, var(--coral) 14%, var(--cream));
-  color: var(--coral);
-  border: 1px solid color-mix(in oklab, var(--coral) 28%, transparent);
-}
-.nav-dd-menu .tag.legacy {
-  background: transparent;
-  color: var(--muted);
-  border-color: var(--rule-strong);
-}
 
-.nav-cta { margin-left: auto; display: flex; gap: 10px; align-items: center; }
-
-.stars {
-  font-family: var(--mono); font-size: 12px;
-  padding: 6px 10px; border: 1px solid var(--rule-strong);
-  border-radius: 999px; display: inline-flex; gap: 6px; align-items: center;
-  min-width: 74px; justify-content: center;
-  text-decoration: none; color: var(--maroon);
-  transition: border-color .2s ease, background .2s ease, color .2s ease;
-}
-.stars:hover {
-  border-color: rgba(190, 81, 51, 0.45);
-  background: color-mix(in oklab, var(--peach) 14%, var(--cream));
-  color: var(--coral);
-}
-.stars .count {
-  width: 4ch;
-  min-width: 4ch;
-  display: inline-block;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
-}
+/* .nav-cta + the .stars pill come from @cocoindex/brand (nav.css + stars.css). */
 
 /* ─── phone hamburger ───
    Hidden on desktop; phone-mode rules quiet both this and `.stars` so
@@ -383,51 +276,6 @@ main.content {
   min-width: 0;
 }
 
-/* ─── sidebar search ───
-   Sits at the top of `aside.side`. The button is rendered server-side
-   and styled to match the docs design tokens (cream fill, hairline
-   border, mono caps row). The actual DocSearch modal is mounted lazily
-   on first interaction by Search.astro — see that file for the env
-   var wiring (PUBLIC_COCOINDEX_DOCS_ALGOLIA_*). */
-.search-wrap {
-  position: sticky; top: 0;
-  background: linear-gradient(var(--paper) 80%, transparent);
-  padding: 0 0 14px;
-  margin-bottom: 6px;
-  z-index: 5;
-}
-.search-btn {
-  width: 100%;
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 8px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--rule-strong);
-  background: var(--cream);
-  color: var(--maroon-ink);
-  font-family: var(--sans); font-size: 13px; font-weight: 500;
-  cursor: pointer;
-  transition: border-color .15s ease, background .15s ease, color .15s ease;
-}
-.search-btn:hover {
-  border-color: var(--coral);
-  color: var(--coral);
-  background: color-mix(in oklab, var(--peach) 10%, var(--cream));
-}
-.search-btn:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
-.search-btn .ic { flex: none; opacity: .8; }
-.search-btn:hover .ic { opacity: 1; }
-.search-btn .lbl { flex: 1; text-align: left; }
-.search-btn .kbd {
-  font-family: var(--mono); font-size: 10px; font-weight: 500;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  border: 1px solid var(--rule);
-  border-radius: 4px;
-  padding: 1px 5px;
-  background: var(--paper);
-  display: inline-flex; align-items: center; gap: 2px;
-}
-.search-btn .kbd .cmd { font-size: 11px; line-height: 1; }
 
 /* ─── DocSearch theme ───
    Maps every @docsearch/css v4 variable to the CocoIndex design
@@ -660,84 +508,9 @@ main.content {
   letter-spacing: -0.005em;
 }
 
-/* ─── sidebar ─── */
-.side-group { margin-bottom: 22px; }
-.side-group > h5 {
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--muted); margin: 0 0 8px; padding: 0 10px;
-  display: flex; justify-content: space-between; align-items: center;
-}
-.side-group > h5 .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--coral); }
-.side-group ul { list-style: none; margin: 0; padding: 0; }
-.side-group li a {
-  display: flex; align-items: center; gap: 10px;
-  padding: 6px 10px;
-  color: var(--maroon-ink);
-  font-size: 13.5px;
-  border-radius: 5px;
-  text-decoration: none;
-  line-height: 1.3;
-}
-.side-group li a:hover { color: var(--coral); text-decoration: none; }
-.side-group li a.on { background: var(--maroon); color: var(--cream); font-weight: 500; }
-.side-group li a.on::before {
-  content: ""; width: 3px; height: 14px; background: var(--peach); border-radius: 2px;
-  margin-left: -7px; margin-right: 7px;
-}
-.side-group li a .num {
-  font-family: var(--mono); font-size: 10px; color: var(--muted);
-  min-width: 18px;
-}
-.side-group li a.on .num { color: rgba(252, 243, 216, 0.65); }
 
-/* ─── toc ─── */
-aside.toc h6 {
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--muted); margin: 0 0 12px; padding-bottom: 10px;
-  border-bottom: 1px solid var(--rule);
-}
-aside.toc ul { list-style: none; margin: 0; padding: 0; }
-aside.toc li a {
-  display: block;
-  padding: 4px 10px;
-  color: var(--muted); font-size: 13px;
-  text-decoration: none;
-  border-left: 2px solid transparent;
-  line-height: 1.4;
-}
-aside.toc li a:hover { color: var(--coral); text-decoration: none; }
-aside.toc li a.on { color: var(--coral); border-left-color: var(--coral); }
-aside.toc li.sub a { padding-left: 22px; font-size: 12.5px; }
-aside.toc li.sub-sub a { padding-left: 34px; font-size: 12px; }
-
-aside.toc .meta {
-  margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--rule);
-  display: flex; flex-direction: column; gap: 4px;
-}
-aside.toc .meta a,
-aside.toc .meta .edited {
-  font-size: 12.5px;
-  color: var(--maroon-ink);
-  padding: 6px 10px;
-  display: flex; gap: 10px; align-items: center;
-  text-decoration: none;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  transition: border-color .2s ease, background .2s ease, color .2s ease;
-}
-aside.toc .meta svg { flex: none; }
-aside.toc .meta a:hover { color: var(--coral); }
-aside.toc .meta .edited { color: var(--muted); cursor: default; }
 
 /* ─── main content ─── */
-.breadcrumb {
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
-  color: var(--muted); margin-bottom: 20px;
-}
-.breadcrumb a { color: var(--muted); text-decoration: none; }
-.breadcrumb a:hover { color: var(--maroon-ink); }
-.breadcrumb .sep { margin: 0 8px; opacity: 0.5; }
-.breadcrumb .now { color: var(--coral); }
 
 /* The .prose selector wraps rendered markdown so we can tune spacing without
    bleeding into the chrome (sidebar, TOC, breadcrumb). */
@@ -903,62 +676,7 @@ aside.toc .meta .edited { color: var(--muted); cursor: default; }
 .prose img, .prose svg { max-width: 100%; }
 .prose hr { border: none; border-top: 1px solid var(--rule); margin: 40px 0; }
 
-/* ─── pager ─── */
-.pager {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
-  margin-top: 56px;
-}
-.pager a {
-  position: relative; overflow: hidden;
-  display: flex; flex-direction: column; gap: 4px;
-  padding: 20px 22px;
-  border: 1px solid var(--rule-strong); border-radius: 8px;
-  text-decoration: none; color: var(--maroon-ink);
-  transition: border-color .2s ease;
-}
-.pager a > * { position: relative; z-index: 1; }
-/* Dotted reveal on hover — same pattern as the homepage .ex-card. The
-   dots fade in from the trailing edge so Prev lights up on the right and
-   Next lights up on the left (the edge where the arrow lives). */
-.pager a::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 0 auto;
-  width: 80px;
-  background-image: radial-gradient(circle, rgba(190, 81, 51, 0.24) 1.2px, transparent 1.6px);
-  background-size: 11px 11px;
-  opacity: 0;
-  transition: opacity .25s ease;
-  pointer-events: none;
-  -webkit-mask-image: linear-gradient(to right, transparent, #000 55%);
-          mask-image: linear-gradient(to right, transparent, #000 55%);
-}
-.pager a.next::before {
-  inset: 0 auto 0 0;
-  -webkit-mask-image: linear-gradient(to left, transparent, #000 55%);
-          mask-image: linear-gradient(to left, transparent, #000 55%);
-}
-.pager a:hover {
-  border-color: color-mix(in oklab, var(--coral) 45%, var(--rule-strong));
-  text-decoration: none;
-}
-.pager a:hover::before { opacity: 1; }
-.pager a.next { text-align: right; }
-.pager a .dir { font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
-.pager a .ttl { font-family: var(--sans); font-size: 16px; font-weight: 600; letter-spacing: -0.015em; color: var(--maroon); margin-top: 2px; }
-.pager a .ttl::before { content: "← "; color: var(--coral); }
-.pager a.next .ttl::before { content: ""; }
-.pager a.next .ttl::after { content: " →"; color: var(--coral); }
 
-/* ─── doc footer ─── */
-.doc-foot {
-  display: flex; justify-content: space-between; align-items: center;
-  margin-top: 40px;
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
-  color: var(--muted);
-}
-.doc-foot a { color: var(--muted); text-decoration: none; padding: 4px 10px; border: 1px solid var(--rule); border-radius: 4px; }
-.doc-foot a:hover { color: var(--coral); border-color: var(--coral); text-decoration: none; }
 
 /* ─── responsive ─── */
 @media (max-width: 1120px) {

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1,20 +1,14 @@
+/* Brand fonts — self-hosted WOFF2, the single font source for every surface
+   (provided by @cocoindex/brand; docs no longer self-hosts its own). */
+@import '@cocoindex/brand/fonts.css';
 /* Shared design layer — from @cocoindex/brand, the single source of truth across
    home, blog, and docs. tokens.css = :root tokens; components.css = the shared
-   primitives (callouts, .btn, .t-* tags, inline code + .code-figure, cards). */
+   primitives (callouts, .btn, .t-* tags, inline code + .code-figure, cards, prose). */
 @import '@cocoindex/brand/tokens.css';
 @import '@cocoindex/brand/components.css';
 /* Docs-only chrome (sidebar groups, TOC, pager, breadcrumb, search button,
    version dropdown, doc footer). Not in components.css — home/blog don't need it. */
 @import '@cocoindex/brand/docs-chrome.css';
-
-/* Self-hosted fonts (WOFF2) — identical to the blog; no Google CDN (GUIDELINE §5.2). */
-@import '@fontsource/inter/400.css';
-@import '@fontsource/inter/500.css';
-@import '@fontsource/inter/600.css';
-@import '@fontsource/jetbrains-mono/400.css';
-@import '@fontsource/jetbrains-mono/500.css';
-@import '@fontsource/source-serif-4/400.css';
-@import '@fontsource/source-serif-4/400-italic.css';
 
 /* Docs-specific layout tokens (3-pane shell). Brand tokens come from the import above.
    --chrome-maxw widens the shared nav + footer to the docs content column (1480). */
@@ -50,72 +44,13 @@ a:hover { text-decoration: underline; }
 
 /* .nav-cta + the .stars pill come from @cocoindex/brand (nav.css + stars.css). */
 
-/* ─── phone hamburger ───
-   Hidden on desktop; phone-mode rules quiet both this and `.stars` so
-   the topbar doesn't read as three competing controls (logo + stars +
-   burger). See @media (max-width: 820px) below for the ghost treatment. */
-
-/* ─── phone drawer (scrim + sheet + tabs + lists) ───
-   Lives at `display: none` on desktop and only materializes at phone
-   width. Tokens mirror design_guidelines/ui/hamburger-toc.html: no drop
-   shadow (elevation reads from the maroon scrim), one coral accent at a
-   time, animation ≤ 220ms. */
-.mobile-scrim,
-.mobile-sheet { display: none; }
-.mobile-scrim {
-  position: fixed; inset: 0;
-  background: color-mix(in oklab, var(--maroon-ink) 38%, transparent);
-  opacity: 0; pointer-events: none;
-  transition: opacity .22s ease;
-  z-index: 60;
-}
-.mobile-scrim.open { opacity: 1; pointer-events: auto; }
-
-.mobile-sheet {
-  position: fixed; top: 0; right: 0; bottom: 0;
-  width: min(86%, 360px);
-  background: var(--paper);
-  border-left: 1px solid var(--rule-strong);
-  transform: translateX(100%);
-  transition: transform .22s cubic-bezier(.2,.8,.2,1);
-  flex-direction: column;
-  z-index: 70;
-  overflow: hidden;
-}
-.mobile-sheet.open { transform: translateX(0); }
-.mobile-sheet[hidden] { display: none !important; }
-
-.mobile-sheet-head {
-  display: flex; align-items: center; gap: 10px;
-  /* y-padding mirrors `.nav-in`'s phone-mode 10px so the sheet's
-     border-bottom lines up exactly with the topbar's, even though the
-     sheet sits in its own stacking context. With a 32px close button
-     this resolves to 52px content + 1px rule = 53px total height,
-     identical to the topbar at ≤820px. */
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--rule);
-  flex: none;
-}
-.mobile-sheet-head .ttl {
-  font-family: var(--mono); font-weight: 500;
-  font-size: 11px; letter-spacing: 0.14em;
-  text-transform: uppercase; color: var(--muted);
-  flex: 1;
-}
-.mobile-close {
-  width: 32px; height: 32px; border-radius: 8px;
-  border: 1px solid transparent; background: transparent;
-  color: var(--muted);
-  display: grid; place-items: center;
-  cursor: pointer; padding: 0;
-  transition: color .16s ease, border-color .16s ease, background .16s ease;
-}
-.mobile-close:hover {
-  color: var(--coral);
-  border-color: var(--rule);
-  background: color-mix(in oklab, var(--peach) 10%, transparent);
-}
-.mobile-close:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+/* ─── phone drawer: docs content ───
+   The drawer shell (scrim + sliding sheet + close header + .mobile-pane /
+   .mobile-list / .mobile-foot) and its open/close behavior come from
+   @cocoindex/brand (MobileSheet.astro + nav.css). What stays here is the
+   docs-only content: the segmented Pages / On-this-page tabs, sidebar groups,
+   and the search box. The hamburger + `.stars` phone treatment is the
+   @media (max-width: 820px) block below. */
 
 .mobile-tabs {
   display: grid; grid-template-columns: 1fr 1fr;
@@ -143,13 +78,6 @@ a:hover { text-decoration: underline; }
 .mobile-tabs button[disabled] { opacity: .35; cursor: not-allowed; }
 .mobile-tabs button:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
 
-.mobile-pane {
-  flex: 1;
-  overflow-y: auto;
-  padding: 14px 6px 24px;
-  -webkit-overflow-scrolling: touch;
-}
-.mobile-pane[hidden] { display: none; }
 .mobile-empty {
   margin: 16px 14px; color: var(--muted);
   font-size: 13.5px; line-height: 1.55;
@@ -170,45 +98,6 @@ a:hover { text-decoration: underline; }
 .mobile-group h6 a { color: inherit; text-decoration: none; }
 .mobile-group h6 a:hover { color: var(--coral); }
 
-.mobile-list { display: flex; flex-direction: column; }
-.mobile-list a {
-  display: flex; align-items: center; gap: 10px;
-  min-height: 44px;
-  padding: 10px 10px;
-  border-radius: 8px;
-  font-family: var(--sans); font-weight: 500;
-  font-size: 14px; letter-spacing: -0.005em;
-  color: var(--maroon-ink); text-decoration: none;
-  transition: background .14s ease, color .14s ease;
-}
-.mobile-list a:hover { background: color-mix(in oklab, var(--coral) 8%, transparent); color: var(--maroon-ink); }
-.mobile-list a[aria-current] {
-  background: color-mix(in oklab, var(--coral) 14%, transparent);
-  color: var(--coral);
-}
-.mobile-list a .num {
-  width: 22px; height: 22px; border-radius: 5px;
-  flex: none; display: grid; place-items: center;
-  font-family: var(--mono); font-size: 10px; font-weight: 500;
-  background: color-mix(in oklab, var(--maroon-ink) 6%, transparent);
-  color: var(--maroon-ink);
-  font-variant-numeric: tabular-nums;
-}
-.mobile-list a[aria-current] .num { background: var(--coral); color: var(--cream); }
-.mobile-list a.sub {
-  padding-left: 36px; min-height: 38px;
-  font-size: 13px;
-  color: var(--muted);
-}
-.mobile-list a.sub:hover { color: var(--maroon-ink); }
-.mobile-list .lbl { flex: 1; min-width: 0; line-height: 1.3; }
-
-@media (prefers-reduced-motion: reduce) {
-  .menu-btn::before, .menu-btn::after, .menu-btn .bar,
-  .mobile-sheet, .mobile-scrim {
-    transition: none !important;
-  }
-}
 
 /* ─── layout ─── */
 .layout {
@@ -473,20 +362,10 @@ main.content {
 
 /* ─── main content ─── */
 
-/* The .prose selector wraps rendered markdown so we can tune spacing without
-   bleeding into the chrome (sidebar, TOC, breadcrumb). */
-.prose h1 {
-  font-family: var(--serif); font-weight: 400;
-  font-size: clamp(40px, 4.6vw, 60px); line-height: 1.02;
-  letter-spacing: -0.03em; margin: 0 0 18px;
-}
-.prose h1 em { font-style: italic; color: var(--coral); }
-
-.prose .lede {
-  font-family: var(--sans); font-size: clamp(17px, 1.4vw, 20px);
-  font-weight: 400; line-height: 1.5; letter-spacing: -0.005em;
-  margin: 0 0 14px; color: var(--maroon-ink); max-width: 62ch;
-}
+/* Prose typography for rendered markdown (.prose h1/lede/h2/h3/h4, lists,
+   blockquotes, tables, mermaid, heading permalinks) lives in
+   @cocoindex/brand/prose.css and renders at the docs default scale. Only the
+   docs-specific .intro-meta strip below stays local. */
 
 /* Intro-meta strip: the Time / Language / Requires / Version / Last
    updated dl under the lede on every doc page. Matches the ruled band
@@ -510,134 +389,6 @@ main.content {
   display: inline-flex; align-items: center; gap: 6px;
 }
 .prose .intro-meta .check { flex: none; }
-
-.prose h2 {
-  font-family: var(--sans); font-weight: 600;
-  font-size: 28px; line-height: 1.1; letter-spacing: -0.025em;
-  margin: 56px 0 12px;
-  scroll-margin-top: 80px;
-}
-.prose h2 em { font-style: normal; color: var(--coral); }
-.prose h3 {
-  font-family: var(--sans); font-weight: 600;
-  font-size: 18px; line-height: 1.3; letter-spacing: -0.01em;
-  margin: 28px 0 10px;
-  scroll-margin-top: 80px;
-}
-.prose h4 {
-  font-family: var(--sans); font-weight: 600;
-  font-size: 15px; line-height: 1.3; letter-spacing: -0.005em;
-  margin: 22px 0 8px;
-  scroll-margin-top: 80px;
-}
-
-/* Shareable permalink affordance on section headings. A link icon sits in the
-   left gutter and reveals on hover; clicking sets the URL hash and copies the
-   section's full URL to the clipboard. Headings already carry Astro-generated
-   ids (the TOC relies on them); the anchors are injected by the script in
-   DocsLayout.astro. Mirrors the blog's `.head-anchor` affordance. */
-.prose :is(h2, h3, h4, h5, h6) { position: relative; }
-.prose .head-anchor {
-  position: absolute;
-  left: -1.4em; top: 0; bottom: 0;
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 1.4em;
-  color: var(--coral);
-  opacity: 0;
-  text-decoration: none;
-  transition: opacity 0.15s ease, color 0.15s ease;
-}
-.prose .head-anchor svg { width: 0.66em; height: 0.66em; }
-.prose :is(h2, h3, h4, h5, h6):hover .head-anchor { opacity: 0.5; }
-.prose .head-anchor:hover,
-.prose .head-anchor:focus-visible { opacity: 1; }
-.prose .head-anchor.copied { opacity: 1; color: var(--palm-ink); }
-.prose .head-anchor.copied::after {
-  content: "Link copied";
-  position: absolute; left: 50%; bottom: calc(100% + 7px);
-  transform: translateX(-50%);
-  background: var(--maroon-ink); color: var(--cream);
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.02em;
-  white-space: nowrap; padding: 3px 8px; border-radius: 5px;
-  pointer-events: none;
-}
-
-.prose p { margin: 12px 0; max-width: 68ch; }
-.prose ul, .prose ol { max-width: 68ch; padding-left: 22px; }
-.prose li { margin: 6px 0; }
-
-
-/* Mermaid diagrams — rendered from ```mermaid fenced blocks by
-   scripts/remark-mermaid.mjs and initialized in MermaidRenderer.astro. */
-.mermaid-figure {
-  margin: 24px 0;
-  padding: 18px;
-  border: 1px solid var(--rule);
-  border-radius: 10px;
-  background: var(--paper);
-  overflow-x: auto;
-}
-.mermaid-figure .mermaid {
-  display: flex;
-  justify-content: center;
-  min-width: 620px;
-  margin: 0;
-  padding: 0 !important;
-  border: 0 !important;
-  background: transparent !important;
-  color: var(--maroon-ink);
-  font-family: var(--sans);
-}
-.mermaid-figure svg {
-  max-width: 100%;
-  height: auto;
-}
-.mermaid-figure-error {
-  border-color: color-mix(in oklab, var(--pink) 70%, var(--rule));
-}
-@media (max-width: 720px) {
-  .mermaid-figure .mermaid { min-width: 560px; }
-}
-
-
-/* Block quotes — plain markdown `> …` surfaces that aren't admonitions. */
-.prose blockquote {
-  margin: 20px 0;
-  padding: 14px 20px;
-  border: 1px solid var(--rule-strong);
-  border-left: 3px solid var(--coral);
-  border-radius: 6px;
-  background: var(--cream);
-  color: var(--maroon-ink);
-}
-.prose blockquote p { margin: 6px 0; }
-.prose blockquote strong { font-weight: 600; }
-
-/* Tables — tech docs lean on these for reference material. */
-.prose table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 20px 0;
-  font-size: 14px;
-}
-.prose th, .prose td {
-  text-align: left;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--rule);
-  vertical-align: top;
-}
-.prose th {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-  border-bottom-color: var(--rule-strong);
-}
-
-.prose img, .prose svg { max-width: 100%; }
-.prose hr { border: none; border-top: 1px solid var(--rule); margin: 40px 0; }
-
-
 
 /* ─── responsive ─── */
 @media (max-width: 1120px) {


### PR DESCRIPTION
Adopts brand v0.2.1 across docs + examples.

- Import `@cocoindex/brand/docs-chrome.css` (sidebar, TOC, pager, breadcrumb, search button, version dropdown, doc-foot); delete the local copies and the bespoke nav/stars/footer CSS (now shared). `--chrome-maxw=--maxw-docs` widens the shared nav + footer to the docs column.
- `Foot.astro` renders the shared `<Footer>` with the docs links/logo.
- Examples: filter chips → `.t-filter`, category tags → `.t-pill` + `--dt` dot colour, card hover → the shared `--dot-reveal` token (consistent with home/blog).

Verified: build green (62 pages); docs chrome + examples pills/tags/hovers + footer render from the shared layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)