### PR TITLE
docs(examples): dedup boilerplate from meta descriptions

### DIFF
--- a/docs/src/content/example-posts/amazon-s3-embedding.md
+++ b/docs/src/content/example-posts/amazon-s3-embedding.md
@@ -1,6 +1,6 @@
 ---
 title: Embed Markdown from *Amazon S3*
-description: 'The Semantic Search 101 pipeline with Amazon S3 as the source instead of a local folder — list Markdown objects from a bucket, chunk and embed each one, and store the vectors in Postgres with pgvector. Plain async Python.'
+description: 'The Semantic Search 101 pipeline with Amazon S3 as the source instead of a local folder — list Markdown objects from a bucket, chunk and embed each one, and store the vectors in Postgres with pgvector.'
 slug: amazon-s3-embedding
 image: https://cocoindex.io/blobs/docs-v1/img/examples/amazon-s3-embedding/cover.png
 tags: [vector-index, amazon-s3]

--- a/docs/src/content/example-posts/audio-to-text.md
+++ b/docs/src/content/example-posts/audio-to-text.md
@@ -1,6 +1,6 @@
 ---
 title: Audio to Text with *LiteLLM*
-description: 'Transcribe a folder of local audio files with CocoIndex V1 — call a LiteLLM speech-to-text model on each file and store one transcript row per file in Postgres, keyed by filename. Plain async Python, ~12 minutes.'
+description: 'Transcribe a folder of local audio files with CocoIndex V1 — call a LiteLLM speech-to-text model on each file and store one transcript row per file in Postgres, keyed by filename.'
 slug: audio-to-text
 image: https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/cover.png
 tags: [transcription, litellm]

--- a/docs/src/content/example-posts/docs-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/docs-to-knowledge-graph.md
@@ -1,6 +1,6 @@
 ---
 title: Turn Docs into a Knowledge Graph
-description: 'Build a concept knowledge graph from Markdown docs with CocoIndex V1 and Neo4j — LLM relationship extraction with instructor + LiteLLM, declarative graph targets, and incremental sync as docs change, in plain async Python.'
+description: 'Build a concept knowledge graph from Markdown docs with CocoIndex V1 and Neo4j — LLM relationship extraction with instructor + LiteLLM, declarative graph targets, and incremental sync as docs change.'
 slug: docs-to-knowledge-graph
 image: https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/cover.png
 tags: [knowledge-graph, llm-extraction]

--- a/docs/src/content/example-posts/entire-session-search.md
+++ b/docs/src/content/example-posts/entire-session-search.md
@@ -1,6 +1,6 @@
 ---
 title: Search Your *AI Coding Sessions*
-description: 'Build a semantic search index over AI coding sessions captured by Entire with CocoIndex V1 — read transcripts, prompts, and context summaries, embed them with sentence-transformers, and store the vectors in Postgres with pgvector, then search every session in natural language. Plain async Python.'
+description: 'Build a semantic search index over AI coding sessions captured by Entire with CocoIndex V1 — read transcripts, prompts, and context summaries, embed them with sentence-transformers, and store the vectors in Postgres with pgvector, then search every session in natural language.'
 slug: entire-session-search
 image: https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/cover.png
 tags: [vector-index, ai-sessions]

--- a/docs/src/content/example-posts/files-transform.md
+++ b/docs/src/content/example-posts/files-transform.md
@@ -1,6 +1,6 @@
 ---
 title: Transform a *Folder of Files*
-description: 'The smallest end-to-end CocoIndex V1 pipeline — watch a directory of Markdown, render each file to HTML with markdown-it-py, and write the .html outputs to a local folder incrementally. Plain async Python, no external services.'
+description: 'The smallest end-to-end CocoIndex V1 pipeline — watch a directory of Markdown, render each file to HTML with markdown-it-py, and write the .html outputs to a local folder incrementally.'
 slug: files-transform
 image: https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/cover.png
 tags: [file-transform, incremental]

--- a/docs/src/content/example-posts/image-search-colpali.md
+++ b/docs/src/content/example-posts/image-search-colpali.md
@@ -1,6 +1,6 @@
 ---
 title: Image Search with *ColPali*
-description: 'Build a higher-fidelity image search engine with CocoIndex V1 — embed images and queries with the multi-vector ColPali model, store every patch vector in Qdrant, and rank with MaxSim through a FastAPI + React app. Plain async Python, live updates.'
+description: 'Build a higher-fidelity image search engine with CocoIndex V1 — embed images and queries with the multi-vector ColPali model, store every patch vector in Qdrant, and rank with MaxSim through a FastAPI + React app.'
 slug: image-search-colpali
 image: https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/cover.png
 tags: [multimodal, image-search]

