### PR TITLE
Docs SEO: sitemap lastmod, FAQPage schema, freshness signals

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,6 +8,7 @@ import remarkCodeTitles from './scripts/remark-code-titles.mjs';
 import remarkMermaid from './scripts/remark-mermaid.mjs';
 import remarkLinkChecker from './scripts/remark-link-checker.mjs';
 import { redirects } from './src/data/docs-sidebar.ts';
+import docsMeta from './src/data/docs-meta.json';
 // One shared Shiki theme (the readability-tuned --code-* palette) so docs and
 // blog highlight code identically — single source of truth (GUIDELINE §5.5).
 import { cocoindexCodeTheme } from '@cocoindex/brand/code-theme';
@@ -51,7 +52,31 @@ export default defineConfig({
       // explicitly so .mdx content collection pages get them for sure.
       remarkPlugins,
     }),
-    sitemap(),
+    sitemap({
+      // Emit a real per-page `lastmod` from the human-set "Last reviewed"
+      // timestamp in docs-meta.json (the same value the on-page stamp uses),
+      // plus a higher priority for the entry pages. Without this every URL
+      // ships bare `<loc>`, so Google has no per-page freshness signal to
+      // decide what to re-crawl. Slug is the path between `/docs/` and the
+      // trailing slash; pages with no recorded review date (examples, index)
+      // simply omit lastmod rather than claiming a bogus build-time date.
+      serialize(item) {
+        const m = item.url.match(/\/docs\/(.*?)\/?$/);
+        const slug = m ? m[1] : '';
+        const ts = docsMeta.files?.[slug]?.reviewedTs;
+        if (ts) item.lastmod = new Date(ts * 1000).toISOString();
+        if (slug === '') {
+          item.priority = 1.0;
+          item.changefreq = 'weekly';
+        } else if (slug.startsWith('getting_started')) {
+          item.priority = 0.9;
+          item.changefreq = 'weekly';
+        } else {
+          item.changefreq = 'weekly';
+        }
+        return item;
+      },
+    }),
   ],
   markdown: {
     remarkPlugins,

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -16,7 +16,7 @@ import ICON_EXT from '../icons/external.svg?raw';
 import ICON_CHATGPT from '../icons/chatgpt.svg?raw';
 import ICON_CLAUDE from '../icons/claude.svg?raw';
 import { flatten, sidebar, type SidebarItem } from '../data/docs-sidebar';
-import { docsVersion, reviewedDate } from '../data/review-meta';
+import { docsVersion, reviewedDate, reviewedTs } from '../data/review-meta';
 
 export interface IntroMeta {
   time?: string;
@@ -36,6 +36,9 @@ export interface Props {
   sourcePath?: string;
   /** Per-page intro-meta strip (Time / Language / Requires) from frontmatter. */
   introMeta?: IntroMeta;
+  /** Extra JSON-LD nodes a route can inject (e.g. FAQPage on the FAQ page).
+   *  Rendered after the page's TechArticle + BreadcrumbList. */
+  extraJsonLd?: unknown[];
 }
 
 const {
@@ -46,6 +49,7 @@ const {
   headings,
   sourcePath,
   introMeta,
+  extraJsonLd = [],
 } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -117,6 +121,10 @@ const next = i >= 0 && i < flat.length - 1 ? flat[i + 1] : null;
 // Structured data: a TechArticle for the page plus a BreadcrumbList built from
 // the same `crumbs` used in the visible breadcrumb. Helps search engines and
 // agents understand the page and its place in the docs hierarchy.
+// `dateModified` comes from the human-set "Last reviewed" timestamp — a real
+// freshness signal for search and AI answer engines. `reviewedTs` is 0 when a
+// page has no stamp, in which case the field is omitted rather than faked.
+const reviewedSeconds = reviewedTs(slug);
 const articleLd = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
@@ -125,7 +133,14 @@ const articleLd = {
   url: canonical,
   inLanguage: 'en',
   image: ogImage,
+  ...(reviewedSeconds ? { dateModified: new Date(reviewedSeconds * 1000).toISOString() } : {}),
   isPartOf: { '@type': 'WebSite', name: 'CocoIndex Docs', url: docsHome },
+  publisher: {
+    '@type': 'Organization',
+    name: 'CocoIndex',
+    url: SITE_URL,
+    logo: { '@type': 'ImageObject', url: `${SITE_URL}/images/cocoindex.svg` },
+  },
 };
 const breadcrumbLd = {
   '@context': 'https://schema.org',
@@ -176,6 +191,9 @@ const breadcrumbLd = {
     <!-- Structured data for search engines and agents. -->
     <script type="application/ld+json" set:html={JSON.stringify(articleLd)} />
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
+    {extraJsonLd.map((node) => (
+      <script type="application/ld+json" set:html={JSON.stringify(node)} />
+    ))}
 
     <link rel="icon" href={`${base}/img/favicon.ico`} />
     <!-- Fonts self-hosted via @fontsource in src/styles/globals.css (GUIDELINE §5.2) —

--- a/docs/src/lib/raw-markdown.ts
+++ b/docs/src/lib/raw-markdown.ts
@@ -106,6 +106,53 @@ export function mdxToMarkdown(body: string): string {
   return out;
 }
 
+// Extract `### question` / answer pairs from an MDX FAQ body for FAQPage
+// JSON-LD (Google's FAQ rich result). Questions are H3 headings; the answer is
+// everything up to the next H2/H3. Bodies run through mdxToMarkdown first (code
+// + admonitions handled), then we flatten the answer to readable plain text so
+// the schema `text` stays close to the visible prose. Returns [] for non-FAQ
+// bodies, so callers can gate on length.
+export function extractFaqEntries(body: string): Array<{ q: string; a: string }> {
+  const md = mdxToMarkdown(body);
+  const lines = md.split('\n');
+  const entries: Array<{ q: string; a: string }> = [];
+  let q: string | null = null;
+  let buf: string[] = [];
+
+  const flush = () => {
+    if (q === null) return;
+    const a = buf
+      .join('\n')
+      .replace(/```[\s\S]*?```/g, ' ') // drop code blocks from the answer text
+      .replace(/`([^`]+)`/g, '$1') // unwrap inline code
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // drop images
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → text
+      .replace(/^[ \t]*[-*]\s+/gm, '') // list bullets → plain lines
+      .replace(/[*_>#]/g, '') // residual markdown emphasis / quote / heading marks
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (a) entries.push({ q, a });
+    q = null;
+    buf = [];
+  };
+
+  for (const line of lines) {
+    const h3 = line.match(/^###\s+(.+?)\s*$/);
+    if (h3) {
+      flush();
+      q = h3[1].replace(/[*_`]/g, '').trim();
+      continue;
+    }
+    if (/^##\s+/.test(line)) {
+      flush(); // section heading ends the current answer
+      continue;
+    }
+    if (q !== null) buf.push(line);
+  }
+  flush();
+  return entries;
+}
+
 // Single source for the docs-page route map, shared by the HTML route
 // ([...slug].astro) and the Markdown twin ([...slug].md.ts) so the two can
 // never enumerate different page sets.

--- a/docs/src/pages/[...slug].astro
+++ b/docs/src/pages/[...slug].astro
@@ -1,8 +1,8 @@
 ---
 import { render, type CollectionEntry } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
-import { docSlug, titleText } from '../consts';
-import { docStaticPaths } from '../lib/raw-markdown';
+import { docSlug, titleText, pageUrl } from '../consts';
+import { docStaticPaths, extractFaqEntries } from '../lib/raw-markdown';
 
 export const getStaticPaths = docStaticPaths;
 
@@ -25,6 +25,24 @@ const metaTitle = titleText(rawTitle);
 const description =
   typeof doc.data.description === 'string' ? doc.data.description : undefined;
 const introMeta = doc.data.meta;
+
+// FAQ pages (### question / answer prose) become FAQPage JSON-LD so the
+// answers are eligible for Google's FAQ rich result — the same win the blog
+// gets from its faq.json. Built from the page body; empty for every other doc.
+const faqEntries = slug === 'faq' || slug.endsWith('/faq') ? extractFaqEntries(doc.body) : [];
+const faqJsonLd =
+  faqEntries.length > 0
+    ? [{
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        url: pageUrl(slug),
+        mainEntity: faqEntries.map((e) => ({
+          '@type': 'Question',
+          name: e.q,
+          acceptedAnswer: { '@type': 'Answer', text: e.a },
+        })),
+      }]
+    : [];
 ---
 
 <DocsLayout
@@ -35,6 +53,7 @@ const introMeta = doc.data.meta;
   headings={mdHeadings}
   sourcePath={sourcePath}
   introMeta={introMeta}
+  extraJsonLd={faqJsonLd}
 >
   <Content />
 </DocsLayout>

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -14,7 +14,7 @@ import ScarfPixel from '../../components/ScarfPixel.astro';
 import Foot from '../../components/Foot.astro';
 import { SITE_URL, titleMarkup, titleText, SCARF_PIXEL_ID, OG_IMAGE_EXAMPLES, OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT, OG_IMAGE_EXAMPLES_ALT } from '../../consts';
 import { examples, findExample, CATEGORY_META, type Category } from '../../data/examples';
-import { reviewedDate } from '../../data/review-meta';
+import { reviewedDate, reviewedTs } from '../../data/review-meta';
 import { getEntry, render } from 'astro:content';
 
 // Group examples by category for the left sidebar, in the same order as
@@ -66,6 +66,7 @@ const sourceUrl = `https://github.com/cocoindex-io/cocoindex/tree/main/examples/
 // Structured data: a TechArticle for the example plus a BreadcrumbList
 // (Docs › Examples › <example>), mirroring DocsLayout so agents and search
 // engines understand the page and its place in the hierarchy.
+const reviewedSeconds = reviewedTs(`examples/${slug}`);
 const articleLd = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
@@ -74,7 +75,14 @@ const articleLd = {
   url: canonical,
   inLanguage: 'en',
   image: ogImage,
+  ...(reviewedSeconds ? { dateModified: new Date(reviewedSeconds * 1000).toISOString() } : {}),
   isPartOf: { '@type': 'WebSite', name: 'CocoIndex Docs', url: docsHome },
+  publisher: {
+    '@type': 'Organization',
+    name: 'CocoIndex',
+    url: SITE_URL,
+    logo: { '@type': 'ImageObject', url: `${SITE_URL}/images/cocoindex.svg` },
+  },
 };
 const breadcrumbLd = {
   '@context': 'https://schema.org',
@@ -118,6 +126,11 @@ const introItems = [
     <title>{fullTitle}</title>
     <meta name="description" content={ex.description} />
     <link rel="canonical" href={canonical} />
+
+    <!-- Raw-Markdown twin of this page, for agents that prefer Markdown over
+         scraping HTML. Advertised here so they don't have to guess the URL
+         (mirrors the doc pages, which already do this). -->
+    <link rel="alternate" type="text/markdown" href={new URL(`${base}/examples/${slug}.md`, SITE_URL).toString()} title="Markdown" />
 
     <!-- Open Graph / Twitter — link previews on social, Slack, iMessage, etc. -->
     <meta property="og:type" content="article" />


### PR DESCRIPTION
Technical SEO improvements to the v1 docs, from a deep SEO audit of the blog + docs. No content changes; structured-data and sitemap only.

## Changes

1. **Sitemap `lastmod`** — `astro.config.mjs` now configures `@astrojs/sitemap` with a `serialize()` that emits a real per-page `lastmod` from `reviewedTs` in `docs-meta.json` (the same timestamp behind the on-page "Last reviewed" stamp), plus `priority`/`changefreq` for the entry pages. Before, every URL shipped bare `<loc>` with no freshness signal, so Google had nothing to prioritize re-crawl on. **78 pages now carry a real date**; pages with no review stamp omit `lastmod` rather than faking a build-time date.

2. **FAQPage schema** — the FAQ page now emits `FAQPage` JSON-LD parsed from its `### question` / answer structure (`extractFaqEntries()` in `raw-markdown.ts`, reusing `mdxToMarkdown` so code/links/admonitions are handled). Makes the answers eligible for Google's FAQ rich result — the same win the blog already gets from `faq.json`. Verified: 5 Q&A extracted with clean answer text.

3. **`dateModified`** — `TechArticle` on doc + example pages now carries `dateModified` from `reviewedTs` (freshness signal for search and AI answer engines), omitted when no stamp exists.

4. **`publisher` Organization** — `TechArticle` now includes a publisher `Organization` node (name, url, logo) for entity association.

5. **Example `.md` alternate** — example pages now advertise their Markdown twin via `<link rel="alternate" type="text/markdown">`, matching the doc pages for consistent agent discoverability.

## Verification
`astro build` green (88 pages). Confirmed in `dist/`: 78 sitemap `lastmod`s, `FAQPage` with 5 questions, `publisher` + `dateModified` on `TechArticle`, `rel=alternate` markdown link on example pages.

## Not in this PR
The audit's **critical** finding — the legacy v0 docs at `/docs-v0/` are fully indexable and cannibalizing v1 (no `noindex`, self-canonical, own sitemap, dofollow nav links) — is fixed separately on the `v0` branch since the source lives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)