### PR TITLE
docs(examples): improve agent followability of example walkthroughs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,6 +4,10 @@
 # internal doc links - docusaurus validates these during build
 ^file://
 
+# internal example-walkthrough self-links - validated at build time; a newly
+# added /docs/examples/<slug>/ page 404s in CI until the site redeploys
+^https://cocoindex\.io/docs/examples/
+
 # used in the docs (as part of setup/launch instructions)
 ^http://localhost
 ^https://localhost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ When adding new functionality that involves I/O or concurrency:
 
 ## Versioning
 
-The current codebase is for CocoIndex v1, which is a fundamental redesign from CocoIndex v0. Currently the `v1` branch is the main branch for CocoIndex v1 code.
+The current codebase is for CocoIndex v1, which is a fundamental redesign from CocoIndex v0. CocoIndex v1 lives on the `main` branch; the legacy v0 code is preserved on the `v0` branch.
 
 ## Docs diagrams
 

--- a/docs/src/content/example-posts/csv-to-kafka.md
+++ b/docs/src/content/example-posts/csv-to-kafka.md
@@ -30,7 +30,16 @@ You [declare the transformation logic](https://cocoindex.io/docs/programming_gui
 
 ## Setup
 
-- A running Kafka broker. Any broker the [`confluent_kafka`](https://github.com/confluentinc/confluent-kafka-python) client can reach works — a local `localhost:9092`, or a managed one like [StreamNative](https://streamnative.io/) with SASL.
+- A running Kafka broker. Any broker the [`confluent_kafka`](https://github.com/confluentinc/confluent-kafka-python) client can reach works — a local `localhost:9092`, or a managed one like [StreamNative](https://streamnative.io/) with SASL. If you don't have one, a single-container [Redpanda](https://redpanda.com/) (Kafka-API compatible) is the quickest local broker:
+
+  ```sh
+  docker run -d --name redpanda -p 9092:9092 redpandadata/redpanda:latest \
+    redpanda start --mode dev-container --smp 1 \
+    --kafka-addr PLAINTEXT://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://localhost:9092
+
+  # CocoIndex never creates topics — create the one it produces into:
+  docker exec redpanda rpk topic create cocoindex-csv-rows
+  ```
 
 - Install CocoIndex with the Kafka extra:
 

--- a/docs/src/lib/raw-markdown.ts
+++ b/docs/src/lib/raw-markdown.ts
@@ -120,7 +120,13 @@ function buildGuard(slug: string, lead: string, extra = ''): string {
   return (
     `> ${lead}\n` +
     `>\n` +
-    `> Source: ${pageUrl(slug)} · Docs index: ${LLMS_TXT_URL} · Agent skill: ${SKILL_MD_URL}${extra}`
+    `> Source: ${pageUrl(slug)} · Docs index: ${LLMS_TXT_URL} · Agent skill: ${SKILL_MD_URL}${extra}\n` +
+    `>\n` +
+    `> v0→v1 quick map — if you reach for these v0 symbols, stop and use the v1 form: ` +
+    `\`@cocoindex.flow_def\`/\`FlowBuilder\` → \`coco.App\` + a \`@coco.fn\` main function; ` +
+    `\`add_collector()\`/\`collect()\`/\`export()\` → declare target states (\`declare_row\`, \`declare_file\`); ` +
+    `\`cocoindex.sources/functions/targets.*\` → connector APIs (\`localfs.walk_dir\`, \`coco.ops.*\`, \`postgres.declare_table_target\`). ` +
+    `Full mapping + API reference: ${SKILL_MD_URL}.`
   );
 }
 

--- a/examples/multi_codebase_summarization/README.md
+++ b/examples/multi_codebase_summarization/README.md
@@ -144,8 +144,8 @@ Edit the `app` definition in `main.py`:
 
 ```python
 app = coco.App(
-    app_main,
     coco.AppConfig(name="MultiCodebaseSummarization"),
+    app_main,
     root_dir=pathlib.Path("./your_projects_dir"),
     output_dir=pathlib.Path("./your_output_dir"),
 )


### PR DESCRIPTION
Fixes from a deep review of the **agent experience** of the example docs (discoverability / followability / teaching quality). The discovery layer (llms.txt, .md twins, catalog) is already strong; these are the concrete followability + teaching gaps.

## What changed
- **csv-to-kafka: a runnable broker.** The doc says *"CocoIndex never creates topics"* but gave no way to start a broker or create the topic. Added a single-container Redpanda (dev-container) `docker run` + `rpk topic create cocoindex-csv-rows`.
- **multi_codebase_summarization README: fixed swapped `coco.App(...)` args** — `AppConfig` must precede the main fn per the `App(name_or_config, main_fn, /, …)` signature. (The walkthrough's string-first form is already valid; only the README was wrong.)
- **v0→v1 quick-map in the agent guard** (`raw-markdown.ts`). The hallucination-blocking symbol map (from `SKILL.md`) now rides on every agent-facing `.md` twin and `llms-full.txt`, not just the one-line "ignore v0 DSL" warning.
- **AGENTS.md:** corrected the stale *"the `v1` branch is the main branch"* line — v1 is on `main`; v0 is preserved on the `v0` branch.
- **ci(links):** ignore internal `/docs/examples/` self-links in lychee — newly added example pages 404 in the checker until the site redeploys (this is why `main` itself is currently red on Check links). Matches the existing `file://` exemption rationale.

## Reviewed but intentionally not changed
- **Postgres setup command** (`docker compose -f dev/postgres.yaml`): the relative path only resolves at the repo root, which the self-contained walkthrough flow never establishes. Considered switching to an inline `docker run`, but kept the compose file as the single source of truth per maintainer preference.
- **Query-snippet schema qualifier** (text-embedding / index-codebase): the walkthroughs omit `pg_schema_name` *consistently* (write + read both use the default schema), so a follower hits no error. The divergence is only walkthrough-vs-shipped-`main.py` — a deliberate teaching simplification, left as-is.
- **Orphaned walkthroughs**: already resolved by #2189, which wired all 5 ported examples into the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)