--- a/docs/src/content/example-posts/image-search.md
+++ b/docs/src/content/example-posts/image-search.md
@@ -1,6 +1,6 @@
 ---
 title: Search Images by Text
-description: 'Build an image search engine with CocoIndex V1 — embed images with CLIP, store the vectors in Qdrant, and query your photos in natural language through a FastAPI + React app. Plain async Python, live updates.'
+description: 'Build an image search engine with CocoIndex V1 — embed images with CLIP, store the vectors in Qdrant, and query your photos in natural language through a FastAPI + React app.'
 slug: image-search
 image: https://cocoindex.io/blobs/docs-v1/img/examples/image-search/cover.png
 tags: [multimodal, image-search]

--- a/docs/src/content/example-posts/index-codebase.md
+++ b/docs/src/content/example-posts/index-codebase.md
@@ -1,6 +1,6 @@
 ---
 title: Index Your Codebase for AI Agents
-description: 'Index a codebase for RAG and AI coding agents with CocoIndex V1 and Tree-sitter — language-aware chunking, embeddings, semantic search, and a live vector index, in plain async Python.'
+description: 'Index a codebase for RAG and AI coding agents with CocoIndex V1 and Tree-sitter — language-aware chunking, embeddings, semantic search, and a live vector index.'
 slug: index-codebase
 image: https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/cover.png
 tags: [data-indexing, semantic-search]

--- a/docs/src/content/example-posts/meeting-notes-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/meeting-notes-to-knowledge-graph.md
@@ -1,6 +1,6 @@
 ---
 title: Turn Meeting Notes into a Knowledge Graph
-description: 'Build a self-updating knowledge graph from Google Drive meeting notes with CocoIndex V1 — LLM extraction with instructor + LiteLLM, embedding-based person entity resolution, and a Neo4j graph, in plain async Python.'
+description: 'Build a self-updating knowledge graph from Google Drive meeting notes with CocoIndex V1 — LLM extraction with instructor + LiteLLM, embedding-based person entity resolution, and a Neo4j graph.'
 slug: meeting-notes-to-knowledge-graph
 image: https://cocoindex.io/blobs/docs-v1/img/examples/meeting-notes-to-knowledge-graph/cover.png
 tags: [knowledge-graph, llm-extraction]

--- a/docs/src/content/example-posts/paper-metadata.md
+++ b/docs/src/content/example-posts/paper-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Index Academic Papers and Extract Metadata
-description: 'Turn a folder of academic PDFs into structured metadata with CocoIndex V1 — read the first page, LLM-extract title, authors, and abstract into typed rows, embed the title and abstract for semantic search, and store it all in Postgres with pgvector. Plain async Python.'
+description: 'Turn a folder of academic PDFs into structured metadata with CocoIndex V1 — read the first page, LLM-extract title, authors, and abstract into typed rows, embed the title and abstract for semantic search, and store it all in Postgres with pgvector.'
 slug: paper-metadata
 image: https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/cover.png
 tags: [llm-extraction, pdf]

--- a/docs/src/content/example-posts/patient-intake-baml.md
+++ b/docs/src/content/example-posts/patient-intake-baml.md
@@ -1,6 +1,6 @@
 ---
 title: Patient Intake Forms to Typed JSON with *BAML*
-description: 'Extract structured patient records from intake-form PDFs with CocoIndex V1 — define the output schema in BAML, run one type-safe Gemini vision extraction per PDF, and write a validated JSON file per patient. Plain async Python, incremental by default.'
+description: 'Extract structured patient records from intake-form PDFs with CocoIndex V1 — define the output schema in BAML, run one type-safe Gemini vision extraction per PDF, and write a validated JSON file per patient.'
 slug: patient-intake-baml
 image: https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/cover.png
 tags: [structured-extraction, baml]

--- a/docs/src/content/example-posts/patient-intake-dspy.md
+++ b/docs/src/content/example-posts/patient-intake-dspy.md
@@ -1,6 +1,6 @@
 ---
 title: Patient Intake Extraction with *DSPy*
-description: 'Turn a folder of patient intake PDFs into structured JSON with CocoIndex V1 — render each page to an image, extract a typed Pydantic Patient with a DSPy ChainOfThought vision module on Gemini, and write one JSON file per form. Plain async Python.'
+description: 'Turn a folder of patient intake PDFs into structured JSON with CocoIndex V1 — render each page to an image, extract a typed Pydantic Patient with a DSPy ChainOfThought vision module on Gemini, and write one JSON file per form.'
 slug: patient-intake-dspy
 image: https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/cover.png
 tags: [structured-extraction, dspy]

