### PR TITLE
docs: drop v0/v1 header dropdowns, link v0 docs from footer

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.7",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.8",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -1,6 +1,7 @@
 ---
 // Docs header: the shared <Nav> bar from @cocoindex/brand, fed this site's
-// links — including the v1/v0 version dropdowns on Examples + Documentation.
+// links. v1 is the only version in the header; the legacy v0 docs are linked
+// from the footer instead.
 // The phone drawer (tabbed sidebar + TOC) is MobileSheet.astro, opened by the
 // bar's hamburger; pass `mobileSheetId` to render that hamburger.
 import Nav from '@cocoindex/brand/Nav.astro';
@@ -15,25 +16,11 @@ const { mobileSheetId } = Astro.props as Props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 const DOCS = base;
 const EXAMPLES_V1 = `${base}/examples`;
-const DOCS_V0 = `${SITE_MAIN}/docs-v0`;
-const EXAMPLES_V0 = `${SITE_MAIN}/docs-v0/examples/`;
 
 const links = [
   { href: `${SITE_MAIN}/cocoindex-code`, label: 'CocoIndex Code' },
-  {
-    href: EXAMPLES_V1, label: 'Examples',
-    versions: [
-      { href: EXAMPLES_V1, label: 'v1', current: true },
-      { href: EXAMPLES_V0, label: 'v0', tag: 'legacy' },
-    ],
-  },
-  {
-    href: DOCS, label: 'Documentation',
-    versions: [
-      { href: DOCS, label: 'v1', current: true },
-      { href: DOCS_V0, label: 'v0', tag: 'legacy' },
-    ],
-  },
+  { href: EXAMPLES_V1, label: 'Examples' },
+  { href: DOCS, label: 'Documentation' },
   { href: `${SITE_MAIN}/enterprise`, label: 'Enterprise' },
   { href: SITE_BLOG, label: 'Blog' },
 ];


### PR DESCRIPTION
## What

- Remove the **v1/v0 version dropdowns** from the docs header (`Topbar.astro`). `v1` is the only in-header version now; `Examples` and `Documentation` are plain links.
- The legacy **v0 docs** are now reachable from the shared footer's Resources column (`Documentation (v0)` → `cocoindex.io/docs-v0/`), added in `@cocoindex/brand` v0.4.8.
- Bump the brand dependency `#v0.4.7` → `#v0.4.8`.

Depends on cocoindex-io/cocoindex-brand#2 (released as `v0.4.8`).

## Verified

Local docs preview: header shows no dropdown; footer Resources lists `Documentation (v0)` → `/docs-v0/`. No console/server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)