### PR TITLE
docs: exact Hum font-size scale (brand v0.4.11)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.10",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.11",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.10",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.11",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/src/components/Tabs.astro
+++ b/docs/src/components/Tabs.astro
@@ -78,7 +78,7 @@ const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
   gap: 6px;
   padding: 9px 16px;
   font-family: var(--sans);
-  font-size: 13.5px;
+  font-size: var(--text-sm);
   font-weight: 500;
   color: var(--muted);
   cursor: pointer;
@@ -169,6 +169,6 @@ const id = `coco-tabs-${crypto.randomUUID().slice(0, 8)}`;
 
 @media (max-width: 640px) {
   .coco-tabs-panels { padding: 18px; }
-  .coco-tabs-label { padding: 8px 12px; font-size: 13px; }
+  .coco-tabs-label { padding: 8px 12px; font-size: var(--text-sm); }
 }
 </style>

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -594,7 +594,7 @@ const breadcrumbLd = {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font: 500 13px/1 var(--sans);
+    font: 500 var(--text-sm)/1 var(--sans);
     color: var(--maroon-ink);
     background: transparent;
     border: 0;
@@ -695,7 +695,7 @@ const breadcrumbLd = {
     display: inline-flex;
     align-items: center;
     gap: 5px;
-    font: 500 14px/1.25 var(--sans);
+    font: 500 var(--text-sm)/1.25 var(--sans);
     color: var(--maroon-ink);
   }
   .ai-t :global(.ext) {
@@ -704,7 +704,7 @@ const breadcrumbLd = {
     opacity: 0.5;
   }
   .ai-d {
-    font: 400 12px/1.3 var(--sans);
+    font: 400 var(--text-sm)/1.3 var(--sans);
     color: var(--muted);
   }
   .ai-item.copied .ai-d {

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -93,7 +93,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 
       .nf .nf-eyebrow {
         display: inline-flex; align-items: center; gap: 10px;
-        font-family: var(--mono); font-size: 11px;
+        font-family: var(--mono); font-size: var(--text-xs);
         letter-spacing: 0.16em; text-transform: uppercase;
         color: var(--muted);
         padding: 8px 14px;
@@ -109,8 +109,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
 
       .nf .nf-title {
         font-family: var(--serif);
-        font-weight: 700;
-        font-size: clamp(64px, 10vw, 152px);
+        font-weight: 600;
+        font-size: clamp(var(--text-4xl), 10vw, var(--text-display));
         line-height: 0.86;
         letter-spacing: -0.035em;
         margin: 24px 0 24px;
@@ -118,12 +118,12 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
       }
       .nf .nf-title em {
         font-style: normal;
-        font-weight: 700;
+        font-weight: 600;
         color: var(--coral);
       }
 
       .nf .nf-lead {
-        font-size: clamp(16px, 1.3vw, 19px);
+        font-size: clamp(var(--text-base), 1.3vw, var(--text-md));
         line-height: 1.55;
         color: rgba(42, 18, 27, 0.78);
         max-width: 52ch;
@@ -141,7 +141,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
         display: inline-flex; align-items: center; gap: 12px;
         padding: 10px 14px;
         border-left: 2px solid var(--coral);
-        font-size: 14px;
+        font-size: var(--text-sm);
         color: var(--muted);
       }
       .nf .nf-tip .caps {

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -110,7 +110,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
       .nf .nf-title {
         font-family: var(--serif);
         font-weight: 600;
-        font-size: clamp(var(--text-4xl), 10vw, var(--text-display));
+        font-size: var(--text-display);
         line-height: 0.86;
         letter-spacing: -0.035em;
         margin: 24px 0 24px;
@@ -123,7 +123,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
       }
 
       .nf .nf-lead {
-        font-size: clamp(var(--text-base), 1.3vw, var(--text-md));
+        font-size: var(--text-md);
         line-height: 1.55;
         color: rgba(42, 18, 27, 0.78);
         max-width: 52ch;

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -430,7 +430,7 @@ app.update_blocking()</code></pre>
         color: var(--coral); display: block; margin-bottom: 14px;
       }
       body.docs-home .sec-head h2 {
-        font-family: var(--sans); font-weight: 600; font-size: clamp(var(--text-lg), 2.6vw, var(--text-xl));
+        font-family: var(--sans); font-weight: 600; font-size: var(--text-xl);
         line-height: 1.2; letter-spacing: -0.025em; margin: 0 0 12px;
       }
       body.docs-home .sec-head h2 em { font-style: normal; font-weight: 600; color: var(--coral); }

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -344,14 +344,14 @@ app.update_blocking()</code></pre>
       body.docs-home .hero-copy .t-eyebrow { margin-bottom: 20px; }
       @keyframes dh-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
       body.docs-home h1.hero-h {
-        font-family: var(--serif); font-weight: 700;
+        font-family: var(--serif); font-weight: 600;
         /* Hum 7 --text-display, exact */
-        font-size: clamp(2.75rem, 5vw + 1rem, 5.25rem); line-height: 1.0; letter-spacing: -0.025em;
+        font-size: var(--text-display); line-height: 1.0; letter-spacing: -0.025em;
         margin: 0 0 20px; max-width: 13ch; overflow-wrap: anywhere; min-width: 0;
       }
-      body.docs-home h1.hero-h em { font-style: normal; font-weight: 700; color: var(--coral); }
+      body.docs-home h1.hero-h em { font-style: normal; font-weight: 600; color: var(--coral); }
       body.docs-home .hero-sub {
-        font-size: clamp(15.5px, 1.2vw, 18px); line-height: 1.55; color: var(--maroon-ink);
+        font-size: var(--text-base); line-height: 1.55; color: var(--maroon-ink);
         max-width: 52ch; margin: 0 0 24px;
       }
       body.docs-home .hero-sub b { font-weight: 600; color: var(--maroon); }
@@ -362,13 +362,13 @@ app.update_blocking()</code></pre>
         background: var(--maroon-ink); border-radius: 8px; padding: 11px 12px 11px 16px;
       }
       body.docs-home .install code {
-        font-family: var(--mono); font-size: 13.5px; color: var(--cream);
+        font-family: var(--mono); font-size: var(--text-sm); color: var(--cream);
         background: transparent; padding: 0; border: none;
       }
       body.docs-home .install code .p { color: var(--peach); margin-right: 8px; }
       body.docs-home .install .copy,
       body.docs-home .codeblk .copy {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em;
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.04em;
         color: var(--cream); background: transparent;
         border: 1px solid rgba(252, 243, 216, 0.25); border-radius: 5px;
         padding: 4px 10px; cursor: pointer; transition: background .15s, border-color .15s, transform .12s var(--ease);
@@ -383,7 +383,7 @@ app.update_blocking()</code></pre>
 
       body.docs-home .hero-meta {
         display: flex; flex-wrap: wrap; gap: 6px 18px; margin-top: 22px;
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.03em; color: var(--muted);
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.03em; color: var(--muted);
       }
       body.docs-home .hero-meta b { color: var(--maroon); font-weight: 600; }
 
@@ -393,7 +393,7 @@ app.update_blocking()</code></pre>
         padding: 24px 22px;
       }
       body.docs-home .viz-label {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; color: var(--muted);
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.06em; color: var(--muted);
         margin-bottom: 16px; text-align: center;
       }
       body.docs-home .viz-flow { display: flex; flex-direction: column; align-items: stretch; gap: 8px; }
@@ -402,9 +402,9 @@ app.update_blocking()</code></pre>
         background: var(--paper); display: flex; flex-direction: column; gap: 3px; text-align: center;
       }
       body.docs-home .node .nt {
-        font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted);
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted);
       }
-      body.docs-home .node .nv { font-size: 13px; font-weight: 600; color: var(--maroon-ink); }
+      body.docs-home .node .nv { font-size: var(--text-sm); font-weight: 600; color: var(--maroon-ink); }
       body.docs-home .node.src .nv { color: var(--maroon); }
       body.docs-home .node.tgt .nv { color: var(--coral); }
       body.docs-home .node.eng { background: var(--maroon); border-color: var(--maroon); }
@@ -413,7 +413,7 @@ app.update_blocking()</code></pre>
       body.docs-home .viz-arrow { text-align: center; color: var(--coral); font-family: var(--mono); line-height: 1; }
       body.docs-home .viz-delta {
         margin: 6px auto 0; display: inline-flex; align-items: center; gap: 7px;
-        font-family: var(--mono); font-size: 11px; color: var(--palm-ink);
+        font-family: var(--mono); font-size: var(--text-xs); color: var(--palm-ink);
         background: color-mix(in oklab, var(--palm) 16%, var(--cream));
         border: 1px solid color-mix(in oklab, var(--palm-ink) 30%, transparent);
         border-radius: 999px; padding: 4px 12px;
@@ -426,15 +426,15 @@ app.update_blocking()</code></pre>
       body.docs-home .sec-head { margin-bottom: 32px; max-width: 64ch; }
       body.docs-home .sec-head.no-mb { margin-bottom: 0; }
       body.docs-home .sec-head .idx {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.14em; text-transform: uppercase;
         color: var(--coral); display: block; margin-bottom: 14px;
       }
       body.docs-home .sec-head h2 {
-        font-family: var(--sans); font-weight: 700; font-size: clamp(24px, 2.6vw, 34px);
+        font-family: var(--sans); font-weight: 600; font-size: clamp(var(--text-lg), 2.6vw, var(--text-xl));
         line-height: 1.1; letter-spacing: -0.025em; margin: 0 0 12px;
       }
-      body.docs-home .sec-head h2 em { font-style: normal; font-weight: 700; color: var(--coral); }
-      body.docs-home .sec-head p { margin: 0; font-size: 16px; color: var(--maroon-ink); line-height: 1.55; max-width: 62ch; }
+      body.docs-home .sec-head h2 em { font-style: normal; font-weight: 600; color: var(--coral); }
+      body.docs-home .sec-head p { margin: 0; font-size: var(--text-base); color: var(--maroon-ink); line-height: 1.55; max-width: 62ch; }
 
       /* card grid — auto-fit so it always fits the (narrower) main column */
       body.docs-home .card-grid { display: grid; gap: 16px; }
@@ -469,17 +469,17 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .card .ico svg { width: 20px; height: 20px; }
       body.docs-home .card h3 {
-        margin: 0 0 6px; font-size: 16px; font-weight: 600; letter-spacing: -0.01em;
+        margin: 0 0 6px; font-size: var(--text-base); font-weight: 600; letter-spacing: -0.01em;
         display: flex; align-items: center; gap: 6px; color: var(--maroon-ink);
       }
       body.docs-home .card h3 .ar { color: var(--coral); transition: transform .18s ease; }
       body.docs-home .card:hover h3 .ar { transform: translateX(3px); }
-      body.docs-home .card p { margin: 0; font-size: 13.5px; color: var(--muted); line-height: 1.5; }
+      body.docs-home .card p { margin: 0; font-size: var(--text-sm); color: var(--muted); line-height: 1.5; }
       body.docs-home .card .meta {
-        display: block; margin-top: 14px; font-family: var(--mono); font-size: 10.5px;
+        display: block; margin-top: 14px; font-family: var(--mono); font-size: var(--text-xs);
         letter-spacing: 0.1em; text-transform: uppercase; color: var(--coral);
       }
-      body.docs-home .card.build h3 { font-size: 17px; }
+      body.docs-home .card.build h3 { font-size: var(--text-base); }
 
       /* steps */
       body.docs-home .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 18px; }
@@ -489,10 +489,10 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .step .num {
         width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center;
-        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-weight: 700; font-size: 20px;
+        background: var(--maroon); color: var(--cream); font-family: var(--serif); font-weight: 600; font-size: var(--text-md);
       }
-      body.docs-home .step h4 { margin: 2px 0 8px; font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
-      body.docs-home .step p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }
+      body.docs-home .step h4 { margin: 2px 0 8px; font-size: var(--text-base); font-weight: 600; letter-spacing: -0.01em; }
+      body.docs-home .step p { margin: 0; font-size: var(--text-sm); color: var(--muted); line-height: 1.55; }
 
       /* code split */
       body.docs-home .split { display: grid; grid-template-columns: 0.85fr 1.15fr; gap: 44px; align-items: center; }
@@ -505,11 +505,11 @@ app.update_blocking()</code></pre>
         border-bottom: 1px solid rgba(252, 243, 216, 0.12);
       }
       body.docs-home .codeblk .bar .d { width: 11px; height: 11px; border-radius: 50%; }
