### PR TITLE
docs: Hum typography (Plus Jakarta Sans)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.2",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.3",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.2",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#5b9339bea306d754adb42503b5ec9f8f88566f44",
+      "version": "0.4.3",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#3f4253515ed897ad1b832abddd50be2c706f0752",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.5",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.6",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.5",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#90bc278be26810952f7b324ba2a353f230acc369",
+      "version": "0.4.6",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f443441b0db241d7761f74fe58e93da85d38ba78",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.1",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.2",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.1",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#37d1eb94b2bda6e4dd57b8bd02f259a0477d2c13",
+      "version": "0.4.2",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#5b9339bea306d754adb42503b5ec9f8f88566f44",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.6",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.7",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.6",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f443441b0db241d7761f74fe58e93da85d38ba78",
+      "version": "0.4.7",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f85ae87b2f8308f27def548cbc84402d6d5b73bd",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.4",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.5",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.4",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f55757ed440f4ec8e5553342de50bef6155dfe1e",
+      "version": "0.4.5",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#90bc278be26810952f7b324ba2a353f230acc369",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.3",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.4",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#3f4253515ed897ad1b832abddd50be2c706f0752",
+      "version": "0.4.4",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f55757ed440f4ec8e5553342de50bef6155dfe1e",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.0",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.1",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,13 +247,12 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#2a1ec88608ba5d666b905e88b044f9eff77d1497",
+      "version": "0.4.1",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#37d1eb94b2bda6e4dd57b8bd02f259a0477d2c13",
       "license": "UNLICENSED",
       "dependencies": {
-        "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/source-serif-4": "^5.2.9"
+        "@fontsource/plus-jakarta-sans": "^5.2.8"
       }
     },
     "node_modules/@docsearch/css": {
@@ -694,15 +693,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fontsource/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
     "node_modules/@fontsource/jetbrains-mono": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
@@ -712,10 +702,10 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource/source-serif-4": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-serif-4/-/source-serif-4-5.2.9.tgz",
-      "integrity": "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==",
+    "node_modules/@fontsource/plus-jakarta-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/plus-jakarta-sans/-/plus-jakarta-sans-5.2.8.tgz",
+      "integrity": "sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.5",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.6",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.1",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.2",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.4",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.5",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.0",
     "@astrojs/sitemap": "^3.7.2",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.1",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.2",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.3",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.3",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.4",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.6",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.7",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -109,7 +109,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 
       .nf .nf-title {
         font-family: var(--serif);
-        font-weight: 400;
+        font-weight: 600;
         font-size: clamp(64px, 10vw, 152px);
         line-height: 0.86;
         letter-spacing: -0.035em;
@@ -117,8 +117,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
         color: var(--maroon-ink);
       }
       .nf .nf-title em {
-        font-style: italic;
-        font-weight: 400;
+        font-style: normal;
+        font-weight: 600;
         color: var(--coral);
       }
 

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -109,7 +109,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 
       .nf .nf-title {
         font-family: var(--serif);
-        font-weight: 600;
+        font-weight: 700;
         font-size: clamp(64px, 10vw, 152px);
         line-height: 0.86;
         letter-spacing: -0.035em;
@@ -118,7 +118,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
       }
       .nf .nf-title em {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 700;
         color: var(--coral);
       }
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -344,11 +344,11 @@ app.update_blocking()</code></pre>
       body.docs-home .hero-copy .t-eyebrow { margin-bottom: 20px; }
       @keyframes dh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
       body.docs-home h1.hero-h {
-        font-family: var(--serif); font-weight: 600;
+        font-family: var(--serif); font-weight: 700;
         font-size: clamp(38px, 4.4vw, 60px); line-height: 1.0; letter-spacing: -0.025em;
         margin: 0 0 20px; max-width: 13ch;
       }
-      body.docs-home h1.hero-h em { font-style: normal; font-weight: 600; color: var(--coral); }
+      body.docs-home h1.hero-h em { font-style: normal; font-weight: 700; color: var(--coral); }
       body.docs-home .hero-sub {
         font-size: clamp(15.5px, 1.2vw, 18px); line-height: 1.55; color: var(--maroon-ink);
         max-width: 52ch; margin: 0 0 24px;
@@ -429,10 +429,10 @@ app.update_blocking()</code></pre>
         color: var(--coral); display: block; margin-bottom: 14px;
       }
       body.docs-home .sec-head h2 {
-        font-family: var(--sans); font-weight: 600; font-size: clamp(24px, 2.6vw, 34px);
+        font-family: var(--sans); font-weight: 700; font-size: clamp(24px, 2.6vw, 34px);
         line-height: 1.1; letter-spacing: -0.025em; margin: 0 0 12px;
       }
-      body.docs-home .sec-head h2 em { font-style: normal; font-weight: 600; color: var(--coral); }
+      body.docs-home .sec-head h2 em { font-style: normal; font-weight: 700; color: var(--coral); }
       body.docs-home .sec-head p { margin: 0; font-size: 16px; color: var(--maroon-ink); line-height: 1.55; max-width: 62ch; }
 
       /* card grid — auto-fit so it always fits the (narrower) main column */
@@ -488,7 +488,7 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .step .num {
         width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center;
-        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-weight: 600; font-size: 20px;
+        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-weight: 700; font-size: 20px;
       }
       body.docs-home .step h4 { margin: 2px 0 8px; font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
       body.docs-home .step p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -344,11 +344,11 @@ app.update_blocking()</code></pre>
       body.docs-home .hero-copy .t-eyebrow { margin-bottom: 20px; }
       @keyframes dh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
       body.docs-home h1.hero-h {
-        font-family: var(--serif); font-weight: 400;
-        font-size: clamp(38px, 4.4vw, 60px); line-height: 1.0; letter-spacing: -0.03em;
+        font-family: var(--serif); font-weight: 600;
+        font-size: clamp(38px, 4.4vw, 60px); line-height: 1.0; letter-spacing: -0.025em;
         margin: 0 0 20px; max-width: 13ch;
       }
-      body.docs-home h1.hero-h em { font-style: italic; color: var(--coral); }
+      body.docs-home h1.hero-h em { font-style: normal; font-weight: 600; color: var(--coral); }
       body.docs-home .hero-sub {
         font-size: clamp(15.5px, 1.2vw, 18px); line-height: 1.55; color: var(--maroon-ink);
         max-width: 52ch; margin: 0 0 24px;
@@ -432,7 +432,7 @@ app.update_blocking()</code></pre>
         font-family: var(--sans); font-weight: 600; font-size: clamp(24px, 2.6vw, 34px);
         line-height: 1.1; letter-spacing: -0.025em; margin: 0 0 12px;
       }
-      body.docs-home .sec-head h2 em { font-style: italic; color: var(--coral); }
+      body.docs-home .sec-head h2 em { font-style: normal; font-weight: 600; color: var(--coral); }
       body.docs-home .sec-head p { margin: 0; font-size: 16px; color: var(--maroon-ink); line-height: 1.55; max-width: 62ch; }
 
       /* card grid — auto-fit so it always fits the (narrower) main column */
@@ -488,7 +488,7 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .step .num {
         width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center;
-        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-size: 20px;
+        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-weight: 600; font-size: 20px;
       }
       body.docs-home .step h4 { margin: 2px 0 8px; font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
       body.docs-home .step p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -346,7 +346,7 @@ app.update_blocking()</code></pre>
       body.docs-home h1.hero-h {
         font-family: var(--serif); font-weight: 700;
         font-size: clamp(38px, 4.4vw, 60px); line-height: 1.0; letter-spacing: -0.025em;
-        margin: 0 0 20px; max-width: 13ch;
+        margin: 0 0 20px; max-width: 13ch; overflow-wrap: anywhere; min-width: 0;
       }
       body.docs-home h1.hero-h em { font-style: normal; font-weight: 700; color: var(--coral); }
       body.docs-home .hero-sub {


### PR DESCRIPTION
Adopt the Hum typography system on the docs + examples site via @cocoindex/brand v0.4.7 (Plus Jakarta Sans, no serif/italic, 700 display headings, 20px cards, mobile overflow fixes). Scoped to docs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)