### PR TITLE
code_match: operator, containment-perf, delimiter fixes + harness

### DIFF
--- a/rust/code_match/examples/stress.rs
+++ b/rust/code_match/examples/stress.rs
@@ -1,0 +1,356 @@
+//! Stress-test the matcher + prefilter over a real codebase.
+//!
+//!   cargo run --release -p cocoindex_code_match --example stress -- <dir> [max_files_per_lang]
+//!
+//! Samples files by extension, auto-generates patterns from real lines (literal,
+//! metavar-injected, containment-wrapped), single-layer templates, and multi-layer
+//! nested containment (`gen_layered_patterns`), then checks the load-bearing
+//! invariants on every (pattern, file): no panic, prefilter soundness
+//! (matches ⟹ might_match), and bounded match time (a pathologically slow match —
+//! e.g. super-linear nested containment — is reported like a panic). The tree is
+//! parsed once per file and reused via `matches_in_tree`, so timing reflects
+//! matching, not parsing. Reports any violation with the pattern + file so it's
+//! reproducible.
+
+use cocoindex_code_match::{LangConfig, Pattern, lang};
+use std::collections::HashSet;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use tree_sitter::Parser;
+
+fn lang_for_ext(ext: &str) -> Option<(&'static str, LangConfig)> {
+    let name = match ext {
+        "rs" => "rust",
+        "py" | "pyi" => "python",
+        "ts" => "typescript",
+        "tsx" => "tsx",
+        "js" | "jsx" | "mjs" | "cjs" => "javascript",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => "cpp",
+        "go" => "go",
+        "java" => "java",
+        "rb" => "ruby",
+        "json" => "json",
+        "toml" => "toml",
+        "yaml" | "yml" => "yaml",
+        "css" => "css",
+        "html" => "html",
+        "sql" => "sql",
+        "swift" => "swift",
+        "kt" | "kts" => "kotlin",
+        "scala" => "scala",
+        "sh" | "bash" => "bash",
+        "cs" => "csharp",
+        "php" => "php",
+        _ => return None,
+    };
+    lang::by_name(name).map(|c| (name, c))
+}
+
+/// Replace the first `[a-z_][A-Za-z0-9_]*` identifier run with `\X` (a crude metavar
+/// injection — invalid results are fine, they exercise the lexer/compiler).
+fn inject_metavar(s: &str) -> Option<String> {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        let c = b[i];
+        if c == b'_' || c.is_ascii_lowercase() {
+            let start = i;
+            while i < b.len() && (b[i] == b'_' || b[i].is_ascii_alphanumeric()) {
+                i += 1;
+            }
+            // skip if it's right after a `.`/`\` (avoid mangling member access oddly)
+            if start > 0 && (b[start - 1] == b'\\') {
+                continue;
+            }
+            return Some(format!("{}\\X{}", &s[..start], &s[i..]));
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The word-shaped tokens (`[A-Za-z_][A-Za-z0-9_]*`) present in the source — used to
+/// gate layered patterns on keywords that actually appear, so they exercise real
+/// nesting instead of trivially failing to compile/match.
+fn word_set(src: &str) -> HashSet<&str> {
+    let mut set = HashSet::new();
+    let b = src.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i].is_ascii_alphabetic() || b[i] == b'_' {
+            let s = i;
+            while i < b.len() && (b[i].is_ascii_alphanumeric() || b[i] == b'_') {
+                i += 1;
+            }
+            set.insert(&src[s..i]);
+        } else {
+            i += 1;
+        }
+    }
+    set
+}
+
+/// Multi-layer nested-containment patterns like `catch \* \{{ if \* \{{ throw \}} \}}`
+/// (a conditional re-throw). Real code has structure several layers deep; these probe
+/// the containment + leading/trailing-tolerance + prefilter interaction that single-
+/// layer patterns never reach. Gated on block/action keywords that appear in `words`
+/// so each pattern has a realistic chance of matching, and bounded so the keyword
+/// cross-product can't explode the run.
+fn gen_layered_patterns(words: &HashSet<&str>) -> Vec<String> {
+    const BLOCKS: &[&str] = &[
+        "if", "for", "while", "catch", "switch", "match", "loop", "function", "fn", "def", "class",
+        "impl",
+    ];
+    const ACTIONS: &[&str] = &["throw", "return", "break", "continue", "raise", "yield"];
+    let blocks: Vec<&str> = BLOCKS
+        .iter()
+        .copied()
+        .filter(|k| words.contains(*k))
+        .collect();
+    let actions: Vec<&str> = ACTIONS
+        .iter()
+        .copied()
+        .filter(|k| words.contains(*k))
+        .collect();
+    let (open, close) = (r"\{{", r"\}}");
+    let mut out = Vec::new();
+    for &outer in &blocks {
+        for &act in &actions {
+            // 2-layer: a block whose body contains an action.
+            out.push(format!(r"{outer} \* {open} {act} {close}"));
+        }
+        for &inner in &blocks {
+            for &act in &actions {
+                // 3-layer: outer block → inner block → action (e.g. the re-throw above).
+                out.push(format!(
+                    r"{outer} \* {open} {inner} \* {open} {act} {close} {close}"
+                ));
+                if out.len() >= 80 {
+                    return out;
+                }
+            }
+        }
+    }
+    out
+}
+
+fn gen_patterns(src: &str) -> Vec<String> {
+    let mut pats = Vec::new();
+    for line in src.lines() {
+        let t = line.trim();
+        if t.len() < 4 || t.len() > 90 {
+            continue;
+        }
+        pats.push(t.to_string()); // the literal line
+        pats.push(format!("\\{{{{ {t} \\}}}}")); // containment over the line
+        if let Some(inj) = inject_metavar(t) {
+            pats.push(inj); // metavar-injected
+        }
+    }
+    // a few language-agnostic templates (panic/soundness coverage, not self-match)
+    for tpl in [
+        r"\X = \Y",
+        r"return \X",
+        r"\X(\*)",
+        r"\X.\Y(\*)",
+        r"\X + \Y",
+        r"\{{ return \X \}}",
+        r"\{{ \X(\*) \}}",
+        r"\(N:/.*/)",
+        r"\(N:/[a-z]+/*\)",
+        r"if \*",
+        // bare compound operators — exercise `match_token_run` (split pattern char-run
+        // vs. one source leaf) across every language. Most won't exist in a given
+        // language; we only care that they never panic and stay prefilter-sound.
+        "=>",
+        "==",
+        "===",
+        "!=",
+        "&&",
+        "||",
+        "->",
+        "::",
+        ">>",
+        "<<",
+        "+=",
+        "<=",
+        r"\X => \Y",
+        r"\X == \Y",
+        r"\X && \Y",
+        r"\X::\Y",
+        // deep metavar-only containment (no keyword needed) — double/triple nesting.
+        r"\{{ \{{ \X = \Y \}} \}}",
+        r"\{{ \X(\*) \{{ return \X \}} \}}",
+        r"\{{ if \* \{{ \X = \Y \}} \}}",
+    ] {
+        pats.push(tpl.to_string());
+    }
+    pats.extend(gen_layered_patterns(&word_set(src)));
+    pats
+}
+
+fn collect_files(root: &Path, max_per_lang: usize) -> Vec<(&'static str, LangConfig, PathBuf)> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&'static str, usize> = HashMap::new();
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with('.')
+                || matches!(
+                    name.as_ref(),
+                    "target" | "node_modules" | "build" | "dist" | "vendor" | "third_party"
+                )
+            {
+                continue;
+            }
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_dir() {
+                stack.push(p);
+            } else if ft.is_file() {
+                if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
+                    if let Some((langname, cfg)) = lang_for_ext(ext) {
+                        let c = counts.entry(langname).or_default();
+                        if *c < max_per_lang {
+                            // skip very large files (keep the run bounded)
+                            if std::fs::metadata(&p)
+                                .map(|m| m.len() < 200_000)
+                                .unwrap_or(false)
+                            {
+                                *c += 1;
+                                out.push((langname, cfg, p));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn main() {
+    let root = std::env::args()
+        .nth(1)
+        .expect("usage: stress <dir> [max_files]");
+    let max_per_lang: usize = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    std::panic::set_hook(Box::new(|_| {})); // suppress the default print; we report ourselves
+
+    let files = collect_files(Path::new(&root), max_per_lang);
+    eprintln!("sampled {} files", files.len());
+
+    // Flag a pattern only when its match time exceeds the file's *index baseline* by
+    // this margin. `matches_in_tree` rebuilds the index every call (cost ∝ file size,
+    // ~0.6µs/node, pattern-independent), so an absolute threshold just flags big
+    // files. Subtracting the baseline isolates a real matcher pathology — super-linear
+    // nested containment, catastrophic backtracking — which is a genuine bug.
+    const SLOW_EXCESS_US: u128 = 20_000;
+    let (mut total, mut compiled, mut panics, mut unsound, mut slow) =
+        (0u64, 0u64, 0u64, 0u64, 0u64);
+    let mut worst = (0u128, String::new(), String::new()); // (excess_us, file, pattern)
+    for (langname, cfg, path) in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.is_empty() {
+            continue;
+        }
+        // Parse ONCE per file and reuse the tree across every pattern via
+        // `matches_in_tree`. `Pattern::matches` re-parses on each call, which at ~250
+        // patterns/file dominated the run; tree-sitter parsing is the same regardless
+        // of pattern, so caching it is pure win and lets timing reflect *matching*.
+        let mut parser = Parser::new();
+        if parser.set_language(&cfg.language).is_err() {
+            continue;
+        }
+        let Some(tree) = parser.parse(&src, None) else {
+            continue;
+        };
+        // Baseline ≈ the per-call index cost: a trivial identifier pattern that still
+        // indexes the whole tree but does almost no DP work. Min of a few runs to
+        // shed scheduler noise. Per-pattern excess over this is the matching cost.
+        let base_us = {
+            let mut b = u128::MAX;
+            if let Ok(p) = Pattern::compile("zz_baseline_zz", cfg) {
+                for _ in 0..3 {
+                    let t = Instant::now();
+                    let _ = p.matches_in_tree(&tree, &src);
+                    b = b.min(t.elapsed().as_micros());
+                }
+            }
+            if b == u128::MAX { 0 } else { b }
+        };
+        for pat in gen_patterns(&src) {
+            total += 1;
+            let res = catch_unwind(AssertUnwindSafe(|| {
+                let p = match Pattern::compile(&pat, cfg) {
+                    Ok(p) => p,
+                    Err(_) => return None, // a malformed pattern is fine
+                };
+                // `matches_prefiltered` is `if might_match { matches } else { empty }`,
+                // so checking it against `matches` is tautological. The real invariant
+                // is soundness: a true match implies the prefilter accepts.
+                let might = p.prefilter(3).might_match(&src);
+                let t0 = Instant::now();
+                let ms = p.matches_in_tree(&tree, &src);
+                Some((ms.len(), might, t0.elapsed().as_micros()))
+            }));
+            match res {
+                Err(payload) => {
+                    panics += 1;
+                    let msg = payload
+                        .downcast_ref::<String>()
+                        .map(|s| s.as_str())
+                        .or_else(|| payload.downcast_ref::<&str>().copied())
+                        .unwrap_or("?");
+                    eprintln!("PANIC [{msg}]\n  lang={langname} file={path:?}\n  pat={pat:?}");
+                }
+                Ok(Some((nm, might, us))) => {
+                    compiled += 1;
+                    if nm > 0 && !might {
+                        unsound += 1;
+                        eprintln!(
+                            "UNSOUND prefilter: {nm} matches but might_match=false\n  lang={langname} file={path:?}\n  pat={pat:?}"
+                        );
+                    }
+                    let excess = us.saturating_sub(base_us);
+                    if excess >= SLOW_EXCESS_US {
+                        slow += 1;
+                        eprintln!(
+                            "SLOW +{}ms over {}ms index ({nm} matches)\n  lang={langname} file={path:?}\n  pat={pat:?}",
+                            excess / 1000,
+                            base_us / 1000,
+                        );
+                    }
+                    if excess > worst.0 {
+                        worst = (excess, format!("{path:?}"), pat.clone());
+                    }
+                }
+                Ok(None) => {}
+            }
+        }
+    }
+    println!(
+        "== {total} patterns run ({compiled} compiled); {panics} panics, {unsound} unsound, {slow} slow (excess >={}ms) ==",
+        SLOW_EXCESS_US / 1000
+    );
+    if worst.0 > 0 {
+        println!(
+            "slowest: +{}ms  pat={:?}  file={}",
+            worst.0 / 1000,
+            worst.2,
+            worst.1
+        );
+    }
+}

--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -223,6 +223,14 @@ pub struct LangConfig {
     /// Bitmask of modes that **preserve** whitespace (the lexer does not skip it)
     /// — e.g. HTML text content. Default 0 (whitespace skipped in every mode).
     pub ws_preserve: u8,
+    /// Anonymous **delimiters** — statement terminators (`;`) and separators (`,`) —
+    /// that trailing tolerance may skip when a pattern's tail lands inside the last
+    /// child just before one, so `if (\X) return \Y` matches `if (c) return foo;`.
+    /// These carry no meaning of their own (pure punctuation), unlike *closers*
+    /// (`}`/`]`/`)`), which are deliberately excluded: skipping a closer would let
+    /// `f(\X` match `f(a)` or `foo(\X)` match `foo(a).bar()`. Grammar-gated (only
+    /// tokens the language actually defines).
+    pub trailing_delimiters: HashSet<String>,
 }
 
 impl LangConfig {
@@ -238,6 +246,13 @@ impl LangConfig {
         let splittable = detect_splittable(&language, &single_char);
         let op_tokens = derive_op_tokens(&language, &splittable);
         let keywords = derive_keywords(&language);
+        // `;` and `,`, each only if the grammar defines it as a token (so a language
+        // missing one carries no meaningless entry).
+        let trailing_delimiters: HashSet<String> = [";", ","]
+            .into_iter()
+            .filter(|t| single_char.contains(*t))
+            .map(String::from)
+            .collect();
         LangConfig {
             language,
             op_tokens,
@@ -246,6 +261,7 @@ impl LangConfig {
             tokenizers,
             transitions: Vec::new(),
             ws_preserve: 0,
+            trailing_delimiters,
         }
     }
 

--- a/rust/code_match/src/config.rs
+++ b/rust/code_match/src/config.rs
@@ -206,9 +206,6 @@ pub struct LangConfig {
     /// Anonymous punctuation/operator tokens, longest-first, excluding the
     /// splittable compounds. Derived from the grammar; used for maximal munch.
     pub op_tokens: Vec<String>,
-    /// Compound operators normalized to single chars on both sides (e.g. `>>` ->
-    /// `>` `>`). Auto-detected from the grammar.
-    pub splittable: HashSet<String>,
     /// The grammar's word-shaped anonymous symbols — its keywords (`if`, `return`,
     /// contextual ones like TS `type`). Complement of `op_tokens` among anonymous
     /// symbols. Used by the prefilter to exclude keywords from identifier terms.
@@ -244,7 +241,6 @@ impl LangConfig {
         LangConfig {
             language,
             op_tokens,
-            splittable,
             keywords,
             meta_char: '\\',
             tokenizers,
@@ -266,10 +262,6 @@ impl LangConfig {
     pub fn with_meta_char(mut self, c: char) -> Self {
         self.meta_char = c;
         self
-    }
-
-    pub fn is_splittable(&self, text: &str) -> bool {
-        self.splittable.contains(text)
     }
 
     /// Whether mode `m` preserves whitespace (the lexer should not skip it).
@@ -318,9 +310,12 @@ fn single_char_punct_tokens(lang: &Language) -> HashSet<String> {
 }
 
 /// A compound token is splittable when it is all-punctuation, longer than one
-/// char, and every character is itself a single-char token. Splitting it on both
-/// sides aligns context-sensitive tokenizations like C++/Rust `>>`. Over-split
-/// (e.g. `==`) is safe — both sides normalize identically.
+/// char, and every character is itself a single-char token. Excluding it from
+/// `op_tokens` makes the *pattern* lexer emit its chars separately (`>>` → `>`
+/// `>`); the source side keeps tree-sitter's own leaves, and the matcher lets a
+/// run of those pattern chars match one source leaf by text (`>` `>` ⟹ a `>>`
+/// shift) or several (`>` `>` ⟹ two generic-close `>`). Over-detecting (e.g.
+/// `==`) is harmless — a single source `==` leaf absorbs the `=` `=` run.
 fn detect_splittable(lang: &Language, single_char: &HashSet<String>) -> HashSet<String> {
     let mut set = HashSet::new();
     for id in 0..lang.node_kind_count() as u16 {

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -230,6 +230,7 @@ impl Pattern {
                     matched_end: 0,
                     tolerant_end: None,
                     contains_cache: &cache,
+                    delimiters: &self.cfg.trailing_delimiters,
                 };
                 if ctx.inner_matches_candidate(inner, close, cand) {
                     hits.push((cand.start_leaf as u32, ci as u32));
@@ -306,6 +307,7 @@ impl Pattern {
                 matched_end: 0,
                 tolerant_end: None,
                 contains_cache: &contains_cache,
+                delimiters: &self.cfg.trailing_delimiters,
             };
 
             // Start positions: each child-start; a leaf candidate has none, so use
@@ -551,6 +553,9 @@ struct Ctx<'a, 's> {
     /// O(N²). Empty when the pattern repeats a name (`!no_dups`): INNER then depends
     /// on outer bindings, so `match_contains` falls back to the per-call scan.
     contains_cache: &'a HashMap<usize, Vec<(u32, u32)>>,
+    /// Delimiters (`;`, `,`) trailing tolerance may skip inside the last child
+    /// (see `LangConfig::trailing_delimiters`).
+    delimiters: &'a HashSet<String>,
 }
 
 impl<'s> Ctx<'_, 's> {
@@ -574,6 +579,21 @@ impl<'s> Ctx<'_, 's> {
                 // child-end boundaries (`stops`), not only at the very end.
                 if li == hi || self.stops.contains(&li) {
                     self.matched_end = li;
+                    return true;
+                }
+                // Trailing tolerance *into* the last child: if the tail landed inside a
+                // child with only statement **terminators** (`;`) between it and the
+                // next child boundary, consume them to that boundary. This is what lets
+                // `if (\X) return \Y` match `if (c) return foo;` — `\Y` binds `foo` and
+                // the `;` is free, the same tolerance `return \Y` gets at the top level.
+                // Terminators only, never closers, so `f(\X` still won't match `f(a)`.
+                if let Some(&s) = self.stops.iter().filter(|&&s| s > li).min()
+                    && (li..s).all(|l| {
+                        let leaf = &self.idx.leaves[l];
+                        leaf.anon && self.delimiters.contains(&leaf.text)
+                    })
+                {
+                    self.matched_end = s;
                     return true;
                 }
                 return false;

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -180,6 +180,90 @@ impl Pattern {
         self.matches_in_tree(&tree, source)
     }
 
+    /// For every containment in the pattern, find the descendants its INNER matches —
+    /// once, up front — keyed by INNER item position (`open + 1`), as `(start_leaf,
+    /// candidate_index)` sorted by `start_leaf`. `match_contains` then binary-searches
+    /// the bracketed node's extent for a hit instead of re-scanning every candidate on
+    /// every outer position, turning containment from O(N²) (O(N³) when nested) into
+    /// O(N·log N).
+    ///
+    /// Built per containment, gated by `containment_inner_cacheable`: only an INNER
+    /// whose captured names never appear outside its bracket is cached (its matches are
+    /// then independent of outer bindings, so the empty-`bound` precompute is valid).
+    /// Others — a backref into the outside — stay uncached and `match_contains` scans.
+    ///
+    /// INNER ranges are processed innermost-first (largest `open` index first) so a
+    /// nested containment's entry is already present when the enclosing INNER is
+    /// resolved against each candidate.
+    fn build_contains_cache(&self, idx: &Indexed, source: &str) -> HashMap<usize, Vec<(u32, u32)>> {
+        let mut cache: HashMap<usize, Vec<(u32, u32)>> = HashMap::new();
+        let mut opens: Vec<(usize, usize)> = self
+            .items
+            .iter()
+            .enumerate()
+            .filter_map(|(pi, it)| match it {
+                PatternItem::ContainsOpen { close } => Some((pi, *close)),
+                _ => None,
+            })
+            .collect();
+        opens.sort_by(|a, b| b.0.cmp(&a.0)); // innermost (largest open) first
+        for (open, close) in opens {
+            // Cache this containment only when its INNER is self-contained — see
+            // `containment_inner_cacheable`. A nested INNER whose name is bound by an
+            // *enclosing* INNER (`\{{ \X(\*) \{{ return \X \}} \}}`) stays uncached and
+            // falls back to the scan; the enclosing, self-contained INNER still caches.
+            if !self.containment_inner_cacheable(open, close) {
+                continue;
+            }
+            let inner = open + 1;
+            let mut hits: Vec<(u32, u32)> = Vec::new();
+            for (ci, cand) in idx.candidates.iter().enumerate() {
+                let mut ctx = Ctx {
+                    items: &self.items,
+                    idx,
+                    source,
+                    use_memo: self.use_memo,
+                    no_dups: self.no_dups,
+                    bound: HashMap::new(),
+                    fail: HashSet::new(),
+                    stops: HashSet::new(),
+                    matched_end: 0,
+                    tolerant_end: None,
+                    contains_cache: &cache,
+                };
+                if ctx.inner_matches_candidate(inner, close, cand) {
+                    hits.push((cand.start_leaf as u32, ci as u32));
+                }
+            }
+            hits.sort_by_key(|&(s, _)| s);
+            cache.insert(inner, hits);
+        }
+        cache
+    }
+
+    /// Whether `\{{ INNER \}}` bracketed by `items[open]`..`items[close]` can use the
+    /// precomputed cache: yes iff no name INNER captures also appears *outside* the
+    /// bracket. Then INNER's matches don't depend on any outer binding (so the
+    /// empty-`bound` precompute is valid) and its captures aren't referenced after the
+    /// containment (so existence, not a specific descendant, suffices). A name repeated
+    /// *within* INNER is fine — that backref resolves inside the INNER match. A name
+    /// shared with the outside (`def foo(\P): \{{ return \P \}}`, or a nested INNER's
+    /// `\X` bound by its enclosing INNER) is not, and keeps that level on the scan.
+    fn containment_inner_cacheable(&self, open: usize, close: usize) -> bool {
+        let name_at = |i: usize| match &self.items[i] {
+            PatternItem::Meta { name: Some(n), .. } => Some(n.as_str()),
+            _ => None,
+        };
+        let inner_names: HashSet<&str> = (open + 1..close).filter_map(name_at).collect();
+        if inner_names.is_empty() {
+            return true;
+        }
+        !(0..open)
+            .chain(close + 1..self.items.len())
+            .filter_map(name_at)
+            .any(|n| inner_names.contains(n))
+    }
+
     /// Match against an already-parsed `tree`, so one compiled AST can be reused
     /// across calls (e.g. shared with the chunk splitter instead of re-parsing).
     /// The tree MUST come from the same grammar as this pattern's
@@ -189,6 +273,10 @@ impl Pattern {
     pub fn matches_in_tree<'s>(&self, tree: &Tree, source: &'s str) -> Vec<Match<'s>> {
         let idx = index_tree(tree.root_node(), source.as_bytes());
         let n_items = self.items.len();
+        // Resolve every containment's INNER against all descendants once, up front, so
+        // the per-candidate DP answers a containment by binary search instead of a
+        // fresh O(N) descendant scan (see `build_contains_cache`).
+        let contains_cache = self.build_contains_cache(&idx, source);
 
         let mut out = Vec::new();
         for cand in &idx.candidates {
@@ -217,6 +305,7 @@ impl Pattern {
                 stops,
                 matched_end: 0,
                 tolerant_end: None,
+                contains_cache: &contains_cache,
             };
 
             // Start positions: each child-start; a leaf candidate has none, so use
@@ -454,6 +543,14 @@ struct Ctx<'a, 's> {
     /// `\{{ throw \}}` matches its `throw_statement`, just like a top-level `throw`.
     /// `None` otherwise (every other sub-pattern end must land exactly on `hi`).
     tolerant_end: Option<usize>,
+    /// Precomputed containment index: INNER item position (`open + 1`) → the
+    /// descendants it matches, as `(start_leaf, candidate_index)` sorted by
+    /// `start_leaf`. Built once per `matches_in_tree` (see `build_contains_cache`),
+    /// so a containment is answered by binary-searching the bracketed node's extent
+    /// instead of re-scanning every candidate per outer position — O(N·log N), not
+    /// O(N²). Empty when the pattern repeats a name (`!no_dups`): INNER then depends
+    /// on outer bindings, so `match_contains` falls back to the per-call scan.
+    contains_cache: &'a HashMap<usize, Vec<(u32, u32)>>,
 }
 
 impl<'s> Ctx<'_, 's> {
@@ -678,6 +775,9 @@ impl<'s> Ctx<'_, 's> {
         let inner = pi + 1; // first INNER item
         let cont = close + 1; // first outer item after `\}}`
         let idx = self.idx;
+        // The precomputed INNER hits (present iff `no_dups`); a Copy reference so the
+        // `&mut self` calls below don't conflict with this borrow.
+        let cached = self.contains_cache.get(&inner);
         // `li` can be the end-exclusive position (`== leaves.len()`, e.g. a preceding
         // `\*` consumed everything up to the candidate end) — there's no node starting
         // there to bracket, so nothing contains INNER.
@@ -691,10 +791,60 @@ impl<'s> Ctx<'_, 's> {
             if next > hi || !idx.single_child(li, next) {
                 continue;
             }
-            if self.contains_then_continue(inner, close, cont, end, li, next, hi) {
+            let matched = match cached {
+                Some(hits) => {
+                    self.contains_region_cached(inner, close, cont, end, li, next, hi, hits)
+                }
+                None => self.contains_then_continue(inner, close, cont, end, li, next, hi),
+            };
+            if matched {
                 return true;
             }
         }
+        false
+    }
+
+    /// Cached containment for a fixed bracketed region `[reg_lo, reg_hi)` (one node):
+    /// the INNER-matching descendants are precomputed (`hits`, sorted by `start_leaf`),
+    /// so we binary-search for one inside the extent rather than re-scanning. A node
+    /// starting inside the extent is, by tree nesting, fully inside it — so a start in
+    /// `[reg_lo, reg_hi)` is enough. Existence is sufficient because under `no_dups` the
+    /// continuation can't depend on INNER's (never-reused) captures, so if it succeeds
+    /// for one matching descendant it succeeds for all; we re-bind INNER on the leftmost
+    /// hit only to expose its report-only captures.
+    #[allow(clippy::too_many_arguments)]
+    fn contains_region_cached(
+        &mut self,
+        inner: usize,
+        inner_end: usize,
+        cont: usize,
+        cont_end: usize,
+        reg_lo: usize,
+        reg_hi: usize,
+        hi: usize,
+        hits: &[(u32, u32)],
+    ) -> bool {
+        let idx = self.idx;
+        let rep = hits.partition_point(|&(s, _)| (s as usize) < reg_lo);
+        if let Some(&(s, ci)) = hits.get(rep)
+            && (s as usize) < reg_hi
+        {
+            let snapshot = self.bound.clone();
+            let cand = &idx.candidates[ci as usize];
+            if self.inner_matches_candidate(inner, inner_end, cand)
+                && self.dp(cont, cont_end, reg_hi, hi)
+            {
+                return true;
+            }
+            self.bound = snapshot; // undo INNER bindings from a failed continuation
+        }
+        // INNER matches zero nodes (all-optional INNER, e.g. `\{{ \? \}}`): match the
+        // empty leaf range, then continue. Not a candidate, so not in `hits`.
+        let snapshot = self.bound.clone();
+        if self.dp(inner, inner_end, reg_lo, reg_lo) && self.dp(cont, cont_end, reg_hi, hi) {
+            return true;
+        }
+        self.bound = snapshot;
         false
     }
 

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -187,7 +187,7 @@ impl Pattern {
     /// workspace-wide, so a tree the splitter parsed for the same language is
     /// compatible.
     pub fn matches_in_tree<'s>(&self, tree: &Tree, source: &'s str) -> Vec<Match<'s>> {
-        let idx = index_tree(tree.root_node(), source.as_bytes(), &self.cfg);
+        let idx = index_tree(tree.root_node(), source.as_bytes());
         let n_items = self.items.len();
 
         let mut out = Vec::new();
@@ -251,8 +251,9 @@ impl Pattern {
                 // Whole-node coverage spans the entire candidate → the whole node, no
                 // ≥2 gate. Otherwise a fragment: it must span **≥2** direct children,
                 // except a single child that is one anonymous leaf (a keyword/punct
-                // like `if` — never a candidate on its own; see §4). A single *named*
-                // child defers to its own candidate, so it isn't reported here.
+                // like `if` or an operator like `=>` — never a candidate on its own;
+                // see §4). A single *named* child defers to its own candidate, so it
+                // isn't reported here.
                 let range = if a == cand.start_leaf && b == hi {
                     Some((cand.start_byte, cand.end_byte))
                 } else if b > a {
@@ -297,10 +298,9 @@ fn detect_dup_names(items: &[PatternItem]) -> bool {
     false
 }
 
-fn index_tree(root: Node, src: &[u8], cfg: &LangConfig) -> Indexed {
+fn index_tree(root: Node, src: &[u8]) -> Indexed {
     let mut c = Collector {
         src,
-        cfg,
         leaves: Vec::new(),
         spans: Vec::new(),
         cs_pairs: Vec::new(),
@@ -364,7 +364,6 @@ fn index_tree(root: Node, src: &[u8], cfg: &LangConfig) -> Indexed {
 /// ownership in a single pass.
 struct Collector<'a> {
     src: &'a [u8],
-    cfg: &'a LangConfig,
     leaves: Vec<Leaf>,
     spans: Vec<Span>,
     cs_pairs: Vec<(usize, u32)>, // (child_start_leaf, parent_id)
@@ -385,26 +384,17 @@ impl Collector<'_> {
 
         if node.child_count() == 0 {
             let text = node.utf8_text(self.src).unwrap_or("").to_string();
-            if self.cfg.is_splittable(&text) {
-                let mut b = node.start_byte();
-                for ch in text.chars() {
-                    let cl = ch.len_utf8();
-                    self.leaves.push(Leaf {
-                        text: ch.to_string(),
-                        anon: true,
-                        start_byte: b,
-                        end_byte: b + cl,
-                    });
-                    b += cl;
-                }
-            } else {
-                self.leaves.push(Leaf {
-                    text,
-                    anon: !node.is_named(),
-                    start_byte: node.start_byte(),
-                    end_byte: node.end_byte(),
-                });
-            }
+            // Keep tree-sitter's own leaf intact — a compound operator like `=>`
+            // stays one anonymous leaf. The *pattern* side splits compounds into
+            // single chars (see `config::detect_splittable`); the matcher's
+            // `match_token_run` reconciles the two by letting a pattern char-run
+            // match one source leaf's text.
+            self.leaves.push(Leaf {
+                text,
+                anon: !node.is_named(),
+                start_byte: node.start_byte(),
+                end_byte: node.end_byte(),
+            });
         } else {
             let mut cursor = node.walk();
             let children: Vec<Node> = node.children(&mut cursor).collect();
@@ -502,9 +492,7 @@ impl<'s> Ctx<'_, 's> {
         // doesn't borrow `self`, leaving `self` free for the `&mut self` calls.
         let items = self.items;
         let ok = match &items[pi] {
-            PatternItem::Token(t) => {
-                li < hi && &self.idx.leaves[li].text == t && self.dp(pi + 1, end, li + 1, hi)
-            }
+            PatternItem::Token(_) => self.match_token_run(pi, end, li, hi),
             PatternItem::Str(s) => self.match_literal(pi, end, li, hi, s),
             PatternItem::Meta { name, card, regex } => match card {
                 Cardinality::One => {
@@ -532,6 +520,42 @@ impl<'s> Ctx<'_, 's> {
             self.fail.insert((pi, li));
         }
         ok
+    }
+
+    /// Match a run of consecutive literal `Token`s against a single source leaf.
+    ///
+    /// A keyword/operator pattern token normally matches one source leaf one-to-one
+    /// (`if` ⟹ `if`, `>` ⟹ a generic-close `>`). But a compound operator is split
+    /// on the pattern side only (`=>` → `=` `>`; `config::detect_splittable`), while
+    /// the source keeps tree-sitter's single `=>` leaf — so we accumulate consecutive
+    /// pattern tokens until their concatenation equals the source leaf's text, then
+    /// consume that one leaf. Stopping at the first exact equality keeps the
+    /// one-to-one path (`>` then `>` over two source `>` leaves) intact; the
+    /// multi-token path only engages when a single source leaf is longer (`=` `>` ⟹
+    /// `=>`, or `>` `>` ⟹ a `>>` shift). A non-`Token` item or a divergent prefix
+    /// ends the run.
+    fn match_token_run(&mut self, pi: usize, end: usize, li: usize, hi: usize) -> bool {
+        if li >= hi {
+            return false;
+        }
+        let items = self.items;
+        let target = &self.idx.leaves[li].text; // `idx` is a Copy ref → not a `self` borrow
+        let mut acc = String::new();
+        let mut j = pi;
+        while j < end {
+            let PatternItem::Token(t) = &items[j] else {
+                break;
+            };
+            acc.push_str(t);
+            if acc.len() > target.len() || !target.starts_with(&acc) {
+                return false;
+            }
+            j += 1;
+            if acc == *target {
+                return self.dp(j, end, li + 1, hi);
+            }
+        }
+        false
     }
 
     fn match_literal(&mut self, pi: usize, end: usize, li: usize, hi: usize, s: &str) -> bool {

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1,6 +1,7 @@
 //! Engine-feature tests (language-agnostic behavior, illustrated in whatever
 //! language is convenient): balancing, precedence, the wildcard DP, cardinality,
-//! metavar equality, the `>>` split, number-lexing limits, and the sigil config.
+//! metavar equality, compound-operator alignment, number-lexing limits, and the
+//! sigil config.
 
 mod common;
 use common::*;
@@ -898,6 +899,9 @@ fn prefilter_passes_comment_text_but_the_matcher_skips_it() {
 #[test]
 fn alignment_operators_and_generics() {
     let ok = |cfg, frag, src| !matches(cfg, frag, src).is_empty();
+    // The pattern splits `>>` into `>` `>`; the source keeps tree-sitter's own
+    // leaves. A `>>` *shift* is one source leaf (the run matches it whole); a
+    // double generic close is two `>` leaves (the run matches them one-to-one).
     assert!(ok(lang::cpp(), "a >> b", "int n = a >> b;"));
     assert!(ok(
         lang::cpp(),
@@ -911,6 +915,52 @@ fn alignment_operators_and_generics() {
         "fn m(){ std::mem::swap(); }"
     ));
     assert!(ok(lang::typescript(), "a === b", "if (a === b) {}"));
+}
+
+#[test]
+fn bare_compound_operator_matches_its_node() {
+    // A *bare* compound operator is split on the pattern side (`=>` → `=` `>`) while
+    // the source keeps tree-sitter's single `=>` leaf. `match_token_run` reconciles
+    // them by letting the pattern char-run match that one leaf. Regression: these
+    // used to find nothing (the run only matched inside a named `string_fragment`).
+    assert!(has_kind(
+        &matches(lang::typescript(), "=>", "const f = (x) => x + 1;"),
+        "arrow_function"
+    ));
+    assert!(has_kind(
+        &matches(lang::typescript(), "==", "if (a == b) {}"),
+        "binary_expression"
+    ));
+    assert!(has_kind(
+        &matches(lang::typescript(), "===", "if (a === b) {}"),
+        "binary_expression"
+    ));
+    assert!(has_kind(
+        &matches(lang::typescript(), "&&", "if (a && b) {}"),
+        "binary_expression"
+    ));
+    // The keyword case is the one-char instance of the same rule.
+    assert!(has_kind(
+        &matches(lang::typescript(), r"if \*", "if (a == b) {}"),
+        "if_statement"
+    ));
+}
+
+#[test]
+fn named_all_anonymous_child_is_not_a_parent_fragment() {
+    // `()` / `{}` are *named* nodes (`arguments` / `statement_block`) whose leaves are
+    // all anonymous. A parent fragment must span ≥2 children or a single anonymous
+    // *leaf* — never a named child — so matching `()` reports only the `arguments`
+    // node, not a spurious `call_expression` fragment of the same span.
+    let parens = matches(lang::typescript(), "()", "foo();");
+    assert!(has_kind(&parens, "arguments"));
+    assert!(
+        !has_kind(&parens, "call_expression"),
+        "a named all-anon child must not be reported as its parent's fragment"
+    );
+    let braces = matches(lang::typescript(), "{}", "function f() {}");
+    assert!(has_kind(&braces, "statement_block"));
+    assert!(!has_kind(&braces, "function_declaration"));
 }
 
 #[test]

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1018,3 +1018,30 @@ fn containment_inner_leading_fragment_at_any_depth() {
         "INNER must reach a throw nested several levels deep",
     );
 }
+
+#[test]
+fn containment_scales_near_linearly() {
+    // Guards the precomputed containment index (`build_contains_cache`). Before it,
+    // each containment re-scanned every candidate per outer position — O(N²), O(N³)
+    // when nested — so `\{{ \{{ \X = \Y \}} \}}` over a large file took *seconds*. The
+    // index resolves INNER once, turning it near-linear. The 2s bound is deliberately
+    // loose (the real time is tens of ms, even on a slow CI box) so this only fires on
+    // a genuine regression to super-linear scanning, never on timing noise.
+    use std::time::Instant;
+    let mut src = String::from("def f():\n");
+    for i in 0..900 {
+        src.push_str(&format!("    a{i} = b{i} + c{i}\n"));
+    }
+    let t = Instant::now();
+    let ms = matches(lang::python(), r"\{{ \{{ \X = \Y \}} \}}", &src);
+    let elapsed = t.elapsed();
+    assert!(
+        !ms.is_empty(),
+        "the nested containment should match the assignments"
+    );
+    assert!(
+        elapsed.as_secs_f64() < 2.0,
+        "nested containment over 900 statements took {elapsed:?} — expected near-linear; \
+         the containment index likely regressed to a per-position scan",
+    );
+}

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1045,3 +1045,47 @@ fn containment_scales_near_linearly() {
          the containment index likely regressed to a per-position scan",
     );
 }
+
+#[test]
+fn trailing_tolerance_skips_delimiters_not_closers() {
+    // A pattern whose tail lands inside the last child, just before a statement
+    // terminator (`;`), still matches — the `;` is free, the same trailing tolerance
+    // `return \Y` gets at the top level. Without this, `if (\X) return \Y` (a very
+    // natural pattern) silently matched nothing.
+    assert!(
+        has_kind(
+            &matches(
+                lang::typescript(),
+                r"if (\X) return \Y",
+                "function g(c){ if (c) return foo; }",
+            ),
+            "if_statement",
+        ),
+        "the `;` terminating the return is free trailing context",
+    );
+    // also reaches through a containment INNER (same tolerance there):
+    assert!(has_kind(
+        &matches(
+            lang::typescript(),
+            r"switch (\X) \{{ case \Y: return \Z \}}",
+            "function f(t){ switch (t) { case 1: return 0.5; } }",
+        ),
+        "switch_statement",
+    ));
+    // A *closer* is never skipped: `f(\X` (no `)`) must NOT match `f(a)` — else
+    // `foo(\X)` would creep onto `foo(a).bar()` and the child-alignment invariant
+    // would be lost.
+    assert!(
+        matches(lang::typescript(), r"f(\X", "f(a);").is_empty(),
+        "the `)` closer must not be skipped",
+    );
+    // Top-level matching is unchanged (the tolerance already applied there).
+    assert!(has_kind(
+        &matches(
+            lang::typescript(),
+            r"return \Y",
+            "function g(){ return foo; }"
+        ),
+        "return_statement",
+    ));
+}


### PR DESCRIPTION
## Summary

Hardening of `cocoindex_code_match`, driven by a new real-codebase stress harness. Four commits:

- **fix: bare compound operators** (`=>`, `==`, `===`, `&&`, `>>`) matched nothing in real code. Root cause: compounds were split into single chars on *both* sides, so a bare operator became a multi-leaf anonymous child the fragment classifier rejected. Now the pattern side splits and `match_token_run` reconciles a pattern char-run against tree-sitter's single source leaf. Also reverts a fragment-rule broadening that briefly mis-reported named all-anonymous children (`()`→`arguments`, `{}`→`statement_block`) as parent fragments.
- **perf: containment** was O(N²) (O(N³) nested) — it re-scanned every candidate per outer bracketed position (1.4s on `\{{ \{{ \X = \Y \}} \}}`, 230ms on `\{{ continue; \}}`). Precompute each INNER's matching descendants once (`build_contains_cache`) and binary-search the bracketed node's extent → **O(N·log N)**, near-linear in practice. Gated per-INNER (`containment_inner_cacheable`): only INNERs whose names don't escape the bracket are cached; a backref into the outside falls back to the scan.
- **feat: trailing tolerance skips statement delimiters** (`;`, `,`). `if (\X) return \Y` now matches `if (c) return foo;` — the tail lands inside the `return_statement`, before the free `;`, the same tolerance `return \Y` gets at the top level. Restricted to delimiters (pure punctuation), never closers (`}`/`]`/`)`), so `f(\X` still won't match `f(a)`.
- **test: stress harness** (`examples/stress`) that found all of the above — samples real files, auto-generates a wide pattern spread, and checks no-panic + prefilter soundness + baseline-relative match time on every (pattern, file).

Validation across cocoindex + openclaw + llvm-project: **0 panics, 0 unsound across ~250K patterns** (llvm alone ran 200,983). A diverse hand-written pattern set (`>>` generics, `??`/`===`/`<<` chains, backreferences, nested containment) matched 22/27 first try; the gap was the delimiter fix above.

## Test plan

- `cargo test -p cocoindex_code_match` (182 tests, green) — includes regression tests for each fix: `bare_compound_operator_matches_its_node`, `named_all_anonymous_child_is_not_a_parent_fragment`, `containment_scales_near_linearly`, `trailing_tolerance_skips_delimiters_not_closers`.
- Stress sweep: `cargo run --release -p cocoindex_code_match --example stress -- <dir>` → 0 panics / 0 unsound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
