### PR TITLE
fix(code_match): single-node terms match anonymous leaves (keywords/ops)

### DIFF
--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -733,6 +733,27 @@ impl<'s> Ctx<'_, 's> {
                 }
             }
         }
+        // A single-node term also matches an **anonymous leaf** (keyword/operator/
+        // punctuation): it is a node like any other — a literal matches it, a `\*` run
+        // spans it, and a literal alternation `\( if | while \)` matches it — so `\X`,
+        // `.`, `\_`, and `\/re/` must too. (Named leaves are already covered by the spans
+        // above, so this only adds the anon ones.) Tried *last*, so the greedy
+        // largest-first preference for named subtrees is unchanged — the bare leaf is a
+        // backtrack fallback (`\/if|while/` matches the `if` keyword; `.` still binds the
+        // enclosing `if_statement` first unless the pattern forces the leaf).
+        let leaf = &idx.leaves[li];
+        if leaf.anon && regex_ok(regex, &self.source[leaf.start_byte..leaf.end_byte]) {
+            let cap = self.make_capture(leaf.start_byte, leaf.end_byte, false);
+            match self.bind(name, cap) {
+                BindResult::Inconsistent => {}
+                bind => {
+                    if self.dp(pi + 1, end, li + 1, hi) {
+                        return true;
+                    }
+                    self.unbind(name, bind);
+                }
+            }
+        }
         false
     }
 

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1102,3 +1102,48 @@ fn trailing_tolerance_skips_delimiters_not_closers() {
         "containment INNER gets the same trailing-delimiter tolerance",
     );
 }
+
+#[test]
+fn single_node_term_matches_anonymous_leaf() {
+    // A keyword/operator is a node like any other — a literal matches it, a `\*` run
+    // spans it (`f(\(A*\))` captures the `,` separators), and a literal alternation
+    // matches it. So a single-node *term* (`\/re/`, `\_`, `\X`) must too, not only named
+    // subtrees. Regex over keyword text now finds the keyword it couldn't before:
+    let kw = matches(
+        lang::typescript(),
+        r"\/if|while/",
+        "function g(x){ if (x) {} while (x) {} }",
+    );
+    let texts: Vec<&str> = kw.iter().map(|m| m.text).collect();
+    assert!(
+        texts.contains(&"if") && texts.contains(&"while"),
+        "regex matches the keyword leaves, got {kw:?}",
+    );
+    // `\_` (the anonymous any-node) matches an operator leaf:
+    assert!(has_kind(
+        &matches(lang::typescript(), r"a \_ b", "let z = a + b;"),
+        "binary_expression",
+    ));
+    // and a named regex capture binds it:
+    assert_eq!(
+        cap(
+            &matches(lang::typescript(), r"a \(OP:/[-+]/\) b", "let z = a + b;"),
+            "OP",
+        )
+        .as_deref(),
+        Some("+"),
+    );
+    // Greedy-largest-first is preserved: a bare `\X` still binds the enclosing *named*
+    // subtree, not a token — the leaf is only a backtrack fallback.
+    assert!(has_kind(
+        &matches(lang::typescript(), r"\X(\*)", "foo(x);"),
+        "call_expression",
+    ));
+    // The leaf fallback is anon-only, so named identifiers aren't double-matched:
+    let asg = matches(lang::typescript(), r"\A = \B", "a = b;");
+    assert!(has_kind(&asg, "assignment_expression"));
+    assert!(
+        !has_kind(&asg, "expression_statement"),
+        "the leaf fallback must not re-report named-leaf nodes",
+    );
+}


### PR DESCRIPTION
## Summary

A single-node term (`\X`, `\_`, `\/re/`) only bound **named** nodes, so `\/if|while/` matched nothing and `\_` couldn't match an operator. But an anonymous leaf (keyword/operator/punctuation) is a node like any other — a literal matches one, a `\*` run spans them, and a literal alternation `\( if | while \)` matches one — so a single-node term must too, for consistency.

`match_single` now tries the anonymous leaf at the position *after* the named `spans_by_start` candidates, so greedy-largest-first is preserved: a bare `\X` still binds the enclosing named subtree (the leaf is only a backtrack fallback, so `\X = \Y` never grabs the `=`), and a named-leaf identifier isn't double-reported (the fallback is anon-only). Result: `\/if|while/` matches the `if`/`while` keyword and `\(OP:/[-+]/\)` binds an operator.

Prefilter stays sound — regex literals use substring/n-gram matching (not the keyword-excluding word index), and short keywords like `if` are dropped by `min_len`. A 44k-pattern real-code sweep reports 0 unsound / 0 panics.

Note: the *explicit* `.` any-node term (`\(.\)`, `\(K:.\)`) is still unparsed — only the short forms (`\_`, `\X`, `\/re/`) and the implicit default matcher exist; those are the working equivalents. Wiring up the explicit `.` term is a separate follow-up.

## Test plan

- `cargo test -p cocoindex_code_match` (183 tests, green) — new `single_node_term_matches_anonymous_leaf` covers regex-on-keyword, `\_`-on-operator, captured operator, greedy-largest preserved, and no double-match of named leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
