### PR TITLE
docs: bump @cocoindex/brand v0.4.8 → v0.4.9

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.7",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.9",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.8",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.9",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",


### PR DESCRIPTION
Bumps the docs/examples brand pin to **v0.4.9**, pulling the color-system tightening:

- Hardcoded `rgba()` brand tints → `color-mix(in oklab, var(--token))` so tints follow the tokens
- `--muted` 0.58 → 0.64 (4.23:1 → 5.16:1, clears WCAG AA on small text)
- New `--coral-text` (#A8432A, 5.55:1) for sustained coral links on light bg

No visual regression (color-mix-with-transparent is identical to the prior rgba); the muted secondary text is marginally darker (now AA), and sustained coral links read a slightly deeper coral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)