### PR TITLE
docs: consistent buttons + chips on @cocoindex/brand v0.2.4

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.3",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.4",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.2.3",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#3321e28617036d23e40ca6c52d5d999d0eb00b21",
+      "version": "0.2.4",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#3787eb69ee75e727922fc911cbb4f603858e36f8",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.3",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.2.4",
     "@astrojs/sitemap": "^3.7.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",

--- a/docs/src/components/Tabs.astro
+++ b/docs/src/components/Tabs.astro
@@ -152,8 +152,8 @@ const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
 .coco-tabs-radio:nth-of-type(3):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(3),
 .coco-tabs-radio:nth-of-type(4):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(4),
 .coco-tabs-radio:nth-of-type(5):focus-visible ~ .coco-tabs-bar > .coco-tabs-label:nth-of-type(5) {
-  outline: 2px solid var(--coral);
-  outline-offset: 2px;
+  outline: var(--focus);
+  outline-offset: var(--focus-offset);
 }
 
 .coco-tabs-panel :global(img) {

--- a/docs/src/components/examples/FeaturedCard.astro
+++ b/docs/src/components/examples/FeaturedCard.astro
@@ -17,7 +17,7 @@ const { ex, href } = Astro.props;
     <h3 set:html={titleMarkup(ex.title + '.')} />
     <p>{ex.description}</p>
     <div class="chips">
-      {ex.tags.map((t) => <span class="chip">{t.label}</span>)}
+      {ex.tags.map((t) => <span class="t-overlay">{t.label}</span>)}
     </div>
     <div class="foot">
       <span>{ex.footMeta}</span>

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -613,6 +613,10 @@ const breadcrumbLd = {
     color: var(--coral);
     background: var(--paper);
   }
+  /* Shared interaction contract — canonical focus ring (inset, since these sit
+     inside the bordered split control). */
+  .ai-primary:focus-visible,
+  .ai-toggle:focus-visible { outline: var(--focus); outline-offset: -2px; }
   .ai-primary :global(svg) {
     width: 14px;
     height: 14px;
@@ -664,8 +668,8 @@ const breadcrumbLd = {
   .ai-item:hover,
   .ai-item:focus-visible {
     background: color-mix(in oklab, var(--coral) 8%, transparent);
-    outline: none;
   }
+  .ai-item:focus-visible { outline: var(--focus); outline-offset: -2px; }
   .ai-ic {
     flex: none;
     display: grid;

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -191,8 +191,8 @@ const introItems = [
            strip under a hairline rule. -->
       <section class="hero">
         <div class="pill-row">
-          {ex.tags.slice(0, 4).map((t) => <span class="pill"><span class="dot"></span>{t.label}</span>)}
-          <span class="pill dark"><span class="dot"></span>Production ready</span>
+          {ex.tags.slice(0, 4).map((t) => <span class="t-pill t-pill-lg"><span class="dt"></span>{t.label}</span>)}
+          <span class="t-status t-status-dark"><span class="dt"></span>Production ready</span>
         </div>
 
         <h1 class="hero-h" set:html={titleMarkup(ex.title)} />
@@ -330,10 +330,8 @@ const introItems = [
          from globals.css so example pages carry the same rhythm as docs. */
       body.ex-detail .hero { padding: 32px 0 32px; position: relative; }
       body.ex-detail .hero .pill-row { display: flex; gap: 10px; flex-wrap: wrap; margin: 0 0 20px; }
-      body.ex-detail .hero .pill { display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 7px 14px; border-radius: 999px; background: var(--cream); border: 1px solid var(--rule); color: var(--maroon); }
-      body.ex-detail .hero .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); flex: none; }
-      body.ex-detail .hero .pill.dark { background: var(--maroon-ink); color: var(--cream); border-color: var(--maroon-ink); }
-      body.ex-detail .hero .pill.dark .dot { background: var(--palm); }
+      /* Hero tags use the shared chip set: .t-pill .t-pill-lg (+ .dt) and the
+         .t-status .t-status-dark "Production ready" flag (@cocoindex/brand/tags.css). */
       body.ex-detail h1.hero-h { font-family: var(--serif); font-weight: 400; font-size: clamp(40px, 4.6vw, 60px); line-height: 1.02; letter-spacing: -0.03em; margin: 0 0 18px; }
       body.ex-detail h1.hero-h em { font-style: italic; color: var(--coral); }
       body.ex-detail .hero .lede { font-family: var(--sans); font-size: clamp(17px, 1.4vw, 20px); font-weight: 400; line-height: 1.5; letter-spacing: -0.005em; color: var(--maroon-ink); max-width: 62ch; margin: 0 0 14px; }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -140,7 +140,7 @@ const breadcrumbLd = {
       <!-- ═══════════ HERO ═══════════ -->
       <section class="ex-hero">
         <div class="hero-top">
-          <span class="eyb"><span class="dot" aria-hidden="true"></span>{total} live examples · updated weekly</span>
+          <span class="t-eyebrow live"><span class="dt" aria-hidden="true"></span>{total} live examples · updated weekly</span>
           <div class="stats">
             <span><b>{total}</b> examples</span>
             <span><b>{SIDEBAR_SOURCES.length}</b> sources</span>
@@ -322,12 +322,7 @@ const breadcrumbLd = {
       /* ── HERO ── */
       body.ex-listing .ex-hero { padding: 72px 0 48px; border-bottom: 1px solid var(--rule); }
       body.ex-listing .hero-top { display: flex; align-items: center; gap: 18px; margin-bottom: 32px; flex-wrap: wrap; }
-      body.ex-listing .hero-top .eyb {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
-        color: var(--coral); padding: 6px 14px; border: 1px solid var(--coral); border-radius: 999px;
-        display: inline-flex; align-items: center; gap: 10px;
-      }
-      body.ex-listing .hero-top .eyb .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--coral); animation: ex-pulse 2s ease-in-out infinite; }
+      /* Hero eyebrow uses the shared .t-eyebrow.live (@cocoindex/brand/tags.css). */
       @keyframes ex-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
       body.ex-listing .hero-top .stats { margin-left: auto; display: flex; gap: 20px; font-family: var(--mono); font-size: 12px; color: var(--muted); letter-spacing: 0.06em; flex-wrap: wrap; }
       body.ex-listing .hero-top .stats b { color: var(--maroon); font-weight: 500; font-size: 14px; }
@@ -413,6 +408,7 @@ const breadcrumbLd = {
         padding: 2px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--rule);
       }
       body.ex-listing .side-nav ol li a:hover { color: var(--coral); background: var(--cream); }
+      body.ex-listing .side-nav ol li a:focus-visible { outline: var(--focus); outline-offset: var(--focus-offset); }
       body.ex-listing .side-nav ol li.active a { color: var(--maroon); background: var(--cream); border-left-color: var(--coral); }
       body.ex-listing .side-nav ol li.active a .count { color: var(--coral); border-color: var(--coral); }
 
@@ -487,12 +483,7 @@ const breadcrumbLd = {
       body.ex-listing .feat-body h3 em { color: var(--peach); font-style: italic; }
       body.ex-listing .feat-body p { color: rgba(252, 243, 216, 0.85); margin: 0; max-width: 44ch; font-size: 16px; line-height: 1.55; }
       body.ex-listing .feat-body .chips { display: flex; flex-wrap: wrap; gap: 8px; }
-      body.ex-listing .feat-body .chip {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
-        padding: 5px 12px; border-radius: 999px;
-        border: 1px solid rgba(252, 243, 216, 0.25);
-        color: rgba(252, 243, 216, 0.85);
-      }
+      /* Featured-card tags use the shared .t-overlay (@cocoindex/brand/tags.css). */
       body.ex-listing .feat-body .foot { margin-top: auto; display: flex; justify-content: space-between; align-items: flex-end; padding-top: 20px; border-top: 1px solid rgba(252, 243, 216, 0.15); font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(252, 243, 216, 0.7); }
       body.ex-listing .feat-body .foot .go {
         font-family: var(--sans); font-size: 13px; font-weight: 500; letter-spacing: 0;
@@ -543,13 +534,25 @@ const breadcrumbLd = {
         min-height: 280px;
         text-decoration: none; color: inherit;
         overflow: hidden;
-        position: relative;
-        transition: background-image .18s ease;
+        position: relative; isolation: isolate;
+        transition: border-color .18s ease;
       }
-      body.ex-listing .ex-card:hover {
-        background-image: var(--dot-reveal);
+      /* Hover dot-reveal: a behind-content accent that fades in from the right
+         edge only (like the homepage cards). Light dots — a soft coral tint, not
+         the full --dot-reveal — and concentrated on the right so they never sit
+         behind the left-aligned title/body text. */
+      body.ex-listing .ex-card::before {
+        content: ""; position: absolute; inset: 0;
+        background-image: radial-gradient(circle, color-mix(in oklab, var(--coral) 20%, transparent) 1.2px, transparent 1.6px);
         background-size: var(--dot-reveal-size) var(--dot-reveal-size);
+        -webkit-mask-image: linear-gradient(to left, #000 0%, #000 12%, transparent 48%);
+                mask-image: linear-gradient(to left, #000 0%, #000 12%, transparent 48%);
+        opacity: 0; pointer-events: none;
+        transition: opacity .25s ease-out;
+        z-index: -1;
       }
+      body.ex-listing .ex-card:hover::before { opacity: 1; }
+      body.ex-listing .ex-card:hover { border-color: color-mix(in oklab, var(--coral) 35%, var(--rule-strong)); }
       body.ex-listing .ex-thumb {
         aspect-ratio: 16/7;
         position: relative; overflow: hidden;

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -106,7 +106,7 @@ const ICONS: Record<string, string> = {
         <section class="dh-hero">
           <div class="hero-grid">
             <div class="hero-copy">
-              <span class="eyb"><span class="dot" aria-hidden="true"></span>Documentation · v1</span>
+              <span class="t-eyebrow"><span class="dt" aria-hidden="true"></span>Documentation · v1</span>
               <h1 class="hero-h" set:html={titleMarkup('Fresh data views for *agents.*')} />
               <p class="hero-sub">
                 CocoIndex is an ultra-performant framework for building data pipelines for AI, with
@@ -339,14 +339,9 @@ app.update_blocking()</code></pre>
       /* ── HERO ── */
       body.docs-home .dh-hero { padding: 8px 0 8px; }
       body.docs-home .hero-grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 48px; align-items: center; }
-      body.docs-home .hero-copy .eyb {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
-        color: var(--coral); display: inline-flex; align-items: center; gap: 9px; margin-bottom: 20px;
-      }
-      body.docs-home .hero-copy .eyb .dot {
-        width: 7px; height: 7px; border-radius: 50%; background: var(--palm-ink);
-        animation: dh-pulse 2.4s ease-in-out infinite;
-      }
+      /* Hero eyebrow uses the shared .t-eyebrow (@cocoindex/brand/tags.css);
+         add bottom margin in this hero layout. */
+      body.docs-home .hero-copy .t-eyebrow { margin-bottom: 20px; }
       @keyframes dh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
       body.docs-home h1.hero-h {
         font-family: var(--serif); font-weight: 400;
@@ -375,10 +370,15 @@ app.update_blocking()</code></pre>
         font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em;
         color: var(--cream); background: transparent;
         border: 1px solid rgba(252, 243, 216, 0.25); border-radius: 5px;
-        padding: 4px 10px; cursor: pointer; transition: background .15s, border-color .15s;
+        padding: 4px 10px; cursor: pointer; transition: background .15s, border-color .15s, transform .12s var(--ease);
       }
       body.docs-home .install .copy:hover,
       body.docs-home .codeblk .copy:hover { background: rgba(252, 243, 216, 0.12); border-color: rgba(252, 243, 216, 0.5); }
+      /* Shared interaction contract — canonical focus ring + press. */
+      body.docs-home .install .copy:active,
+      body.docs-home .codeblk .copy:active { transform: translateY(1px); }
+      body.docs-home .install .copy:focus-visible,
+      body.docs-home .codeblk .copy:focus-visible { outline: var(--focus); outline-offset: var(--focus-offset); }
 
       body.docs-home .hero-meta {
         display: flex; flex-wrap: wrap; gap: 6px 18px; margin-top: 22px;
@@ -543,7 +543,6 @@ app.update_blocking()</code></pre>
         body.docs-home .split { grid-template-columns: 1fr; gap: 26px; }
       }
       @media (prefers-reduced-motion: reduce) {
-        body.docs-home .hero-copy .eyb .dot { animation: none; }
         body.docs-home .card, body.docs-home .card h3 .ar { transition: none; }
       }
     </style>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -76,7 +76,7 @@ a:hover { text-decoration: underline; }
   box-shadow: inset 0 0 0 1px var(--rule);
 }
 .mobile-tabs button[disabled] { opacity: .35; cursor: not-allowed; }
-.mobile-tabs button:focus-visible { outline: 2px solid var(--coral); outline-offset: 2px; }
+.mobile-tabs button:focus-visible { outline: var(--focus); outline-offset: var(--focus-offset); }
 
 .mobile-empty {
   margin: 16px 14px; color: var(--muted);


### PR DESCRIPTION
Consolidates the docs/examples buttons + chips onto the shared `@cocoindex/brand` design system (v0.2.4).

**Buttons** — one interaction contract (`var(--focus)` ring + `translateY(1px)` press) across the AI-actions split button + menu, the copy buttons, code-language tabs, examples sidebar links, and the mobile drawer tabs (previously a mix of `2px solid coral` / none / suppressed `outline:none`).

**Chips** — migrated the examples gallery onto the brand tag set: hero eyebrow → `.t-eyebrow.live`, detail tags → `.t-pill .t-pill-lg`, the "Production ready" flag → `.t-status .t-status-dark`, featured-card tags → `.t-overlay`; docs-home eyebrow → `.t-eyebrow`. Deletes the bespoke `.eyb`/`.pill`/`.chip` CSS.

**Card hover** — the example-card dot-reveal is now a light (coral 20%), right-edge-masked, behind-content layer so it accents the card without sitting behind the body text.

Builds green (63 pages); verified the detail hero (`.t-pill-lg` + dark "PRODUCTION READY" pill), the listing eyebrow + filters, and the card hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)