### PR TITLE
docs: hum-07 alignment (nav/type/DocCards) + clickable example facet filters

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.26",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.27",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.26",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#2ed83c62e8b04cc523084b35c3be9470f21cb8f2",
+      "version": "0.4.27",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#d8f7a271d57fc9a9804a7eb86c6e4038f0ad7992",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.11",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.26",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,12 +247,13 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.7",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#f85ae87b2f8308f27def548cbc84402d6d5b73bd",
+      "version": "0.4.26",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#2ed83c62e8b04cc523084b35c3be9470f21cb8f2",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/plus-jakarta-sans": "^5.2.8"
+        "@fontsource/plus-jakarta-sans": "^5.2.8",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/@docsearch/css": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.26",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.27",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.11",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.26",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",

--- a/docs/src/components/Topbar.astro
+++ b/docs/src/components/Topbar.astro
@@ -5,28 +5,18 @@
 // The phone drawer (tabbed sidebar + TOC) is MobileSheet.astro, opened by the
 // bar's hamburger; pass `mobileSheetId` to render that hamburger.
 import Nav from '@cocoindex/brand/Nav.astro';
-import { SITE_MAIN, SITE_BLOG } from '../consts';
 
 interface Props {
   /** When set, renders the phone hamburger wired (aria-controls) to that sheet id. */
   mobileSheetId?: string;
 }
 const { mobileSheetId } = Astro.props as Props;
-
-const base = import.meta.env.BASE_URL.replace(/\/$/, '') || '/';
-const DOCS = base;
-const EXAMPLES_V1 = `${base}/examples`;
-
-const links = [
-  { href: `${SITE_MAIN}/cocoindex-code`, label: 'CocoIndex Code' },
-  { href: EXAMPLES_V1, label: 'Examples' },
-  { href: DOCS, label: 'Documentation' },
-  { href: `${SITE_MAIN}/enterprise`, label: 'Enterprise' },
-  { href: SITE_BLOG, label: 'Blog' },
-];
+// Links + branding come from @cocoindex/brand (the canonical NAV_LINKS), so the
+// bar is identical to home + blog. `floating={false}` keeps it a fixed,
+// full-width bar — docs + examples don't collapse into the scroll pill.
 ---
 
-<Nav links={links} mobileSheetId={mobileSheetId} />
+<Nav mobileSheetId={mobileSheetId} floating={false} />
 
 <!-- Copy-to-clipboard for every `.code-figure .copy` button — shared behavior
      from @cocoindex/brand/copy-code (identical to home + blog). -->

--- a/docs/src/components/examples/ExampleCard.astro
+++ b/docs/src/components/examples/ExampleCard.astro
@@ -12,8 +12,11 @@ interface Props {
 }
 const { ex, href } = Astro.props;
 const title = titleText(ex.title);
+// Facet values for the side-nav filters (By target / source / LLM).
+const facetVals = (kind: 'tgt' | 'src' | 'llm') =>
+  ex.tags.filter((t) => t.kind === kind).map((t) => t.label).join('|');
 ---
-<a class="ex-card" href={href}>
+<a class="ex-card" href={href} data-tgt={facetVals('tgt')} data-src={facetVals('src')} data-llm={facetVals('llm')}>
   <div class="ex-art">
     <img class="ex-art-img" src={exampleCardImg(ex.slug)} alt={`${title} pipeline`} width="480" height="300" loading="lazy" decoding="async" data-card={ex.slug} />
     <span class="ex-open">Open example →</span>

