### PR TITLE
feat(code_match): whole-node boundary `\{ P \}` ("is")

### DIFF
--- a/rust/code_match/src/lexer.rs
+++ b/rust/code_match/src/lexer.rs
@@ -94,6 +94,12 @@ pub enum PatternItem {
     ContainsOpen { close: usize },
     /// `\}}` — closes the containment opened by the matching `ContainsOpen`.
     ContainsClose,
+    /// `\{` — opens a whole-node boundary `\{ P \}` ("is"): `P` must match an
+    /// *entire* node (anchored, no leading/trailing tolerance). Same flat
+    /// back-patched representation as `ContainsOpen`; `P` is `items[self+1 .. close]`.
+    WholeOpen { close: usize },
+    /// `\}` — closes the whole-node boundary opened by the matching `WholeOpen`.
+    WholeClose,
 }
 
 pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
@@ -142,6 +148,19 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
             if pattern[after..].starts_with("}}") {
                 out.push(PatternItem::ContainsClose);
                 i = after + 2;
+                continue;
+            }
+            // whole-node boundary markers `\{` / `\}` (single brace; the doubled
+            // `\{{`/`\}}` above already consumed the containment form). Back-patched
+            // alongside the containment markers by `resolve_brackets`.
+            if pattern[after..].starts_with('{') {
+                out.push(PatternItem::WholeOpen { close: 0 });
+                i = after + 1;
+                continue;
+            }
+            if pattern[after..].starts_with('}') {
+                out.push(PatternItem::WholeClose);
+                i = after + 1;
                 continue;
             }
             if let Some((item, next)) = lex_metavar(pattern, bytes, after, cfg.meta_char)? {
@@ -211,23 +230,41 @@ pub fn lex(pattern: &str, cfg: &LangConfig) -> Result<Vec<PatternItem>> {
         i += clen;
     }
 
-    resolve_contains(&mut out)?;
+    resolve_brackets(&mut out)?;
     Ok(out)
 }
 