-      body.docs-home .codeblk .bar .fname { margin-left: 6px; font-family: var(--mono); font-size: 12px; color: var(--stone); }
+      body.docs-home .codeblk .bar .fname { margin-left: 6px; font-family: var(--mono); font-size: var(--text-sm); color: var(--stone); }
       body.docs-home .codeblk .bar .copy { margin-left: auto; }
       body.docs-home .codeblk pre { margin: 0; padding: 22px 24px; overflow-x: auto; }
       body.docs-home .codeblk code {
-        font-family: var(--mono); font-size: 12.5px; line-height: 1.75; color: var(--cream);
+        font-family: var(--mono); font-size: var(--text-sm); line-height: 1.75; color: var(--cream);
         background: transparent; padding: 0; border: none;
       }
       body.docs-home .codeblk .cm { color: var(--taupe); font-style: italic; }
@@ -523,12 +523,12 @@ app.update_blocking()</code></pre>
       /* building blocks */
       body.docs-home .bb { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 22px; }
       body.docs-home .bb-col h4 {
-        font-family: var(--mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        font-family: var(--mono); font-size: var(--text-xs); letter-spacing: 0.14em; text-transform: uppercase;
         color: var(--coral); margin: 0 0 14px; padding-bottom: 10px; border-bottom: 1px solid var(--rule);
       }
       body.docs-home .chips { display: flex; flex-wrap: wrap; gap: 8px; }
       body.docs-home .chip {
-        font-family: var(--mono); font-size: 12px; padding: 6px 11px;
+        font-family: var(--mono); font-size: var(--text-sm); padding: 6px 11px;
         border: 1px solid var(--rule-strong); border-radius: 999px; color: var(--maroon);
         text-decoration: none; transition: background .15s, border-color .15s, color .15s;
       }

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -346,7 +346,7 @@ app.update_blocking()</code></pre>
       body.docs-home h1.hero-h {
         font-family: var(--serif); font-weight: 600;
         /* Hum 7 --text-display, exact */
-        font-size: var(--text-display); line-height: 1.0; letter-spacing: -0.025em;
+        font-size: var(--text-display); line-height: 1; letter-spacing: -0.025em;
         margin: 0 0 20px; max-width: 13ch; overflow-wrap: anywhere; min-width: 0;
       }
       body.docs-home h1.hero-h em { font-style: normal; font-weight: 600; color: var(--coral); }
@@ -431,7 +431,7 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .sec-head h2 {
         font-family: var(--sans); font-weight: 600; font-size: clamp(var(--text-lg), 2.6vw, var(--text-xl));
-        line-height: 1.1; letter-spacing: -0.025em; margin: 0 0 12px;
+        line-height: 1.2; letter-spacing: -0.025em; margin: 0 0 12px;
       }
       body.docs-home .sec-head h2 em { font-style: normal; font-weight: 600; color: var(--coral); }
       body.docs-home .sec-head p { margin: 0; font-size: var(--text-base); color: var(--maroon-ink); line-height: 1.55; max-width: 62ch; }
@@ -474,7 +474,7 @@ app.update_blocking()</code></pre>
       }
       body.docs-home .card h3 .ar { color: var(--coral); transition: transform .18s ease; }
       body.docs-home .card:hover h3 .ar { transform: translateX(3px); }
