### PR TITLE
docs(examples): Search Images by Text walkthrough

### DIFF
--- a/docs/src/content/example-posts/image-search.md
+++ b/docs/src/content/example-posts/image-search.md
@@ -1,0 +1,214 @@
+---
+title: Search Images by Text
+description: 'Build an image search engine with CocoIndex V1 — embed images with CLIP, store the vectors in Qdrant, and query your photos in natural language through a FastAPI + React app. Plain async Python, live updates.'
+slug: image-search
+image: https://cocoindex.io/blobs/docs-v1/img/examples/image-search/cover.png
+tags: [multimodal, image-search]
+---
+
+![Search images by text with CLIP and CocoIndex V1](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/cover.png)
+
+We'll take a folder of images and make it searchable in plain English — type *"long neck"* and get the giraffe back, with no tags, no captions, no manual labeling. The trick is [CLIP](https://openai.com/research/clip): it embeds images **and** text into the *same* vector space, so a text query and a matching picture land near each other. We store the image vectors in [Qdrant](https://qdrant.tech/) and serve search through a small FastAPI + React app.
+
+The whole pipeline is ordinary `async` Python and your own types. The heavy lifting — [incremental processing](https://cocoindex.io/docs/programming_guide/core_concepts/), change tracking, the managed Qdrant collection — runs in a Rust engine underneath, and the flow runs in [live mode](https://cocoindex.io/docs/programming_guide/live_mode/) inside the API server, so dropping a new photo into the folder updates the index within a second.
+
+[→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search)
+
+## Flow overview
+
+![CocoIndex image search indexing flow: walk a folder of images, embed each with the CLIP image encoder, and declare a point into a Qdrant collection](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/flow-v1.png)
+
+The indexing path is short — there's no text to chunk, just one embedding per image:
+
+1. Read image files from a local directory (live).
+2. Embed each image with the [CLIP](https://huggingface.co/openai/clip-vit-large-patch14) image encoder.
+3. Store the vector in Qdrant (as a [point](https://cocoindex.io/docs/connectors/qdrant/), keyed by a stable id, with the filename in the payload).
+
+You [declare the transformation logic](https://cocoindex.io/docs/programming_guide/core_concepts/) with native Python, without worrying about how updates propagate. Think: **target_state = transformation(source_state)**.
+
+## One embedding space for images and text
+
+This is the idea the whole example rests on. CLIP was trained to pull an image and its caption *together* in vector space, so the image of a giraffe and the words "long neck" end up close — even though one is pixels and the other is text. That means **indexing and querying use the same model, two different encoders**:
+
+```python title="pipeline.py"
+@functools.cache
+def get_clip_model() -> tuple[CLIPModel, CLIPProcessor]:
+    model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)       # openai/clip-vit-large-patch14
+    processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
+    return model, processor
+
+
+def embed_image_bytes(img_bytes: bytes) -> list[float]:     # indexing side
+    model, processor = get_clip_model()
+    image = Image.open(io.BytesIO(img_bytes)).convert("RGB")
+    inputs = processor(images=image, return_tensors="pt")
+    with torch.no_grad():
+        out = model.get_image_features(**inputs)
+    return _projected_features(out)[0].tolist()
+
+
+def embed_query(text: str) -> list[float]:                  # query side
+    model, processor = get_clip_model()
+    inputs = processor(text=[text], return_tensors="pt", padding=True)
+    with torch.no_grad():
+        out = model.get_text_features(**inputs)
+    return _projected_features(out)[0].tolist()
+```
+
+Both produce a 768-d vector in the same space, so a cosine search with a text vector finds the nearest *image* vectors. `@functools.cache` loads the (large) CLIP model once and reuses it for every image and every query.
+
+## Setup
+
+- A running [Qdrant](https://qdrant.tech/):
+
+  ```sh
+  docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+  export QDRANT_URL="http://localhost:6334/"
+  ```
+
+- Install CocoIndex and the dependencies this example uses:
+
+  ```sh
+  pip install -U "cocoindex[qdrant]" torch transformers pillow fastapi "uvicorn[standard]" python-dotenv
+  ```
+
+- A few images. The example ships an `img/` folder (a cat, a dog, an elephant, a giraffe) — or drop your own `.jpg` / `.png` files in.
+
+## Shared resources: the Qdrant client
+
+The [lifespan](https://cocoindex.io/docs/programming_guide/context/) provides the Qdrant client once at startup, via a [context key](https://cocoindex.io/docs/programming_guide/context/):
+
+```python title="pipeline.py"
+QDRANT_DB = coco.ContextKey[QdrantClient]("image_search_qdrant")
+
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    client = qdrant.create_client(qdrant_url(), prefer_grpc=True)
+    builder.provide(QDRANT_DB, client)
+    yield
+```
+
+## Process an image
+
+![One process_file component per image, fanned out with mount_each: each image is CLIP-embedded and declared as a Qdrant point](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/stage-file-process.png)
+
+`process_file` runs once per image: read the bytes, embed with CLIP, and declare a Qdrant point keyed by a stable id derived from the path, with the filename in the payload.
+
+```python title="pipeline.py"
+@coco.fn(memo=True)
+async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
+    content = await file.read()
+    embedding = embed_image_bytes(content)
+    point = qdrant.PointStruct(
+        id=_image_id(file.file_path.path),                  # uuid5 of the path — stable
+        vector=embedding,
+        payload={"filename": str(file.file_path.path)},
+    )
+    target.declare_point(point)
+```
+
+[`@coco.fn(memo=True)`](https://cocoindex.io/docs/programming_guide/function/) makes it [incremental](https://cocoindex.io/docs/advanced_topics/memoization_keys/): an unchanged image is never re-embedded. Each image runs as its own [processing component](https://cocoindex.io/docs/programming_guide/processing_component/), so the engine tracks them independently — delete an image and its point is removed from Qdrant automatically. `declare_point` declares the point as a [target state](https://cocoindex.io/docs/programming_guide/target_state/); CocoIndex upserts or deletes to match.
+
+## Define the main function
+
+`app_main` mounts the Qdrant collection — sizing the vector to CLIP's projection dimension and using cosine distance — then walks the image folder and mounts one component per file:
+
+```python title="pipeline.py"
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    model, _ = get_clip_model()
+    dim = model.config.projection_dim   # 768 for ViT-L/14
+
+    target_collection = await qdrant.mount_collection_target(
+        QDRANT_DB,
+        collection_name=QDRANT_COLLECTION,   # "ImageSearch"
+        schema=await qdrant.CollectionSchema.create(
+            vectors=qdrant.QdrantVectorDef(
+                schema=VectorSchema(dtype=np.dtype(np.float32), size=dim),
+                distance="cosine",
+            )
+        ),
+    )
+
+    files = localfs.walk_dir(
+        sourcedir,
+        recursive=True,
+        path_matcher=PatternFilePathMatcher(
+            included_patterns=["**/*.jpg", "**/*.jpeg", "**/*.png"]
+        ),
+        live=True,   # api.py runs the app with live=True
+    )
+    await coco.mount_each(process_file, files.items(), target_collection)
+
+
+app = coco.App(
+    coco.AppConfig(name="ImageSearchQdrantV1"),
+    app_main,
+    sourcedir=pathlib.Path("./img"),
+)
+```
+
+`mount_collection_target` creates and manages the Qdrant collection for you — schema, idempotent upserts, and cleanup when an image disappears. The vector size comes straight from the model, so swapping CLIP variants just works.
+
+## Run it as a service
+
+Unlike the batch examples, image search runs as a server. `api.py` is a FastAPI app whose [lifespan](https://fastapi.tiangolo.com/advanced/events/) starts the CocoIndex flow in **live mode** in the background — it blocks startup until the initial sweep finishes (so the collection is queryable), then keeps watching `img/` while it serves requests. There's no separate "build the index" step.
+
+```python title="api.py"
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async with coco.runtime():
+        _client = qdrant.create_client(pipeline.qdrant_url(), prefer_grpc=True)
+
+        # Start a live update; block until the initial sweep is READY, then run on.
+        update_handle = pipeline.app.update(live=True)
+        async for snap in update_handle.watch():
+            if snap.status is coco.UpdateStatus.READY:
+                break
+        update_task = asyncio.create_task(update_handle.result())
+        try:
+            yield
+        finally:
+            update_task.cancel()
+
+
+@app.get("/search")
+async def search(q: str, limit: int = 5) -> dict:
+    query_embedding = pipeline.embed_query(q)               # text → CLIP vector
+    results = pipeline._qdrant_search(_client, pipeline.QDRANT_COLLECTION, query_embedding, limit)
+    return {"results": [{"filename": (r.payload or {}).get("filename"), "score": r.score} for r in results]}
+```
+
+Start the server, then the frontend:
+
+```sh
+python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
+
+cd frontend && npm install && npm run dev   # http://localhost:5173
+```
+
+## Search it
+
+The React app posts your query to `/search`, which embeds the text with CLIP and runs a cosine search in Qdrant. Here it is answering *"long neck"* — the giraffe ranks first, then the other animals by visual similarity, none of which was ever tagged with a word:
+
+![The image search app: a query for "long neck" returns the giraffe first (score 0.231), then elephant, cat, and dog, ranked by CLIP similarity — alongside the indexed images and their 768-element embeddings](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/search-results.png)
+
+That's the whole point of a shared image-text space: the match is by *meaning*, not metadata.
+
+## Incremental updates
+
+Because the flow runs live inside the server, the index tracks the folder with no extra work from you:
+
+- **Add an image** — `process_file` runs once for it, embeds it, and upserts one Qdrant point. It's searchable within a second.
+- **Replace an image** — same id (derived from the path), new vector; the point is updated in place.
+- **Delete an image** — its component disappears and the point is removed from Qdrant.
+- **Restart the server** — the initial sweep reconciles against what's already in Qdrant and re-embeds nothing that's unchanged.
+
+Swap the CLIP model and CocoIndex re-embeds everything against the new space; leave it alone and a restart is nearly free.
+
+## Run it
+
+The full, runnable example is in the CocoIndex repo: [examples/image_search](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search). For higher-fidelity retrieval, [image_search_colpali](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search_colpali) swaps CLIP for the multi-vector ColPali model with Qdrant MaxSim; for the text equivalent, see [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/).
+
+Got a photo library, a product catalog, or a screenshot pile you want to search by meaning? Come tell us on [Discord](https://discord.com/invite/zpA9S2DR7s) — and if this was useful, [star CocoIndex on GitHub](https://github.com/cocoindex-io/cocoindex).

--- a/docs/src/data/docs-meta.json
+++ b/docs/src/data/docs-meta.json
@@ -113,6 +113,10 @@
       "sourcePath": "example-posts/docs-to-knowledge-graph.md",
       "reviewedTs": 1781265600
     },
+    "examples/image-search": {
+      "sourcePath": "example-posts/image-search.md",
+      "reviewedTs": 1782129600
+    },
     "examples/index-codebase": {
       "sourcePath": "example-posts/index-codebase.md",
       "reviewedTs": 1781092800

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -44,7 +44,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'text-embedding',
     title: 'Semantic Search *101*',
-    index: '01 / 09',
+    index: '01 / 10',
     category: 'search',
     thumbLabel: 'Markdown · embeddings',
     motif: MOTIFS.textVec,
@@ -61,7 +61,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'index-codebase',
     title: 'Index Your *Codebase*',
-    index: '02 / 09',
+    index: '02 / 10',
     category: 'search',
     thumbLabel: 'Code · Tree-sitter',
     motif: MOTIFS.codeChunks,
@@ -78,7 +78,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'multi-codebase-summarization',
     title: 'Multi-codebase *Summarization*',
-    index: '03 / 09',
+    index: '03 / 10',
     category: 'llm',
     thumbLabel: 'Code · structured output',
     motif: MOTIFS.repos,
@@ -97,7 +97,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'pdf-to-markdown',
     title: 'PDF → *Markdown*',
-    index: '04 / 09',
+    index: '04 / 10',
     category: 'ingest',
     thumbLabel: 'PDF · custom blocks',
     motif: MOTIFS.pdfToMd,
@@ -113,7 +113,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'podcast-to-knowledge-graph',
     title: 'Podcasts → *Knowledge Graph*',
-    index: '05 / 09',
+    index: '05 / 10',
     category: 'agents',
     thumbLabel: 'YouTube · LLM + graph',
     motif: MOTIFS.graph,
@@ -131,7 +131,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'docs-to-knowledge-graph',
     title: 'Docs → *Knowledge Graph*',
-    index: '06 / 09',
+    index: '06 / 10',
     category: 'agents',
     thumbLabel: 'Markdown · LLM + Neo4j',
     motif: MOTIFS.graph,
@@ -148,7 +148,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'meeting-notes-to-knowledge-graph',
     title: 'Meeting Notes → *Knowledge Graph*',
-    index: '07 / 09',
+    index: '07 / 10',
     category: 'agents',
     thumbLabel: 'Google Drive · LLM + Neo4j',
     motif: MOTIFS.graph,
@@ -166,7 +166,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'csv-to-kafka',
     title: 'CSV → *Kafka*',
-    index: '08 / 09',
+    index: '08 / 10',
     category: 'ingest',
     thumbLabel: 'CSV · live Kafka target',
     motif: MOTIFS.pdfToMd,
@@ -183,7 +183,7 @@ export const examples: ExampleCard[] = [
   {
     slug: 'pdf-embedding',
     title: 'Semantic Search over *PDFs*',
-    index: '09 / 09',
+    index: '09 / 10',
     category: 'search',
     thumbLabel: 'PDF · docling + embeddings',
     motif: MOTIFS.textVec,
@@ -196,6 +196,23 @@ export const examples: ExampleCard[] = [
     ],
     footMeta: '~12 min',
     sourceSlug: 'pdf_embedding',
+  },
+  {
+    slug: 'image-search',
+    title: 'Search Images by *Text*',
+    index: '10 / 10',
+    category: 'image',
+    thumbLabel: 'Images · CLIP + Qdrant',
+    motif: MOTIFS.textVec,
+    description: 'Embed images with CLIP, store the vectors in Qdrant, and search your photos in natural language through a FastAPI + React app — live updates, no tags or captions.',
+    tags: [
+      { kind: 'src', label: 'Local FS' },
+      { kind: 'ops', label: 'CLIP' },
+      { kind: 'tgt', label: 'Qdrant' },
+      { kind: 'lvl', label: 'Intermediate' },
+    ],
+    footMeta: '~15 min',
+    sourceSlug: 'image_search',
   },
 ];
 
@@ -224,6 +241,7 @@ export const POPULAR: Array<{ slug: string; label: string; count: string }> = [
   { slug: 'meeting-notes-to-knowledge-graph', label: 'Meeting Notes → Knowledge Graph', count: '★' },
   { slug: 'csv-to-kafka', label: 'CSV → Kafka', count: '★' },
   { slug: 'pdf-embedding', label: 'Semantic Search over PDFs', count: '★' },
+  { slug: 'image-search', label: 'Search Images by Text', count: '★' },
 ];
 
 // Full catalog of runnable examples in the cocoindex monorepo, used to build the
@@ -264,6 +282,7 @@ export const EXAMPLE_CATALOG_GROUPS: ExampleCatalogGroup[] = [
       { dir: 'meeting_notes_graph_neo4j', docs: 'meeting-notes-to-knowledge-graph', title: 'Meeting Notes → Knowledge Graph', description: 'Turn Google Drive meeting notes into a Neo4j knowledge graph: LLM extraction of organizers, attendees, and tasks, plus embedding-based person entity resolution.', run: RUN_MAIN },
       { dir: 'csv_to_kafka', docs: 'csv-to-kafka', title: 'CSV → Kafka', description: 'Watch a folder of CSV files and publish each row as a JSON message to a Kafka topic: declarative target states, only-changed-rows produces, and live mode.', run: 'cocoindex update -L main.py' },
       { dir: 'pdf_embedding', docs: 'pdf-embedding', title: 'Semantic Search over PDFs', description: 'Convert local PDFs to Markdown with docling (on a GPU runner), chunk, embed, and store the vectors in Postgres (pgvector); natural-language query demo.', run: RUN_MAIN },
+      { dir: 'image_search', docs: 'image-search', title: 'Search Images by Text', description: 'Embed images with CLIP, store the vectors in Qdrant, and search your photos in natural language through a FastAPI + React app; live updates.', run: 'python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000' },
     ],
   },
   {
@@ -285,7 +304,6 @@ export const EXAMPLE_CATALOG_GROUPS: ExampleCatalogGroup[] = [
     title: 'Multimodal',
     blurb: 'Images and audio — same declarative flow, different encoder.',
     entries: [
-      { dir: 'image_search', title: 'Image Search (CLIP)', description: 'Build an image-search index with CLIP embeddings and Qdrant; query in natural language via FastAPI + React.', run: 'python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000' },
       { dir: 'image_search_colpali', title: 'Image Search (ColPali)', description: 'Image search using the ColPali multi-vector model with Qdrant MaxSim; natural-language queries via FastAPI.', run: 'python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000' },
       { dir: 'audio_to_text', title: 'Audio → Text', description: 'Transcribe local audio files with LiteLLM and store one row per file in Postgres, keyed by filename.', run: RUN_MAIN_PY },
     ],


### PR DESCRIPTION
Adds a V1 example walkthrough for the existing `image_search` example.

## What it covers
Embed images with **CLIP**, store the vectors in **Qdrant**, and search photos in plain English through a FastAPI + React app. The key idea: CLIP puts images and text in one embedding space, so a text query finds matching images — type "long neck", get the giraffe. The flow runs in **live mode** inside the API server (no separate build step).

## Changes
- **New post** `docs/src/content/example-posts/image-search.md` — adapts the example structure to a run-as-a-service shape, with a "one embedding space for images and text" section (the `embed_image_bytes` / `embed_query` two-encoder code) and the reused search-results screenshot.
- **`examples.ts`** — new `image` (Multimodal) card, counts bumped to `10`, added to `POPULAR`, `image_search` catalog entry moved into **Documented walkthroughs**.
- **`docs-meta.json`** — `reviewedTs` entry.

## Images
In the **blobs repo** under `public/docs-v1/img/examples/image-search/` (cocoindex-io/blobs#4, merged): cover + brand-style `flow-v1` / `stage-file-process` diagrams + the reused `search-results` screenshot.

## Verification
- `npm run build` passes (66 pages; `check-agent-output: all agent-facing artifacts OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)