### PR TITLE
test(code_match): containment INNER trailing-delimiter tolerance

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -582,11 +582,16 @@ impl<'s> Ctx<'_, 's> {
                     return true;
                 }
                 // Trailing tolerance *into* the last child: if the tail landed inside a
-                // child with only statement **terminators** (`;`) between it and the
+                // child with only statement **delimiters** (`;`, `,`) between it and the
                 // next child boundary, consume them to that boundary. This is what lets
                 // `if (\X) return \Y` match `if (c) return foo;` — `\Y` binds `foo` and
                 // the `;` is free, the same tolerance `return \Y` gets at the top level.
-                // Terminators only, never closers, so `f(\X` still won't match `f(a)`.
+                // Applies equally to a containment INNER (this branch covers both, via
+                // `tolerant_end`): the integral-fragment rule for whole match *and* INNER
+                // exists to avoid precedence violations (extracting `a+b` from `a+b*c`),
+                // which an insignificant trailing delimiter can't cause — so skipping it
+                // is sound there too. Delimiters only, never closers, so `f(\X` still
+                // won't match `f(a)`.
                 if let Some(&s) = self.stops.iter().filter(|&&s| s > li).min()
                     && (li..s).all(|l| {
                         let leaf = &self.idx.leaves[l];

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1088,4 +1088,17 @@ fn trailing_tolerance_skips_delimiters_not_closers() {
         ),
         "return_statement",
     ));
+    // The same tolerance applies to a containment INNER: `if (\X) return \Y` as INNER
+    // matches the `if_statement` through its trailing `;`, so the containment matches.
+    // (An insignificant trailing delimiter can't cause the precedence violation the
+    // integral-fragment rule guards against, so skipping it is sound for INNER too.)
+    assert!(
+        !matches(
+            lang::typescript(),
+            r"\{{ if (\X) return \Y \}}",
+            "function f(c) { if (c) return foo; }",
+        )
+        .is_empty(),
+        "containment INNER gets the same trailing-delimiter tolerance",
+    );
 }


### PR DESCRIPTION
## Summary

Follow-up to #2176. The trailing-delimiter tolerance (`if (\X) return \Y` matching `if (c) return foo;`) already applies to a containment **INNER** — the skip lives in the base-case branch that `tolerant_end` (the INNER path) takes — so `\{{ if (\X) return \Y \}}` matches a node containing `if (c) return foo;`. This adds a regression test pinning that, and clarifies the code comment with the rationale: the integral-fragment rule (for whole match *and* INNER) guards against precedence violations (`a+b` out of `a+b*c`); an insignificant trailing delimiter carries no precedence, so the skip is sound at both levels. Design docs updated accordingly.

Behavior unchanged — test + comment only.

## Test plan

- `cargo test -p cocoindex_code_match` (green); new assertion in `trailing_tolerance_skips_delimiters_not_closers` covers `\{{ if (\X) return \Y \}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
