### PR TITLE
docs: hero → Hum --text-display + brand v0.4.10

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.9",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.10",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.9",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.10",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -345,7 +345,8 @@ app.update_blocking()</code></pre>
       @keyframes dh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
       body.docs-home h1.hero-h {
         font-family: var(--serif); font-weight: 700;
-        font-size: clamp(38px, 4.4vw, 60px); line-height: 1.0; letter-spacing: -0.025em;
+        /* Hum 7 --text-display, exact */
+        font-size: clamp(2.75rem, 5vw + 1rem, 5.25rem); line-height: 1.0; letter-spacing: -0.025em;
         margin: 0 0 20px; max-width: 13ch; overflow-wrap: anywhere; min-width: 0;
       }
       body.docs-home h1.hero-h em { font-style: normal; font-weight: 700; color: var(--coral); }


### PR DESCRIPTION
- Docs home hero font-size → `clamp(2.75rem, 5vw + 1rem, 5.25rem)` (Hum 7's `--text-display`), matching the homepage hero scale.
- Bump `@cocoindex/brand` pin v0.4.9 → **v0.4.10**: transition easings normalized to one curve (`var(--ease)`) + three duration tokens, and a global `:focus-visible` floor so docs/examples links get a keyboard ring.

No static visual change beyond the hero size; the motion change is timing/easing-feel only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)