-/// Pair up `\{{` / `\}}` markers and back-patch each `ContainsOpen.close` with the
-/// index of its matching `ContainsClose`. A `client` error on any unbalanced
-/// marker (the pattern is malformed). Nesting is handled by the stack.
-fn resolve_contains(items: &mut [PatternItem]) -> Result<()> {
-    let mut stack: Vec<usize> = Vec::new();
+/// Pair up the bracket markers — containment `\{{`/`\}}` and whole-node `\{`/`\}` —
+/// back-patching each open's `close` with its matching close index. A **typed** stack
+/// enforces proper nesting per kind: a `\}` must close a `\{`, a `\}}` a `\{{` (so
+/// `\{{ … \} … \}}` is the malformed cross-nesting it looks like). Any unmatched or
+/// crossed marker is a `client` error (the pattern is malformed).
+fn resolve_brackets(items: &mut [PatternItem]) -> Result<()> {
+    // (open index, is_containment)
+    let mut stack: Vec<(usize, bool)> = Vec::new();
     for idx in 0..items.len() {
         match &items[idx] {
-            PatternItem::ContainsOpen { .. } => stack.push(idx),
+            PatternItem::ContainsOpen { .. } => stack.push((idx, true)),
+            PatternItem::WholeOpen { .. } => stack.push((idx, false)),
             PatternItem::ContainsClose => {
-                let open = stack
+                let (open, is_cont) = stack
                     .pop()
                     .ok_or_else(|| Error::client("unmatched `\\}}` in pattern"))?;
+                if !is_cont {
+                    return Err(Error::client("`\\}}` closing a `\\{` in pattern"));
+                }
                 if let PatternItem::ContainsOpen { close } = &mut items[open] {
+                    *close = idx;
+                }
+            }
+            PatternItem::WholeClose => {
+                let (open, is_cont) = stack
+                    .pop()
+                    .ok_or_else(|| Error::client("unmatched `\\}` in pattern"))?;
+                if is_cont {
+                    return Err(Error::client("`\\}` closing a `\\{{` in pattern"));
+                }
+                if let PatternItem::WholeOpen { close } = &mut items[open] {
                     *close = idx;
                 }
             }
@@ -235,7 +272,7 @@ fn resolve_contains(items: &mut [PatternItem]) -> Result<()> {
         }
     }
     if !stack.is_empty() {
-        return Err(Error::client("unmatched `\\{{` in pattern"));
+        return Err(Error::client("unmatched `\\{` or `\\{{` in pattern"));
     }
     Ok(())
 }

--- a/rust/code_match/src/matcher.rs
+++ b/rust/code_match/src/matcher.rs
@@ -135,11 +135,17 @@ impl Pattern {
     /// metavar matcher (e.g. an unparseable regex) or unbalanced `\{{` / `\}}`.
     pub fn compile(pattern: &str, cfg: &LangConfig) -> Result<Pattern> {
         let items = lex(pattern, cfg)?;
-        let has_contains = items
-            .iter()
-            .any(|it| matches!(it, PatternItem::ContainsOpen { .. }));
+        // A bounded sub-region (`\{{ \}}` or `\{ \}`) matches its inner pattern against
+        // *several* candidates with different `hi`/`stops`, so the start-independent
+        // `(pi, li)` fail-memo isn't globally sound — disable it (as for containment).
+        let has_brackets = items.iter().any(|it| {
+            matches!(
+                it,
+                PatternItem::ContainsOpen { .. } | PatternItem::WholeOpen { .. }
+            )
+        });
         let no_dups = !detect_dup_names(&items);
-        let use_memo = no_dups && !has_contains;
+        let use_memo = no_dups && !has_brackets;
         Ok(Pattern {
             items,
             cfg: cfg.clone(),
@@ -633,9 +639,10 @@ impl<'s> Ctx<'_, 's> {
                 }
             },
             PatternItem::ContainsOpen { close } => self.match_contains(pi, *close, end, li, hi),
+            PatternItem::WholeOpen { close } => self.match_whole(pi, *close, end, li, hi),
             // Never landed on: the outer DP jumps over `[open+1, close]` to
-            // `close+1`, and an INNER sub-DP stops at `pi == end == close`.
-            PatternItem::ContainsClose => false,
+            // `close+1`, and an INNER/P sub-DP stops at `pi == end == close`.
+            PatternItem::ContainsClose | PatternItem::WholeClose => false,
         };
 
         if !ok && self.use_memo {
@@ -800,6 +807,39 @@ impl<'s> Ctx<'_, 's> {
                     self.unbind(name, bind);
                 }
             }
+        }
+        false
+    }
+
+    /// `\{ P \}` — whole-node boundary ("is", §5). `P` (`items[pi+1..close]`) must match
+    /// a node starting at `li` **in full** — no leading or trailing tolerance — then the
+    /// outer match continues from that node's end. So `\{ if (\X) { \Y } \}` matches an
+    /// `if` with no `else` (P has to span every child). Tried largest-first and **bounded
+    /// to `spans_by_start[li]`** (the nodes anchored at this leaf), so it stays O(spans·k)
+    /// — no descendant scan, none of the old containment pathology. P's captures thread
+    /// forward; a `bound` snapshot undoes them on a failed attempt.
+    fn match_whole(&mut self, pi: usize, close: usize, end: usize, li: usize, hi: usize) -> bool {
+        let inner = pi + 1; // first item of P
+        let cont = close + 1; // first outer item after `\}`
+        let idx = self.idx;
+        let Some(spans) = idx.spans_by_start.get(li) else {
+            return false;
+        };
+        for sp in spans {
+            let next = sp.end_leaf + 1;
+            if next > hi {
+                continue;
+            }
+            let snapshot = self.bound.clone();
+            // Whole-node: clear `tolerant_end` so the base case requires the match to land
+            // exactly on `next` (the node's end), not at any earlier child boundary.
+            let saved_tol = self.tolerant_end.take();
+            let p_ok = self.dp(inner, close, li, next);
+            self.tolerant_end = saved_tol;
+            if p_ok && self.dp(cont, end, next, hi) {
+                return true;
+            }
+            self.bound = snapshot; // undo P's bindings from a failed attempt
         }
         false
     }

--- a/rust/code_match/tests/features.rs
+++ b/rust/code_match/tests/features.rs
@@ -1147,3 +1147,58 @@ fn single_node_term_matches_anonymous_leaf() {
         "the leaf fallback must not re-report named-leaf nodes",
     );
 }
