### PR TITLE
fix: unwrap PEP 695 type aliases in analyze_type_info (numpy 2.5 NDArray)

### DIFF
--- a/python/cocoindex/_internal/datatype.py
+++ b/python/cocoindex/_internal/datatype.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     PYDANTIC_AVAILABLE = False
 
+# PEP 695 ``type`` aliases (``typing.TypeAliasType``) only exist on Python 3.12+.
+# numpy >= 2.5 defines ``numpy.typing.NDArray`` as one, so we must transparently
+# unwrap it to reach the underlying ``numpy.ndarray[...]`` type.
+_TypeAliasType = getattr(typing, "TypeAliasType", None)
+
 
 def extract_ndarray_elem_dtype(ndarray_type: Any) -> Any:
     args = typing.get_args(ndarray_type)
@@ -210,6 +215,16 @@ def analyze_type_info(t: Any, *, nullable: bool = False) -> DataTypeInfo:
         if base_type is Annotated:
             annotations += t.__metadata__
             t = t.__origin__
+        elif _TypeAliasType is not None and isinstance(t, _TypeAliasType):
+            # Bare PEP 695 ``type`` alias (e.g. unsubscripted ``numpy.typing.NDArray``):
+            # resolve to the aliased type and continue unwrapping.
+            t = t.__value__
+        elif _TypeAliasType is not None and isinstance(base_type, _TypeAliasType):
+            # Subscripted PEP 695 ``type`` alias (e.g. ``NDArray[np.float32]`` on
+            # numpy >= 2.5): substitute the type arguments into the alias value so
+            # the underlying ``numpy.ndarray[...]`` (with its dtype) is recovered.
+            type_args = typing.get_args(t)
+            t = base_type.__value__[type_args] if type_args else base_type.__value__
         else:
             if base_type is None:
                 base_type = t

--- a/python/tests/core/test_datatype.py
+++ b/python/tests/core/test_datatype.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Mapping, Sequence
-from typing import Annotated, NamedTuple
+from typing import Annotated, Any, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -60,6 +60,39 @@ def test_ndarray_int64_no_dim() -> None:
     assert result.nullable is False
     assert get_origin(result.core_type) == np.ndarray
     assert get_args(result.core_type)[1] == np.dtype[np.int64]
+
+
+def test_ndarray_pep695_type_alias() -> None:
+    """numpy>=2.5 defines ``numpy.typing.NDArray`` as a PEP 695 ``type`` alias
+    (``typing.TypeAliasType``) instead of a plain generic alias, so unwrapping
+    must resolve the alias to recover ``numpy.ndarray`` and its dtype.
+
+    Regression for https://github.com/cocoindex-io/cocoindex-code/issues/198.
+    """
+    import typing
+    from typing import get_args, get_origin
+
+    type_alias_type = getattr(typing, "TypeAliasType", None)
+    if type_alias_type is None:
+        import pytest
+
+        pytest.skip("PEP 695 type aliases require Python 3.12+")
+
+    ScalarT = typing.TypeVar("ScalarT", bound=np.generic)
+    # Mirror numpy>=2.5: ``type NDArray[ScalarT] = np.ndarray[Any, np.dtype[ScalarT]]``.
+    # Built dynamically (the value/alias are runtime objects, not static types).
+    alias_value: Any = np.ndarray[tuple[Any, ...], np.dtype[ScalarT]]  # type: ignore[valid-type]
+    ndarray_alias: Any = type_alias_type("NDArray", alias_value, type_params=(ScalarT,))
+
+    marker = object()
+    typ: Any = Annotated[ndarray_alias[np.float32], marker]
+    result = analyze_type_info(typ)
+    assert isinstance(result.variant, SequenceType)
+    assert result.variant.elem_type == np.float32
+    assert result.nullable is False
+    assert get_origin(result.core_type) == np.ndarray
+    assert get_args(result.core_type)[1] == np.dtype[np.float32]
+    assert marker in result.annotations
 
 
 def test_nullable_ndarray() -> None:


### PR DESCRIPTION
## Summary
- numpy 2.5.0 redefines `numpy.typing.NDArray` as a PEP 695 `type` alias (`typing.TypeAliasType`) instead of a plain generic alias. `typing.get_origin(NDArray[np.float32])` then returns the `NDArray` alias object rather than `numpy.ndarray`, so `analyze_type_info` no longer recognized ndarray-typed fields — vector columns failed with *"VectorSchemaProvider is only supported for NumPy ndarray type."*
- Teach the unwrap loop in `analyze_type_info` to resolve `TypeAliasType` transparently: bare aliases via `__value__`, and subscripted aliases by substituting the type args into the alias value so the underlying `numpy.ndarray[...]` dtype is recovered. Guarded with `getattr(typing, "TypeAliasType", None)` so it is a no-op on Python 3.11.
- Added regression test `test_ndarray_pep695_type_alias` (constructs a PEP 695 alias mirroring numpy 2.5's `NDArray`; skips on Python < 3.12).

Fixes cocoindex-io/cocoindex-code#198

## Test plan
- `pytest python/tests/core/test_datatype.py` — 18 passed (+ new test passes on Python 3.12 with numpy 2.5.0, skips on 3.11).
- Verified end-to-end against numpy 2.5.0 + Python 3.12: the failing case `Annotated[NDArray[np.float32], <ContextKey>]` now resolves `base_type=numpy.ndarray` with `elem_type=numpy.float32`.
- `mypy` clean; no regression on numpy 2.4.2 / Python 3.11.