--- a/docs/src/content/example-posts/pdf-embedding.md
+++ b/docs/src/content/example-posts/pdf-embedding.md
@@ -1,6 +1,6 @@
 ---
 title: Semantic Search over PDFs
-description: 'Build a vector index from local PDFs with CocoIndex V1 — convert to Markdown with docling on a GPU runner, chunk, embed with sentence-transformers, and store the vectors in Postgres with pgvector, then query in natural language. Plain async Python.'
+description: 'Build a vector index from local PDFs with CocoIndex V1 — convert to Markdown with docling on a GPU runner, chunk, embed with sentence-transformers, and store the vectors in Postgres with pgvector, then query in natural language.'
 slug: pdf-embedding
 image: https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/cover.png
 tags: [vector-index, pdf]

--- a/docs/src/content/example-posts/podcast-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/podcast-to-knowledge-graph.md
@@ -1,6 +1,6 @@
 ---
 title: Turn Podcasts into a Knowledge Graph
-description: 'Turn YouTube podcasts into a queryable knowledge graph with CocoIndex V1 — transcription with speaker diarization, two-step LLM extraction, entity resolution with embeddings, and a SurrealDB graph, in plain async Python.'
+description: 'Turn YouTube podcasts into a queryable knowledge graph with CocoIndex V1 — transcription with speaker diarization, two-step LLM extraction, entity resolution with embeddings, and a SurrealDB graph.'
 slug: podcast-to-knowledge-graph
 image: https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/cover.png
 tags: [knowledge-graph, llm-extraction]

--- a/docs/src/content/example-posts/postgres-source.md
+++ b/docs/src/content/example-posts/postgres-source.md
@@ -1,6 +1,6 @@
 ---
 title: Postgres as a *Source*
-description: 'Use an existing Postgres table as a CocoIndex source — read product rows, derive fields, embed each row, and write the vectors back to Postgres with pgvector. Plain async Python, incremental, ~8 minutes.'
+description: 'Use an existing Postgres table as a CocoIndex source — read product rows, derive fields, embed each row, and write the vectors back to Postgres with pgvector.'
 slug: postgres-source
 image: https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/cover.png
 tags: [postgres-source, vector-index]

--- a/docs/src/content/example-posts/text-embedding-qdrant.md
+++ b/docs/src/content/example-posts/text-embedding-qdrant.md
@@ -1,6 +1,6 @@
 ---
 title: Semantic Search with *Qdrant*
-description: 'The Semantic Search 101 pipeline with Qdrant as the vector store — chunk Markdown, embed each chunk, and upsert the vectors into a managed Qdrant collection, incrementally, in plain async Python.'
+description: 'The Semantic Search 101 pipeline with Qdrant as the vector store — chunk Markdown, embed each chunk, and upsert the vectors into a managed Qdrant collection, incrementally.'
 slug: text-embedding-qdrant
 image: https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-qdrant/cover.png
 tags: [vector-index, qdrant]

--- a/docs/src/content/example-posts/text-embedding-turbopuffer.md
+++ b/docs/src/content/example-posts/text-embedding-turbopuffer.md
@@ -1,6 +1,6 @@
 ---
 title: Semantic Search with *Turbopuffer*
-description: 'The Semantic Search 101 pipeline with CocoIndex V1, pointed at a managed vector store — chunk Markdown, embed each chunk, and upsert the vectors into a Turbopuffer namespace, all in plain async Python.'
+description: 'The Semantic Search 101 pipeline with CocoIndex V1, pointed at a managed vector store — chunk Markdown, embed each chunk, and upsert the vectors into a Turbopuffer namespace.'
 slug: text-embedding-turbopuffer
 image: https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-turbopuffer/cover.png
 tags: [vector-index, turbopuffer]

--- a/docs/src/content/example-posts/text-embedding.md
+++ b/docs/src/content/example-posts/text-embedding.md
@@ -1,6 +1,6 @@
 ---
 title: Semantic Search 101
-description: 'The simplest end-to-end vector index with CocoIndex V1 — chunk Markdown files, embed each chunk, store the vectors in Postgres with pgvector, and search them in natural language. Plain async Python, ~6 minutes.'
+description: 'The simplest end-to-end vector index with CocoIndex V1 — chunk Markdown files, embed each chunk, store the vectors in Postgres with pgvector, and search them in natural language.'
 slug: text-embedding
 image: https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/cover.png
 tags: [vector-index, semantic-search]


### PR DESCRIPTION
The frontmatter `description:` is each example page's meta/SEO description, but ~19 of 27 ended with the same "Plain async Python[, …]" boilerplate — repetitive and non-distinctive. This strips that tail so every meta description is unique and descriptive. The brand "plain async Python" line stays in the post bodies.

(face-recognition's description is fixed in #2186.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)