--- a/docs/src/data/docs-meta.json
+++ b/docs/src/data/docs-meta.json
@@ -3,315 +3,315 @@
   "files": {
     "advanced_topics/concurrency_control": {
       "sourcePath": "advanced_topics/concurrency_control.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/custom_target_connector": {
       "sourcePath": "advanced_topics/custom_target_connector.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/exception_handlers": {
       "sourcePath": "advanced_topics/exception_handlers.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/internal_storage": {
       "sourcePath": "advanced_topics/internal_storage.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/live_component": {
       "sourcePath": "advanced_topics/live_component.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/memoization_keys": {
       "sourcePath": "advanced_topics/memoization_keys.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "advanced_topics/multiple_environments": {
       "sourcePath": "advanced_topics/multiple_environments.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "cli": {
       "sourcePath": "cli.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "cli_commands": {
       "sourcePath": "cli_commands.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "common_resources/data_types": {
       "sourcePath": "common_resources/data_types.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "common_resources/id_generation": {
       "sourcePath": "common_resources/id_generation.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "common_resources/vector_schema": {
       "sourcePath": "common_resources/vector_schema.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/amazon_s3": {
       "sourcePath": "connectors/amazon_s3.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/doris": {
       "sourcePath": "connectors/doris.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/falkordb": {
       "sourcePath": "connectors/falkordb.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/google_drive": {
       "sourcePath": "connectors/google_drive.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/kafka": {
       "sourcePath": "connectors/kafka.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/lancedb": {
       "sourcePath": "connectors/lancedb.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/localfs": {
       "sourcePath": "connectors/localfs.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/oci_object_storage": {
       "sourcePath": "connectors/oci_object_storage.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/postgres": {
       "sourcePath": "connectors/postgres.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/qdrant": {
       "sourcePath": "connectors/qdrant.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/sqlite": {
       "sourcePath": "connectors/sqlite.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/surrealdb": {
       "sourcePath": "connectors/surrealdb.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "contributing/guide": {
       "sourcePath": "contributing/guide.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "contributing/setup_dev_environment": {
       "sourcePath": "contributing/setup_dev_environment.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "examples/csv-to-kafka": {
       "sourcePath": "example-posts/csv-to-kafka.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/docs-to-knowledge-graph": {
       "sourcePath": "example-posts/docs-to-knowledge-graph.md",
-      "reviewedTs": 1781265600
+      "reviewedTs": 1782216000
     },
     "examples/image-search": {
       "sourcePath": "example-posts/image-search.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/index-codebase": {
       "sourcePath": "example-posts/index-codebase.md",
-      "reviewedTs": 1781092800
+      "reviewedTs": 1782216000
     },
     "examples/meeting-notes-to-knowledge-graph": {
       "sourcePath": "example-posts/meeting-notes-to-knowledge-graph.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/pdf-embedding": {
       "sourcePath": "example-posts/pdf-embedding.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/multi-codebase-summarization": {
       "sourcePath": "example-posts/multi-codebase-summarization.md",
-      "reviewedTs": 1781092800
+      "reviewedTs": 1782216000
     },
     "examples/pdf-to-markdown": {
       "sourcePath": "example-posts/pdf-to-markdown.md",
-      "reviewedTs": 1781092800
+      "reviewedTs": 1782216000
     },
     "examples/podcast-to-knowledge-graph": {
       "sourcePath": "example-posts/podcast-to-knowledge-graph.md",
-      "reviewedTs": 1781092800
+      "reviewedTs": 1782216000
     },
     "faq": {
       "sourcePath": "faq.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "getting_started/ai_coding_agents": {
       "sourcePath": "getting_started/ai_coding_agents.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "getting_started/installation": {
       "sourcePath": "getting_started/installation.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "getting_started/overview": {
       "sourcePath": "getting_started/overview.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "getting_started/quickstart": {
       "sourcePath": "getting_started/quickstart.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "ops/entity_resolution": {
       "sourcePath": "ops/entity_resolution.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "ops/litellm": {
       "sourcePath": "ops/litellm.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "ops/sentence_transformers": {
       "sourcePath": "ops/sentence_transformers.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "ops/text": {
       "sourcePath": "ops/text.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/app": {
       "sourcePath": "programming_guide/app.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/context": {
       "sourcePath": "programming_guide/context.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/core_concepts": {
       "sourcePath": "programming_guide/core_concepts.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/function": {
       "sourcePath": "programming_guide/function.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/live_mode": {
       "sourcePath": "programming_guide/live_mode.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/processing_component": {
       "sourcePath": "programming_guide/processing_component.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/sdk_overview": {
       "sourcePath": "programming_guide/sdk_overview.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/serialization": {
       "sourcePath": "programming_guide/serialization.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "programming_guide/target_state": {
       "sourcePath": "programming_guide/target_state.md",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/iggy": {
       "sourcePath": "connectors/iggy.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/neo4j": {
       "sourcePath": "connectors/neo4j.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "connectors/turbopuffer": {
       "sourcePath": "connectors/turbopuffer.mdx",
-      "reviewedTs": 1780444800
+      "reviewedTs": 1782216000
     },
     "examples/audio-to-text": {
       "sourcePath": "example-posts/audio-to-text.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/hackernews-trending-topics": {
       "sourcePath": "example-posts/hackernews-trending-topics.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/paper-metadata": {
       "sourcePath": "example-posts/paper-metadata.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/patient-intake-baml": {
       "sourcePath": "example-posts/patient-intake-baml.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/patient-intake-dspy": {
       "sourcePath": "example-posts/patient-intake-dspy.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/postgres-source": {
       "sourcePath": "example-posts/postgres-source.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/files-transform": {
       "sourcePath": "example-posts/files-transform.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/kafka-to-lancedb": {
       "sourcePath": "example-posts/kafka-to-lancedb.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/entire-session-search": {
       "sourcePath": "example-posts/entire-session-search.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/image-search-colpali": {
       "sourcePath": "example-posts/image-search-colpali.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/text-embedding-qdrant": {
       "sourcePath": "example-posts/text-embedding-qdrant.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/text-embedding-lancedb": {
       "sourcePath": "example-posts/text-embedding-lancedb.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/text-embedding-turbopuffer": {
       "sourcePath": "example-posts/text-embedding-turbopuffer.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/amazon-s3-embedding": {
       "sourcePath": "example-posts/amazon-s3-embedding.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/google-drive-embedding": {
       "sourcePath": "example-posts/google-drive-embedding.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/oci-object-storage-embedding": {
       "sourcePath": "example-posts/oci-object-storage-embedding.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/face-recognition": {
       "sourcePath": "example-posts/face-recognition.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/product-recommendation": {
       "sourcePath": "example-posts/product-recommendation.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/manuals-llm-extraction": {
       "sourcePath": "example-posts/manuals-llm-extraction.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/multi-format-indexing": {
       "sourcePath": "example-posts/multi-format-indexing.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/slides-to-speech": {
       "sourcePath": "example-posts/slides-to-speech.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     },
     "examples/sec-edgar-analytics": {
       "sourcePath": "example-posts/sec-edgar-analytics.md",
-      "reviewedTs": 1782129600
+      "reviewedTs": 1782216000
     }
   }
 }

--- a/docs/src/data/docs-meta.json
+++ b/docs/src/data/docs-meta.json
@@ -65,6 +65,10 @@
       "sourcePath": "connectors/google_drive.mdx",
       "reviewedTs": 1782216000
     },
+    "connectors/iggy": {
+      "sourcePath": "connectors/iggy.mdx",
+      "reviewedTs": 1782216000
+    },
     "connectors/kafka": {
       "sourcePath": "connectors/kafka.mdx",
       "reviewedTs": 1782216000
@@ -75,6 +79,10 @@
     },
     "connectors/localfs": {
       "sourcePath": "connectors/localfs.mdx",
+      "reviewedTs": 1782216000
+    },
+    "connectors/neo4j": {
+      "sourcePath": "connectors/neo4j.mdx",
       "reviewedTs": 1782216000
     },
     "connectors/oci_object_storage": {
@@ -97,12 +105,28 @@
       "sourcePath": "connectors/surrealdb.mdx",
       "reviewedTs": 1782216000
     },
+    "connectors/turbopuffer": {
+      "sourcePath": "connectors/turbopuffer.mdx",
+      "reviewedTs": 1782216000
+    },
+    "connectors/zvec": {
+      "sourcePath": "connectors/zvec.mdx",
+      "reviewedTs": 1782216000
+    },
     "contributing/guide": {
       "sourcePath": "contributing/guide.md",
       "reviewedTs": 1782216000
     },
     "contributing/setup_dev_environment": {
       "sourcePath": "contributing/setup_dev_environment.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/amazon-s3-embedding": {
+      "sourcePath": "example-posts/amazon-s3-embedding.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/audio-to-text": {
+      "sourcePath": "example-posts/audio-to-text.md",
       "reviewedTs": 1782216000
     },
     "examples/csv-to-kafka": {
@@ -113,24 +137,76 @@
       "sourcePath": "example-posts/docs-to-knowledge-graph.md",
       "reviewedTs": 1782216000
     },
+    "examples/entire-session-search": {
+      "sourcePath": "example-posts/entire-session-search.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/face-recognition": {
+      "sourcePath": "example-posts/face-recognition.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/files-transform": {
+      "sourcePath": "example-posts/files-transform.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/google-drive-embedding": {
+      "sourcePath": "example-posts/google-drive-embedding.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/hackernews-trending-topics": {
+      "sourcePath": "example-posts/hackernews-trending-topics.md",
+      "reviewedTs": 1782216000
+    },
     "examples/image-search": {
       "sourcePath": "example-posts/image-search.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/image-search-colpali": {
+      "sourcePath": "example-posts/image-search-colpali.md",
       "reviewedTs": 1782216000
     },
     "examples/index-codebase": {
       "sourcePath": "example-posts/index-codebase.md",
       "reviewedTs": 1782216000
     },
+    "examples/kafka-to-lancedb": {
+      "sourcePath": "example-posts/kafka-to-lancedb.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/manuals-llm-extraction": {
+      "sourcePath": "example-posts/manuals-llm-extraction.md",
+      "reviewedTs": 1782216000
+    },
     "examples/meeting-notes-to-knowledge-graph": {
       "sourcePath": "example-posts/meeting-notes-to-knowledge-graph.md",
       "reviewedTs": 1782216000
     },
-    "examples/pdf-embedding": {
-      "sourcePath": "example-posts/pdf-embedding.md",
-      "reviewedTs": 1782216000
-    },
     "examples/multi-codebase-summarization": {
       "sourcePath": "example-posts/multi-codebase-summarization.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/multi-format-indexing": {
+      "sourcePath": "example-posts/multi-format-indexing.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/oci-object-storage-embedding": {
+      "sourcePath": "example-posts/oci-object-storage-embedding.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/paper-metadata": {
+      "sourcePath": "example-posts/paper-metadata.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/patient-intake-baml": {
+      "sourcePath": "example-posts/patient-intake-baml.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/patient-intake-dspy": {
+      "sourcePath": "example-posts/patient-intake-dspy.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/pdf-embedding": {
+      "sourcePath": "example-posts/pdf-embedding.md",
       "reviewedTs": 1782216000
     },
     "examples/pdf-to-markdown": {
@@ -139,6 +215,34 @@
     },
     "examples/podcast-to-knowledge-graph": {
       "sourcePath": "example-posts/podcast-to-knowledge-graph.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/postgres-source": {
+      "sourcePath": "example-posts/postgres-source.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/product-recommendation": {
+      "sourcePath": "example-posts/product-recommendation.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/sec-edgar-analytics": {
+      "sourcePath": "example-posts/sec-edgar-analytics.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/slides-to-speech": {
+      "sourcePath": "example-posts/slides-to-speech.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/text-embedding-lancedb": {
+      "sourcePath": "example-posts/text-embedding-lancedb.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/text-embedding-qdrant": {
+      "sourcePath": "example-posts/text-embedding-qdrant.md",
+      "reviewedTs": 1782216000
+    },
+    "examples/text-embedding-turbopuffer": {
+      "sourcePath": "example-posts/text-embedding-turbopuffer.md",
       "reviewedTs": 1782216000
     },
     "faq": {
@@ -211,106 +315,6 @@
     },
     "programming_guide/target_state": {
       "sourcePath": "programming_guide/target_state.md",
-      "reviewedTs": 1782216000
-    },
-    "connectors/iggy": {
-      "sourcePath": "connectors/iggy.mdx",
-      "reviewedTs": 1782216000
-    },
-    "connectors/neo4j": {
-      "sourcePath": "connectors/neo4j.mdx",
-      "reviewedTs": 1782216000
-    },
-    "connectors/turbopuffer": {
-      "sourcePath": "connectors/turbopuffer.mdx",
-      "reviewedTs": 1782216000
-    },
-    "examples/audio-to-text": {
-      "sourcePath": "example-posts/audio-to-text.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/hackernews-trending-topics": {
-      "sourcePath": "example-posts/hackernews-trending-topics.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/paper-metadata": {
-      "sourcePath": "example-posts/paper-metadata.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/patient-intake-baml": {
-      "sourcePath": "example-posts/patient-intake-baml.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/patient-intake-dspy": {
-      "sourcePath": "example-posts/patient-intake-dspy.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/postgres-source": {
-      "sourcePath": "example-posts/postgres-source.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/files-transform": {
-      "sourcePath": "example-posts/files-transform.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/kafka-to-lancedb": {
-      "sourcePath": "example-posts/kafka-to-lancedb.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/entire-session-search": {
-      "sourcePath": "example-posts/entire-session-search.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/image-search-colpali": {
-      "sourcePath": "example-posts/image-search-colpali.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/text-embedding-qdrant": {
-      "sourcePath": "example-posts/text-embedding-qdrant.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/text-embedding-lancedb": {
-      "sourcePath": "example-posts/text-embedding-lancedb.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/text-embedding-turbopuffer": {
-      "sourcePath": "example-posts/text-embedding-turbopuffer.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/amazon-s3-embedding": {
-      "sourcePath": "example-posts/amazon-s3-embedding.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/google-drive-embedding": {
-      "sourcePath": "example-posts/google-drive-embedding.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/oci-object-storage-embedding": {
-      "sourcePath": "example-posts/oci-object-storage-embedding.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/face-recognition": {
-      "sourcePath": "example-posts/face-recognition.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/product-recommendation": {
-      "sourcePath": "example-posts/product-recommendation.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/manuals-llm-extraction": {
-      "sourcePath": "example-posts/manuals-llm-extraction.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/multi-format-indexing": {
-      "sourcePath": "example-posts/multi-format-indexing.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/slides-to-speech": {
-      "sourcePath": "example-posts/slides-to-speech.md",
-      "reviewedTs": 1782216000
-    },
-    "examples/sec-edgar-analytics": {
-      "sourcePath": "example-posts/sec-edgar-analytics.md",
       "reviewedTs": 1782216000
     }
   }

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -188,17 +188,17 @@ const breadcrumbLd = {
 
           <div class="side-group">
             <h6>By target</h6>
-            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <span class="t-pill">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_TARGETS.map((t) => <button type="button" class="t-pill" data-facet="tgt" data-value={t}>{t}</button>)}</div>
           </div>
 
           <div class="side-group">
             <h6>By source</h6>
-            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <span class="t-pill">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_SOURCES.map((t) => <button type="button" class="t-pill" data-facet="src" data-value={t}>{t}</button>)}</div>
           </div>
 
           <div class="side-group">
             <h6>By LLM</h6>
-            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <span class="t-pill">{t}</span>)}</div>
+            <div class="tags-row">{SIDEBAR_LLMS.map((t) => <button type="button" class="t-pill" data-facet="llm" data-value={t}>{t}</button>)}</div>
           </div>
 
           <div class="side-group">
@@ -258,20 +258,43 @@ const breadcrumbLd = {
     </div>
 
     <script is:inline>
-      // Category filter chips — toggle visibility of category sections.
+      // Filters — category chips (top) toggle whole category sections; the side
+      // facet pills (By target / source / LLM) filter individual cards by tag and
+      // hide now-empty sections. Two modes; picking a facet resets category to All.
       (function(){
-        const chips = document.querySelectorAll('#filters .t-filter');
-        const sections = document.querySelectorAll('section.cat[data-cat]');
+        const catChips = Array.from(document.querySelectorAll('#filters .t-filter'));
+        const facetPills = Array.from(document.querySelectorAll('.side-group .t-pill[data-facet]'));
+        const sections = Array.from(document.querySelectorAll('section.cat[data-cat]'));
+        const cards = Array.from(document.querySelectorAll('.ex-card'));
+        let cat = 'all';
+        let facet = null; // { facet: 'tgt'|'src'|'llm', value }
 
-        chips.forEach((chip) => chip.addEventListener('click', () => {
-          const f = chip.dataset.filter;
-          chips.forEach((c) => c.classList.toggle('on', c === chip));
-          if (f === 'all') {
-            sections.forEach((s) => s.style.display = '');
-            return;
+        function render(){
+          if (facet){
+            cards.forEach((c) => {
+              const vals = (c.getAttribute('data-' + facet.facet) || '').split('|');
+              c.style.display = vals.indexOf(facet.value) > -1 ? '' : 'none';
+            });
+            sections.forEach((s) => {
+              const any = Array.from(s.querySelectorAll('.ex-card')).some((c) => c.style.display !== 'none');
+              s.style.display = any ? '' : 'none';
+            });
+          } else {
+            cards.forEach((c) => { c.style.display = ''; });
+            sections.forEach((s) => { s.style.display = (cat === 'all' || s.dataset.cat === cat) ? '' : 'none'; });
           }
-          sections.forEach((s) => s.style.display = (s.dataset.cat === f ? '' : 'none'));
+          catChips.forEach((c) => c.classList.toggle('on', c.dataset.filter === cat));
+          facetPills.forEach((p) => p.classList.toggle('on', !!facet && p.dataset.facet === facet.facet && p.dataset.value === facet.value));
+        }
+
+        catChips.forEach((chip) => chip.addEventListener('click', () => { cat = chip.dataset.filter; facet = null; render(); }));
+        facetPills.forEach((pill) => pill.addEventListener('click', () => {
+          const same = facet && facet.facet === pill.dataset.facet && facet.value === pill.dataset.value;
+          facet = same ? null : { facet: pill.dataset.facet, value: pill.dataset.value };
+          if (facet) cat = 'all';
+          render();
         }));
+        render();
       })();
 
       // Highlight the active category in the side nav based on scroll.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/globals.css';
+import '@cocoindex/brand/doc-card.css';
+import DocCard from '@cocoindex/brand/DocCard.astro';
 import Topbar from '../components/Topbar.astro';
 import Sidebar from '../components/Sidebar.astro';
 import MobileSheet from '../components/MobileSheet.astro';
@@ -25,26 +27,26 @@ const canonical = new URL(`${base}/`, SITE_URL).toString();
 // "Start here" entry points — labels and slugs match the sidebar exactly.
 const startCards = [
   { slug: 'getting_started/quickstart', label: 'Quickstart', meta: '5 min',
-    body: 'Build your first pipeline end to end — convert PDFs to Markdown and watch only changed files reprocess.', icon: 'rocket' },
+    body: 'Build your first pipeline end to end — convert PDFs to Markdown and watch only changed files reprocess.', icon: 'rocket', accent: 'coral' },
   { slug: 'getting_started/installation', label: 'Installation', meta: 'Setup',
-    body: 'Install the package and the Rust engine. Python 3.10+, pip / uv / poetry.', icon: 'download' },
+    body: 'Install the package and the Rust engine. Python 3.10+, pip / uv / poetry.', icon: 'download', accent: 'peach' },
   { slug: 'programming_guide/core_concepts', label: 'Core Concepts', meta: 'Mental model',
-    body: 'App, processing components, target states, and how incremental syncing works.', icon: 'concept' },
+    body: 'App, processing components, target states, and how incremental syncing works.', icon: 'concept', accent: 'palm' },
   { slug: 'getting_started/ai_coding_agents', label: 'Use with AI coding agents', meta: 'Skill',
-    body: 'Drop in the CocoIndex skill so Claude Code or Cursor writes correct v1 flows.', icon: 'agent' },
-];
+    body: 'Drop in the CocoIndex skill so Claude Code or Cursor writes correct v1 flows.', icon: 'agent', accent: 'lavender' },
+] as const;
 
 // What you can build — each links to runnable examples or the product page.
 const buildCards = [
-  { href: doc('examples/index-codebase'), title: 'Semantic & vector search',
+  { href: doc('examples/index-codebase'), title: 'Semantic & vector search', icon: 'search', accent: 'coral',
     body: 'Chunk, embed, and index documents or code into pgvector, Qdrant, LanceDB, or Turbopuffer.', meta: 'RAG · retrieval' },
-  { href: 'https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph_neo4j', title: 'Knowledge graphs',
+  { href: 'https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph_neo4j', title: 'Knowledge graphs', icon: 'graph', accent: 'palm',
     body: 'Extract entities and relationships into Neo4j, FalkorDB, or SurrealDB — structured context for agents.', meta: 'Entities · relations' },
-  { href: CODE, title: 'Live code index',
+  { href: CODE, title: 'Live code index', icon: 'code', accent: 'peach',
     body: 'AST-aware semantic chunks and call graphs kept fresh on every commit, served over MCP.', meta: 'CocoIndex Code' },
-  { href: 'https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_dspy', title: 'Structured extraction',
+  { href: 'https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_dspy', title: 'Structured extraction', icon: 'extract', accent: 'lavender',
     body: 'Turn PDFs, transcripts, and inboxes into typed rows with LLM extraction and entity resolution.', meta: 'Ingest · transform' },
-];
+] as const;
 
 // Building blocks — connectors and ops straight from the sidebar.
 const sources = [
@@ -75,10 +77,20 @@ const targets = [
 ];
 
 const ICONS: Record<string, string> = {
+  // start here
   rocket: '<path d="M4.5 16.5 12 4l7.5 12.5"/><path d="M12 4v16"/>',
   download: '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/><path d="M12 15V3"/>',
   concept: '<circle cx="12" cy="12" r="3"/><path d="M5 12H2m20 0h-3M12 5V2m0 20v-3M7 7 5 5m14 14-2-2M17 7l2-2M5 19l2-2"/>',
   agent: '<rect x="3" y="4" width="18" height="14" rx="2"/><path d="M8 21h8M12 18v3M9 9l-2 2 2 2m6-4 2 2-2 2"/>',
+  // what you can build
+  search: '<circle cx="10.5" cy="10.5" r="6.5"/><path d="m21 21-5-5"/><circle cx="10.5" cy="10.5" r="1.6" fill="currentColor" stroke="none"/>',
+  graph: '<circle cx="5" cy="6" r="2.4"/><circle cx="19" cy="6" r="2.4"/><circle cx="12" cy="18" r="2.4"/><path d="M7.2 7 10.8 16M16.8 7 13.2 16M7.4 6h9.2"/>',
+  code: '<path d="m9 8-4 4 4 4"/><path d="m15 8 4 4-4 4"/><path d="M13 5 11 19" stroke-opacity="0.5"/>',
+  extract: '<path d="M13 3v4a1 1 0 0 0 1 1h4"/><path d="M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9z"/><path d="M9 13h6M9 17h6"/>',
+  // community
+  github: '<path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 0 0-1.3-3.2 4.2 4.2 0 0 0-.1-3.2s-1-.3-3.4 1.3a11.6 11.6 0 0 0-6 0C6.3 2.6 5.3 2.9 5.3 2.9a4.2 4.2 0 0 0-.1 3.2A4.6 4.6 0 0 0 3.8 9.3c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/>',
+  discord: '<path d="M18 5a18 18 0 0 0-4.5-1.4l-.3.6a14 14 0 0 1 4 2 16 16 0 0 0-12.4 0 14 14 0 0 1 4-2l-.3-.6A18 18 0 0 0 4 5C1.6 8.5 1 12 1.2 15.4A18 18 0 0 0 6.7 18l.7-1a12 12 0 0 1-1.9-.9l.5-.4a13 13 0 0 0 11 0l.5.4a12 12 0 0 1-1.9.9l.7 1a18 18 0 0 0 5.5-2.6C21.2 11.5 20.2 8 18 5z"/><circle cx="8.5" cy="12" r="1.3" fill="currentColor" stroke="none"/><circle cx="15.5" cy="12" r="1.3" fill="currentColor" stroke="none"/>',
+  grid: '<rect x="3" y="3" width="7" height="7" rx="1.6"/><rect x="14" y="3" width="7" height="7" rx="1.6"/><rect x="3" y="14" width="7" height="7" rx="1.6"/><rect x="14" y="14" width="7" height="7" rx="1.6"/>',
 };
 ---
 <!doctype html>
@@ -161,14 +173,7 @@ const ICONS: Record<string, string> = {
           </div>
           <div class="card-grid four">
             {startCards.map((c) => (
-              <a class="card" href={doc(c.slug)}>
-                <span class="ico" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={ICONS[c.icon]} />
-                </span>
-                <h3>{c.label} <span class="ar">→</span></h3>
-                <p>{c.body}</p>
-                <span class="meta">{c.meta}</span>
-              </a>
+              <DocCard href={doc(c.slug)} title={c.label} body={c.body} meta={c.meta} icon={ICONS[c.icon]} accent={c.accent} />
             ))}
           </div>
         </section>
@@ -207,11 +212,7 @@ const ICONS: Record<string, string> = {
           </div>
           <div class="card-grid four">
             {buildCards.map((c) => (
-              <a class="card build" href={c.href}>
-                <h3>{c.title} <span class="ar">→</span></h3>
-                <p>{c.body}</p>
-                <span class="meta">{c.meta}</span>
-              </a>
+              <DocCard href={c.href} title={c.title} body={c.body} meta={c.meta} icon={ICONS[c.icon]} accent={c.accent} />
             ))}
           </div>
         </section>
@@ -295,9 +296,9 @@ app.update_blocking()</code></pre>
             <p>An incremental engine for agents — Apache-2.0, built fully in the open.</p>
           </div>
           <div class="card-grid four">
-            <a class="card build" href={GITHUB_REPO}><h3>GitHub <span class="ar">→</span></h3><p>Star the repo, read the source, open an issue.</p></a>
-            <a class="card build" href={DISCORD_URL}><h3>Discord <span class="ar">→</span></h3><p>Showcase, release notes, and help from maintainers.</p></a>
-            <a class="card build" href={EXAMPLES}><h3>Examples <span class="ar">→</span></h3><p>Runnable recipes you can clone, run, and bend to your data.</p></a>
+            <DocCard href={GITHUB_REPO} title="GitHub" body="Star the repo, read the source, open an issue." icon={ICONS.github} accent="coral" />
+            <DocCard href={DISCORD_URL} title="Discord" body="Showcase, release notes, and help from maintainers." icon={ICONS.discord} accent="lavender" />
+            <DocCard href={EXAMPLES} title="Examples" body="Runnable recipes you can clone, run, and bend to your data." icon={ICONS.grid} accent="palm" />
           </div>
         </section>
       </main>
@@ -439,47 +440,8 @@ app.update_blocking()</code></pre>
       /* card grid — auto-fit so it always fits the (narrower) main column */
       body.docs-home .card-grid { display: grid; gap: 16px; }
       body.docs-home .card-grid.four { grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
-      body.docs-home .card {
-        position: relative; overflow: hidden;
-        display: block; background: var(--cream); border: 1px solid var(--rule);
-        border-radius: 12px; padding: 22px; text-decoration: none; color: var(--maroon-ink);
-        transition: border-color .18s ease;
-      }
-      /* Corner-dots hover motif — matches the homepage (.integ / .code-feat)
-         and the blog list rows: a bottom-right radial-gradient dot field that
-         fades in. No drop-shadow, no lift. */
-      body.docs-home .card::before {
-        content: ""; position: absolute; inset: auto 0 0 auto;
-        width: 200px; height: 120px;
-        background-image: radial-gradient(circle, rgba(190, 81, 51, 0.45) 1.2px, transparent 1.6px);
-        background-size: 9px 9px; background-position: 100% 100%;
-        opacity: 0; transition: opacity .25s ease; pointer-events: none;
-        -webkit-mask-image: radial-gradient(circle at 100% 100%, #000 0%, transparent 75%);
-                mask-image: radial-gradient(circle at 100% 100%, #000 0%, transparent 75%);
-      }
-      body.docs-home .card > * { position: relative; z-index: 1; }
-      body.docs-home .card:hover { border-color: rgba(190, 81, 51, 0.4); text-decoration: none; }
-      /* On hover the dot-field simply fades in — no motion. */
-      body.docs-home .card:hover::before {
-        opacity: 1;
-      }
-      body.docs-home .card .ico {
-        width: 38px; height: 38px; border-radius: 8px; display: grid; place-items: center;
-        background: color-mix(in oklab, var(--coral) 12%, var(--cream)); color: var(--coral); margin-bottom: 16px;
-      }
-      body.docs-home .card .ico svg { width: 20px; height: 20px; }
-      body.docs-home .card h3 {
-        margin: 0 0 6px; font-size: var(--text-base); font-weight: 600; letter-spacing: -0.01em;
-        display: flex; align-items: center; gap: 6px; color: var(--maroon-ink);
-      }
-      body.docs-home .card h3 .ar { color: var(--coral); transition: transform .18s ease; }
-      body.docs-home .card:hover h3 .ar { transform: translateX(3px); }
-      body.docs-home .card p { margin: 0; font-size: var(--text-sm); color: var(--muted); line-height: 1.55; }
-      body.docs-home .card .meta {
-        display: block; margin-top: 14px; font-family: var(--mono); font-size: var(--text-xs);
-        letter-spacing: 0.1em; text-transform: uppercase; color: var(--coral);
-      }
-      body.docs-home .card.build h3 { font-size: var(--text-base); }
+      /* The cards are now the shared <DocCard> (@cocoindex/brand/doc-card.css):
+         hum-07 lift + accent tint + springy icon tile, multi-accent per card. */
 
       /* steps */
       body.docs-home .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 18px; }
@@ -543,9 +505,7 @@ app.update_blocking()</code></pre>
         body.docs-home .hero-grid { grid-template-columns: 1fr; gap: 32px; }
         body.docs-home .split { grid-template-columns: 1fr; gap: 26px; }
       }
-      @media (prefers-reduced-motion: reduce) {
-        body.docs-home .card, body.docs-home .card h3 .ar { transition: none; }
-      }
+      /* DocCard handles its own reduced-motion (doc-card.css). */
     </style>
 
     <Foot />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -118,7 +118,6 @@ const ICONS: Record<string, string> = {
         <section class="dh-hero">
           <div class="hero-grid">
             <div class="hero-copy">
-              <span class="t-eyebrow"><span class="dt" aria-hidden="true"></span>Documentation · v1</span>
               <h1 class="hero-h" set:html={titleMarkup('Fresh data views for *agents.*')} />
               <p class="hero-sub">
                 CocoIndex is an ultra-performant framework for building data pipelines for AI, with

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -14,3 +14,20 @@
    lives in one place. Docs-only brand files (home/blog don't import them). */
 @import '@cocoindex/brand/docs-layout.css';
 @import '@cocoindex/brand/docsearch.css';
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Typography — align the display sizes to the Hum-07 brand reference. Fonts
+   already match it (Plus Jakarta Sans + JetBrains Mono); these two tokens just
+   bring the hero and the section/article titles down to the Hum-07 scale.
+   Driven through the scale tokens (not per-selector) so the change cascades
+   everywhere reliably. Weights stay at the brand 600. Docs-scoped — home/blog
+   keep their own globals.
+   ───────────────────────────────────────────────────────────────────────── */
+:root {
+  /* Hero — Hum-07 --display, exact. Was clamp(2.75rem, 5vw + 1rem, 5.25rem)
+     (~84px at 1440px); this caps at 4.9rem (~78px) and starts smaller. */
+  --text-display: clamp(2.6rem, 5.2vw + 0.6rem, 4.9rem);
+  /* Section + article titles (the only --text-3xl users) — Hum-07 --h2: fluid,
+     ceiling 3rem. Was a fixed 3.05rem that stayed oversized on narrow screens. */
+  --text-3xl: clamp(1.9rem, 3.2vw + 0.4rem, 3rem);
+}


### PR DESCRIPTION
Aligns the docs + examples site to the **hum-07** brand pass and makes the examples facet pills functional. Bumps `@cocoindex/brand` to `#v0.4.26` (the matching brand PR is cocoindex-io/cocoindex-brand#4 — **merge that first**).

## Docs site
- Inherit the canonical nav links + a fixed (non-morph) bar from the shared brand.
- Align hero + title sizes to the hum-07 brand scale; drop the hero eyebrow.
- Use the shared `<DocCard>` for all entry-point card grids on the docs home.
- Set Last-reviewed dates (Jun 23, 2026) across pages.

## Examples — clickable facet filters
The "By target / By source / By LLM" pills were inert `<span>`s. Now they filter:
- Each card stamps `data-tgt/src/llm` from its tags.
- A unified script filters cards by the picked facet, hides now-empty category sections, toggles off on re-click, and resets the category chip to All.
- Verified: Postgres → 7, Neo4j → 3 of 32.

## Dependency
`@cocoindex/brand` `#v0.4.11 → #v0.4.26` — required for the hum-07 nav/footer/chip styling and the facet active-pill state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)