-      body.docs-home .card p { margin: 0; font-size: var(--text-sm); color: var(--muted); line-height: 1.5; }
+      body.docs-home .card p { margin: 0; font-size: var(--text-sm); color: var(--muted); line-height: 1.55; }
       body.docs-home .card .meta {
         display: block; margin-top: 14px; font-family: var(--mono); font-size: var(--text-xs);
         letter-spacing: 0.1em; text-transform: uppercase; color: var(--coral);
@@ -509,7 +509,7 @@ app.update_blocking()</code></pre>
       body.docs-home .codeblk .bar .copy { margin-left: auto; }
       body.docs-home .codeblk pre { margin: 0; padding: 22px 24px; overflow-x: auto; }
       body.docs-home .codeblk code {
-        font-family: var(--mono); font-size: var(--text-sm); line-height: 1.75; color: var(--cream);
+        font-family: var(--mono); font-size: var(--text-sm); line-height: 1.6; color: var(--cream);
         background: transparent; padding: 0; border: none;
       }
       body.docs-home .codeblk .cm { color: var(--taupe); font-style: italic; }


### PR DESCRIPTION
Adopts the Hum modular type scale across the docs, pinned to **@cocoindex/brand v0.4.11**.

- Every font-size resolves to a Hum scale step (`--text-xs…4xl`, x1.25 major third) — no off-scale intermediates; only the hero uses the `--text-display` clamp.
- Display/heading weight 600 (Hum register); line-heights tokenized to 4 values.
- Docs markdown prose, the doc-title `h1`, Tabs, and the AI-menu labels all snap to Hum tokens (caught the `font:` shorthand + `var(--x, NNpx)` fallbacks too).
- Diagram-internal labels left bespoke (illustration geometry, not type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)