### PR TITLE
fix(examples): align csv_to_kafka/kafka_to_lancedb Kafka topic + correct docs

### DIFF
--- a/examples/csv_to_kafka/README.md
+++ b/examples/csv_to_kafka/README.md
@@ -12,7 +12,7 @@ Edit `.env` to set your Kafka connection:
 
 ```
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
-KAFKA_TOPIC=csv-rows
+KAFKA_TOPIC=cocoindex-csv-rows
 ```
 
 ## Run
@@ -29,4 +29,4 @@ Run the pipeline in live mode so changes to CSV files are picked up automaticall
 cocoindex update -L main.py
 ```
 
-Each row is published as a JSON message with key `{filename}/{first_column_value}`. For example, a row in `products.csv` with SKU `SKU001` gets key `products.csv/SKU001`.
+Each row is published as a JSON message keyed by its first column value, with the full row as the JSON value. For example, a row in `products.csv` with SKU `SKU001` is published with key `SKU001` and value `{"sku": "SKU001", "name": "Wireless Mouse", ...}`.

--- a/examples/kafka_to_lancedb/.env.example
+++ b/examples/kafka_to_lancedb/.env.example
@@ -5,7 +5,7 @@ COCOINDEX_DB=./cocoindex.db
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
 # Kafka topic to consume from (must match csv_to_kafka producer)
-KAFKA_TOPIC=cocoindex-example-csv-rows
+KAFKA_TOPIC=cocoindex-csv-rows
 
 # Kafka consumer group ID
 KAFKA_GROUP_ID=kafka-to-lancedb

--- a/examples/kafka_to_lancedb/README.md
+++ b/examples/kafka_to_lancedb/README.md
@@ -13,7 +13,7 @@ Copy `.env.example` to `.env` and edit as needed:
 
 ```
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
-KAFKA_TOPIC=cocoindex-example-csv-rows
+KAFKA_TOPIC=cocoindex-csv-rows
 KAFKA_GROUP_ID=kafka-to-lancedb
 LANCEDB_URI=./lancedb_data
 ```

--- a/examples/kafka_to_lancedb/main.py
+++ b/examples/kafka_to_lancedb/main.py
@@ -20,7 +20,7 @@ from confluent_kafka.aio import AIOConsumer
 import cocoindex as coco
 from cocoindex.connectors import kafka, lancedb
 
-KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "csv-rows")
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "cocoindex-csv-rows")
 KAFKA_BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
 KAFKA_GROUP_ID = os.environ.get("KAFKA_GROUP_ID", "kafka-to-lancedb")
 KAFKA_SASL_USERNAME = os.environ.get("KAFKA_SASL_USERNAME", "")


### PR DESCRIPTION
## What

The `csv_to_kafka` (producer) and `kafka_to_lancedb` (consumer) examples ship as a pair — the consumer reads the topic the producer writes — but they disagreed on the Kafka topic name in **four** different places:

| Location | Was |
|---|---|
| `csv_to_kafka/main.py` default | `cocoindex-csv-rows` |
| `csv_to_kafka/.env.example` | `cocoindex-csv-rows` |
| `csv_to_kafka/README.md` | `csv-rows` |
| `kafka_to_lancedb/main.py` default | `csv-rows` |
| `kafka_to_lancedb/.env.example` | `cocoindex-example-csv-rows` |
| `kafka_to_lancedb/README.md` | `cocoindex-example-csv-rows` |

A user copying the shipped `.env.example` for both examples would have the producer publish to `cocoindex-csv-rows` and the consumer read `cocoindex-example-csv-rows` — so the pipeline silently never connects.

This PR standardizes every reference on **`cocoindex-csv-rows`**.

It also corrects the `csv_to_kafka` README, which described the message key as `{filename}/{first_column_value}` (e.g. `products.csv/SKU001`). The actual key is just the row's first column value (e.g. `SKU001`).

## Testing

Verified end-to-end against a local Kafka-compatible broker (Redpanda):

- **Producer** (`csv_to_kafka`, catch-up): published 9 messages — 5 products + 4 employees — with keys `SKU001…SKU005` / `E101…E104` and the full row as JSON value.
- **Consumer** (`kafka_to_lancedb`, catch-up): `process_message: 9 total | 9 added`; LanceDB `products` table got 5 rows (price coerced to `float`) and `employees` got 4 rows, routed correctly by `sku` vs `emp_id`.

> Note: these examples already existed (added in #2050); this PR only fixes the topic-name inconsistency and the README key description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