+
+#[test]
+fn whole_node_boundary_is() {
+    // `\{ P \}` ("is") requires P to match an *entire* node — no leading/trailing
+    // tolerance — so it's the strict counterpart to the default fragment match, and the
+    // tight end of the scope family (`\{ \}` is ⊂ default fragment ⊂ `\{{ \}}` has).
+    let ts = lang::typescript();
+    // P fills the whole binary_expression; precedence still from the tree, so over
+    // `a + b * c` the whole node is `a + b*c` (\Y = b*c), never the fragment `a + b`.
+    assert!(has_kind(
+        &matches(ts.clone(), r"\{ \X + \Y \}", "let z = a + b;"),
+        "binary_expression",
+    ));
+    let prec = matches(ts.clone(), r"\{ \X + \Y \}", "let z = a + b * c;");
+    assert_eq!(prec.len(), 1);
+    assert_eq!(prec[0].capture_text("Y"), Some("b * c"));
+
+    // The headline query: an `if` with **no `else`**. Whole-node coverage forces P to
+    // span every child, so the else-form (an extra `else_clause` child) is excluded —
+    // while the *default* fragment pattern matches both.
+    let no_else = "function f(c){ if (c) { x(); } }";
+    let with_else = "function f(c){ if (c) { x(); } else { y(); } }";
+    assert!(has_kind(
+        &matches(ts.clone(), r"\{ if (\X) { \Y } \}", no_else),
+        "if_statement",
+    ));
+    assert!(
+        !has_kind(
+            &matches(ts.clone(), r"\{ if (\X) { \Y } \}", with_else),
+            "if_statement"
+        ),
+        "whole-node `is` must exclude the if-with-else (P doesn't span the else_clause)",
+    );
+    assert!(
+        has_kind(
+            &matches(ts.clone(), r"if (\X) { \Y }", with_else),
+            "if_statement"
+        ),
+        "the default fragment pattern still matches the if-with-else",
+    );
+
+    // Nests with containment: a whole `if` that *has* a `return`.
+    assert!(has_kind(
+        &matches(
+            ts.clone(),
+            r"\{ if (\X) \{{ return \Y \}} \}",
+            "function f(c){ if (c) { return a; } }",
+        ),
+        "if_statement",
+    ));
+
+    // Malformed bracket nesting is a compile error (typed open/close pairing).
+    assert!(Pattern::compile(r"\{ a \}}", &ts).is_err());
+    assert!(Pattern::compile(r"\{{ a \}", &ts).is_err());
+}


### PR DESCRIPTION
## Summary

Adds the whole-node boundary **`\{ P \}` ("is")**: P must match an *entire* node — anchored, no leading/trailing tolerance — the strict counterpart to the default fragment match.

- `\{ if (\X) { \Y } \}` matches an `if` with **no `else`** (whole-node coverage forces P to span every child; the else-form's extra `else_clause` child breaks it). The default `if (\X) { \Y }` matches both.
- Precedence still comes from the tree: `\{ \X + \Y \}` over `a + b * c` binds `\Y = b * c` (the whole `binary_expression`), never the fragment `a + b`.
- Completes the structural-scope family — `\{ \}` is (whole) ⊂ default fragment ⊂ `\{{ \}}` has (descendant). The sub-pattern delimiter is reassigned `\{ \}`→`\[ \]` in the grammar (not yet implemented) so braces are a clean scope family that doesn't look like containment.

Implementation mirrors containment: flat `WholeOpen{close}`/`WholeClose` markers paired by a **typed** stack (`resolve_brackets` — `\}` closes `\{`, `\}}` closes `\{{`; crossed nesting is a `client` error); a `match_whole` DP arm tries `spans_by_start[li]` (largest-first) and requires P to cover one exactly (`tolerant_end` cleared). Bounded to nodes anchored at the leaf — **no descendant scan**, none of the O(N²) containment risk fixed in #2176. The `(pi,li)` fail-memo is disabled when a bracket is present (as for containment). Prefilter unchanged (P's literals are still required).

37k-pattern real-code sweep: **0 panics, 0 unsound**.

## Test plan

- `cargo test -p cocoindex_code_match` (184 tests, green) — new `whole_node_boundary_is`: whole `binary_expression` + precedence, if-with/without-else vs the fragment default, nesting with containment, malformed-nesting errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
