### PR TITLE
examples: glow up every README (SVG covers + Scarf) + fix gpt-5.4 + AGENTS catalog

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -108,19 +108,26 @@ A walkthrough URL means there's a step-by-step guide at
 - `amazon_s3_embedding` / `gdrive_text_embedding` / `oci_object_storage_embedding` — same flow, remote source (S3 / Google Drive / OCI).
 - `postgres_source` — read from an existing Postgres table as the source.
 - `entire_session_search` — semantic search over AI coding sessions captured by Entire.
+- `sec_edgar_analytics` — multi-format SEC filings → Apache Doris with a vector **and** a full-text index; hybrid (semantic + keyword) RRF search. *(walkthrough: sec-edgar-analytics)*
 
 ### Multimodal
 - `image_search` — CLIP embeddings + Qdrant, queried via FastAPI + React.
 - `image_search_colpali` — ColPali multi-vector model + Qdrant MaxSim.
+- `multi_format_indexing` — PDFs + images as page screenshots → ColPali → Qdrant; no OCR, no chunking. *(walkthrough: multi-format-indexing)*
+- `face_recognition` — detect faces (dlib) → 128-d embeddings → Qdrant face search. *(walkthrough: face-recognition)*
 - `audio_to_text` — transcribe audio with LiteLLM → Postgres.
+- `slides_to_speech` — slides → vision-LLM notes → Piper TTS narration → LanceDB semantic search. *(walkthrough: slides-to-speech)*
 
 ### Structured extraction (LLM / BAML / DSPy)
 - `multi_codebase_summarization` — LLM per-file summaries across many repos. *(walkthrough: multi-codebase-summarization)*
 - `hn_trending_topics` — scrape HackerNews → LLM topic extraction → Postgres.
+- `manuals_llm_extraction` — PDF manuals → Markdown (docling) → typed module records → Postgres. *(walkthrough: manuals-llm-extraction)*
 - `patient_intake_extraction_baml` / `patient_intake_extraction_dspy` — structured PDF extraction with BAML / DSPy (Gemini vision).
 
 ### Knowledge graphs
 - `conversation_to_knowledge` — YouTube podcasts → SurrealDB knowledge graph. *(walkthrough: podcast-to-knowledge-graph)*
+- `docs_to_knowledge_graph` — Markdown docs → Neo4j concept graph of LLM-extracted triples. *(walkthrough: docs-to-knowledge-graph)*
+- `product_recommendation` — product catalog → LLM taxonomy extraction → Neo4j recommendation graph. *(walkthrough: product-recommendation)*
 - `meeting_notes_graph_neo4j` / `meeting_notes_graph_falkordb` — Google Drive meeting notes → Neo4j / FalkorDB graph.
 
 ### Custom sources / targets / streaming

--- a/examples/amazon_s3_embedding/README.md
+++ b/examples/amazon_s3_embedding/README.md
@@ -1,42 +1,104 @@
-# Amazon S3 Embedding (v1) 🪣
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/amazon-s3-embedding/" title="Embed Markdown from an Amazon S3 bucket with CocoIndex — list objects, chunk, embed, and store vectors in Postgres + pgvector, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/amazon-s3-embedding/cover.svg" alt="Embed Markdown from Amazon S3 with CocoIndex — list Markdown objects from a bucket, chunk and embed each one locally, and store the vectors in Postgres with pgvector for natural-language search" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds markdown files from an S3 bucket, stores the chunks + embeddings in Postgres (pgvector), and provides a simple semantic-search query demo.
+<h1 align="center">Semantic search over Markdown in an <em>S3 bucket</em>.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>The Semantic Search 101 pipeline with one thing swapped: the source is an <em>Amazon S3</em> bucket instead of a local folder.</b><br/>
+  List objects, chunk, embed locally, store in Postgres + pgvector — incrementally — in plain async Python.
+</p>
 
-- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/amazon-s3-embedding/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+<div align="center">
 
-- An S3 bucket (or S3-compatible service like MinIO) with markdown files
-- AWS credentials configured (e.g. via `aws configure`, env vars, or IAM role)
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-Copy `.env.example` to `.env` and fill in your values:
+</div>
 
-```sh
-cp .env.example .env
+<br/>
+
+This is [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) with one thing swapped: the source is an Amazon S3 bucket instead of a local directory. Everything downstream — chunking, embedding, the Postgres/pgvector target, and the query — is identical. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so adding one object embeds one object, not the whole bucket.
+
+## How it works
+
+The S3 connector needs an [aiobotocore](https://github.com/aio-libs/aiobotocore) client, opened once in the lifespan alongside the Postgres pool and embedder. `app_main` mounts the Postgres table exactly as in the base example, then swaps `localfs.walk_dir` for `amazon_s3.list_objects` — same `path_matcher` glob, same `mount_each` fan-out. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def app_main() -> None:
+    target_table = await postgres.mount_table_target(
+        PG_DB, table_name=TABLE_NAME,
+        table_schema=await postgres.TableSchema.from_class(DocEmbedding, primary_key=["id"]),
+        pg_schema_name=PG_SCHEMA_NAME,
+    )
+    client = coco.use_context(S3_CLIENT)
+    files = amazon_s3.list_objects(
+        client, S3_BUCKET, prefix=S3_PREFIX,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+    )
+    await coco.mount_each(process_file, files.items(), target_table)
 ```
 
-## Run
+`list_objects` yields one `S3File` per matching object; `prefix` scopes the listing server-side, and the glob filters the rest. `process_file` then reads, chunks, and embeds each one — identical to the base example. `create_client("s3")` picks up standard AWS credentials (env vars, `~/.aws/credentials`, or an IAM role); set `AWS_ENDPOINT_URL` to point at an S3-compatible service like MinIO.
 
-Install deps:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/amazon-s3-embedding/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the S3 client, the prefix/glob listing, the Postgres target, and the catch-up run.
+</p>
+
+## Why it's worth a star ⭐
+
+- **S3 as a first-class source.** `amazon_s3.list_objects` drops into the same `mount_each` fan-out as a local folder — the source is a swappable detail, not a rewrite.
+- **Scoped listing.** `prefix` filters server-side and the `**/*.md` glob filters the rest, so you index only what you mean to.
+- **S3-compatible too.** Point `AWS_ENDPOINT_URL` at MinIO or any S3-compatible service; credentials come from the standard AWS chain.
+- **Incremental by default.** `@coco.fn(memo=True)` skips objects whose content and code are unchanged; each row's `id` is derived from its chunk text, so re-running upserts only changed rows and deletes rows whose source object is gone.
+- **Managed Postgres target.** A single `mount_table_target` owns the schema, idempotent upserts, and orphan cleanup; the same local `all-MiniLM-L6-v2` embedder is reused at query time so indexing and search stay consistent.
+
+## Run it
+
+**1. Start Postgres + pgvector:**
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install** — set the bucket, optional prefix, and your AWS credentials:
+
+```sh
+cp .env.example .env     # set S3_BUCKET, optional S3_PREFIX; AWS creds from env / ~/.aws / IAM role
 pip install -e .
 ```
 
-Build/update the index (one-shot catch-up; the amazon_s3 source does not support live mode):
+**3. Build the index** — the `amazon_s3` source does not support live mode, so this is a one-shot catch-up run (scan the bucket, sync, exit):
 
 ```sh
 cocoindex update main
 ```
 
-Query:
+**4. Search** — embeds your query with the *same* model and returns the nearest chunks by pgvector cosine distance:
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-Note: this example **does not create a vector index**; queries will do a sequential scan.
+The most semantically similar chunks come back ranked — even when they share none of the words in your query. Re-run `cocoindex update main` to pick up bucket changes; the engine still applies just the difference.
+
+---
+
+<p align="center">
+  If this made your S3 archive searchable by meaning, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/amazon-s3-embedding/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/amazon_s3_embedding" alt="" width="1" height="1" />

--- a/examples/audio_to_text/README.md
+++ b/examples/audio_to_text/README.md
@@ -1,50 +1,118 @@
-# Audio to Text (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/audio-to-text/" title="Transcribe a folder of audio files with CocoIndex — a LiteLLM speech-to-text model into Postgres, one row per file, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/cover.svg" alt="Transcribe audio to text with CocoIndex and LiteLLM — walk a folder of voice memos and recordings, send each to a speech-to-text model, and write one transcript row per file into Postgres keyed by filename" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example transcribes local audio files with LiteLLM and stores one row per file in Postgres. The filename is the primary key, so the table can be used as an index of available transcriptions.
+<h1 align="center">Turn a folder of audio into a <em>transcript</em> table.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Walk a directory of recordings, send each file to a LiteLLM speech-to-text model, and write one transcript row per file into Postgres — keyed by filename.</b><br/>
+  A plain table you can query, join, or feed into an embedding pipeline — in plain async Python.
+</p>
 
-- A running Postgres database. If you don't have one, start a local instance with the compose file in this repo:
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/audio-to-text/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+<div align="center">
 
-- LiteLLM credentials for the transcription model. For the default `whisper-1` model, set `OPENAI_API_KEY`.
-- `POSTGRES_URL` set, e.g.
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-  ```sh
-  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-  export OPENAI_API_KEY="..."
-  ```
+</div>
 
-## Input Files
+<br/>
 
-Put audio files under `./audio_files`. The example recursively picks up common audio extensions such as `.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg`, and `.webm`.
+A folder of voice memos, meeting recordings, and podcast clips is dead weight until it's text. CocoIndex walks the directory, sends every file to a [LiteLLM](https://docs.litellm.ai/) transcription model, and writes the result to Postgres as one row per file, keyed by filename. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only new or changed files get re-transcribed and removed files have their rows cleaned up automatically.
 
-## Run
+## How it works
 
-Install deps:
+The indexing path is the shortest there is — no chunking, one row per file:
+
+- **Walk** a local directory (recursive), matching common audio extensions (`.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg`, `.webm`, `.aac`, `.aiff`).
+- **Transcribe** each file with a LiteLLM speech-to-text model (`whisper-1` by default).
+- **Store** one `AudioTranscription` row per file in Postgres, keyed by filename.
+
+`process_file` runs once per file: read the audio, transcribe it, declare a single target row. Read it in [`main.py`](main.py):
+
+```python
+_transcriber = LiteLLMTranscriber("whisper-1")
+
+@dataclass
+class AudioTranscription:
+    filename: str
+    text: str
+
+@coco.fn(memo=True)   # unchanged file is never re-transcribed
+async def process_file(
+    file: localfs.File,
+    table: postgres.TableTarget[AudioTranscription],
+) -> None:
+    transcript = await _transcriber.transcribe(file)
+    table.declare_row(
+        row=AudioTranscription(filename=str(file.file_path.path), text=transcript),
+    )
+```
+
+`mount_table_target` creates and manages the Postgres table for you with `primary_key=["filename"]` — so each file maps to exactly one row, the table doubles as an index of what's been transcribed, and re-runs upsert only what changed.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/audio-to-text/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the row schema, the LiteLLM transcriber, the managed Postgres target, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Swap the model with one string.** `LiteLLMTranscriber("whisper-1")` wraps LiteLLM's transcription API — change that string (and the matching credential) for `elevenlabs/scribe_v1`, a self-hosted endpoint, whatever.
+- **The table is the index.** `filename` is the primary key, so the output table doubles as a record of which files have been transcribed — no separate bookkeeping.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a file when its content and the function's code are both unchanged, so you never pay for the same transcription twice.
+- **Managed Postgres target.** `mount_table_target` handles schema, idempotent upserts, and orphan cleanup — delete a file and its row is removed automatically.
+- **Logic changes reconcile too.** Swap the transcription model and CocoIndex re-transcribes against it, compares with what's in Postgres, and applies only the difference.
+
+## Run it
+
+> Needs a running **Postgres** and **LiteLLM credentials** for the transcription model (the default `whisper-1` uses `OPENAI_API_KEY`).
+
+**1. Start Postgres** — a ready compose file ships in the repo:
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set OPENAI_API_KEY; POSTGRES_URL defaults to the local container
 pip install -e .
 ```
 
-Build/update the index:
+**3. Build the table** — drop a few audio files into `audio_files/`, then:
 
 ```sh
 cocoindex update main.py
 ```
 
-The target table is `coco_examples.audio_transcriptions` with:
+This writes to `coco_examples.audio_transcriptions`, with `filename` as the primary key and `text` as the transcript.
 
-- `filename` as the primary key
-- `text` as the transcript
-
-Check the results:
+**4. Check the results** with plain SQL:
 
 ```sh
-psql "$POSTGRES_URL" -c 'SELECT filename, left(text, 200) AS preview FROM coco_examples.audio_transcriptions ORDER BY filename;'
+psql "$POSTGRES_URL" -c \
+  'SELECT filename, left(text, 200) AS preview FROM coco_examples.audio_transcriptions ORDER BY filename;'
 ```
 
-Re-running `cocoindex update main.py` incrementally processes added, changed, and removed audio files.
+Re-running `cocoindex update main.py` incrementally processes only added, changed, and removed files.
+
+---
+
+<p align="center">
+  If this turned your recordings into a searchable table, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/audio-to-text/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/audio_to_text" alt="" width="1" height="1" />

--- a/examples/code_embedding/README.md
+++ b/examples/code_embedding/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://cocoindex.io/docs/examples/index-codebase/" title="Index your codebase for AI agents with CocoIndex — Tree-sitter chunking, embeddings, and a live pgvector index">
-    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/cover.png" alt="Index your codebase for AI agents with CocoIndex and Tree-sitter — language-aware chunking, embeddings, semantic search, and a live vector index in plain async Python" width="100%" draggable="false"/>
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/cover.svg" alt="Index your codebase for AI agents with CocoIndex and Tree-sitter — language-aware chunking, embeddings, semantic search, and a live vector index in plain async Python" width="100%" draggable="false"/>
   </a>
 </p>
 
@@ -43,10 +43,6 @@ query: "where do we embed chunks?"
 ## How it works
 
 Walk a repo → detect language → split along the **syntax tree** with Tree-sitter → embed each chunk → upsert into Postgres (pgvector). With `live=True`, the source keeps watching and the index stays fresh as you code.
-
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/flow-v1.png" alt="CocoIndex code-embedding flow: localfs.walk_dir source → per-file processing component (detect language, Tree-sitter RecursiveSplitter, coco.map → embed each chunk → declare CodeEmbedding rows) → Postgres pgvector target with a cosine vector index" width="70%"/>
-</p>
 
 The whole indexing path is the snippet below — read it top-to-bottom in [`main.py`](main.py):
 
@@ -91,10 +87,6 @@ async def app_main(sourcedir: pathlib.Path) -> None:
 - **Plain Python, your stack.** Swap the embedding model (12k+ on Hugging Face), the chunking, or the [vector store](https://cocoindex.io/docs/). No DSL.
 - **Consistent index & query.** The same embedder is shared by the indexing and query paths, so what you index is what you search.
 
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/incremental-diff.png" alt="A file edited and re-chunked: unchanged chunks are reused with no re-embedding, a removed chunk's row is deleted, and a new chunk is embedded and inserted" width="78%"/>
-</p>
-
 ## Run it
 
 **1. Postgres + pgvector.** If you don't have one, start a local instance with the compose file in this repo:
@@ -123,21 +115,11 @@ cocoindex update -L main    # live: catch up, then keep watching for edits
 python main.py "embedding"
 ```
 
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/search-results.png" alt="Semantic search results in the terminal: similarity score, filename, matched line range, and the code snippet" width="80%"/>
-</p>
-
 Each result carries `start_line`/`end_line`, so hits point straight at the lines that matched. Query uses pgvector's `<=>` cosine distance, turned into a similarity score.
 
 ## Want it production-ready, not DIY?
 
 [**CocoIndex Code**](https://github.com/cocoindex-io/cocoindex-code) is this exact pipeline — AST-aware chunking, incremental re-index, local embeddings — hardened and packaged as a CLI and an MCP server you can plug straight into a coding or code-review agent.
-
-<p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex-code" title="CocoIndex Code — semantic code search for coding agents, as a CLI and MCP server">
-    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/index-codebase/cocoindex-code.png" alt="CocoIndex Code — semantic code search for coding agents, as a CLI and MCP server" width="80%"/>
-  </a>
-</p>
 
 ```sh
 npx skills add cocoindex-io/cocoindex-code     # Claude Code skill, then /ccc
@@ -151,3 +133,5 @@ ccc index && ccc search "where we embed chunks" # CLI
   If this made your agents smarter, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
   <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/index-codebase/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
 </p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/code_embedding" alt="" width="1" height="1" />

--- a/examples/code_embedding_lancedb/README.md
+++ b/examples/code_embedding_lancedb/README.md
@@ -1,55 +1,133 @@
-# Code Embedding with LanceDB (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/index-codebase/" title="Index your codebase for AI agents with CocoIndex — Tree-sitter chunking, embeddings, and a live LanceDB index">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/code-embedding-lancedb/cover.svg" alt="Index your codebase for AI agents with CocoIndex and Tree-sitter — language-aware chunking, embeddings, semantic search, and a live LanceDB index with no database to run, in plain async Python" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example extracts code chunks from local Python, Rust, TOML, and Markdown files, stores the code and their vector embeddings in LanceDB, and provides a simple semantic search demo for code.
+<h1 align="center">Index your <em>codebase</em> into LanceDB.</h1>
 
-## Key Features
+<p align="center">
+  <b>A live, syntax-aware vector index over your repo — into embedded LanceDB, with no database to run — in ~100 lines of plain async Python.</b><br/>
+  Point it at a directory, search it in natural language, and it re-embeds only what changes as you edit.
+</p>
 
-- **No database setup needed**: LanceDB is embedded - no external database required
-- **Vector search**: Semantic code search using sentence embeddings
-- **Full-text search**: FTS index on code content for keyword search
-- **Portable**: Data stored in `./lancedb_data/` directory - just copy to move it
-- **Syntax-aware chunking**: Uses RecursiveSplitter with language detection
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/index-codebase/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Data Storage
+<div align="center">
 
-All data is stored in the `./lancedb_data/` directory in your project folder. This directory is created automatically on first run.
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-To start fresh, simply delete the `./lancedb_data/` directory and re-run the indexing.
+</div>
 
-## Run
+<br/>
 
-Install dependencies:
+This is the Tree-sitter code-embedding pipeline, targeting [LanceDB](https://lancedb.github.io/lancedb/) instead of Postgres. LanceDB is an embedded vector store — no server to start, no connection string; the index is just a `./lancedb_data/` directory you can copy or delete. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)`. The heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so a one-line edit re-embeds one chunk, not the repo.
+
+```python
+query: "where do we embed chunks?"
+
+[0.582] examples/code_embedding_lancedb/main.py (L66-L82)
+    @coco.fn
+    async def process_chunk(chunk, filename, id_gen, table):
+        ... embedding=await coco.use_context(EMBEDDER).embed(chunk.text) ...
+```
+
+## How it works
+
+Walk a repo → detect language → split along the **syntax tree** with Tree-sitter → embed each chunk → upsert into LanceDB. With `live=True`, the source keeps watching and the index stays fresh as you code.
+
+The whole indexing path is the snippet below — read it top-to-bottom in [`main.py`](main.py):
+
+```python
+@coco.fn(memo=True)
+async def process_file(file: FileLike, table: lancedb.TableTarget[CodeEmbedding]) -> None:
+    text = await file.read_text()
+    language = detect_code_language(filename=str(file.file_path.path.name))
+    chunks = _splitter.split(text, chunk_size=1000, min_chunk_size=300,
+                             chunk_overlap=300, language=language)   # Tree-sitter, syntax-aware
+    id_gen = IdGenerator()
+    await coco.map(process_chunk, chunks, file.file_path.path, id_gen, table)
+
+@coco.fn
+async def process_chunk(chunk, filename, id_gen, table) -> None:
+    table.declare_row(row=CodeEmbedding(
+        id=await id_gen.next_id(chunk.text), filename=str(filename), code=chunk.text,
+        embedding=await coco.use_context(EMBEDDER).embed(chunk.text),
+        start_line=chunk.start.line, end_line=chunk.end.line,
+    ))
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    table = await lancedb.mount_table_target(
+        LANCE_DB, table_name=TABLE_NAME,
+        table_schema=await lancedb.TableSchema.from_class(CodeEmbedding, primary_key=["id"]),
+    )
+    files = localfs.walk_dir(sourcedir, recursive=True,
+                             path_matcher=PatternFilePathMatcher(included_patterns=["**/*.py", ...]),
+                             live=True)
+    await coco.mount_each(process_file, files.items(), table)
+```
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/index-codebase/">Full Tutorial →</a></b><br/>
+  The closest walkthrough is the Postgres version — same chunking, embedding, and incremental flow; only the target store differs. Step-by-step coverage of the data model, the lifespan, chunking, embedding, the App, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **No database to run.** LanceDB is embedded — the index lives in `./lancedb_data/`. Nothing to start, nothing to connect to; copy the directory to move it, delete it to start fresh.
+- **Syntax-aware chunking, built in.** Tree-sitter splits along real code structure — functions, classes, blocks — so retrieval returns whole units, not fragments cut mid-statement. Every major language; unknown types fall back to plain text.
+- **Incremental by default.** `@coco.fn(memo=True)` skips unchanged files and reuses embeddings for unchanged chunks; `mount_table_target` upserts only the rows that moved and deletes orphans. Edit one function → one chunk is re-embedded.
+- **Live updates.** `live=True` + `cocoindex update -L` keeps watching the filesystem and applies changes with low latency — always-fresh context for an agent.
+- **Plain Python, your stack.** Swap the embedding model (12k+ on Hugging Face), the chunking, or the [vector store](https://cocoindex.io/docs/). No DSL.
+
+## Run it
+
+LanceDB is embedded, so there's no server to start — the index is created on first run.
+
+**1. Install deps:**
 
 ```sh
 pip install -e .
 ```
 
-Build/update the index (writes rows into LanceDB). Pick one of the two modes:
+**2. Build / update the index** (writes rows into LanceDB at `./lancedb_data/`) — pick one:
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main       # catch-up: scan, sync changes, exit
+cocoindex update -L main    # live: catch up, then keep watching for edits
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**3. Query it** — semantic search from the terminal:
 
 ```sh
 python main.py "embedding"
 ```
 
-## Environment
+Each result carries `start_line`/`end_line`, so hits point straight at the lines that matched. Query uses LanceDB's vector search, with the returned distance turned into a similarity score.
 
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
+## Want it production-ready, not DIY?
+
+[**CocoIndex Code**](https://github.com/cocoindex-io/cocoindex-code) is this exact pipeline — AST-aware chunking, incremental re-index, local embeddings — hardened and packaged as a CLI and an MCP server you can plug straight into a coding or code-review agent.
 
 ```sh
-cp .env.example .env
+npx skills add cocoindex-io/cocoindex-code     # Claude Code skill, then /ccc
+claude mcp add cocoindex-code -- ccc mcp        # MCP: Codex, OpenCode, Cursor, any client
+ccc index && ccc search "where we embed chunks" # CLI
 ```
 
-LanceDB is an embedded local store, so there are no required secrets — the file documents the optional `LANCEDB_URI` override.
+---
+
+<p align="center">
+  If this made your agents smarter, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/index-codebase/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/code_embedding_lancedb" alt="" width="1" height="1" />

--- a/examples/conversation_to_knowledge/.env.example
+++ b/examples/conversation_to_knowledge/.env.example
@@ -16,5 +16,5 @@ SURREALDB_PASS=root
 INPUT_DIR=./input
 
 # Models (optional, shown with defaults)
-LLM_MODEL=openai/gpt-5.4
+LLM_MODEL=openai/gpt-5-mini
 RESOLUTION_LLM_MODEL=openai/gpt-5-mini

--- a/examples/conversation_to_knowledge/README.md
+++ b/examples/conversation_to_knowledge/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://cocoindex.io/docs/examples/podcast-to-knowledge-graph/" title="Turn podcasts into a knowledge graph with LLM and CocoIndex — transcription, LLM extraction, entity resolution, and a SurrealDB graph">
-    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/cover.png" alt="Turn podcasts into a knowledge graph with LLM and CocoIndex — podcast episodes transcribed, extracted, and resolved into a graph of people, statements, technologies, and organizations" width="100%" draggable="false"/>
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/cover.svg" alt="Turn podcasts into a knowledge graph with LLM and CocoIndex — podcast episodes transcribed, extracted, and resolved into a graph of people, statements, technologies, and organizations" width="100%" draggable="false"/>
   </a>
 </p>
 
@@ -33,10 +33,6 @@ You declare the graph in native Python and your own types — `target_state = tr
 ## How it works
 
 Read YouTube URLs → fetch & transcribe (yt-dlp + AssemblyAI diarization) → extract speakers, statements, and mentioned entities with an LLM → resolve duplicate people/techs/orgs with embeddings + LLM → declare nodes and relationships into SurrealDB.
-
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/pipeline-overview.png" alt="Pipeline: YouTube URLs → Phase 1 per-session processing (fetch transcript, identify speakers with LLM, extract statements with LLM) → Phase 2 entity resolution (embedding similarity + LLM confirmation) → Phase 3 knowledge base creation (canonical entities, relationships) → SurrealDB knowledge graph" width="100%"/>
-</p>
 
 The whole graph is declared as **target states** — read it in [`conv_knowledge/app.py`](conv_knowledge/app.py):
 
@@ -102,7 +98,7 @@ export SURREALDB_DB="yt_conversations"
 export SURREALDB_USER="root"
 export SURREALDB_PASS="root"
 export INPUT_DIR="./input"
-export LLM_MODEL="openai/gpt-5.4"
+export LLM_MODEL="openai/gpt-5-mini"
 export RESOLUTION_LLM_MODEL="openai/gpt-5-mini"
 ```
 
@@ -137,15 +133,7 @@ SELECT name,
 FROM tech ORDER BY person_count DESC LIMIT 10;
 ```
 
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/surreal_top_mentioned_tech.png" alt="Surrealist query results: technologies ranked by how many distinct people mentioned them — artificial intelligence, language model, machine learning, AI agent, and more" width="85%"/>
-</p>
-
-The graph is small and expressive — `session`, `statement`, `person`, `tech`, `org` nodes, joined by `session_statement`, `person_session`, `person_statement`, and the polymorphic `statement_mentions`:
-
-<p align="center">
-  <img src="https://cocoindex.io/blobs/docs-v1/img/examples/podcast-to-knowledge-graph/schema.png" alt="Knowledge graph schema: session, statement, person, tech, and org nodes connected by session_statement, person_session, person_statement, and statement_mentions relationships" width="80%"/>
-</p>
+The graph is small and expressive — `session`, `statement`, `person`, `tech`, `org` nodes, joined by `session_statement`, `person_session`, `person_statement`, and the polymorphic `statement_mentions`.
 
 ## More graph examples
 
@@ -157,3 +145,5 @@ Building graphs from other sources? See [meeting notes → Neo4j](https://github
   If this turned hours of podcasts into something you can actually query, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
   <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/podcast-to-knowledge-graph/">Tutorial</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
 </p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/conversation_to_knowledge" alt="" width="1" height="1" />

--- a/examples/conversation_to_knowledge/conv_knowledge/app.py
+++ b/examples/conversation_to_knowledge/conv_knowledge/app.py
@@ -102,7 +102,7 @@ async def coco_lifespan(
     )
     builder.provide(
         LLM_MODEL,
-        os.environ.get("LLM_MODEL", "openai/gpt-5.4"),
+        os.environ.get("LLM_MODEL", "openai/gpt-5-mini"),
     )
     builder.provide(
         RESOLUTION_LLM_MODEL,

--- a/examples/conversation_to_knowledge/design.md
+++ b/examples/conversation_to_knowledge/design.md
@@ -10,7 +10,7 @@ Convert podcast sessions (from YouTube) into a structured knowledge graph stored
 |---------|--------|-----------|
 | Audio download | `yt-dlp` | Standard, reliable YouTube downloader |
 | Transcription + diarization | AssemblyAI | Single API call gives speaker-labeled transcript with utterances. No file size / duration limits. No GPU needed |
-| LLM (extraction) | `instructor` + `litellm` → **`openai/gpt-5.4`** (configurable via `LLM_MODEL` in `.env`) | Strong model for structured extraction from transcripts |
+| LLM (extraction) | `instructor` + `litellm` → **`openai/gpt-5-mini`** (configurable via `LLM_MODEL` in `.env`) | Strong model for structured extraction from transcripts |
 | LLM (entity resolution) | `instructor` + `litellm` → **`openai/gpt-5-mini`** (configurable via `RESOLUTION_LLM_MODEL` in `.env`) | Lighter model sufficient for simple entity deduplication decisions |
 | Embedding (entity resolution) | `sentence-transformers/all-MiniLM-L6-v2` | Fast, good for short entity name similarity |
 | In-memory vector search | `faiss-cpu` (`IndexFlatIP`) | SIMD-optimized exact search with incremental `add()`; no GPU needed |
@@ -566,7 +566,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
     ))
     builder.provide(EMBEDDER, SentenceTransformerEmbedder(
         "sentence-transformers/all-MiniLM-L6-v2"))
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     builder.provide(RESOLUTION_LLM_MODEL, os.environ.get("RESOLUTION_LLM_MODEL", "openai/gpt-5-mini"))
     yield
 ```
@@ -581,7 +581,7 @@ SURREALDB_URL=ws://localhost:8000/rpc
 # Optional (with defaults)
 SURREALDB_USER=root
 SURREALDB_PASS=root
-LLM_MODEL=openai/gpt-5.4
+LLM_MODEL=openai/gpt-5-mini
 RESOLUTION_LLM_MODEL=openai/gpt-5-mini
 ```
 

--- a/examples/csv_to_kafka/README.md
+++ b/examples/csv_to_kafka/README.md
@@ -1,32 +1,122 @@
-# CSV to Kafka
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/csv-to-kafka/" title="Watch a folder of CSV files and publish each row as a JSON message to a Kafka topic with CocoIndex — only-changed-rows, live, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/csv-to-kafka/cover.svg" alt="Watch a folder of CSV files and turn it into a live Kafka stream with CocoIndex — each row published as a JSON message keyed by its primary key, with a message produced only for rows that actually changed" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example watches local CSV files, converts each row to a JSON object (using the header row as keys), and publishes messages to a Kafka topic. When a CSV file is modified, only the changed rows are re-published.
+<h1 align="center">Stream a folder of CSVs to <em>Kafka</em>, row by row.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Each row published as a JSON message keyed by its primary key — edit one cell and exactly <em>one</em> message lands on the topic, within a second — in plain async Python.</b><br/>
+  Declare the topic as a target state; CocoIndex produces the upserts and deletes, never the no-ops.
+</p>
 
-- A running Kafka broker (default: `localhost:9092`)
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/csv-to-kafka/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Configuration
+<div align="center">
 
-Edit `.env` to set your Kafka connection:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
+</div>
+
+<br/>
+
+CSV is the format that shows up everywhere and gets respect nowhere — BI exports, vendor dumps, spreadsheets parked in a shared drive, dropped into a folder and edited at random with no schema contract. This pipeline turns a directory of them into a clean, row-keyed, diff-only [Kafka](https://kafka.apache.org/) stream. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the Rust engine does the [incremental processing](https://cocoindex.io/docs/programming_guide/core_concepts/) underneath: it tracks what each row last looked like and produces a message only for rows that *actually changed* — no producer loop, no dedup bookkeeping.
+
+## How it works
+
+The Kafka topic is just a [target](https://cocoindex.io/docs/connectors/kafka/) you declare on, the same way you'd declare a Postgres table. `process_csv` runs once per file: parse rows with `csv.DictReader`, then declare each row as a target state — key from the first column, value the JSON-encoded row. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn(memo=True)
+async def process_csv(file: FileLike, topic_target: kafka.KafkaTopicTarget) -> None:
+    reader = csv.DictReader(io.StringIO(await file.read_text()))
+    headers = reader.fieldnames
+    if not headers:
+        return
+    first_col = headers[0]
+    for row in reader:
+        key_value = row.get(first_col)
+        if key_value is not None:
+            topic_target.declare_target_state(key=key_value, value=json.dumps(row))
+
+@coco.fn
+async def app_main() -> None:
+    topic_target = await kafka.mount_kafka_topic_target(KAFKA_PRODUCER, KAFKA_TOPIC)
+    files = localfs.walk_dir(
+        localfs.FilePath(path="./data"),
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.csv"]),
+        live=True,  # watch for changes; pass -L to `cocoindex update` to run live
+    )
+    await coco.mount_each(process_csv, files.items(), topic_target)
 ```
-KAFKA_BOOTSTRAP_SERVERS=localhost:9092
-KAFKA_TOPIC=csv-rows
-```
 
-## Run
+The one line worth pausing on is `declare_target_state` — deliberately *not* `produce()`. You describe what the topic *should be* as a function of the source; CocoIndex turns the state transitions into wire messages. A new or changed key produces an upsert `(k, v)`; a key that's no longer declared produces a delete `(k, None)`; a key declared with the same value sends **nothing**.
 
-Install deps:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/csv-to-kafka/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the producer lifespan, the state-vs-messages model, live mode, and exactly which messages each change produces.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Declare states, not messages.** A topic is a log of events; you only ever talk about row states. CocoIndex owns the gap — it produces the upserts and deletes a hand-rolled producer would, and skips the no-ops.
+- **Live mode is one keyword + one flag.** `live=True` on `walk_dir` and `-L` on the CLI is the entire difference between a catch-up run and a streaming one — `process_csv` and the target don't change. No separate "streaming" code path.
+- **Survives restarts.** An [internal state store](https://cocoindex.io/docs/advanced_topics/internal_storage/) remembers the last value sent for every key, so stopping and restarting never re-broadcasts unchanged rows.
+- **User-managed topic.** CocoIndex never creates or deletes topics — it produces into one you already own, so it slots into existing Kafka ops.
+- **Managed broker ready.** A SASL block in the lifespan covers managed brokers (StreamNative and similar); drop it for a local broker.
+
+## Run it
+
+> Needs a running Kafka broker. CocoIndex never creates topics — you create the one it produces into.
+
+**1. Start a broker & create the topic** — a single-container [Redpanda](https://redpanda.com/) (Kafka-API compatible) is the quickest local broker:
 
 ```sh
+docker run -d --name redpanda -p 9092:9092 redpandadata/redpanda:latest \
+  redpanda start --mode dev-container --smp 1 \
+  --kafka-addr PLAINTEXT://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://localhost:9092
+
+docker exec redpanda rpk topic create cocoindex-csv-rows
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set KAFKA_BOOTSTRAP_SERVERS / KAFKA_TOPIC (+ SASL creds for a managed broker)
 pip install -e .
 ```
 
-Run the pipeline in live mode so changes to CSV files are picked up automatically:
+**3. Run the pipeline** — the example ships a `data/` folder of sample CSVs. Choose catch-up (scan, sync, exit) or live (catch up, then keep watching `./data`):
 
 ```sh
+# Catch-up run: reconcile the topic up to now, then exit
+cocoindex update main.py
+
+# Live run: catch up, then produce on every change
 cocoindex update -L main.py
 ```
 
-Each row is published as a JSON message with key `{filename}/{first_column_value}`. For example, a row in `products.csv` with SKU `SKU001` gets key `products.csv/SKU001`.
+**4. Look at the topic** — keys are each row's first column, values the JSON-encoded rows:
+
+```sh
+docker exec redpanda rpk topic consume cocoindex-csv-rows --num 10
+```
+
+Edit a cell in `data/products.csv` while live mode runs, and a new message with the *same key* appears within a second. The consumer side — [kafka_to_lancedb](https://github.com/cocoindex-io/cocoindex/tree/main/examples/kafka_to_lancedb) — reads these messages back off the topic and dispatches them into LanceDB tables.
+
+---
+
+<p align="center">
+  If this got your CSVs onto a topic, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/csv-to-kafka/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/csv_to_kafka" alt="" width="1" height="1" />

--- a/examples/docs_to_knowledge_graph/.env.example
+++ b/examples/docs_to_knowledge_graph/.env.example
@@ -14,6 +14,6 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=cocoindex
 NEO4J_DATABASE=neo4j
 
-# LLM model (LiteLLM-prefixed; e.g. openai/gpt-5.4, anthropic/claude-...,
+# LLM model (LiteLLM-prefixed; e.g. openai/gpt-5-mini, anthropic/claude-...,
 # gemini/..., or ollama/llama3.2 to run locally with no API key).
-LLM_MODEL=openai/gpt-5.4
+LLM_MODEL=openai/gpt-5-mini

--- a/examples/docs_to_knowledge_graph/README.md
+++ b/examples/docs_to_knowledge_graph/README.md
@@ -1,119 +1,126 @@
-# Build a Knowledge Graph for Docs — Neo4j (CocoIndex v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/docs-to-knowledge-graph/" title="Turn a folder of Markdown docs into a concept knowledge graph with CocoIndex and Neo4j — LLM triple extraction, incremental, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/cover.svg" alt="Turn a folder of Markdown docs into a concept knowledge graph with CocoIndex and Neo4j — an LLM extracts (subject, predicate, object) triples per document, and the deduplicated Entity nodes plus RELATIONSHIP / MENTION edges become a graph you query in Cypher" width="100%" draggable="false"/>
+  </a>
+</p>
 
-Turn a folder of Markdown documentation into a concept knowledge graph in
-[Neo4j](https://neo4j.com/). For each document an LLM (via
-[LiteLLM](https://docs.litellm.ai/) + [instructor](https://python.useinstructor.com/))
-produces a short summary and a set of `(subject, predicate, object)` triples
-about the concepts it covers — "concepts, not code" — and the triples become a
-property graph.
+<h1 align="center">Turn a folder of docs into a <em>concept</em> knowledge graph.</h1>
 
-This is the CocoIndex **v1** port of the blog post
-[Build a Knowledge Graph for Documents](https://cocoindex.io/blogs/knowledge-graph-for-docs/).
+<p align="center">
+  <b>An LLM reads each Markdown doc and emits <em>(subject, predicate, object)</em> triples; the shared concept nodes and predicate edges become a graph you query in Cypher — in plain async Python.</b><br/>
+  Point it at a docs folder, and it re-extracts only the doc you edited, then reconciles the graph.
+</p>
 
-Please drop [CocoIndex on Github](https://github.com/cocoindex-io/cocoindex) a
-star to support us and stay tuned for more updates. Thank you so much 🥥🤗.
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/docs-to-knowledge-graph/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## What this builds
+<div align="center">
 
-- `Document` nodes — one per Markdown file, keyed by filename, with an
-  LLM-generated `title` and `summary`
-- `Entity` nodes — one per distinct concept named in a triple, keyed by `value`
-- Relationships:
-  - `RELATIONSHIP` — `Entity → Entity`, with the `predicate` stored on the edge
-  - `MENTION` — `Document → Entity`, recording which document named which concept
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-The flow watches the source folder and keeps the graph up to date
-incrementally.
+</div>
+
+<br/>
+
+Documentation is a web of concepts pretending to be a list of files — "incremental processing relies on change detection", "a target receives declared target states" — every page asserts relationships, but they're locked in prose. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed graph targets) runs in a Rust engine underneath, so editing one doc re-extracts one doc, and the graph reconciles itself: no orphaned nodes, no stale edges, no cleanup scripts.
 
 ## How it works
 
-The pipeline runs in two phases:
+Two node types, two relationship types, and the concept map falls out of the graph:
 
-1. **Per-file extraction.** Read each Markdown file, extract a `DocumentSummary`
-   (title + summary) and a list of relationship triples with LiteLLM +
-   instructor. The `Document` node is declared in this phase; the triples are
-   carried forward.
-2. **Graph building.** A single pass declares the deduplicated `Entity` nodes
-   and the `RELATIONSHIP` / `MENTION` edges across all documents. Each distinct
-   triple is keyed by a stable hash, so re-asserting the same fact in another
-   doc maps to the same edge.
+- **`Document`** nodes — one per Markdown file, keyed by filename, with an LLM-generated `title` and `summary`.
+- **`Entity`** nodes — one per distinct concept named in any triple, keyed by the concept name and **shared** across documents.
+- **`RELATIONSHIP`** edges — `Entity → Entity`, with the `predicate` stored as an edge property.
+- **`MENTION`** edges — `Document → Entity`, recording which document named which concept.
 
-CocoIndex reconciles changes incrementally — re-running after editing one doc
-only re-extracts that doc, and the graph pass only re-runs when the set of
-triples changes. To collapse near-identical entity names (e.g. "CocoIndex" vs
-"Cocoindex"), add an entity-resolution pass like the one in
-[`meeting_notes_graph_neo4j`](../meeting_notes_graph_neo4j).
+Because entities are shared across documents, the pipeline runs in two phases — read it top-to-bottom in [`main.py`](main.py):
 
-## Prerequisites
+```python
+@coco.fn(memo=True)  # Phase 1 — per doc: declare the Document node, carry triples forward
+async def process_file(file: localfs.File, document_table: neo4j.TableTarget[Document]) -> DocTriples:
+    content = await file.read_text()
+    filename = file.file_path.path.as_posix()
+    summary = await extract_summary(content)
+    document_table.declare_record(row=Document(filename=filename, title=summary.title, summary=summary.summary))
+    triples = await extract_relationships(content)
+    return DocTriples(filename=filename, triples=triples)
 
-- A running Neo4j 5.18+ instance:
-  ```sh
-  docker run -d \
-    -p 7474:7474 -p 7687:7687 \
-    -e NEO4J_AUTH=neo4j/cocoindex \
-    --name cocoindex-neo4j \
-    neo4j:5.26-community
-  ```
-  The browser UI is at <http://localhost:7474>; log in with `neo4j` /
-  `cocoindex`.
-
-- An LLM. Defaults to OpenAI (set `OPENAI_API_KEY`); set `LLM_MODEL` to any
-  [LiteLLM provider](https://docs.litellm.ai/docs/providers) — e.g.
-  `LLM_MODEL=ollama/llama3.2` to run the extraction locally with no API key.
-
-## Environment
-
-Copy `.env.example` to `.env` and fill in the blanks:
-
-```sh
-cp .env.example .env
-set -a && source .env && set +a
+@coco.fn              # Phase 2 — one pass owns the shared Entity nodes + both edge types
+async def build_graph(docs, entity_table, relationship_rel, mention_rel) -> None:
+    for doc in docs:
+        for t in doc.triples:
+            rel_id = await generate_id((t.subject, t.predicate, t.object))   # stable edge identity
+            relationship_rel.declare_relation(from_id=t.subject, to_id=t.object,
+                                              record=Relationship(id=rel_id, predicate=t.predicate))
+            mention_rel.declare_relation(from_id=doc.filename, to_id=t.subject)
+            ...
+    for value in entities:  entity_table.declare_record(row=Entity(value=value))
 ```
 
-## Run
+Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/) with your own Pydantic models; `MENTION` carries no payload, so the Neo4j connector derives its identity from the `(document, entity)` endpoints — one edge per pair.
 
-Install dependencies:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/docs-to-knowledge-graph/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the graph schema, the two-phase flow, the extraction models, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Shared nodes, done right.** Concepts are deduplicated and owned by a single graph pass, so `Incremental Processing` is one `Entity` node every doc can point at — not a copy per doc.
+- **Incremental by default.** `@coco.fn(memo=True)` caches each LLM extraction by content; edit one doc and only that doc re-extracts, then the graph diffs — adding new nodes/edges and removing ones no longer supported anywhere. A no-change re-run makes zero LLM calls.
+- **Stable edge identity.** `generate_id` hashes each triple, so the same `(subject, predicate, object)` always maps to one edge — re-asserting a fact in another doc is a no-op, not a duplicate.
+- **Plain Python, your stack.** Swap `LLM_MODEL` for any [LiteLLM provider](https://docs.litellm.ai/docs/providers) (OpenAI, Ollama, …). No DSL.
+- **Honest cache busting.** `LLM_MODEL` is declared with `detect_change=True`, so swapping the model re-extracts the whole corpus against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start Neo4j:**
 
 ```sh
-uv pip install -e .
+docker run -d -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/cocoindex --name cocoindex-neo4j neo4j:5.26-community
 ```
 
-This example ships a small `markdown_files/` folder of sample concept docs so it
-runs out of the box. Build/update the graph:
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set OPENAI_API_KEY (or LLM_MODEL=ollama/llama3.2 to run locally)
+pip install -e .
+```
+
+**3. Build the graph** — the example ships a `markdown_files/` folder of sample docs so it runs out of the box:
 
 ```sh
 cocoindex update main
 ```
 
-To index your own docs, drop `.md` / `.mdx` files into `markdown_files/` (or
-point `sourcedir` in `main.py` at another directory — e.g. CocoIndex's own
-`docs/`) and re-run.
+To graph your own docs, drop `.md` / `.mdx` files into `markdown_files/` (or point `sourcedir` at your real docs folder) and re-run.
 
-## Browse the knowledge graph
-
-Open Neo4j Browser at <http://localhost:7474>, log in, and run Cypher queries:
+**4. Explore the graph** — open [Neo4j Browser](http://localhost:7474) (`neo4j` / `cocoindex`) and ask:
 
 ```cypher
-// Everything
-MATCH p=()-->() RETURN p LIMIT 200
-
-// Concept-to-concept relationships
+-- How concepts relate
 MATCH (a:Entity)-[r:RELATIONSHIP]->(b:Entity)
 RETURN a.value, r.predicate, b.value
 
-// Which documents mention which concepts
-MATCH (d:Document)-[:MENTION]->(e:Entity)
-RETURN d.filename, d.title, e.value
-
-// Concepts mentioned in the most documents
+-- Concepts mentioned in the most documents
 MATCH (d:Document)-[:MENTION]->(e:Entity)
 RETURN e.value, count(DISTINCT d) AS docs
 ORDER BY docs DESC LIMIT 10
 ```
 
-To wipe the graph between runs:
+The LLM will sometimes name the same concept two ways ("CocoIndex" vs "Cocoindex"). The [meeting notes graph example](https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph_neo4j) adds an embedding + LLM entity-resolution pass that collapses near-duplicates — it drops into this pipeline between the two phases.
 
-```cypher
-MATCH (n) DETACH DELETE n
-```
+---
+
+<p align="center">
+  If this turned your docs into a graph, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/docs-to-knowledge-graph/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/docs_to_knowledge_graph" alt="" width="1" height="1" />

--- a/examples/docs_to_knowledge_graph/main.py
+++ b/examples/docs_to_knowledge_graph/main.py
@@ -76,7 +76,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
     )
     # LiteLLM-prefixed model id. Defaults to OpenAI; set LLM_MODEL=ollama/llama3.2
     # (or any LiteLLM provider) to run the extraction locally.
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     yield
 
 

--- a/examples/entire_session_search/README.md
+++ b/examples/entire_session_search/README.md
@@ -1,105 +1,125 @@
-# Entire Session Search
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/entire-session-search/" title="Semantic search over AI coding sessions captured by Entire with CocoIndex — embed transcripts, prompts, and context into Postgres pgvector, incrementally, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/cover.svg" alt="Search your AI coding sessions with CocoIndex — walk a folder of Entire checkpoints, route each file by name, embed transcripts, prompts, and context summaries with sentence-transformers, and store the vectors in Postgres pgvector alongside a metadata table" width="100%" draggable="false"/>
+  </a>
+</p>
 
-Semantic search over AI coding sessions captured by [Entire](https://entire.io), powered by CocoIndex.
+<h1 align="center">Search your <em>AI coding sessions</em> in plain English.</h1>
 
-## What it does
+<p align="center">
+  <b>Walk a folder of <a href="https://entire.io">Entire</a> checkpoints, <em>route</em> each file by name, and <em>embed</em> transcripts, prompts, and context into Postgres pgvector.</b><br/>
+  "How did I fix the auth bug" finds the right session even with zero shared keywords — in plain async Python.
+</p>
 
-- Reads Entire checkpoint data (transcripts, prompts, context summaries, metadata)
-- Chunks and embeds text with SentenceTransformers, stores in Postgres with pgvector
-- Provides cosine-similarity search across all your AI coding sessions
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/entire-session-search/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-Because CocoIndex is incremental, re-running after new sessions only processes what changed.
+<div align="center">
 
-## Prerequisites
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-- Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+</div>
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+<br/>
 
-- [Entire](https://entire.io) installed with some captured sessions
-- Python 3.11+
+[Entire](https://entire.io) captures every AI coding session you run — the full transcript, the prompt you started from, an AI-written context summary, and metadata like token counts and files touched — as checkpoints on disk. This pipeline turns that folder into a [vector index](https://github.com/pgvector/pgvector) you can search in plain English. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so each new session you capture only embeds what changed.
 
-## Setup
+## How it works
 
-**1. Check out the Entire checkpoint data:**
+A checkpoint folder holds four file types, and `process_file` routes on the name: `full.jsonl` is parsed into per-turn transcript chunks, `prompt.txt` is embedded whole, `context.md` is split into overlapping chunks, and `metadata.json` becomes a structured row in a *second* table. The transcript and context paths fan out to many rows via `coco.map(process_chunk, ...)`; the prompt is a single short string embedded inline. Read it in [`main.py`](main.py):
 
-```sh
-# From any repo where Entire is capturing sessions
-git worktree add entire_checkpoints entire/checkpoints/v1
+```python
+@coco.fn(memo=True)
+async def process_file(file, emb_table, meta_table) -> None:
+    info = extract_session_info(file)
+    filename = file.file_path.path.name
+    id_gen = IdGenerator()
+
+    if filename == "full.jsonl":
+        chunks = parse_transcript(await file.read_text())
+        await coco.map(process_chunk,
+            [ChunkInput(text=c.text, content_type="transcript", role=c.role) for c in chunks],
+            info, id_gen, emb_table)
+
+    elif filename == "prompt.txt":
+        text = (await file.read_text()).strip()
+        if text:
+            emb_table.declare_row(row=SessionEmbeddingRow(
+                id=await id_gen.next_id(text), ..., content_type="prompt", role="user",
+                text=text, embedding=await coco.use_context(EMBEDDER).embed(text)))
+
+    elif filename == "context.md":
+        ...   # split into chunks, then coco.map(process_chunk, ..., content_type="context")
+
+    elif filename == "metadata.json":
+        meta = json.loads(await file.read_text())
+        meta_table.declare_row(row=SessionMetadataRow(..., total_tokens=..., files_touched=...))
 ```
 
-**2. Install deps:**
+Three content types and a structured record, all from one component. Each embedding row's `id` is derived from its text, so a turn that survives a re-parse keeps its row.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/entire-session-search/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the two row shapes, the per-filename routing, the chunk fan-out, and the query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **One component, four file types.** A single `included_patterns` list pulls `full.jsonl`, `prompt.txt`, `context.md`, and `metadata.json` into the same `process_file`, which routes on the name — no four separate pipelines.
+- **Two tables, one pass.** Searchable text lands in the embeddings table; structured fields (tokens, files touched, agent percentage) land in a metadata table — declared side by side.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a file whose content and code are unchanged, so a finished session is never re-embedded; `id` derived from text means only genuinely new turns are inserted and vanished turns are deleted.
+- **Live without re-scanning.** The filesystem source declares `live=True` — pass `-L` and new sessions are picked up and embedded as they're written.
+- **Plain Python, your stack.** Local `all-MiniLM-L6-v2` embedder, no API key; swap `EMBED_MODEL` for any of the 12k+ sentence-transformer models on Hugging Face.
+
+## Run it
+
+**1. Start Postgres + pgvector** (the repo ships a compose file):
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set POSTGRES_URL (schema/table names are optional overrides)
 pip install -e .
 ```
 
-**3. Set env vars (or edit `.env`):**
+**3. Check out some checkpoints** — from any repo where [Entire](https://entire.io) is capturing sessions:
 
 ```sh
-# .env
-COCOINDEX_DB=./cocoindex.db
-POSTGRES_URL=postgres://cocoindex:cocoindex@localhost/cocoindex
+git worktree add entire_checkpoints entire/checkpoints/v1
 ```
 
-## Run
+Each session is laid out as `<checkpoint_id[:2]>/<checkpoint_id[2:]>/<session_idx>/` with `full.jsonl`, `prompt.txt`, `context.md`, and `metadata.json`.
 
-Build/update the index (writes rows into Postgres). Pick one of the two modes:
+**4. Build the index** — catch-up (scan, sync, exit) or live (catch up, then keep watching for new sessions):
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main        # catch-up
+cocoindex update -L main     # live
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**5. Search from the command line:**
 
 ```sh
 python main.py "how did I fix the auth bug"
 ```
 
-## Configuration
+Results print which session and content type matched, so a transcript turn, a prompt, and a context chunk are all distinguishable. This example keeps it minimal and doesn't declare a vector index, so queries do a sequential scan — fine for a personal history. For a larger corpus, add `emb_table.declare_vector_index(column="embedding")` exactly as [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) does.
 
-| Variable | Default | Description |
-|---|---|---|
-| `COCOINDEX_DB` | `./cocoindex.db` | SQLite path for CocoIndex internal state |
-| `POSTGRES_URL` | `postgres://cocoindex:cocoindex@localhost/cocoindex` | Postgres connection for embedding/metadata tables |
-| `TABLE_EMBEDDINGS` | `session_embeddings` | Embeddings table name |
-| `TABLE_METADATA` | `session_metadata` | Metadata table name |
-| `PG_SCHEMA_NAME` | `entire` | Postgres schema |
+---
 
-## How it works
+<p align="center">
+  If this made your coding history searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/entire-session-search/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-```mermaid
-graph TD
-    checkpoints[Entire Checkpoints] --> walk[walk_dir]
-    walk --> mount_each[mount_each]
-    mount_each --> process_file[<b>process_file</b>]
-    process_file -->|full.jsonl| parse[parse_transcript]
-    process_file -->|prompt.txt| embed_prompt[embed directly]
-    process_file -->|context.md| split[RecursiveSplitter]
-    process_file -->|metadata.json| meta_table[(session_metadata)]
-    parse --> embed[SentenceTransformer]
-    embed_prompt --> embed
-    split --> embed
-    embed --> emb_table[(session_embeddings)]
-```
-
-## Entire checkpoint layout
-
-```
-<checkpoint_id[:2]>/<checkpoint_id[2:]>/<session_idx>/
-  ├── metadata.json     # token counts, files touched, timestamps (note: if one prompt spans multiple commits, each gets its own checkpoint with the same token data; don't sum across checkpoints)
-  ├── full.jsonl        # conversation transcript
-  ├── prompt.txt        # user's initial prompt
-  ├── context.md        # AI-generated session summary
-  └── content_hash.txt  # content fingerprint (skipped)
-```
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/entire_session_search" alt="" width="1" height="1" />

--- a/examples/face_recognition/README.md
+++ b/examples/face_recognition/README.md
@@ -1,0 +1,117 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/face-recognition/" title="Build your own photo face search with CocoIndex — detect every face, embed with face_recognition (dlib), index in Qdrant, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/face-recognition/cover.svg" alt="Build your own photo face search with CocoIndex — detect every face in a folder of photos, embed each into a 128-d vector with face_recognition (dlib), and index them in Qdrant so a query face finds the same person across photos" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Search your photos <em>by face</em>.</h1>
+
+<p align="center">
+  <b>Detect every face in a folder of photos, embed each into a 128-d vector with <code>face_recognition</code> (dlib), and index them in Qdrant — then a query face finds the same person across photos.</b><br/>
+  The core of "find every photo of this person," with no labels or tags — in plain async Python.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/face-recognition/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+A folder of group photos has every person hiding in plain sight — the same face shows up across shots, but that knowledge is locked in pixels. This pipeline makes it searchable: detect every face, crop it, embed it into a 128-d vector with [`face_recognition`](https://github.com/ageitgey/face_recognition) (dlib), and index the faces in [Qdrant](https://qdrant.tech/). You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — while incremental processing, change tracking, and the managed Qdrant collection run in a Rust engine underneath, and the slow detection/embedding steps run on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/) instead of blocking the event loop.
+
+## How it works
+
+Unlike a one-embedding-per-image index, an image here fans out to **many** faces — so the shape is *image → N faces → N points*:
+
+- **Walk** a local image folder (live), matching `.jpg` / `.jpeg` / `.png`.
+- **Detect** every face in each image (CNN detector, downscaling large images first), and crop it.
+- **Embed** each face into a 128-d vector and store one Qdrant point per face, keyed by `(filename, bounding box)`, with the source filename and box in the payload.
+
+The dlib calls are synchronous and CPU/GPU-heavy, so each is wrapped with `@coco.fn.as_async(runner=coco.GPU)`. `process_file` detects a photo's faces, then maps each through `process_face` with [`coco.map`](https://cocoindex.io/docs/programming_guide/app/). Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_face(face: Face, filename: str, target: qdrant.CollectionTarget) -> None:
+    embedding = await embed_face(face.image)
+    target.declare_point(
+        qdrant.PointStruct(
+            id=_face_id(filename, face.rect),     # uuid5 of (filename, box) — stable
+            vector=embedding,
+            payload={"filename": filename, "min_x": face.rect.min_x, "min_y": face.rect.min_y,
+                     "max_x": face.rect.max_x, "max_y": face.rect.max_y},
+        )
+    )
+
+@coco.fn(memo=True)   # unchanged photo is never re-detected
+async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
+    faces = await extract_faces(await file.read())
+    await coco.map(process_face, faces, str(file.file_path.path), target)
+```
+
+The collection is sized to the 128-d face vector with **Euclidean** distance — dlib's own rule of thumb is that a distance under ~0.6 means "same person."
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/face-recognition/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with face detection and embedding, the image → faces fan-out, the Euclidean Qdrant collection, and searching by face.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Image → many faces.** Each photo fans out to one Qdrant point per detected face with `coco.map` — the multi-face equivalent of chunking a document.
+- **Recognition without labels.** dlib's 128-d encodings put the same person close together; a Euclidean search under ~0.6 means "same person," with no tags or training.
+- **The box travels with the match.** Each point's payload carries the bounding box, so a search hit tells you *where* in the source image the face is.
+- **Incremental & self-cleaning.** `@coco.fn(memo=True)` skips unchanged photos; each image is its own processing component, so deleting a photo removes all its faces from Qdrant automatically.
+- **Heavy work off the event loop.** CNN detection and embedding run on a `coco.GPU` runner; large images are downscaled for detection, then boxes are mapped back to full size.
+
+## Run it
+
+> Needs **Qdrant** plus the `face_recognition` library (it depends on **dlib** — see its [install notes](https://github.com/ageitgey/face_recognition#installation) if the build needs CMake/boost).
+
+**1. Start Qdrant:**
+
+```sh
+docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # QDRANT_URL (defaults to the local container above)
+pip install -e .
+```
+
+**3. Build the index** — the example ships a handful of famous group photos in `images/` (the 1927 Solvay physics conference, Steve Jobs & Bill Gates, …):
+
+```sh
+cocoindex update main        # or: cocoindex update -L main   (keep watching the folder)
+```
+
+On the sample set this indexes **36 faces** — 29 from the Solvay conference alone — each a Qdrant point keyed by `(filename, bounding box)`.
+
+**4. Search by face** — embed a query face the same way and find the nearest indexed faces:
+
+```sh
+python main.py query images/einplanck3.jpg
+```
+
+Because Einstein appears in *both* the Einstein–Planck photo and the Solvay conference, the query pulls his Solvay face back as a close match — a Euclidean distance around `0.46`, comfortably under dlib's ~0.6 same-person threshold. That's face recognition across photos, with no labels or tags.
+
+---
+
+<p align="center">
+  If this made your photo library searchable by face, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/face-recognition/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/face_recognition" alt="" width="1" height="1" />

--- a/examples/files_transform/README.md
+++ b/examples/files_transform/README.md
@@ -1,34 +1,99 @@
-# Files Transform
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/files-transform/" title="The smallest end-to-end CocoIndex pipeline — watch a folder of Markdown, render each file to HTML with markdown-it-py, and write the outputs incrementally, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/cover.svg" alt="Transform a folder of files with CocoIndex — watch a directory of Markdown, render each file to HTML with markdown-it-py, and write the .html outputs to a local folder that stays in sync with the source" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example watches a directory of local Markdown files, converts each one to HTML using [markdown-it-py](https://github.com/executablebooks/markdown-it-py), and writes the resulting `.html` files to an output folder. It runs in live mode, so it continues watching for file changes after the initial sync.
+<h1 align="center">The smallest <em>source → transform → target</em> pipeline.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Watch a folder of Markdown, render each file to HTML with <em>markdown-it-py</em>, and write the <code>.html</code> outputs to a folder that stays in sync.</b><br/>
+  No database, no embeddings, no API keys — files in, files out, in plain async Python.
+</p>
 
-- Python 3.11+
-- No external services required.
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/files-transform/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Run
+<div align="center">
 
-Install deps:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Take a folder of Markdown files, render each one to HTML, and write the results to a second folder that stays in sync with the source. It's the smallest complete CocoIndex pipeline, and the cleanest way to see the **source → transform → target** shape that every larger example is built from. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, watching the directory, keeping the output folder in sync) runs in a Rust engine underneath, so only the files that actually changed get re-rendered.
+
+## How it works
+
+The whole pipeline is about 25 lines. `process_file` reads the Markdown, renders it to HTML, derives a flat output name from the source path, and declares the output file as a target state; `app_main` walks the source folder for `*.md` and mounts one component per file. Read all of [`main.py`](main.py):
+
+```python
+_markdown_it = MarkdownIt("gfm-like")
+
+@coco.fn(memo=True)
+async def process_file(file: FileLike, outdir: pathlib.Path) -> None:
+    html = _markdown_it.render(await file.read_text())
+    outname = "__".join(file.file_path.path.parts) + ".html"
+    localfs.declare_file(outdir / outname, html, create_parent_dirs=True)
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
+    files = localfs.walk_dir(
+        sourcedir,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live=True,
+    )
+    await coco.mount_each(process_file, files.items(), outdir)
+```
+
+The transform itself is just two lines: read the text, render it. The output name joins the source path parts with `__`, so `subdir/file.md` becomes `subdir__file.html` — a flat, collision-free name. `localfs.declare_file` describes the file you *want to exist*; CocoIndex writes it, overwrites it on change, and deletes it when the source Markdown is gone.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/files-transform/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the transform, the main function, the App, and how incremental updates work.
+</p>
+
+## Why it's worth a star ⭐
+
+- **The whole shape, minimized.** Source → transform → target in ~25 lines, no database or embeddings — once it clicks, every larger example reads the same way.
+- **Your transform is just a function.** `_markdown_it.render` is plain Python; swap it for any function and you have a different pipeline.
+- **Managed file targets.** `localfs.declare_file` handles writing, overwriting on change, and deleting the `.html` when the source `.md` disappears — you never write file I/O glue.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a file whose content and code are unchanged; add, edit, or delete one Markdown file and only that file's HTML moves.
+- **Live without re-scanning.** The filesystem source declares `live=True` — pass `-L` and it keeps watching the directory, applying each change with low latency.
+
+## Run it
+
+**1. Install** (no external services required):
 
 ```sh
 pip install -e .
 ```
 
-Place the Markdown files you want to transform in a `data/` directory (sample files are already included).
+**2. Add some Markdown** — the example ships a `data/` folder of sample files, or drop your own in. The `.env` sets `COCOINDEX_DB=./cocoindex.db` for internal state.
 
-Build/update the index (converts Markdown and writes HTML to `output_html/`). Pick one of the two modes:
+**3. Build the output folder** — catch-up (scan, sync, exit) or live (catch up, then keep watching):
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main        # catch-up
+cocoindex update -L main     # live: keep watching for file changes
+```
 
-  ```sh
-  cocoindex update main
-  ```
+The converted files appear in `./output_html/`, one `.html` per source `.md` (named by the source path parts joined with `__`, e.g. `subdir__file.html`).
 
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
+**4. Try incremental updates** — add, edit, or delete a `.md` in `data/` and re-run: only the changed file is re-rendered, and a removed source's `.html` is deleted automatically.
 
-  ```sh
-  cocoindex update -L main
-  ```
+---
 
-The converted `.html` files will appear in `./output_html/`, with each file named after the path parts of the original Markdown file joined by `__` (e.g. `subdir__file.html`).
+<p align="center">
+  If this clicked, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/files-transform/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/files_transform" alt="" width="1" height="1" />

--- a/examples/gdrive_text_embedding/README.md
+++ b/examples/gdrive_text_embedding/README.md
@@ -1,42 +1,108 @@
-# Google Drive Text Embedding (v1) 📄
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/google-drive-embedding/" title="Semantic search over a Google Drive folder with CocoIndex — read documents, chunk, embed, and store vectors in Postgres + pgvector, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/google-drive-embedding/cover.svg" alt="Semantic Search over Google Drive with CocoIndex — point at a Drive folder, export Docs/Sheets/Slides to text, chunk and embed every document locally, and store the vectors in Postgres with pgvector for natural-language search" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds text files from Google Drive, stores chunk embeddings in Postgres (pgvector), and includes a simple query demo.
+<h1 align="center">Semantic search over a <em>Google Drive</em> folder.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>The Semantic Search 101 pipeline with one thing swapped: it reads documents straight from a <em>Google Drive</em> folder instead of local disk.</b><br/>
+  Export Docs/Sheets/Slides to text, chunk, embed locally, store in Postgres + pgvector — incrementally — in plain async Python.
+</p>
 
-- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/google-drive-embedding/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+<div align="center">
 
-- A Google Cloud service account with Drive access
-- Environment variables:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-  ```sh
-  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-  export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL="/path/to/service-account.json"
-  export GOOGLE_DRIVE_ROOT_FOLDER_IDS="folder_id_1,folder_id_2"
-  ```
+</div>
 
-## Run
+<br/>
 
-Install deps:
+This is [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) with exactly one thing swapped: instead of reading Markdown off local disk, it reads documents straight from a Google Drive folder. Everything downstream — chunking, embedding, and storing the vectors in Postgres with pgvector — is identical. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so adding one document embeds one document, not the whole folder.
+
+## How it works
+
+The Drive source needs two things, both read from environment variables so nothing is hardcoded: a Google Cloud **service-account JSON key** with Drive access, and the **folder id(s)** to index. `GoogleDriveSource` walks each root folder recursively and yields one `DriveFile` per document; native Docs, Sheets, and Slides are exported to text, and any other file is downloaded as-is. From there a `DriveFile` behaves like any other `FileLike`, so the rest is the base example. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def app_main() -> None:
+    table = await postgres.mount_table_target(
+        PG_DB, table_name=TABLE_NAME,
+        table_schema=await postgres.TableSchema.from_class(DocEmbedding, primary_key=["id"]),
+        pg_schema_name=PG_SCHEMA_NAME,
+    )
+    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
+    root_folder_ids = [f.strip() for f in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",") if f.strip()]
+
+    source = google_drive.GoogleDriveSource(
+        service_account_credential_path=credential_path,
+        root_folder_ids=root_folder_ids,
+    )
+    await coco.mount_each(process_file, source.items(), table)
+```
+
+`source.items()` yields `(key, file)` pairs keyed by the file's name path — exactly what `mount_each` expects — so the engine tracks each Drive file as its own component and updates them independently. `mount_table_target` creates and manages the Postgres table: schema, idempotent upserts, and orphan cleanup when a file disappears from the folder.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/google-drive-embedding/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the Drive source, the service-account wiring, the Postgres target, and the catch-up run.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Drive as a first-class source.** `GoogleDriveSource.items()` drops into the same `mount_each` fan-out as a local folder — the source is a swappable detail, not a rewrite.
+- **Docs/Sheets/Slides handled.** Native Google formats are exported to text (Markdown, CSV, plain text); everything else downloads as-is, then `await file.read_text()` works just like a local file.
+- **Nothing hardcoded.** The service-account key path and folder id(s) come from environment variables, so forks and deployments configure their own.
+- **Incremental by default.** `@coco.fn(memo=True)` skips Drive files whose content and code are unchanged; each row's `id` is derived from its chunk text, so re-running upserts only changed rows and deletes rows whose source is gone.
+- **Managed Postgres target.** A single `mount_table_target` owns the schema, idempotent upserts, and orphan cleanup; the same local `all-MiniLM-L6-v2` embedder is reused at query time so indexing and search stay consistent.
+
+## Run it
+
+**1. Start Postgres + pgvector:**
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Set up Google Drive access** — create a Google Cloud service account with Drive access, then share the folder(s) you want to index with the service account's email.
+
+**3. Configure & install:**
+
+```sh
+cp .env.example .env     # set GOOGLE_SERVICE_ACCOUNT_CREDENTIAL (JSON key path) and GOOGLE_DRIVE_ROOT_FOLDER_IDS
 pip install -e .
 ```
 
-Build/update the index (one-shot catch-up; the google_drive source does not support live mode):
+**4. Build the index** — the `google_drive` source does not support live mode, so this is a one-shot catch-up run:
 
 ```sh
 cocoindex update main
 ```
 
-Query:
+**5. Search** — embeds your query with the *same* model and returns the nearest chunks by pgvector cosine distance:
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-Note: this example does not create a vector index; queries do a sequential scan.
+The most semantically similar chunks come back ranked — even when they share none of the words in your query. Re-run `cocoindex update main` to rescan the folders; the engine applies exactly the difference.
+
+---
+
+<p align="center">
+  If this made your Drive searchable by meaning, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/google-drive-embedding/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/gdrive_text_embedding" alt="" width="1" height="1" />

--- a/examples/hn_trending_topics/README.md
+++ b/examples/hn_trending_topics/README.md
@@ -1,51 +1,119 @@
-# HackerNews Trending Topics (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/hackernews-trending-topics/" title="Scrape HackerNews, LLM-extract topics, and rank what's trending with CocoIndex — Postgres, incremental, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/hackernews-trending-topics/cover.svg" alt="Rank what HackerNews is talking about with CocoIndex — fetch recent threads and comments from the Algolia HN API, an LLM pulls the topics out of every message, and a SQL score surfaces what's trending in Postgres" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<h1 align="center">What is HackerNews <em>talking about</em> right now?</h1>
 
-This example scrapes recent HackerNews threads (and their comments) via the [Algolia HN API](https://hn.algolia.com/api), uses an LLM to extract topics from each message, and stores everything in Postgres. A small CLI demo prints trending topics ranked by mention score and lets you search messages by topic.
+<p align="center">
+  <b>Scrape recent HN threads and comments from a live HTTP API, let an LLM pull the <em>topics</em> out of every message, and rank what's trending in Postgres — in plain async Python.</b><br/>
+  The source isn't a folder of files; it's a public API — so this doubles as a recipe for plugging any custom source into a pipeline.
+</p>
 
-## Prerequisites
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/hackernews-trending-topics/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-- A running Postgres. If you don't have one, start a local instance with the compose file in this repo:
+<div align="center">
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-- `POSTGRES_URL` set, e.g.
+</div>
 
-  ```sh
-  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-  ```
+<br/>
 
-- An API key for the LLM. The default model is `gemini/gemini-2.5-flash` (set `GEMINI_API_KEY`). Any provider supported by [litellm](https://docs.litellm.ai/docs/providers) works — change `LLM_MODEL` in `main.py` and set the matching credential.
+The tech community's attention is hiding in plain sight — scattered across story titles and thousands of comments. This pipeline fetches recent HackerNews threads on the fly with the [Algolia HN API](https://hn.algolia.com/api), asks an LLM to normalize each message into a list of topics, and writes messages and topics into two Postgres tables you can rank and search. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so re-running only does the work for content it hasn't seen.
 
-You can put these in a `.env` file in this directory; `python main.py` loads it automatically.
+## How it works
 
-## Run
+The data source is a custom one: two small `async` functions over the Algolia HN API fetch the recent story IDs and flatten each thread's comment tree — no special decorator, just plain HTTP. Then each thread becomes its own processing component:
 
-Install deps:
+- **`extract_topics`** — text in, a list of topics out, via [litellm](https://docs.litellm.ai/) with a strict Pydantic schema. The prompt in `TopicsResponse` does the heavy lifting: it normalizes phrases into separate topics, keeps proper nouns canonical (`PostgreSQL`, `Claude`), and emits aliases for the same thing (`JFK`, `John Kennedy`).
+- **`process_thread`** — fetches one story and its comments, extracts topics for each, and declares an `HnMessage` row plus one `HnTopic` row per topic.
+
+The same topic mentioned in many messages becomes many `HnTopic` rows keyed on `(topic, message_id)` — exactly what makes the trending ranking meaningful. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_thread(thread_id: str, targets: TableTargets) -> None:
+    async with aiohttp.ClientSession() as session:
+        thread = await fetch_thread(session, thread_id)
+    thread_topics = await extract_topics(thread.text)
+
+    targets.messages.declare_row(row=HnMessage(
+        id=thread.id, thread_id=thread.id, content_type="thread",
+        author=thread.author, text=thread.text, url=thread.url, created_at=thread.created_at,
+    ))
+    for topic in thread_topics:
+        targets.topics.declare_row(row=HnTopic(
+            topic=topic, message_id=thread.id, thread_id=thread.id,
+            content_type="thread", created_at=thread.created_at,
+        ))
+    for comment in thread.comments:
+        comment_topics = await extract_topics(comment.text)
+        targets.messages.declare_row(row=HnMessage(..., content_type="comment", ...))
+        for topic in comment_topics:
+            targets.topics.declare_row(row=HnTopic(..., content_type="comment", ...))
+```
+
+You *declare* what rows should exist — no inserts or deletes. `app_main` mounts the two Postgres tables, fetches the recent thread IDs, and fans out one `process_thread` component per thread with `mount_each`. If a thread drops out of the feed, the rows it owned are cleaned up automatically.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/hackernews-trending-topics/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the data models, the custom HTTP source, the per-thread component, and the trending SQL.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Any source, not just files.** The source here is a live HTTP API — `fetch_thread_list` and `fetch_thread` are ordinary `async def` functions. Any API, queue, or SDK plugs in the same way: fetch in plain Python, hand it to the pipeline.
+- **A component per thread.** Each thread's work and its rows are grouped together, run in parallel, and committed to Postgres as soon as that thread is done — no waiting for the batch.
+- **Incremental by default.** Per-message extraction is tracked, so the expensive LLM calls only run for content CocoIndex hasn't seen; re-running catches up on new stories and reuses committed rows.
+- **The prompt is the product.** Topic normalization (splitting phrases, canonical proper nouns, aliases) is what makes the trending ranking meaningful — and it lives in one Pydantic `Field` description.
+- **Plain Python, your stack.** Extraction is litellm, so swapping `LLM_MODEL` switches providers (Gemini, OpenAI, Ollama, …). No DSL.
+
+## Run it
+
+**1. Start Postgres:**
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install** — the default model is `gemini/gemini-2.5-flash`:
+
+```sh
+cp .env.example .env     # set POSTGRES_URL and GEMINI_API_KEY (or LLM_MODEL + matching key)
 pip install -e .
 ```
 
-Build/update the index (one-shot catch-up; this example doesn't use a live source):
+**3. Build the index** — a one-shot catch-up over the latest threads (this source isn't live):
 
 ```sh
 cocoindex update main
 ```
 
-Each run fetches the latest `MAX_THREADS` (default 10) threads, runs LLM topic extraction on the thread + each comment, and writes rows into `coco_examples.hn_messages` and `coco_examples.hn_topics`. CocoIndex memoizes per-message extraction, so re-running is incremental.
+This fetches the most recent `MAX_THREADS` (default 10) stories and their comments, runs LLM topic extraction on every message, and writes `coco_examples.hn_messages` and `coco_examples.hn_topics`.
 
-Query — show top trending topics, then enter a search loop:
-
-```sh
-python main.py
-```
-
-Or jump straight to a topic search:
+**4. Explore the results** — show the top trending topics and drop into a search loop, or jump straight to a topic:
 
 ```sh
-python main.py "rust"
+python main.py            # top 20 trending topics + interactive search
+python main.py "rust"     # search content for one topic
 ```
+
+The trending score is computed in SQL: a thread-level mention counts for more than a comment-level one, grouped by topic and ordered by score. Re-run `cocoindex update main` anytime to catch up on new stories — only new content hits the LLM.
+
+---
+
+<p align="center">
+  If this surfaced what HN is buzzing about, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/hackernews-trending-topics/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/hn_trending_topics" alt="" width="1" height="1" />

--- a/examples/image_search/README.md
+++ b/examples/image_search/README.md
@@ -1,61 +1,116 @@
-# Image Search with CocoIndex (v1)
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/image-search/" title="Search a folder of images by text with CocoIndex — CLIP embeddings into Qdrant, live, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/image-search/cover.svg" alt="Search images by text with CocoIndex and CLIP — embed every image into the same vector space as your words, store the vectors in Qdrant, and type 'long neck' to get the giraffe back, no tags or captions" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example builds an image search index with CLIP embeddings and Qdrant, then queries it with natural language via a small FastAPI server and React frontend.
+<h1 align="center">Search a photo folder by <em>meaning</em>, not tags.</h1>
 
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<p align="center">
+  <b>CLIP embeds images <em>and</em> text into the <em>same</em> vector space — so "long neck" lands next to the giraffe, with no captions, no labels, no manual tagging.</b><br/>
+  Vectors live in Qdrant, the index runs live inside a FastAPI app, and it's all plain async Python.
+</p>
 
-<img width="1105" alt="cover" src="https://github.com/user-attachments/assets/544fb80d-c085-4150-84b6-b6e62c4a12b9" />
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/image-search/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Technologies
-- CocoIndex v1 app pipeline
-- CLIP ViT-L/14 for embeddings
-- Qdrant for vector storage
+<div align="center">
 
-## Setup
-- Make sure Qdrant is running
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-  ```sh
-  docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
-  ```
+</div>
 
-## Run
+<br/>
 
-Install dependencies:
+A folder of photos is searchable by *meaning* the moment you stop relying on filenames and tags. [CLIP](https://huggingface.co/openai/clip-vit-large-patch14) is the trick: it embeds an image and its caption into the *same* space, so a text query and a matching picture land near each other. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, the managed Qdrant collection) runs in a Rust engine underneath, in **live mode** inside the API server, so dropping a new photo into the folder updates the index within a second.
+
+## How it works
+
+The indexing path is short — there's no text to chunk, just one embedding per image:
+
+- **Walk** a local image folder (live), matching `.jpg` / `.jpeg` / `.png`.
+- **Embed** each image with the CLIP image encoder.
+- **Store** the vector as a Qdrant point, keyed by a stable `uuid5` of the path, with the filename in the payload.
+
+The whole point is one shared space: the **same** CLIP model embeds images at index time and text at query time, so a cosine search with a text vector finds the nearest *image* vectors. Each image runs as its own [processing component](https://cocoindex.io/docs/programming_guide/processing_component/), so delete a photo and its point is removed automatically. Read it in [`pipeline.py`](pipeline.py):
+
+```python
+@coco.fn(memo=True)   # unchanged image is never re-embedded
+async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
+    content = await file.read()
+    embedding = embed_image_bytes(content)
+    point = qdrant.PointStruct(
+        id=_image_id(file.file_path.path),                  # uuid5 of the path — stable
+        vector=embedding,
+        payload={"filename": str(file.file_path.path)},
+    )
+    target.declare_point(point)
+
+def embed_query(text: str) -> list[float]:                  # query side — same model, text encoder
+    model, processor = get_clip_model()
+    inputs = processor(text=[text], return_tensors="pt", padding=True)
+    with torch.no_grad():
+        out = model.get_text_features(**inputs)
+    return _projected_features(out)[0].tolist()
+```
+
+`api.py` is a FastAPI app whose [lifespan](https://fastapi.tiangolo.com/advanced/events/) starts the flow in live mode, blocks startup until the initial sweep is `READY`, then keeps watching `img/` while serving `/search`. There's no separate "build the index" step.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/image-search/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the shared image-text space, the Qdrant collection setup, the live-mode API server, and the React frontend.
+</p>
+
+## Why it's worth a star ⭐
+
+- **One model, two encoders.** CLIP embeds images at index time and text at query time into the *same* 768-d space — search matches by meaning, never by metadata.
+- **Live by default.** The flow runs in [live mode](https://cocoindex.io/docs/programming_guide/live_mode/) inside the API server; drop a photo into `img/` and it's searchable within a second, no rebuild step.
+- **Incremental & self-cleaning.** `@coco.fn(memo=True)` skips unchanged images; each photo is its own processing component, so deleting one removes its Qdrant point automatically.
+- **Managed Qdrant target.** `mount_collection_target` creates and reconciles the collection — the vector size comes straight from `model.config.projection_dim`, so swapping CLIP variants just works.
+- **Plain Python, your stack.** FastAPI + React + Qdrant, no DSL — the indexing logic is a handful of ordinary async functions.
+
+## Run it
+
+> Needs **Qdrant** (vector store) and the CLIP model deps (`torch`, `transformers`, `pillow`), all pulled in by `pip install -e .`.
+
+**1. Start Qdrant:**
 
 ```sh
+docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # QDRANT_URL (defaults to the local container above)
 pip install -e .
 ```
 
-Start the FastAPI server:
+**3. Run it as a service** — the example ships an `img/` folder (a cat, a dog, an elephant, a giraffe). The server runs the index in live mode in the background and blocks startup until the first sweep finishes, so there's no separate indexing command:
 
 ```sh
 python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
 ```
 
-The server runs the index in **live mode** in the background — startup blocks until the initial sweep over `img/` finishes (so the collection is queryable), then file changes keep flowing into Qdrant while requests are served. There is no separate "build the index" step.
-
-Then in another terminal, start the frontend:
+**4. Open the frontend:**
 
 ```sh
-cd frontend
-npm install
-npm run dev
+cd frontend && npm install && npm run dev   # http://localhost:5173
 ```
 
-Then open `http://localhost:5173`.
+Query *"long neck"* and the giraffe ranks first, then the other animals by CLIP similarity — none of which was ever tagged with a word. That's the whole point of a shared image-text space: the match is by *meaning*.
 
-## Code layout
+---
 
-- `pipeline.py` — defines the CocoIndex `app`, the CLIP embedder helpers, and a small `_qdrant_search` shim. Library only — not an entry point.
-- `api.py` — FastAPI server. Imports `pipeline`, runs `pipeline.app.update(live=True)` in the background, and exposes `/search`.
+<p align="center">
+  If this made your photo folder searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/image-search/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-## Environment
-
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
-
-```sh
-cp .env.example .env
-```
-
-Requires a running Qdrant (`QDRANT_URL`, default `http://localhost:6334/`).
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/image_search" alt="" width="1" height="1" />

--- a/examples/image_search_colpali/README.md
+++ b/examples/image_search_colpali/README.md
@@ -1,54 +1,118 @@
-# Image Search with ColPali (v1)
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/image-search-colpali/" title="Higher-fidelity image search with ColPali multi-vector embeddings and Qdrant MaxSim — live, in plain async Python with CocoIndex">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/cover.svg" alt="Image search with CocoIndex and ColPali — embed every image into a bag of patch vectors, store them in a Qdrant MaxSim multivector collection, and match a text query patch-by-patch for finer-grained retrieval on dense images" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example builds an image search index using the ColPali multi-vector embedding model and stores vectors in Qdrant (MaxSim multivector config), then queries it with natural language via a small FastAPI server and React frontend.
+<h1 align="center">Image search with <em>multi-vector</em> ColPali.</h1>
 
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<p align="center">
+  <b>Instead of one vector per image, ColPali emits a <em>bag</em> of patch vectors — and Qdrant's MaxSim scores a query against each image's best-matching patches, late-interaction style.</b><br/>
+  Finer-grained retrieval on dense, text-heavy, busy images — live, in plain async Python.
+</p>
 
-## Setup
-- Make sure Qdrant is running
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/image-search-colpali/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-  ```sh
-  docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
-  ```
+<div align="center">
 
-## Run
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-Install dependencies:
+</div>
+
+<br/>
+
+This is the multi-vector cousin of the [CLIP image search example](https://github.com/cocoindex-io/cocoindex/tree/main/examples/image_search). Same idea — type *"long neck"*, get the giraffe back — but instead of squeezing each image into a *single* vector, [ColPali](https://huggingface.co/vidore/colpali-v1.2) emits a *bag* of vectors, one per image patch, and matches a query token-against-patch. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — while incremental processing, change tracking, and the managed Qdrant collection run in a Rust engine underneath, in **live mode** inside the API server. The cost is more vectors per image; the payoff is retrieval that holds up on dense, text-heavy, or busy images where a single embedding blurs everything together.
+
+## How it works
+
+The indexing path is short — there's no text to chunk, just one *multi-vector* embedding per image:
+
+- **Walk** a local image folder (live), matching `.jpg` / `.jpeg` / `.png`.
+- **Embed** each image with ColPali into a list of 128-d patch vectors — `list[list[float]]`, not one vector.
+- **Store** it as a point in a Qdrant **multivector** collection configured for **MaxSim**, keyed by a stable `uuid5` of the path.
+
+The store does the heavy lifting on the query side: the query's bag of token vectors and an image's bag of patch vectors are scored late-interaction style — each query vector finds its best-matching patch, summed across the query. The only difference from the CLIP version is the *shape* of the embedding. Read it in [`pipeline.py`](pipeline.py):
+
+```python
+@coco.fn(memo=True)   # unchanged image is never re-embedded
+async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
+    content = await file.read()
+    embedding = embed_image_bytes(content)              # list[list[float]] — multi-vector
+    point = qdrant.PointStruct(
+        id=_image_id(file.file_path.path),              # uuid5 of the path — stable
+        vector=embedding,
+        payload={"filename": str(file.file_path.path)},
+    )
+    target.declare_point(point)
+
+# the collection itself carries the multi-vector setup:
+schema = await qdrant.CollectionSchema.create(
+    vectors=qdrant.QdrantVectorDef(
+        schema=MultiVectorSchema(vector_schema=VectorSchema(dtype=np.dtype(np.float32), size=dim)),
+        distance="cosine",
+        multivector_comparator="max_sim",               # late-interaction MaxSim
+    )
+)
+```
+
+`api.py` is a FastAPI app whose [lifespan](https://fastapi.tiangolo.com/advanced/events/) starts the flow in live mode, blocks startup until the initial sweep is `READY`, then watches `img/` while serving `/search` — which hands Qdrant the query's *bag* of vectors and lets it do the MaxSim scoring.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/image-search-colpali/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with multi-vector embeddings, the MaxSim multivector collection, the live-mode API server, and how it differs from the CLIP sibling.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Multi-vector, not single.** ColPali emits a vector per patch and matches a query patch-by-patch — finer-grained than a single CLIP embedding on dense or text-heavy images.
+- **MaxSim in the store.** A `MultiVectorSchema` + `multivector_comparator="max_sim"` makes Qdrant do the late-interaction scoring; the query side just hands over the query's bag of vectors.
+- **Live by default.** The flow runs in [live mode](https://cocoindex.io/docs/programming_guide/live_mode/) inside the API server; a new photo in `img/` is searchable within a second, no rebuild step.
+- **Incremental & self-cleaning.** `@coco.fn(memo=True)` skips unchanged images; each photo is its own processing component, so deleting one removes its Qdrant point automatically.
+- **Drop-in swap from CLIP.** Same Qdrant target, same fan-out, same FastAPI + React app — only the encoder and the collection's vector schema change.
+
+## Run it
+
+> Needs **Qdrant** (vector store) plus the ColPali model deps (`torch`, `transformers`, `pillow`), all pulled in by `pip install -e .` (`cocoindex[colpali,qdrant]`).
+
+**1. Start Qdrant:**
 
 ```sh
+docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # QDRANT_URL (defaults to the local container above)
 pip install -e .
 ```
 
-Start the FastAPI server:
+**3. Run it as a service** — the example ships an `img/` folder (a cat, a dog, an elephant, a giraffe). The server runs the index in live mode in the background and blocks startup until the first sweep finishes, so there's no separate indexing command:
 
 ```sh
 python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000
 ```
 
-The server runs the index in **live mode** in the background — startup blocks until the initial sweep over `img/` finishes (so the collection is queryable), then file changes keep flowing into Qdrant while requests are served. There is no separate "build the index" step.
-
-Then in another terminal, start the frontend:
+**4. Open the frontend:**
 
 ```sh
-cd frontend
-npm install
-npm run dev
+cd frontend && npm install && npm run dev   # http://localhost:5173
 ```
 
-Go to `http://localhost:5173` to search.
+The React app posts your query to `/search`, which embeds the text into ColPali's per-token space and runs a MaxSim search in Qdrant — the match is by *meaning*, patch by patch, never by metadata.
 
-## Code layout
+---
 
-- `pipeline.py` — defines the CocoIndex `app`, the ColPali embedder helpers, and a small `_qdrant_search` shim. Library only — not an entry point.
-- `api.py` — FastAPI server. Imports `pipeline`, runs `pipeline.app.update(live=True)` in the background, and exposes `/search`.
+<p align="center">
+  If this sharpened your image search, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/image-search-colpali/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-## Environment
-
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
-
-```sh
-cp .env.example .env
-```
-
-Requires a running Qdrant (`QDRANT_URL`, default `http://localhost:6334/`).
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/image_search_colpali" alt="" width="1" height="1" />

--- a/examples/kafka_to_lancedb/README.md
+++ b/examples/kafka_to_lancedb/README.md
@@ -1,53 +1,126 @@
-# Kafka to LanceDB
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/kafka-to-lancedb/" title="Consume a Kafka topic of JSON messages and dispatch each one by shape into the right LanceDB table with CocoIndex — offsets committed after each durable write, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/kafka-to-lancedb/cover.svg" alt="Consume a live Kafka topic of JSON messages with CocoIndex and fan them into LanceDB tables — a message with a sku field becomes a products row, one with an emp_id field an employees row, with the Kafka offset committed only after each row is durably written" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example consumes JSON messages from a Kafka topic (produced by the [csv_to_kafka](../csv_to_kafka) example) and dispatches them to two LanceDB tables — `products` and `employees` — based on the message content.
+<h1 align="center">Consume a Kafka topic into <em>LanceDB</em>, routed by shape.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Each message parsed and dispatched to the table that matches it — a <em>sku</em> field becomes a <code>products</code> row, an <em>emp_id</em> field an <code>employees</code> row — in plain async Python.</b><br/>
+  CocoIndex commits each Kafka offset only after the row is durably written, so a crash mid-flight replays cleanly.
+</p>
 
-- A running Kafka broker (default: `localhost:9092`)
-- The `csv_to_kafka` example running (or having run) to populate the topic
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/kafka-to-lancedb/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Configuration
+<div align="center">
 
-Copy `.env.example` to `.env` and edit as needed:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
+</div>
+
+<br/>
+
+A topic is often a firehose of heterogeneous events — orders, users, inventory — sharing a transport but not a schema. The consumer's job is to *sort the mail*: read each envelope, decide what it is, and put it where it belongs. This is the consumer side of [csv-to-kafka](https://github.com/cocoindex-io/cocoindex/tree/main/examples/csv_to_kafka): the same declarative flow that *produced* the topic now *consumes* it. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the Rust engine consumes one message per processing component, writes the row, and only then commits the offset, so a crash replays from the last durably-written message.
+
+## How it works
+
+Kafka is a [source](https://cocoindex.io/docs/connectors/kafka/) you treat as a keyed map; each LanceDB table is a [target](https://cocoindex.io/docs/connectors/lancedb/) you declare rows on. `process_message` runs once per message: decode the value, `json.loads` it, and dispatch on shape. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_message(
+    msg: Message,
+    products_table: lancedb.TableTarget[Product],
+    employees_table: lancedb.TableTarget[Employee],
+) -> None:
+    value = msg.value()
+    if value is None:
+        return
+    text = value.decode() if isinstance(value, bytes) else value
+    row = json.loads(text)
+    if "sku" in row:
+        products_table.declare_row(row=Product(**{**row, "price": float(row["price"])}))
+    elif "emp_id" in row:
+        employees_table.declare_row(row=Employee(**row))
+
+@coco.fn
+async def app_main() -> None:
+    products_table = await lancedb.mount_table_target(
+        LANCE_DB, table_name="products",
+        table_schema=await lancedb.TableSchema.from_class(Product, primary_key=["sku"]))
+    employees_table = await lancedb.mount_table_target(
+        LANCE_DB, table_name="employees",
+        table_schema=await lancedb.TableSchema.from_class(Employee, primary_key=["emp_id"]))
+    config = {"bootstrap.servers": KAFKA_BOOTSTRAP_SERVERS, "group.id": KAFKA_GROUP_ID,
+              "enable.auto.commit": "false", "auto.offset.reset": "earliest"}
+    consumer = AIOConsumer(config)
+    items = kafka.topic_as_map(consumer, [KAFKA_TOPIC])
+    await coco.mount_each(process_message, items, products_table, employees_table)
 ```
-KAFKA_BOOTSTRAP_SERVERS=localhost:9092
-KAFKA_TOPIC=cocoindex-example-csv-rows
-KAFKA_GROUP_ID=kafka-to-lancedb
-LANCEDB_URI=./lancedb_data
-```
 
-## Run
+The line worth pausing on is `declare_row` — deliberately *not* `upsert()`. A new or changed primary key is upserted; a tombstone (null value) removes that key's row; the same row declared again writes nothing. `enable.auto.commit` is **off** on purpose: CocoIndex commits each offset *after* the row is durably written, so the consumer group resumes from the last message it actually persisted.
 
-Install deps:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/kafka-to-lancedb/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the row schemas, shape dispatch, offset-after-write delivery, and exactly what each message does.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Sort the mail.** Branch on a discriminator field (`sku` vs `emp_id`) and declare a typed row — the same pattern whether the destination is LanceDB, Postgres, or a vector index. A message matching neither shape is quietly skipped.
+- **At-least-once, your offsets won't drift.** Auto-commit off + offset-after-write means `__consumer_offsets` never runs ahead of the data; a crash mid-flight replays from the last committed offset.
+- **The dataclass is the schema.** [`TableSchema.from_class`](https://cocoindex.io/docs/connectors/lancedb/) maps your dataclass to LanceDB/PyArrow column types — `Product` keyed by `sku`, `Employee` by `emp_id`, the same keys the messages carried in.
+- **Embedded target, no server.** LanceDB tables are just files under `./lancedb_data` — there's nothing to run alongside the consumer.
+- **Live mode is one flag.** `-L` is the entire difference between draining the backlog and exiting versus consuming forever — `process_message` doesn't change.
+
+## Run it
+
+> Needs a running Kafka broker with a topic to consume. The easy way to populate it: run [csv-to-kafka](https://github.com/cocoindex-io/cocoindex/tree/main/examples/csv_to_kafka) first.
+
+**1. Configure & install** — point `KAFKA_TOPIC` at the topic csv-to-kafka produced (its default is `cocoindex-csv-rows`):
 
 ```sh
+cp .env.example .env     # set KAFKA_BOOTSTRAP_SERVERS / KAFKA_TOPIC / LANCEDB_URI (+ SASL for a managed broker)
 pip install -e .
 ```
 
-Run the pipeline in live mode to continuously consume new messages:
+**2. Run the pipeline** — choose catch-up (drain what's there, then exit) or live (catch up, then keep consuming):
 
 ```sh
+# Catch-up run: consume everything up to now, write the rows, then exit
+cocoindex update main.py
+
+# Live run: catch up, then keep consuming new messages
 cocoindex update -L main.py
 ```
 
-Messages with a `sku` field are written to the `products` table; messages with an `emp_id` field go to the `employees` table.
-
-## Inspect LanceDB data
-
-After the pipeline has processed some messages, you can inspect the tables with Python:
+**3. Look at the tables** — they're just files under `./lancedb_data`:
 
 ```python
 import lancedb
 
 db = lancedb.connect("./lancedb_data")
-
-print("=== Products ===")
 for row in db.open_table("products").to_arrow().to_pylist():
     print(row)
-
-print("\n=== Employees ===")
 for row in db.open_table("employees").to_arrow().to_pylist():
     print(row)
 ```
+
+Every `sku` message is a row in `products`, every `emp_id` message a row in `employees` — keyed exactly as it was on the topic, so re-consuming the same key updates the row in place rather than duplicating.
+
+---
+
+<p align="center">
+  If this sorted your topic into typed tables, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/kafka-to-lancedb/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/kafka_to_lancedb" alt="" width="1" height="1" />

--- a/examples/manuals_llm_extraction/README.md
+++ b/examples/manuals_llm_extraction/README.md
@@ -1,0 +1,124 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/manuals-llm-extraction/" title="Turn PDF manuals into typed records with CocoIndex — convert to Markdown with docling, LLM-extract a structured module summary, store in Postgres, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/manuals-llm-extraction/cover.svg" alt="Turn a folder of PDF manuals into typed records with CocoIndex — convert each PDF to Markdown with docling on a GPU runner, LLM-extract a structured module summary of classes, methods, and arguments, and store a row per manual in Postgres" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Turn PDF manuals into <em>structured</em> records.</h1>
+
+<p align="center">
+  <b>Convert each PDF manual to Markdown with docling, LLM-extract a typed summary — <em>classes, methods, arguments</em> — and store it in Postgres — in plain async Python.</b><br/>
+  Manuals are full of structure laid out for humans, not machines; this pulls it back out into a nested schema.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/manuals-llm-extraction/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Manuals, datasheets, and reference docs are full of structure — classes, functions, parameters, defaults — laid out for humans, not machines. This pipeline pulls that structure out: convert each PDF to Markdown with [docling](https://github.com/docling-project/docling), LLM-extract a typed summary of the module it documents, and store the result in Postgres. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (the GPU PDF parse, incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so editing one manual re-parses and re-extracts only that one.
+
+## How it works
+
+The output type is nested Pydantic, and the structure itself tells the model what to pull out — a `ModuleInfo` has `classes` (each with `methods`) and module-level `methods` (each with `args`). Per manual, two transforms and a row: `pdf_to_markdown` runs docling on a GPU runner, `extract_module` does the [instructor](https://github.com/instructor-ai/instructor)-over-[LiteLLM](https://docs.litellm.ai/) extraction, and `process_file` declares one Postgres row with the summary counts plus the full structure as JSON. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn.as_async(runner=coco.GPU)
+def pdf_to_markdown(content: bytes) -> str:
+    source = DocumentStream(name="manual.pdf", stream=io.BytesIO(content))
+    return pdf_converter().convert(source).document.export_to_markdown()
+
+
+@coco.fn(memo=True)
+async def extract_module(markdown: str) -> ModuleInfo:
+    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
+    result = await client.chat.completions.create(
+        model=coco.use_context(LLM_MODEL), response_model=ModuleInfo,
+        messages=[{"role": "system", "content": EXTRACT_PROMPT},
+                  {"role": "user", "content": markdown}],
+    )
+    return ModuleInfo.model_validate(result.model_dump())
+
+
+@coco.fn(memo=True)
+async def process_file(file: FileLike, table: postgres.TableTarget[ModuleRecord]) -> None:
+    markdown = await pdf_to_markdown(await file.read())
+    info = await extract_module(markdown)
+    table.declare_row(row=ModuleRecord(
+        filename=file.file_path.path.name, title=info.title, description=info.description,
+        num_classes=len(info.classes), num_methods=len(info.methods),
+        module_info=json.dumps(info.model_dump()),
+    ))
+```
+
+You *declare* the row; CocoIndex inserts, updates, or deletes it to match. `app_main` mounts the Postgres table, walks the source for `*.pdf`, and runs one `process_file` component per manual with `mount_each`.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/manuals-llm-extraction/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the nested extraction schema, the GPU PDF parse, the Postgres row, and the per-manual results.
+</p>
+
+## Why it's worth a star ⭐
+
+- **The schema is the prompt.** A nested `ModuleInfo` — module → classes → methods → args — tells the model exactly what to pull out, no hand-tuned prompt for each level.
+- **Heavy parse on a GPU runner.** `pdf_to_markdown` is decorated `@coco.fn.as_async(runner=coco.GPU)`, so the docling parse runs where the hardware is while the rest stays async.
+- **Incremental by default.** `@coco.fn(memo=True)` caches both the PDF parse and the extraction by content, so editing one manual re-parses and re-extracts only that one — the row is updated in place.
+- **Plain Python, your stack.** Extraction is instructor over LiteLLM, so swapping `LLM_MODEL` switches providers (OpenAI, Gemini, a local Ollama model). No DSL.
+- **Honest cache busting.** `LLM_MODEL` is declared with `detect_change=True`, so swapping the model re-extracts everything against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start Postgres:**
+
+```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install** — the example ships a `manuals/` folder of Python module reference PDFs (`array`, `base64`, `copy`):
+
+```sh
+cp .env.example .env     # set POSTGRES_URL and OPENAI_API_KEY (or LLM_MODEL=gemini/gemini-2.0-flash, ollama/llama3.2, …)
+pip install -e .
+```
+
+**3. Build the index** — catch-up (scan, sync, exit) or live (catch up, then keep watching):
+
+```sh
+cocoindex update main       # catch-up run
+cocoindex update -L main    # live run — watch the manuals/ folder for changes
+```
+
+This produces one row per manual in `coco_examples.modules_info`, and the extraction is faithful to each module's shape — `base64` comes out function-based (22 module functions, no classes), while `array` is a single class.
+
+**4. Explore the results:**
+
+```sql
+SELECT filename, title, num_classes, num_methods FROM coco_examples.modules_info;
+
+-- pull the full nested structure for one module
+SELECT module_info::jsonb -> 'classes' -> 0 -> 'methods'
+FROM coco_examples.modules_info WHERE filename = 'copy.pdf';
+```
+
+Re-run `cocoindex update main` anytime — only changed manuals are re-parsed and re-extracted.
+
+---
+
+<p align="center">
+  If this turned your manuals into structured rows, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/manuals-llm-extraction/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/manuals_llm_extraction" alt="" width="1" height="1" />

--- a/examples/meeting_notes_graph_falkordb/.env.example
+++ b/examples/meeting_notes_graph_falkordb/.env.example
@@ -18,5 +18,5 @@ GOOGLE_DRIVE_ROOT_FOLDER_IDS=id1,id2
 # FalkorDB connection (LiteLLM-prefixed model id, FalkorDB URI + graph name)
 FALKORDB_URI=falkor://localhost:6379
 FALKORDB_GRAPH=meeting_notes
-LLM_MODEL=openai/gpt-5.4
+LLM_MODEL=openai/gpt-5-mini
 RESOLUTION_LLM_MODEL=openai/gpt-5-mini

--- a/examples/meeting_notes_graph_falkordb/README.md
+++ b/examples/meeting_notes_graph_falkordb/README.md
@@ -1,129 +1,130 @@
-# Build Meeting Notes Knowledge Graph from Google Drive — FalkorDB (CocoIndex v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/" title="Turn Google Drive meeting notes into a self-updating knowledge graph with CocoIndex and FalkorDB — LLM extraction, embedding-based person resolution, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/meeting-notes-to-knowledge-graph-falkordb/cover.svg" alt="Turn a Google Drive folder of meeting notes into a self-updating knowledge graph with CocoIndex and FalkorDB — an LLM extracts the organizer, participants, and tasks per meeting, an embedding plus LLM pass collapses the same person written five ways into one node, and the result is a Person / Meeting / Task graph you query in Cypher" width="100%" draggable="false"/>
+  </a>
+</p>
 
-Extract structured information from meeting notes stored in Google Drive and
-build a knowledge graph in [FalkorDB](https://www.falkordb.com/). The flow
-ingests Markdown notes, splits them by headings into per-meeting sections,
-uses an LLM (via [LiteLLM](https://docs.litellm.ai/) +
-[instructor](https://python.useinstructor.com/)) to parse participants,
-organizer, time, and tasks, and writes nodes and relationships into the graph.
+<h1 align="center">Turn meeting notes into a <em>self-updating</em> graph in FalkorDB.</h1>
 
+<p align="center">
+  <b>An LLM pulls the organizer, participants, and tasks out of each meeting; an embedding + LLM pass collapses "Alice", "Alice Chen", and "alice c." into <em>one</em> Person node — into FalkorDB, in plain async Python.</b><br/>
+  Point it at a Drive folder of Markdown notes, and it re-extracts only the note you edited, then reconciles the graph.
+</p>
 
-Please drop [CocoIndex on Github](https://github.com/cocoindex-io/cocoindex) a
-star to support us and stay tuned for more updates. Thank you so much 🥥🤗.
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## What this builds
+<div align="center">
 
-- `Meeting` nodes — one per meeting section, keyed by a stable integer id
-  derived from `(note_file, date)`
-- `Person` nodes — canonical organizers, participants, and task assignees,
-  deduplicated by an embedding + LLM entity-resolution pass (so "Alice",
-  "Alice Chen", and "alice c." collapse to a single node)
-- `Task` nodes — tasks decided in meetings (keyed by description)
-- Relationships:
-  - `ATTENDED` — `Person → Meeting` (with `is_organizer` flag)
-  - `DECIDED` — `Meeting → Task`
-  - `ASSIGNED_TO` — `Person → Task`
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-The source is one or more Google Drive folders shared with a service account.
-The flow watches for changes and keeps the graph up to date incrementally.
+</div>
+
+<br/>
+
+This is the meeting-notes knowledge graph, targeting [FalkorDB](https://www.falkordb.com/) instead of Neo4j — a Redis-based property graph you talk to in Cypher. Meeting notes are a graph pretending to be a folder of documents: every note records who ran the meeting, who showed up, what got decided, and who owns each task. But it's prose, scattered across a shared drive, so you can full-text search it and not much else. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed graph targets) runs in a Rust engine underneath, so editing one note re-extracts one note, and the graph reconciles itself: no orphaned people, no stale edges, no cleanup scripts.
 
 ## How it works
 
-The pipeline runs in three phases:
+Three node types, three relationship types, and "who is on the hook for what" becomes an edge you traverse:
 
-1. **Per-file extraction.** Read each file from Google Drive, split it by
-   Markdown headings (`#` / `##`) into meeting sections, and for each section
-   extract a structured `Meeting` via LiteLLM + instructor (date, note,
-   organizer, participants, tasks with assignees). `Meeting` and `Task` nodes
-   plus `DECIDED` edges are declared in this phase. Raw person names are
-   carried forward.
-2. **Person entity resolution.** All raw person names from all files are
-   deduplicated using sentence-transformer embeddings and an LLM pair resolver
-   to produce a canonical-name mapping.
-3. **Person-touching relations.** Canonical `Person` nodes are declared, then
-   `ATTENDED` and `ASSIGNED_TO` edges are wired up using resolved names.
+- **`Meeting`** nodes — one per meeting section, keyed by a stable integer id derived from `(note_file, date)`.
+- **`Person`** nodes — canonical organizers, participants, and assignees, deduplicated by an embedding + LLM entity-resolution pass.
+- **`Task`** nodes — tasks decided in meetings, keyed by description.
+- **`ATTENDED`** edges — `Person → Meeting`, carrying an `is_organizer` flag. **`DECIDED`** edges — `Meeting → Task`. **`ASSIGNED_TO`** edges — `Person → Task`.
 
-CocoIndex reconciles changes incrementally — re-running after editing one note
-only re-processes the affected sections, and the resolution phase only re-runs
-when the set of raw names changes.
+Because people are shared across notes, the pipeline runs in three phases — read it top-to-bottom in [`main.py`](main.py):
 
-## Prerequisites
+```python
+@coco.fn(memo=True)  # Phase 1 — per note: split into meetings, declare Meeting/Task + DECIDED, carry raw names forward
+async def process_file(file, meeting_table, task_table, decided_rel) -> list[MeetingExtraction]:
+    for section in _split_meetings(await file.read_text()):
+        extracted = await extract_meeting(section)
+        meeting_id = await id_generator.next_id(extracted.time)
+        meeting_table.declare_record(row=Meeting(id=meeting_id, ...))
+        for task in extracted.tasks:
+            task_table.declare_record(row=Task(description=task.description))
+            decided_rel.declare_relation(from_id=meeting_id, to_id=task.description)
+        ...
 
-- A running FalkorDB instance:
-  ```sh
-  docker run -d -p 6379:6379 -p 3000:3000 falkordb/falkordb:latest
-  ```
-  The browser UI is at <http://localhost:3000>.
-- An LLM key (defaults to OpenAI; configure via `LLM_MODEL` for other
-  providers — see [LiteLLM providers](https://docs.litellm.ai/docs/providers)).
-- A Google Cloud service account with read access to the source folders, and
-  the folder IDs you want to ingest. See
-  [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account).
+@coco.fn(memo=True)  # Phase 2 — collapse "Alice" / "Alice Chen" / "alice c." into canonical names
+async def _resolve_persons(raw_persons: set[str]) -> ResolvedEntities:
+    return await resolve_entities(entities=raw_persons, embedder=coco.use_context(EMBEDDER),
+                                  resolve_pair=LlmPairResolver(model=coco.use_context(RESOLUTION_LLM_MODEL)))
 
-## Environment
-
-Set the following variables (copy `.env.example` to `.env` and fill in):
-
-```sh
-export OPENAI_API_KEY="your-openai-api-key"
-export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/absolute/path/to/service_account.json
-export GOOGLE_DRIVE_ROOT_FOLDER_IDS=folderId1,folderId2
-export FALKORDB_URI=falkor://localhost:6379
-export FALKORDB_GRAPH=meeting_notes
-export LLM_MODEL=openai/gpt-5.4
-export RESOLUTION_LLM_MODEL=openai/gpt-5-mini   # used for entity resolution
+@coco.fn              # Phase 3 — declare canonical Person nodes + ATTENDED / ASSIGNED_TO using resolved names
+async def create_person_relations(meetings, persons, person_table, attended_rel, assigned_rel) -> None:
+    for canonical_name in persons.canonicals():  person_table.declare_record(row=Person(name=canonical_name))
+    ...
 ```
 
-Then:
+Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/) with your own Pydantic models; `DECIDED` and `ASSIGNED_TO` carry no payload, so the FalkorDB connector derives their identity from the endpoints — one edge per pair.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/">Full Tutorial →</a></b><br/>
+  The closest walkthrough is the Neo4j version — same extraction, resolution, and three-phase flow; only the graph store differs. Step-by-step coverage of the property-graph schema, entity resolution, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Entity resolution built in.** CocoIndex's [`entity_resolution`](https://cocoindex.io/docs/ops/entity_resolution/) op embeds every raw name, filters by vector similarity, and asks the LLM to confirm *only* the close pairs — so the same person written five ways collapses to one node, cheaply.
+- **Cross-file nodes, owned in one place.** People are shared across notes, so no single note's component can own a `Person` node. The two cross-file phases own the canonical set and the person-touching edges, exactly once.
+- **Incremental by default.** `@coco.fn(memo=True)` caches each extraction by content; edit one note and only that note re-extracts, then resolution and the graph diff. A no-change re-run makes zero LLM calls.
+- **Two models on purpose.** A stronger `LLM_MODEL` does the structured extraction; a cheaper `RESOLUTION_LLM_MODEL` confirms resolution pairs — both are [LiteLLM provider strings](https://docs.litellm.ai/docs/providers) you can swap.
+- **Honest cache busting.** The model ids and embedder are declared with `detect_change=True`, so swapping any of them re-extracts against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start FalkorDB** (Docker) — the image bundles a browser UI on port 3000:
 
 ```sh
-set -a && source .env && set +a
+docker run -d -p 6379:6379 -p 3000:3000 --name cocoindex-falkordb falkordb/falkordb:latest
 ```
 
-## Run
-
-Install dependencies:
+**2. Configure & install** — this source reads notes from one or more Google Drive folders shared with a service account (see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)):
 
 ```sh
-uv pip install -e .
+cp .env.example .env     # set OPENAI_API_KEY, GOOGLE_SERVICE_ACCOUNT_CREDENTIAL, GOOGLE_DRIVE_ROOT_FOLDER_IDS
+pip install -e .
 ```
 
-Build/update the graph:
+Both the extraction and resolution models default to `openai/gpt-5-mini`; override `LLM_MODEL` / `RESOLUTION_LLM_MODEL` for any [LiteLLM provider](https://docs.litellm.ai/docs/providers). `FALKORDB_URI` and `FALKORDB_GRAPH` default to `falkor://localhost:6379` and `meeting_notes`.
+
+**3. Build the graph:**
 
 ```sh
 cocoindex update main
 ```
 
-## Browse the knowledge graph
-
-Open the FalkorDB browser at <http://localhost:3000>, select the
-`meeting_notes` graph, and run Cypher queries.
+**4. Explore the graph** — open the bundled FalkorDB Browser at [localhost:3000](http://localhost:3000), select the `meeting_notes` graph, and ask:
 
 ```cypher
-// All relationships
-MATCH p=()-->() RETURN p
-
-// Who attended which meetings (including organizer; one edge per attendee)
+-- Who attended which meetings (including organizer; one edge per attendee)
 MATCH (p:Person)-[:ATTENDED]->(m:Meeting)
-RETURN p.name, m.note_file, m.time, m.id
+RETURN p.name, m.note_file, m.time
 
-// Tasks decided in meetings
-MATCH (m:Meeting)-[:DECIDED]->(t:Task)
-RETURN m.note_file, m.time, t.description
+-- Everything one person is on the hook for
+MATCH (p:Person {name: "Alice Chen"})-[:ASSIGNED_TO]->(t:Task)
+RETURN t.description
 
-// Task assignments
-MATCH (p:Person)-[:ASSIGNED_TO]->(t:Task)
-RETURN p.name, t.description
-
-// Meetings someone organized
+-- Meetings someone organized
 MATCH (p:Person)-[r:ATTENDED {is_organizer: true}]->(m:Meeting)
 RETURN p.name, m.note_file, m.time
 ```
 
-You can also use `redis-cli`:
+This pipeline is the [docs knowledge graph](https://cocoindex.io/docs/examples/docs-to-knowledge-graph/) plus an entity-resolution pass — the natural next step when the LLM names the same thing two ways. Want Neo4j instead? See the [Neo4j variant](https://github.com/cocoindex-io/cocoindex/tree/main/examples/meeting_notes_graph_neo4j).
 
-```sh
-redis-cli GRAPH.QUERY meeting_notes \
-  "MATCH (p:Person)-[:ATTENDED]->(m:Meeting) RETURN p.name, m.note_file, m.time"
-```
+---
+
+<p align="center">
+  If this turned your shared drive into a graph, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/meeting_notes_graph_falkordb" alt="" width="1" height="1" />

--- a/examples/meeting_notes_graph_falkordb/main.py
+++ b/examples/meeting_notes_graph_falkordb/main.py
@@ -72,7 +72,7 @@ async def coco_lifespan(
             graph=os.environ.get("FALKORDB_GRAPH", "meeting_notes"),
         ),
     )
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     builder.provide(
         RESOLUTION_LLM_MODEL,
         os.environ.get("RESOLUTION_LLM_MODEL", "openai/gpt-5-mini"),

--- a/examples/meeting_notes_graph_neo4j/.env.example
+++ b/examples/meeting_notes_graph_neo4j/.env.example
@@ -21,6 +21,6 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=cocoindex
 NEO4J_DATABASE=neo4j
 
-# LLM models (LiteLLM-prefixed; e.g. openai/gpt-5.4, anthropic/claude-..., ...)
-LLM_MODEL=openai/gpt-5.4
+# LLM models (LiteLLM-prefixed; e.g. openai/gpt-5-mini, anthropic/claude-..., ...)
+LLM_MODEL=openai/gpt-5-mini
 RESOLUTION_LLM_MODEL=openai/gpt-5-mini

--- a/examples/meeting_notes_graph_neo4j/README.md
+++ b/examples/meeting_notes_graph_neo4j/README.md
@@ -1,147 +1,128 @@
-# Build Meeting Notes Knowledge Graph from Google Drive — Neo4j (CocoIndex v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/" title="Turn Google Drive meeting notes into a self-updating knowledge graph with CocoIndex and Neo4j — LLM extraction, embedding-based person resolution, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/meeting-notes-to-knowledge-graph/cover.svg" alt="Turn a Google Drive folder of meeting notes into a self-updating knowledge graph with CocoIndex and Neo4j — an LLM extracts the organizer, participants, and tasks per meeting, an embedding plus LLM pass collapses the same person written five ways into one node, and the result is a Person / Meeting / Task graph in Cypher" width="100%" draggable="false"/>
+  </a>
+</p>
 
-Extract structured information from meeting notes stored in Google Drive and
-build a knowledge graph in [Neo4j](https://neo4j.com/). The flow ingests
-Markdown notes, splits them by headings into per-meeting sections, uses an
-LLM (via [LiteLLM](https://docs.litellm.ai/) +
-[instructor](https://python.useinstructor.com/)) to parse participants,
-organizer, time, and tasks, and writes nodes and relationships into the graph.
+<h1 align="center">Turn meeting notes into a <em>self-updating</em> knowledge graph.</h1>
 
-Please drop [CocoIndex on Github](https://github.com/cocoindex-io/cocoindex) a
-star to support us and stay tuned for more updates. Thank you so much 🥥🤗.
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<p align="center">
+  <b>An LLM pulls the organizer, participants, and tasks out of each meeting; an embedding + LLM pass collapses "Alice", "Alice Chen", and "alice c." into <em>one</em> Person node — in plain async Python.</b><br/>
+  Point it at a Drive folder of Markdown notes, and it re-extracts only the note you edited, then reconciles the graph.
+</p>
 
-## What this builds
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-- `Meeting` nodes — one per meeting section, keyed by a stable integer id
-  derived from `(note_file, date)`
-- `Person` nodes — canonical organizers, participants, and task assignees,
-  deduplicated by an embedding + LLM entity-resolution pass (so "Alice",
-  "Alice Chen", and "alice c." collapse to a single node)
-- `Task` nodes — tasks decided in meetings (keyed by description)
-- Relationships:
-  - `ATTENDED` — `Person → Meeting` (with `is_organizer` flag)
-  - `DECIDED` — `Meeting → Task`
-  - `ASSIGNED_TO` — `Person → Task`
+<div align="center">
 
-The source is one or more Google Drive folders shared with a service account.
-The flow watches for changes and keeps the graph up to date incrementally.
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Meeting notes are a graph pretending to be a folder of documents — every note records who ran the meeting, who showed up, what got decided, and who owns each task. But it's prose, scattered across a shared drive, so you can full-text search it and not much else. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed graph targets) runs in a Rust engine underneath, so editing one note re-extracts one note, and the graph reconciles itself: no orphaned people, no stale edges, no cleanup scripts.
 
 ## How it works
 
-The pipeline runs in three phases:
+Three node types, three relationship types, and "who is on the hook for what" becomes an edge you traverse:
 
-1. **Per-file extraction.** Read each file from Google Drive, split it by
-   Markdown headings (`#` / `##`) into meeting sections, and for each section
-   extract a structured `Meeting` via LiteLLM + instructor (date, note,
-   organizer, participants, tasks with assignees). `Meeting` and `Task` nodes
-   plus `DECIDED` edges are declared in this phase. Raw person names are
-   carried forward.
-2. **Person entity resolution.** All raw person names from all files are
-   deduplicated using sentence-transformer embeddings and an LLM pair resolver
-   to produce a canonical-name mapping.
-3. **Person-touching relations.** Canonical `Person` nodes are declared, then
-   `ATTENDED` and `ASSIGNED_TO` edges are wired up using resolved names.
+- **`Meeting`** nodes — one per meeting section, keyed by a stable integer id derived from `(note_file, date)`.
+- **`Person`** nodes — canonical organizers, participants, and assignees, deduplicated by an embedding + LLM entity-resolution pass.
+- **`Task`** nodes — tasks decided in meetings, keyed by description.
+- **`ATTENDED`** edges — `Person → Meeting`, carrying an `is_organizer` flag. **`DECIDED`** edges — `Meeting → Task`. **`ASSIGNED_TO`** edges — `Person → Task`.
 
-CocoIndex reconciles changes incrementally — re-running after editing one note
-only re-processes the affected sections, and the resolution phase only re-runs
-when the set of raw names changes.
+Because people are shared across notes, the pipeline runs in three phases — read it top-to-bottom in [`main.py`](main.py):
 
-## Prerequisites
+```python
+@coco.fn(memo=True)  # Phase 1 — per note: split into meetings, declare Meeting/Task + DECIDED, carry raw names forward
+async def process_file(file, meeting_table, task_table, decided_rel) -> list[MeetingExtraction]:
+    for section in _split_meetings(await file.read_text()):
+        extracted = await extract_meeting(section)
+        meeting_id = await id_generator.next_id(extracted.time)
+        meeting_table.declare_record(row=Meeting(id=meeting_id, ...))
+        for task in extracted.tasks:
+            task_table.declare_record(row=Task(description=task.description))
+            decided_rel.declare_relation(from_id=meeting_id, to_id=task.description)
+        ...
 
-- A running Neo4j 5.18+ instance:
-  ```sh
-  docker run -d \
-    -p 7474:7474 -p 7687:7687 \
-    -e NEO4J_AUTH=neo4j/cocoindex \
-    --name cocoindex-neo4j \
-    neo4j:5.26-community
-  ```
-  The browser UI is at <http://localhost:7474>; log in with `neo4j` /
-  `cocoindex`.
+@coco.fn(memo=True)  # Phase 2 — collapse "Alice" / "Alice Chen" / "alice c." into canonical names
+async def _resolve_persons(raw_persons: set[str]) -> ResolvedEntities:
+    return await resolve_entities(entities=raw_persons, embedder=coco.use_context(EMBEDDER),
+                                  resolve_pair=LlmPairResolver(model=coco.use_context(RESOLUTION_LLM_MODEL)))
 
-  > **Why 5.18+?** Vector index DDL (`CREATE VECTOR INDEX … OPTIONS { indexConfig: {...} }`)
-  > shipped in 5.18. Older Neo4j 5 servers need the
-  > `db.index.vector.createNodeIndex` procedure, which this connector
-  > doesn't emit. The flow itself doesn't use vector indexes, but the
-  > connector requires 5.18+ for parity.
-
-- An LLM key (defaults to OpenAI; configure via `LLM_MODEL` for other
-  providers — see [LiteLLM providers](https://docs.litellm.ai/docs/providers)).
-- A Google Cloud service account with read access to the source folders, and
-  the folder IDs you want to ingest. See
-  [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account).
-
-## Environment
-
-Set the following variables (copy `.env.example` to `.env` and fill in):
-
-```sh
-export OPENAI_API_KEY="your-openai-api-key"
-export GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/absolute/path/to/service_account.json
-export GOOGLE_DRIVE_ROOT_FOLDER_IDS=folderId1,folderId2
-export NEO4J_URI=bolt://localhost:7687
-export NEO4J_USER=neo4j
-export NEO4J_PASSWORD=cocoindex
-export NEO4J_DATABASE=neo4j
-export LLM_MODEL=openai/gpt-5.4
-export RESOLUTION_LLM_MODEL=openai/gpt-5-mini   # used for entity resolution
+@coco.fn              # Phase 3 — declare canonical Person nodes + ATTENDED / ASSIGNED_TO using resolved names
+async def create_person_relations(meetings, persons, person_table, attended_rel, assigned_rel) -> None:
+    for canonical_name in persons.canonicals():  person_table.declare_record(row=Person(name=canonical_name))
+    ...
 ```
 
-Then:
+Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/) with your own Pydantic models; `DECIDED` and `ASSIGNED_TO` carry no payload, so the Neo4j connector derives their identity from the endpoints — one edge per pair.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the property-graph schema, the three-phase flow, entity resolution, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Entity resolution built in.** CocoIndex's [`entity_resolution`](https://cocoindex.io/docs/ops/entity_resolution/) op embeds every raw name, filters by vector similarity, and asks the LLM to confirm *only* the close pairs — so the same person written five ways collapses to one node, cheaply.
+- **Cross-file nodes, owned in one place.** People are shared across notes, so no single note's component can own a `Person` node. The two cross-file phases own the canonical set and the person-touching edges, exactly once.
+- **Incremental by default.** `@coco.fn(memo=True)` caches each extraction by content; edit one note and only that note re-extracts, then resolution and the graph diff. A no-change re-run makes zero LLM calls.
+- **Two models on purpose.** A stronger `LLM_MODEL` does the structured extraction; a cheaper `RESOLUTION_LLM_MODEL` confirms resolution pairs — both are [LiteLLM provider strings](https://docs.litellm.ai/docs/providers) you can swap.
+- **Honest cache busting.** The model ids and embedder are declared with `detect_change=True`, so swapping any of them re-extracts against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start Neo4j:**
 
 ```sh
-set -a && source .env && set +a
+docker run -d -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/cocoindex --name cocoindex-neo4j neo4j:5.26-community
 ```
 
-## Run
-
-Install dependencies:
+**2. Configure & install** — this source reads notes from one or more Google Drive folders shared with a service account (see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)):
 
 ```sh
-uv pip install -e .
+cp .env.example .env     # set OPENAI_API_KEY, GOOGLE_SERVICE_ACCOUNT_CREDENTIAL, GOOGLE_DRIVE_ROOT_FOLDER_IDS
+pip install -e .
 ```
 
-Build/update the graph:
+**3. Build the graph:**
 
 ```sh
 cocoindex update main
 ```
 
-## Browse the knowledge graph
-
-Open Neo4j Browser at <http://localhost:7474>, log in, and run Cypher queries:
+**4. Explore the graph** — open [Neo4j Browser](http://localhost:7474) (`neo4j` / `cocoindex`) and ask:
 
 ```cypher
-// All relationships
-MATCH p=()-->() RETURN p LIMIT 100
-
-// Who attended which meetings (including organizer; one edge per attendee)
+-- Who attended which meetings (including organizer; one edge per attendee)
 MATCH (p:Person)-[:ATTENDED]->(m:Meeting)
-RETURN p.name, m.note_file, m.time, m.id
+RETURN p.name, m.note_file, m.time
 
-// Tasks decided in meetings
-MATCH (m:Meeting)-[:DECIDED]->(t:Task)
-RETURN m.note_file, m.time, t.description
+-- Everything one person is on the hook for
+MATCH (p:Person {name: "Alice Chen"})-[:ASSIGNED_TO]->(t:Task)
+RETURN t.description
 
-// Task assignments
-MATCH (p:Person)-[:ASSIGNED_TO]->(t:Task)
-RETURN p.name, t.description
-
-// Meetings someone organized
+-- Meetings someone organized
 MATCH (p:Person)-[r:ATTENDED {is_organizer: true}]->(m:Meeting)
 RETURN p.name, m.note_file, m.time
 ```
 
-To wipe the graph between runs:
+This pipeline is the [docs knowledge graph](https://cocoindex.io/docs/examples/docs-to-knowledge-graph/) plus an entity-resolution pass — the natural next step when the LLM names the same thing two ways.
 
-```cypher
-MATCH (n) DETACH DELETE n
-```
+---
 
-You can also use `cypher-shell` from the command line:
+<p align="center">
+  If this turned your shared drive into a graph, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/meeting-notes-to-knowledge-graph/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-```sh
-docker exec -it cocoindex-neo4j cypher-shell -u neo4j -p cocoindex \
-  "MATCH (p:Person)-[:ATTENDED]->(m:Meeting) RETURN p.name, m.note_file, m.time"
-```
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/meeting_notes_graph_neo4j" alt="" width="1" height="1" />

--- a/examples/meeting_notes_graph_neo4j/main.py
+++ b/examples/meeting_notes_graph_neo4j/main.py
@@ -81,7 +81,7 @@ async def coco_lifespan(
             database=os.environ.get("NEO4J_DATABASE", "neo4j"),
         ),
     )
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     builder.provide(
         RESOLUTION_LLM_MODEL,
         os.environ.get("RESOLUTION_LLM_MODEL", "openai/gpt-5-mini"),

--- a/examples/multi_codebase_summarization/README.md
+++ b/examples/multi_codebase_summarization/README.md
@@ -1,184 +1,114 @@
 <p align="center">
-    <img src="https://cocoindex.io/images/github.svg" alt="CocoIndex">
+  <a href="https://cocoindex.io/docs/examples/multi-codebase-summarization/" title="Generate a self-updating wiki page for every project in a folder with CocoIndex — structured LLM code analysis, Mermaid diagrams, incremental, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/multi-codebase-summarization/cover.svg" alt="Generate a self-updating one-pager wiki for every Python project in a folder with CocoIndex — an LLM extracts public classes, functions, and CocoIndex call graphs per file, aggregates them into a project summary, and writes Markdown with Mermaid diagrams that never goes out of date" width="100%" draggable="false"/>
+  </a>
 </p>
 
-<h1 align="center">Self-Updating Wiki for Your Codebases with LLM</h1>
+<h1 align="center">A <em>self-updating</em> wiki for every codebase in a folder.</h1>
+
+<p align="center">
+  <b>An LLM reads each Python file, extracts its public classes, functions, and CocoIndex call graphs, and aggregates them into a one-pager Markdown wiki per project — in plain async Python.</b><br/>
+  Edit a file, re-run, and only that file is re-analyzed; the wiki stays fresh without going out of date.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/multi-codebase-summarization/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
 <div align="center">
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
-[![Documentation](https://img.shields.io/badge/Documentation-394e79?logo=readthedocs&logoColor=00B9FF)](https://cocoindex.io/docs/getting_started/quickstart)
-[![License](https://img.shields.io/badge/license-Apache%202.0-5B5BD6?logoColor=white)](https://opensource.org/licenses/Apache-2.0)
-[![PyPI version](https://img.shields.io/pypi/v/cocoindex?color=5B5BD6)](https://pypi.org/project/cocoindex/)
-<!--[![PyPI - Downloads](https://img.shields.io/pypi/dm/cocoindex)](https://pypistats.org/packages/cocoindex) -->
-[![PyPI Downloads](https://static.pepy.tech/badge/cocoindex/month)](https://pepy.tech/projects/cocoindex)
-[![CI](https://github.com/cocoindex-io/cocoindex/actions/workflows/CI.yml/badge.svg?event=push&color=5B5BD6)](https://github.com/cocoindex-io/cocoindex/actions/workflows/CI.yml)
-[![release](https://github.com/cocoindex-io/cocoindex/actions/workflows/release.yml/badge.svg?event=push&color=5B5BD6)](https://github.com/cocoindex-io/cocoindex/actions/workflows/release.yml)
-[![Link Check](https://github.com/cocoindex-io/cocoindex/actions/workflows/links.yml/badge.svg)](https://github.com/cocoindex-io/cocoindex/actions/workflows/links.yml)
-[![Discord](https://img.shields.io/discord/1314801574169673738?logo=discord&color=5B5BD6&logoColor=white)](https://discord.com/invite/zpA9S2DR7s)
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
 </div>
 
-<div align="center">
+<br/>
 
-[Step By Step Tutorial](https://cocoindex.io/docs/examples/multi-codebase-summarization/)
+Your code is the source of truth, but a hand-written wiki drifts the moment someone merges a PR. This pipeline builds your own deep wiki — a one-pager per project that's always fresh, because it's regenerated by [incremental processing](https://cocoindex.io/docs/programming_guide/core_concepts/) instead of by hand. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the Rust engine reprocesses the minimum: switch the model or edit one file, and only what changed is re-analyzed, keeping the wikis current in production.
 
-</div>
+## How it works
 
-<div align="center">
+Each top-level subdirectory is treated as a project. The pipeline extracts a structured `CodebaseInfo` per file with an LLM, aggregates files into a project summary, and writes Markdown with Mermaid diagrams. Read it in [`main.py`](main.py):
 
-Star 🌟 [CocoIndex](https://github.com/cocoindex-io/cocoindex) if you like it!!
+```python
+@coco.fn(memo=True)   # per file — structured LLM extraction, cached by content
+async def extract_file_info(file: FileLike) -> CodebaseInfo:
+    result = await _instructor_client.chat.completions.create(
+        model=LLM_MODEL, response_model=CodebaseInfo,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return CodebaseInfo.model_validate(result.model_dump())
 
-</div>
+@coco.fn(memo=True)   # per project — extract every file, aggregate, write one Markdown page
+async def process_project(project_name: str, files, output_dir: pathlib.Path) -> None:
+    file_infos = await coco.map(extract_file_info, files)         # concurrent extraction
+    project_info = await aggregate_project_info(project_name, file_infos)
+    markdown = generate_markdown(project_name, project_info, file_infos)
+    localfs.declare_file(output_dir / f"{project_name}.md", markdown, create_parent_dirs=True)
 
-<img width="1366" height="768" alt="cover-0a6fa4e51bb8b18149a08c074f2d9ed8" src="https://github.com/user-attachments/assets/ed36f8b9-bf91-4183-beef-321b35ab3505" />
-
-
-
-This example shows how to use [instructor](https://github.com/jxnl/instructor) with Gemini to analyze multiple Python codebases and generate markdown documentation using CocoIndex v1.
-
-<img width="1180" height="1190" alt="image" src="https://github.com/user-attachments/assets/0efbdf7f-8fd3-460c-afd3-417285d42c69" />
-
-
-## What It Does
-
-1. **Scans subdirectories** of a root directory (each expected to be a separate Python project)
-2. **Per-file extraction** using LLM with a unified `CodebaseInfo` model:
-   - Public classes and functions with functionality summaries
-   - CocoIndex app call relationship graphs (Mermaid format)
-   - File-level summaries
-3. **Project aggregation** - combines file-level `CodebaseInfo` into a project-level summary
-4. **Outputs markdown** documentation to `output/PROJECT_NAME.md`
-
-## Key Features
-
-- **Instructor Integration**: Uses instructor library for structured LLM outputs with Pydantic
-- **Unified Data Model**: Same `CodebaseInfo` type for both file-level and project-level extraction
-- **LLM-Generated Mermaid Graphs**: The LLM generates mermaid syntax directly with:
-  - Bold text for `@coco.fn` decorated functions
-  - Thick arrows (`==>`) for `mount`/`use_mount` calls
-- **Incremental Processing**: CocoIndex handles caching - only re-processes changed files
-- **Multi-Project Support**: Processes multiple codebases in parallel
-
-## Output Format
-
-The generated markdown includes:
-
-- **Overview** - High-level project description
-- **Components** - Classes and functions with summaries
-- **CocoIndex Pipeline** - Mermaid diagrams (if CocoIndex is used)
-- **File Details** - Per-file summaries (for multi-file projects)
-
-### Example Mermaid Graph
-
-```mermaid
-graph TD
-    %% App: SampleApp
-    app_main[<b>app_main</b>] ==> process_file[<b>process_file</b>]
-    process_file --> helper_func[helper_func]
+@coco.fn
+async def app_main(root_dir: pathlib.Path, output_dir: pathlib.Path) -> None:
+    for entry in root_dir.resolve().iterdir():
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        files = [f async for f in localfs.walk_dir(entry, recursive=True,
+                 path_matcher=PatternFilePathMatcher(included_patterns=["**/*.py"],
+                                                     excluded_patterns=["**/.*", "**/__pycache__"]))]
+        if files:
+            await coco.mount(coco.component_subpath("project", entry.name),
+                             process_project, entry.name, files, output_dir)
 ```
 
-*Bold = `@coco.fn`, thick arrows (`==>`) = `mount`/`use_mount` calls*
+Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/) with the Pydantic models in [`models.py`](models.py); the LLM emits Mermaid graph syntax directly (bold for `@coco.fn` functions, thick `==>` arrows for `mount`/`use_mount` calls). Each project mounts as its own [processing component](https://cocoindex.io/docs/programming_guide/processing_component/), so projects run in parallel and one finishing doesn't wait on the rest.
 
-## Run
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/multi-codebase-summarization/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the data models, per-project granularity, concurrent extraction, and the Markdown + Mermaid output.
+</p>
 
-### 1. Install dependencies
+## Why it's worth a star ⭐
+
+- **Always fresh, never by hand.** The wiki is a [target state](https://cocoindex.io/docs/programming_guide/target_state/) regenerated from the code — edit a file and the one-pager updates itself; the docs can't drift from the source.
+- **Incremental by default.** `@coco.fn(memo=True)` caches each file's extraction by content, so re-running only re-analyzes changed files. Add a project and only that project is processed.
+- **Concurrent by construction.** `coco.map(extract_file_info, files)` fans every file out at once while staying visible to the pipeline — far faster than sequential LLM calls.
+- **You pick the granularity.** Here it's one wiki page per project directory, but the same shape works per file, per page, or per semantic unit.
+- **Structured outputs, your stack.** One `CodebaseInfo` Pydantic model drives both file- and project-level extraction; swap `LLM_MODEL` for any [LiteLLM provider](https://docs.litellm.ai/docs/providers).
+
+## Run it
+
+**1. Configure & install** — the default model is `gemini/gemini-2.5-flash`:
 
 ```sh
+cp .env.example .env     # set GEMINI_API_KEY (or LLM_MODEL=<provider/model> with its matching key)
 pip install -e .
 ```
 
-### 2. Set up environment variables
-
-Create a `.env` file in the example directory:
-
-```sh
-echo "GEMINI_API_KEY=your_api_key_here" > .env
-```
-
-Replace `your_api_key_here` with your actual Gemini API key.
-
-Optionally, set a different LLM model:
-
-```sh
-echo "LLM_MODEL=gemini/gemini-2.5-flash" >> .env
-```
-
-### 3. Prepare your projects
-
-Create a `projects/` directory with subdirectories for each Python project:
-
-```
-projects/
-├── my_project_1/
-│   ├── main.py
-│   └── utils.py
-├── my_project_2/
-│   └── app.py
-└── ...
-```
-
-### 4. Run the application
+**2. Generate the wiki** — `root_dir` defaults to `../`, so out of the box it documents the CocoIndex `examples/` folder itself, writing one page per example into `./output`:
 
 ```sh
 cocoindex update main.py
 ```
 
-This will:
-1. Scan all subdirectories in `projects/`
-2. Extract information from all `.py` files (excluding `.venv*` directories)
-3. Generate markdown documentation in `output/`
+To document your own code, point `root_dir` in `main.py` at a folder of project subdirectories and re-run.
 
-### 5. Verify the output
+**3. Read the output:**
 
 ```sh
-ls -la output/
-cat output/my_project_1.md
+ls output/
+cat output/code_embedding.md
 ```
 
-## Customization
+Each page has an **Overview**, a **Components** list (★ marks `@coco.fn` functions), a **CocoIndex Pipeline** Mermaid diagram where applicable, and per-file summaries for multi-file projects. Edit a `.py` file and re-run — only that file is re-analyzed, every other file served from the memo cache.
 
-### Change Input/Output Directories
+---
 
-Edit the `app` definition in `main.py`:
+<p align="center">
+  If this kept your codebase docs fresh, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/multi-codebase-summarization/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-```python
-app = coco.App(
-    coco.AppConfig(name="MultiCodebaseSummarization"),
-    app_main,
-    root_dir=pathlib.Path("./your_projects_dir"),
-    output_dir=pathlib.Path("./your_output_dir"),
-)
-```
-
-### Use a Different LLM
-
-Set the `LLM_MODEL` environment variable to any LiteLLM-supported model:
-
-```sh
-# OpenAI
-export LLM_MODEL=gpt-4o
-
-# Anthropic
-export LLM_MODEL=anthropic/claude-3-5-sonnet
-
-# Local (Ollama)
-export LLM_MODEL=ollama/llama3.2
-```
-
-## How It Works
-
-```mermaid
-graph TD
-    %% App: MultiCodebaseSummarization
-    app_main[<b>app_main</b>] ==> process_project[<b>process_project</b>]
-    process_project ==> extract_file_info[<b>extract_file_info</b>]
-    process_project ==> aggregate_project_info[<b>aggregate_project_info</b>]
-    process_project --> generate_markdown[generate_markdown]
-```
-
-1. **app_main**: Lists subdirectories, sets up output target, mounts `process_project` for each
-2. **process_project**: Extracts info from each file, aggregates, outputs markdown
-3. **extract_file_info**: Uses instructor + LLM to extract `CodebaseInfo` from each file
-4. **aggregate_project_info**: Combines file `CodebaseInfo` into project-level `CodebaseInfo`
-5. **generate_markdown**: Converts `CodebaseInfo` to markdown and calls `declare_file`
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/multi_codebase_summarization" alt="" width="1" height="1" />

--- a/examples/multi_format_indexing/README.md
+++ b/examples/multi_format_indexing/README.md
@@ -1,0 +1,114 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/multi-format-indexing/" title="Index PDFs and images into one searchable Qdrant collection with ColPali + MaxSim — no text extraction, in plain async Python with CocoIndex">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/multi-format-indexing/cover.svg" alt="Index any format together with CocoIndex and ColPali — render every PDF page to an image, embed pages and standalone images alike into multi-vector embeddings, and retrieve the most relevant page from one Qdrant MaxSim collection, no text extraction" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Index PDFs and images <em>together</em>, no parsing.</h1>
+
+<p align="center">
+  <b>Render every PDF page to an image, embed pages and images alike with multi-vector ColPali, and retrieve the most relevant <em>page</em> with MaxSim — whatever format it came from.</b><br/>
+  No OCR, no text extraction, no brittle per-format parsers — in plain async Python.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/multi-format-indexing/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Real document sets are a mix — scanned reports, slide exports, screenshots, and PDFs all jumbled together. Parsing each format into clean text is brittle and loses the layout (tables, charts, figures) that often *is* the answer. This pipeline sidesteps parsing entirely: render every PDF page to an image, embed pages and standalone images alike with the multi-vector [ColPali](https://huggingface.co/vidore/colpali-v1.2) model, and store them in one [Qdrant](https://qdrant.tech/) collection. You declare the transformation in native Python — `target_state = transformation(source_state)` — the slow per-page inference runs on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/), and the Rust engine handles incremental processing, so adding a document embeds only its pages.
+
+## How it works
+
+A file fans out to **pages**, so the shape is *file → N pages → N points*:
+
+- **Walk** a folder of PDFs and images (live), matching `.pdf` / `.jpg` / `.jpeg` / `.png`.
+- **Split** each file into pages — a PDF renders to one image per page via [`pdf2image`](https://github.com/Belval/pdf2image); a standalone image is a single page; anything else is skipped.
+- **Embed** every page with ColPali into a multi-vector and store one MaxSim Qdrant point per page, tagged with filename and page number.
+
+One file-splitting function handles every format, and `process_file` fans each page out with [`coco.map`](https://cocoindex.io/docs/programming_guide/app/). Read it in [`main.py`](main.py):
+
+```python
+@coco.fn.as_async(runner=coco.GPU)
+def file_to_pages(filename: str, content: bytes) -> list[Page]:
+    mime_type, _ = mimetypes.guess_type(filename)
+    if mime_type == "application/pdf":
+        return [Page(page_number=i + 1, image=_to_png(img))
+                for i, img in enumerate(convert_from_bytes(content, dpi=PDF_RENDER_DPI))]
+    if mime_type and mime_type.startswith("image/"):
+        return [Page(page_number=None, image=content)]
+    return []
+
+@coco.fn(memo=True)   # unchanged file is never re-rendered or re-embedded
+async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
+    filename = str(file.file_path.path)
+    pages = await file_to_pages(filename, await file.read())
+    await coco.map(process_page, pages, filename, target)   # one point per page
+```
+
+The Qdrant collection is declared with a `MultiVectorSchema` and `multivector_comparator="max_sim"`, so a text query is scored against the *best-matching patch* of each page — the same query reaches pages from PDFs and standalone images alike.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/multi-format-indexing/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the file-to-pages split, the GPU runner, the multi-vector MaxSim collection, and cross-format search.
+</p>
+
+## Why it's worth a star ⭐
+
+- **One index, every format.** PDFs and images funnel into the same Qdrant collection through one `file_to_pages` path — a query reaches them all, no per-format retrievers.
+- **No parsing, no OCR.** ColPali embeds the rendered *page image*, so tables, charts, and figures stay intact — exactly the layout that OCR-and-embed throws away.
+- **MaxSim multi-vector retrieval.** A `MultiVectorSchema` + `max_sim` comparator scores a query against each page's best-matching patches, late-interaction style.
+- **Fan-out done right.** A file expands to N pages with `coco.map`, each its own point keyed by `(filename, page)` — re-running reconciles cleanly instead of duplicating.
+- **Incremental on a GPU runner.** Slow per-page inference runs on `coco.GPU`; `@coco.fn(memo=True)` means adding a document embeds only its pages and leaves the rest untouched.
+
+## Run it
+
+> Needs **Qdrant** plus the ColPali deps (`torch`, `transformers`, `pdf2image`). `pdf2image` needs **poppler** installed for PDF rendering (`brew install poppler` / `apt install poppler-utils`).
+
+**1. Start Qdrant:**
+
+```sh
+docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # QDRANT_URL (defaults to the local container above)
+pip install -e .
+```
+
+**3. Build the index** — the example ships a `source_files/` folder mixing PDFs (papers) and images (financial report pages). A PDF expands to one point per page (the sample BERT paper alone is 16 pages):
+
+```sh
+cocoindex update main        # or: cocoindex update -L main   (keep watching the folder)
+```
+
+**4. Search across formats** — embed a text query with ColPali; the same query reaches pages from PDFs and standalone images alike:
+
+```sh
+python main.py "revenue growth"
+```
+
+On the sample set, *"revenue growth"* ranks the two financial-report images at the top (Sweetgreen, then Restaurant Brands), above an unrelated healthcare page — MaxSim matching the query against the most relevant patches of each page, with zero text extraction.
+
+---
+
+<p align="center">
+  If this made your mixed-format documents searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/multi-format-indexing/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/multi_format_indexing" alt="" width="1" height="1" />

--- a/examples/oci_object_storage_embedding/README.md
+++ b/examples/oci_object_storage_embedding/README.md
@@ -1,80 +1,115 @@
-# OCI Object Storage Embedding (v1) ☁️
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/oci-object-storage-embedding/" title="Embed Markdown objects from an OCI Object Storage bucket into Postgres pgvector with CocoIndex — incremental, live via OCI Streaming, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/oci-object-storage-embedding/cover.svg" alt="Embed an OCI Object Storage bucket with CocoIndex — list Markdown objects, chunk and embed each one with sentence-transformers, store the vectors in Postgres pgvector, and keep them live off OCI Streaming events" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds markdown files from an Oracle Cloud Infrastructure (OCI) Object Storage bucket, stores the chunks + embeddings in Postgres (pgvector), and provides a simple semantic-search query demo.
+<h1 align="center">Semantic search over an <em>OCI</em> Object Storage bucket.</h1>
 
-It optionally subscribes to **OCI Streaming** (Kafka-protocol-compatible) for live updates: when configured, object create/update/delete events flowing through the stream trigger incremental re-processing without re-scanning the whole bucket.
+<p align="center">
+  <b>List Markdown objects from an Oracle Cloud bucket, <em>chunk</em> and <em>embed</em> each one, and store the vectors in Postgres pgvector — kept <em>live</em> off OCI Streaming.</b><br/>
+  It's Semantic Search 101 with the source swapped for a bucket — in plain async Python.
+</p>
 
-## Prerequisites
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/oci-object-storage-embedding/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+<div align="center">
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-- An OCI Object Storage bucket with markdown files
-- An OCI config file (default `~/.oci/config`) with API-key auth set up — see [OCI SDK config docs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm)
-- *(Optional, for live mode)* An OCI Streaming stream pool with object events from the bucket published to a topic, plus a streaming auth token
+</div>
 
-Copy `.env.example` to `.env` and fill in your values:
+<br/>
 
-```sh
-cp .env.example .env
+Most documents already live in object storage, not on your laptop. This pipeline lists Markdown objects from an [OCI Object Storage](https://cocoindex.io/docs/connectors/oci_object_storage/) bucket, splits each into overlapping chunks, embeds them with sentence-transformers, and stores the vectors in Postgres with pgvector. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so adding one object embeds one object, not the whole bucket.
+
+## How it works
+
+The chunk → embed → store half is identical to [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/); the part that differs is the source. The OCI SDK is synchronous and you create the client yourself, so the example builds one from a config-file profile, hands it to the [context](https://cocoindex.io/docs/programming_guide/context/), and lists objects with `oci_object_storage.list_objects` — the OCI analogue of `localfs.walk_dir`. Live mode is opt-in: when the four `OCI_STREAMING_*` env vars are set, it builds a Kafka-protocol `AIOConsumer` against OCI Streaming and passes it through as a `LiveStream[bytes]`. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def app_main() -> None:
+    target_table = await postgres.mount_table_target(
+        PG_DB, table_name=TABLE_NAME,
+        table_schema=await postgres.TableSchema.from_class(DocEmbedding, primary_key=["id"]),
+        pg_schema_name=PG_SCHEMA_NAME,
+    )
+    client = coco.use_context(OCI_CLIENT)
+
+    # Live mode is opt-in: build a LiveStream[bytes] from OCI Streaming if configured.
+    consumer = _build_streaming_consumer()
+    live_stream = None
+    if consumer is not None and OCI_STREAMING_TOPIC is not None:
+        live_stream = kafka.topic_as_stream(consumer, [OCI_STREAMING_TOPIC]).payloads()
+
+    files = oci_object_storage.list_objects(
+        client, OCI_NAMESPACE, OCI_BUCKET, prefix=OCI_PREFIX,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        live_stream=live_stream,
+    )
+    await coco.mount_each(process_file, files.items(), target_table)
 ```
 
-## Run
+With `live_stream=None` (the default), `list_objects` does a one-shot catch-up scan. Pass a stream and the connector keeps watching, re-reading each post-cutoff object to apply an authoritative update or delete. `mount_each` runs one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per object so the engine tracks each independently.
 
-Install deps:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/oci-object-storage-embedding/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the OCI client, the source call, the row schema, and exactly how live mode rides OCI Streaming.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Swap the source, keep the flow.** Only the source line changes from the local-folder example — `process_file` takes an `oci_object_storage.OCIFile` and reads it with `await file.read_text()`, just like a local `FileLike`.
+- **Live without re-scanning.** OCI Streaming is Kafka-compatible, so object create/update/delete events ride the [Kafka connector](https://cocoindex.io/docs/connectors/kafka/) and drive incremental updates with no full bucket re-scan.
+- **Authoritative, not event-trusting.** For each accepted event the connector re-reads the object (`head_object`) to determine current state, then issues an update (present) or delete (404) — the event type is never trusted as the dispatch signal.
+- **Incremental by default.** `@coco.fn(memo=True)` skips an object whose content and code are unchanged; `mount_table_target` upserts only changed rows and deletes rows whose source is gone.
+- **Plain Python, your stack.** Local sentence-transformer embedder, no API key; swap `EMBED_MODEL` for any of the 12k+ models on Hugging Face.
+
+## Run it
+
+**1. Start Postgres + pgvector** (the repo ships a compose file):
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install** — point at a bucket with Markdown objects and an [OCI config file](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm) (default `~/.oci/config`):
+
+```sh
+cp .env.example .env     # set POSTGRES_URL, OCI_NAMESPACE, OCI_BUCKET (optional OCI_PREFIX)
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres). Pick one of the two modes:
+For live mode, also set `OCI_STREAMING_BOOTSTRAP_SERVERS`, `OCI_STREAMING_TOPIC`, `OCI_STREAMING_USERNAME`, and `OCI_STREAMING_AUTH_TOKEN` in `.env` (the `.env.example` documents each format). With those unset, the connector skips the subscription and just does the catch-up scan.
 
-- **Catch-up run** — scan the bucket, sync changes, exit:
+**3. Build the index** — catch-up (scan, sync, exit) or live (catch up, then keep watching the topic):
 
-  ```sh
-  cocoindex update main
-  ```
+```sh
+cocoindex update main        # catch-up
+cocoindex update -L main     # live
+```
 
-- **Live run** — catch up, then keep watching the OCI Streaming topic for change events and apply incremental updates:
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Live mode requires `OCI_STREAMING_BOOTSTRAP_SERVERS`, `OCI_STREAMING_TOPIC`, `OCI_STREAMING_USERNAME`, and `OCI_STREAMING_AUTH_TOKEN` to be set in `.env`. With those unset, the connector skips live-stream subscription and just performs the catch-up scan.
-
-### `OCI_STREAMING_USERNAME` format
-
-`<tenancy-name>/<username>/<stream-pool-ocid>` — note the first two segments are **plain names, not OCIDs**:
-
-- `tenancy-name`: e.g. `acme-corp` (NOT `ocid1.tenancy.oc1..…`). If your tenancy uses Identity Domains, the format is `<tenancy-name>/<domain-name>/<username>/<stream-pool-ocid>`.
-- `username`: e.g. `alice@example.com` (NOT `ocid1.user.oc1..…`). For federated users, prefix with the IDP, e.g. `oracleidentitycloudservice/alice@example.com`.
-- `stream-pool-ocid`: this one *is* an OCID, e.g. `ocid1.streampool.oc1.iad.aaaa…`.
-
-The OCI Console pre-formats this exact string for you under **Streaming → Stream Pools → \<your pool\> → Kafka Connection Settings → "SASL Connection String"**. Just copy that value verbatim.
-
-### `OCI_STREAMING_AUTH_TOKEN`
-
-This is a per-user "Auth Token" — a one-shot credential, distinct from your Console password and from API signing keys. Generate via Console → **Profile → My profile → Auth tokens → Generate token**. Copy it immediately; it cannot be viewed again.
-
-Query:
+**4. Search from the command line:**
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-Note: this example **does not create a vector index**; queries will do a sequential scan.
+This example keeps it minimal and doesn't declare a vector index, so queries do a sequential scan — fine for a few objects. For a larger corpus, add `target_table.declare_vector_index(column="embedding")` exactly as [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) does.
 
-## How live mode works
+---
 
-OCI Streaming exposes a Kafka-compatible interface. The example builds a `confluent_kafka.aio.AIOConsumer` configured with `SASL_SSL` + `PLAIN` auth pointing at the streaming endpoint, wraps it via `cocoindex.connectors.kafka.topic_as_stream(...).payloads()` to get a `LiveStream[bytes]`, and passes that to `oci_object_storage.list_objects(..., live_stream=...)`. The connector then:
+<p align="center">
+  If this made your bucket searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/oci-object-storage-embedding/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-1. Snapshots a wall-clock cutoff (`now - 5s`) before the scan starts.
-2. Runs the initial scan concurrently with stream consumption.
-3. Drops streamed events whose `eventTime` predates the cutoff (the scan covers them).
-4. For accepted post-cutoff events: re-reads the object via `head_object` to determine current state, then issues an authoritative `update` (object present) or `delete` (404) — event type is not trusted as a dispatch signal.
-
-See `python/cocoindex/connectors/oci_object_storage/_source.py` for details.
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/oci_object_storage_embedding" alt="" width="1" height="1" />

--- a/examples/paper_metadata/README.md
+++ b/examples/paper_metadata/README.md
@@ -1,57 +1,129 @@
-# Paper Metadata (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/paper-metadata/" title="Index academic PDFs into structured metadata with CocoIndex — LLM-extract title/authors/abstract, embed for semantic search, store in Postgres pgvector, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/cover.svg" alt="Turn a folder of academic PDFs into structured metadata with CocoIndex — read the first page, LLM-extract title, authors, and abstract into typed rows, embed the title and abstract for semantic search, and store it all in Postgres with pgvector" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<h1 align="center">Turn a folder of papers into <em>structured</em> metadata.</h1>
 
-This example extracts metadata (title, authors, abstract) from PDF papers, stores it in Postgres, and builds embeddings for semantic search.
+<p align="center">
+  <b>Read just the first page, LLM-extract <em>title, authors, abstract</em> into typed rows, then embed the metadata so you can search papers by <em>meaning</em> — in plain async Python.</b><br/>
+  One PDF fans out into three Postgres tables, and CocoIndex keeps all three in sync as the folder changes.
+</p>
 
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/paper-metadata/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Prerequisites
+<div align="center">
 
-- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+</div>
 
-- Set `OPENAI_API_KEY` for metadata extraction
-- Set `POSTGRES_URL` for Postgres access
+<br/>
 
-## Run
+The first page of a paper holds almost everything you'd want to query — title, authors, abstract — but it's locked in PDF prose. This pipeline reads just that page, hands the text to an LLM with a strict schema, and gets back clean typed JSON; the same metadata is then embedded so you can search by meaning, not exact words. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only changed PDFs get re-extracted and re-embedded.
 
-Install dependencies:
+## How it works
+
+One PDF flows through three small functions and fans into three tables:
+
+1. **`extract_basic_info`** slices the first page out of the PDF and counts the pages; **`pdf_to_markdown`** pulls the text off that page with [pypdf](https://github.com/py-pdf/pypdf).
+2. **`extract_metadata`** hands that text to `gpt-4o` (via the `openai` SDK) with `response_format={"type": "json_object"}` and `temperature=0`, then `model_validate_json` parses it into a typed `PaperMetadataModel` — a malformed response fails loudly instead of writing junk.
+3. **`process_file`** declares the rows: one metadata row, one author-index row per author, one embedding row for the title plus one per abstract chunk.
+
+Read it in [`main.py`](main.py):
+
+```python
+@coco.fn(memo=True)
+async def process_file(
+    file: FileLike,
+    metadata_table: postgres.TableTarget[PaperMetadataRow],
+    author_table: postgres.TableTarget[AuthorPaperRow],
+    embedding_table: postgres.TableTarget[MetadataEmbeddingRow],
+) -> None:
+    content = await file.read()
+    basic_info = extract_basic_info(content)
+    metadata = extract_metadata(pdf_to_markdown(basic_info.first_page))
+
+    metadata_table.declare_row(row=PaperMetadataRow(
+        filename=str(file.file_path.path), title=metadata.title,
+        authors=[a.model_dump() for a in metadata.authors],
+        abstract=metadata.abstract, num_pages=basic_info.num_pages,
+    ))
+    for author in metadata.authors:
+        if author.name:
+            author_table.declare_row(row=AuthorPaperRow(
+                author_name=author.name, filename=str(file.file_path.path)))
+
+    title_embedding = await coco.use_context(EMBEDDER).embed(metadata.title)
+    embedding_table.declare_row(row=MetadataEmbeddingRow(
+        id=uuid.uuid4(), filename=str(file.file_path.path),
+        location="title", text=metadata.title, embedding=title_embedding))
+    for chunk in _abstract_splitter.split(metadata.abstract, chunk_size=500, ...):
+        embedding_table.declare_row(row=MetadataEmbeddingRow(
+            id=uuid.uuid4(), filename=str(file.file_path.path), location="abstract",
+            text=chunk.text, embedding=await coco.use_context(EMBEDDER).embed(chunk.text)))
+```
+
+`embedding: Annotated[NDArray, EMBEDDER]` ties the vector column to the embedder, so its dimensions are inferred automatically. `app_main` mounts the three tables (with different primary keys), walks the source for `*.pdf`, and runs one `process_file` component per file with `mount_each`.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/paper-metadata/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the Pydantic schema, the three-table fan-out, the abstract splitter, and the pgvector query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **One file, three tables, kept in sync.** Paper metadata, an author-to-paper index, and embeddings — `mount_table_target` upserts only what changed and removes rows whose PDF is gone, across all three.
+- **First page only, capped at 4000 chars.** That's almost always enough for the title block and abstract, and it keeps token cost flat regardless of paper length.
+- **Typed extraction, validated loud.** `gpt-4o` returns JSON, `PaperMetadataModel.model_validate_json` rejects anything off-schema — junk never reaches Postgres.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a PDF entirely when its bytes and the function's code are unchanged, so you never re-pay for the LLM call or the embeddings on a file you've seen.
+- **Honest cache busting.** `EMBEDDER` is declared with `detect_change=True`, so swapping the embedding model re-embeds everything with no cache to clear by hand.
+
+## Run it
+
+**1. Start Postgres (with pgvector):**
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install** — the example ships a `papers/` folder of well-known papers:
+
+```sh
+cp .env.example .env     # set POSTGRES_URL and OPENAI_API_KEY
 pip install -e .
 ```
 
-Set environment variables:
+**3. Build the index** — catch-up (scan, sync, exit) or live (catch up, then keep watching):
 
 ```sh
-export OPENAI_API_KEY="your_key"
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+cocoindex update main       # catch-up run
+cocoindex update -L main    # live run — watch the papers/ folder for changes
 ```
 
-This example uses the `coco_examples_v1` schema by default to avoid clashing with the legacy example tables.
+This reads each PDF's first page, LLM-extracts the metadata, embeds the title and abstract chunks, and writes the `coco_examples_v1` schema's three tables.
 
-Build/update the index (writes rows into Postgres). Pick one of the two modes:
-
-- **Catch-up run** — scan sources, sync changes, exit:
-
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**4. Search by meaning** — a plain SQL query over pgvector's cosine distance, reusing the *same* embedder:
 
 ```sh
 python main.py "graph neural networks"
 ```
 
-Note: this example **does not create a vector index**; queries will do a sequential scan.
+The most semantically similar titles and abstracts come back ranked — even when they share none of the query's words. Note: to keep the example minimal it declares **no vector index**, so queries do a sequential scan (fine for a handful of papers).
+
+---
+
+<p align="center">
+  If this turned your PDFs into searchable rows, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/paper-metadata/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/paper_metadata" alt="" width="1" height="1" />

--- a/examples/patient_intake_extraction_baml/README.md
+++ b/examples/patient_intake_extraction_baml/README.md
@@ -1,66 +1,115 @@
-# Extract structured data from patient intake forms with BAML (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/patient-intake-baml/" title="Extract typed patient records from intake-form PDFs with CocoIndex and BAML — one type-safe Gemini vision extraction per form, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/cover.svg" alt="Turn messy patient intake PDFs into validated JSON with CocoIndex and BAML — declare the Patient schema in BAML, run one type-safe Gemini vision extraction per form, and write a schema-validated JSON record per patient" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<h1 align="center">Patient intake forms to <em>typed</em> JSON, with BAML.</h1>
 
-This example shows how to use [BAML](https://boundaryml.com/) to extract structured data from patient intake PDFs using CocoIndex v1. BAML provides type-safe structured data extraction with native PDF support.
+<p align="center">
+  <b>Declare the <em>Patient</em> schema in BAML, run one type-safe Gemini vision extraction per intake PDF, and get back a validated JSON record — the same shape every time — in plain async Python.</b><br/>
+  The hard part isn't reading the PDF; it's getting data that matches a schema so downstream code can trust it.
+</p>
 
-- **BAML Schema** (`baml_src/patient.baml`) - Defines the data structure and extraction function
-- **CocoIndex v1 App** (`main.py`) - Wraps BAML in a custom function, processes files incrementally, and writes results to JSON files
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/patient-intake-baml/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Run
+<div align="center">
 
-### 1. Install dependencies
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-Install from the project's pyproject.toml:
+</div>
+
+<br/>
+
+Intake forms are messy, multi-section PDFs — demographics, insurance, medications, allergies, consent — and the real challenge is getting back data that *matches a schema* every time. This pipeline uses [BAML](https://boundaryml.com/) to declare that schema and run a single type-safe extraction per form against a Gemini vision model. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only changed PDFs get re-extracted and the LLM call is skipped entirely for forms you've already processed.
+
+## How it works
+
+The schema lives in `baml_src/patient.baml`, not in Python. You describe the `Patient` record as BAML classes; the same file holds the extraction function and the `Gemini` client (pointing at `gemini-2.5-flash`), which reads PDFs natively as vision input — no separate parse or OCR step. Running `baml generate` compiles this into a `baml_client/` package you import from Python: `b.ExtractPatientInfo(...)` and the `Patient` Pydantic model.
+
+The CocoIndex side is two short functions — wrap BAML in a `@coco.fn`, then declare one JSON file per form. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def extract_patient_info(content: bytes) -> Patient:
+    """Extract patient information from PDF content using BAML."""
+    pdf = baml_py.Pdf.from_base64(base64.b64encode(content).decode("utf-8"))
+    return await b.ExtractPatientInfo(pdf)
+
+
+@coco.fn(memo=True)
+async def process_patient_form(file: FileLike, outdir: pathlib.Path) -> None:
+    content = await file.read()
+    patient_info = await extract_patient_info(content)
+    patient_json = patient_info.model_dump_json(indent=2)
+    output_filename = file.file_path.path.stem + ".json"
+    localfs.declare_file(outdir / output_filename, patient_json, create_parent_dirs=True)
+```
+
+The return type is `Patient` — the actual Pydantic class BAML generated, not a dict — so everything downstream is typed and validated. There's no prompt engineering or response parsing here; that all lives in the BAML schema, and the LLM call is one `await`. `app_main` walks `data/patient_forms/` for `*.pdf` and runs one `process_patient_form` component per file with `mount_each`.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/patient-intake-baml/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the BAML schema, the type-safe extraction function, the per-form component, and what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **The schema is the contract.** `ExtractPatientInfo(intake_form: pdf) -> Patient` is the whole spec — BAML forces the model's output to conform, so every record has the same shape, ready to load into a database or chart.
+- **Native PDF vision, no OCR.** The `Gemini` client reads the PDF directly as vision input — checkboxes, hand-filled fields, tables — with no separate parse or Markdown step.
+- **Typed all the way down.** `b.ExtractPatientInfo` returns a generated Pydantic `Patient`, not a string to parse — `model_dump_json` serializes the validated model straight to disk.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a form entirely when its bytes and the function's code are unchanged, so you never pay for a second Gemini call on a PDF you've already extracted.
+- **Compare libraries on one flow.** A [DSPy twin](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_dspy) runs the exact same task with a DSPy signature instead of BAML — same input, same output, swap the extraction layer.
+
+## Run it
+
+**1. Install:**
 
 ```sh
 pip install -e .
 ```
 
-### 2. Generate BAML client code
-
-This is a required step that generates the Python client code from your BAML schema:
+**2. Generate the BAML client** — compiles `baml_src/patient.baml` into the `baml_client/` package that `main.py` imports (required):
 
 ```sh
 baml generate
 ```
 
-This will create a `baml_client/` directory with the generated Python code.
-
-### 3. Set up environment variables
-
-Create a `.env` file in the example directory:
+**3. Configure** — the extraction uses a Gemini vision model:
 
 ```sh
-echo "GEMINI_API_KEY=your_api_key_here" > .env
+cp .env.example .env     # set GEMINI_API_KEY
 ```
 
-Replace `your_api_key_here` with your actual Gemini API key.
-
-### 4. Run the application
+**4. Run the pipeline** — a catch-up run scans the forms, extracts, writes, and exits:
 
 ```sh
 cocoindex update main.py
 ```
 
-This will:
-
-1. Read all PDF files from `data/patient_forms/`
-2. Extract patient information using BAML
-3. Write the extracted data as JSON files to `output_patients/`
-
-### 5. Verify the output
-
-After running, check the `output_patients/` directory:
+This reads each PDF in `data/patient_forms/`, extracts a `Patient`, and writes one JSON file per form to `output_patients/`:
 
 ```sh
-ls -la output_patients/
+ls output_patients/
+# Patient_Intake_Form_David_Artificial.json
+# Patient_Intake_Form_Emily_Artificial.json
+# ...one .json per intake PDF
 ```
 
-You should see JSON files such as:
+Each file is a fully populated, schema-validated patient record — the same shape every time. Edit the BAML schema or swap the model, run `baml generate` again, and the next `cocoindex update main.py` re-extracts only what changed.
 
-- `Patient_Intake_Form_David_Artificial.json`
-- `Patient_Intake_Form_Emily_Artificial.json`
-- `Patient_Intake_Form_Joe_Artificial.json`
-- `Patient_Intake_Form_Jane_Artificial.json`
+---
+
+<p align="center">
+  If this turned a stack of forms into clean records, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/patient-intake-baml/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/patient_intake_extraction_baml" alt="" width="1" height="1" />

--- a/examples/patient_intake_extraction_dspy/README.md
+++ b/examples/patient_intake_extraction_dspy/README.md
@@ -1,66 +1,117 @@
-# Extract structured data from patient intake forms with DSPy (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/patient-intake-dspy/" title="Extract typed patient records from intake-form PDFs with CocoIndex and DSPy — render each page to an image, a ChainOfThought vision module on Gemini extracts a typed Patient, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/cover.svg" alt="Turn patient intake PDFs into validated JSON with CocoIndex and DSPy — render each page to an image, a typed ChainOfThought vision module on Gemini reads the form like a person and returns a validated Patient, one JSON file per form" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<h1 align="center">Patient intake forms to <em>typed</em> JSON, with DSPy.</h1>
 
-This example shows how to use [DSPy](https://github.com/stanfordnlp/dspy) with Gemini 2.5 Flash (vision model) to extract structured data from patient intake PDFs using CocoIndex v1.
+<p align="center">
+  <b>Render each PDF page to an image and let a typed <em>ChainOfThought</em> vision module on Gemini read the form the way a person would — returning a validated <em>Patient</em>, no prompt strings to hand-tune — in plain async Python.</b><br/>
+  Intake forms are visual: checkboxes, hand-filled fields, tables of medications — so we extract from the rendered page, not the text.
+</p>
 
-- **Pydantic Models** (`main.py`) - Defines the data structure using Pydantic for type safety
-- **DSPy Module** (`main.py`) - Defines the extraction signature and module using DSPy's ChainOfThought with vision support
-- **CocoIndex v1 App** (`main.py`) - Wraps DSPy in a custom function, processes files incrementally, and writes results to JSON files
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/patient-intake-dspy/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Key Features
+<div align="center">
 
-- **Native PDF Support**: Converts PDFs to images and processes directly with vision models
-- **DSPy Vision Integration**: Uses DSPy's `Image` type with `ChainOfThought` for visual document understanding
-- **Structured Outputs**: Pydantic models ensure type-safe, validated extraction
-- **No Text Extraction Required**: Directly processes PDF images without intermediate markdown conversion
-- **Incremental Processing**: CocoIndex handles batching and caching automatically
-- **Portable outputs**: JSON results stored locally under `output_patients/`
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-## Run
+</div>
 
-### 1. Install dependencies
+<br/>
 
-Install from the project's pyproject.toml:
+Intake forms are *visual* — checkboxes, hand-filled fields, tables of medications — so instead of extracting text, this pipeline renders each PDF page to an image and lets a vision model read the form the way a person would. [DSPy](https://github.com/stanfordnlp/dspy) handles the prompting: you declare a typed `Signature` and it produces a Pydantic `Patient`, no prompt strings to hand-tune. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only changed forms get re-extracted and each one becomes exactly one JSON file on disk.
+
+## How it works
+
+The output is just Python types: `Patient` (in `models.py`) is a Pydantic model with nested models for address, insurance, medications, and the rest. That model *is* the contract — DSPy fills it in, Pydantic validates it, it serializes straight to JSON. Rather than write a prompt, you declare a typed `Signature` and wrap it in `ChainOfThought` so the model reasons before it answers; `extract_patient` rasterizes every page to a PNG and runs the extractor. Read it in [`main.py`](main.py):
+
+```python
+class PatientExtractionSignature(dspy.Signature):
+    """Extract structured patient information from a medical intake form image."""
+    form_images: list[dspy.Image] = dspy.InputField(desc="Images of the intake form pages")
+    patient: Patient = dspy.OutputField(desc="Extracted patient information")
+
+
+class PatientExtractor(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.extract = dspy.ChainOfThought(PatientExtractionSignature)
+
+    def forward(self, form_images: list[dspy.Image]) -> Patient:
+        return self.extract(form_images=form_images).patient
+
+
+@coco.fn
+def extract_patient(pdf_content: bytes) -> Patient:
+    pdf_doc = pymupdf.open(stream=pdf_content, filetype="pdf")
+    form_images = []
+    for page in pdf_doc:
+        pix = page.get_pixmap(matrix=pymupdf.Matrix(2, 2))   # 2x scale: small print stays legible
+        form_images.append(dspy.Image(pix.tobytes("png")))
+    pdf_doc.close()
+    return PatientExtractor()(form_images=form_images)
+```
+
+Because the `OutputField` is typed as `Patient`, DSPy asks the model for that exact shape and hands back a validated object, not a string to parse. The LM is configured once at module load — `dspy.configure(lm=dspy.LM("gemini/gemini-2.5-flash"))`. `process_patient_form` (decorated `@coco.fn(memo=True)`) reads each PDF, extracts the `Patient`, and declares one JSON file named after the source form; `app_main` runs one component per file with `mount_each`.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/patient-intake-dspy/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the Pydantic schema, the DSPy signature and module, the PDF rasterization, and what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Read the form, not the text.** Each page is rendered at `Matrix(2, 2)` so small hand-entered text stays legible — the difference between reading a zip code and guessing one. No OCR, no Markdown step.
+- **Declared, not prompted.** A typed `Signature` plus `ChainOfThought` is the whole spec; DSPy compiles the typed in/out into the actual prompt and reasons before answering on dense, checkbox-heavy forms.
+- **Typed and validated.** The `OutputField` is `Patient`, so DSPy returns a validated Pydantic object; optional fields and `default_factory=list` mean a form that omits medications yields an empty list, not a failure.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a form entirely when its bytes and the function's code are unchanged, so you never re-run the slow, paid vision extraction on a PDF you've already processed.
+- **Compare libraries on one flow.** A [BAML twin](https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_baml) runs the exact same task with a BAML schema instead of a DSPy signature — same input, same output, swap the extraction layer.
+
+## Run it
+
+**1. Install** — this pulls in DSPy, PyMuPDF (to rasterize PDFs), and Pillow (for the image bytes DSPy passes along):
 
 ```sh
 pip install -e .
 ```
 
-This installs Pillow, which DSPy uses to process image bytes.
-
-### 2. Set up environment variables
-
-Create a `.env` file in the example directory:
+**2. Configure** — the extraction runs on a Gemini vision model:
 
 ```sh
-echo "GEMINI_API_KEY=your_api_key_here" > .env
+cp .env.example .env     # set GEMINI_API_KEY
 ```
 
-Replace `your_api_key_here` with your actual Gemini API key.
-
-### 3. Run the application
+**3. Run the pipeline** — a catch-up run scans the forms, extracts, writes, and exits:
 
 ```sh
 cocoindex update main.py
 ```
 
-This will:
-1. Read all PDF files from `data/patient_forms/`
-2. Extract patient information using DSPy
-3. Write the extracted data as JSON files to `output_patients/`
-
-### 4. Verify the output
-
-After running, check the `output_patients/` directory:
+Each PDF in `data/patient_forms/` becomes a JSON file in `output_patients/`, named after the source form:
 
 ```sh
-ls -la output_patients/
+ls output_patients/
+# Patient_Intake_Form_David_Artificial.json
+# Patient_Intake_Form_Emily_Artificial.json
+# ...one .json per intake PDF
 ```
 
-You should see JSON files such as:
-- `Patient_Intake_Form_David_Artificial.json`
-- `Patient_Intake_Form_Emily_Artificial.json`
-- `Patient_Intake_Form_Joe_Artificial.json`
-- `Patient_Intake_Form_Jane_Artificial.json`
+Open one and you'll see the full `Patient` record — name, date of birth, address, insurance, the medication and allergy lists, consent — extracted straight from the rendered form and validated against the schema. Add a field to the `Patient` model or switch the LM, and the next run re-extracts only the affected forms.
+
+---
+
+<p align="center">
+  If this turned a stack of forms into clean records, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/patient-intake-dspy/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/patient_intake_extraction_dspy" alt="" width="1" height="1" />

--- a/examples/pdf_embedding/README.md
+++ b/examples/pdf_embedding/README.md
@@ -1,51 +1,103 @@
-# PDF Embedding (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/pdf-embedding/" title="Build a vector index from local PDFs with CocoIndex — convert to Markdown with docling on a GPU runner, chunk, embed, and store in Postgres pgvector, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/cover.svg" alt="Semantic search over PDFs with CocoIndex — walk a folder of PDFs, convert each to Markdown with docling on a GPU runner, split into chunks, embed with sentence-transformers, and store the vectors in Postgres with pgvector" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<h1 align="center">Semantic search over a folder of <em>PDFs</em>.</h1>
 
-This example builds an embedding index from local PDF files. It converts PDFs to markdown, chunks the text, embeds each chunk, and stores the results in Postgres (pgvector). It also provides a simple query demo.
+<p align="center">
+  <b>Convert each PDF to Markdown with <em>docling</em> on a GPU runner, <em>chunk</em> and <em>embed</em> it, and store the vectors in Postgres pgvector.</b><br/>
+  Papers, RFCs, manuals, contracts — searchable in plain English, in plain async Python.
+</p>
 
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/pdf-embedding/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Prerequisite
+<div align="center">
 
-A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Take a folder of PDFs and turn it into a [vector index](https://github.com/pgvector/pgvector) you can search in plain English. The trick PDFs add over plain text: they have to be *parsed* first. This pipeline uses [docling](https://github.com/docling-project/docling) to convert each PDF to clean Markdown, then chunks, embeds, and stores the vectors in Postgres. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only changed PDFs get re-parsed and re-embedded.
+
+## How it works
+
+The one genuinely expensive step is PDF parsing, so it runs on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/) and the docling converter is built once with `@functools.cache`. `process_file` converts the PDF to Markdown, splits it into overlapping chunks, and maps each chunk to `process_chunk` for embedding. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn.as_async(runner=coco.GPU)
+def pdf_to_markdown(content: bytes) -> str:
+    source = DocumentStream(name="input.pdf", stream=io.BytesIO(content))
+    return pdf_converter().convert(source).document.export_to_markdown()
+
+@coco.fn(memo=True)
+async def process_file(file: FileLike, table: postgres.TableTarget[PdfEmbedding]) -> None:
+    markdown = await pdf_to_markdown(await file.read())
+    chunks = _splitter.split(markdown, chunk_size=2000, chunk_overlap=500, language="markdown")
+    id_gen = IdGenerator()
+    await coco.map(process_chunk, chunks, file.file_path.path, id_gen, table)
+```
+
+`@coco.fn.as_async(runner=coco.GPU)` wraps the *synchronous*, GPU-heavy parse so it runs off the async event loop. Each chunk's row `id` is derived from its text, so a chunk that survives a re-parse keeps its row.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/pdf-embedding/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the docling converter, the GPU runner, the row schema, and the query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Parsing where text embedding has none.** docling reads the PDF and exports Markdown that preserves headings, tables, and reading order — which is exactly what makes the downstream chunks coherent.
+- **The slow step, off the event loop.** `@coco.fn.as_async(runner=coco.GPU)` offloads PDF parsing to a dedicated GPU runner; `@functools.cache` loads the docling model once, not per file.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a PDF whose bytes and code are unchanged, so docling never re-parses a file you've already converted; `mount_table_target` upserts only changed rows and deletes rows whose source is gone.
+- **Live without re-scanning.** The filesystem source declares `live=True` — pass `-L` and added, replaced, or deleted PDFs are picked up as they change.
+- **Plain Python, your stack.** Local `all-MiniLM-L6-v2` embedder, no API key; swap `EMBED_MODEL` for any of the 12k+ sentence-transformer models on Hugging Face.
+
+## Run it
+
+**1. Start Postgres + pgvector** (the repo ships a compose file):
 
 ```sh
 docker compose -f ../../dev/postgres.yaml up -d
 ```
 
-## Run
-
-Install dependencies:
+**2. Configure & install** (docling pulls in the PDF parser):
 
 ```sh
+cp .env.example .env     # set POSTGRES_URL
 pip install -e .
 ```
 
-Set a database URL (or use `.env`):
+**3. Build the index** — the example ships a `pdf_files/` folder of sample papers/RFCs; catch-up or live:
 
 ```sh
-export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
+cocoindex update main        # catch-up
+cocoindex update -L main     # live: keep watching for file changes
 ```
 
-Build/update the index (writes rows into Postgres). Pick one of the two modes:
-
-- **Catch-up run** — scan sources, sync changes, exit:
-
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**4. Search from the command line:**
 
 ```sh
 python main.py "what is attention?"
 ```
 
-Note: this example **does not create a vector index**; queries will do a sequential scan.
+With the sample papers indexed, the most semantically similar passages come back ranked — even when they share none of the words in your query. This example keeps it minimal and doesn't declare a vector index, so queries do a sequential scan. For a larger corpus, add `target_table.declare_vector_index(column="embedding")` exactly as [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) does.
+
+---
+
+<p align="center">
+  If this made your PDFs searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/pdf-embedding/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/pdf_embedding" alt="" width="1" height="1" />

--- a/examples/pdf_to_markdown/README.md
+++ b/examples/pdf_to_markdown/README.md
@@ -1,26 +1,103 @@
-# PDF to Markdown
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/pdf-to-markdown/" title="Convert a folder of PDFs to Markdown with docling and CocoIndex — incremental, files in and files out, in plain Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/pdf-to-markdown/cover.svg" alt="Convert PDFs to Markdown with CocoIndex — walk a folder of PDFs, convert each one to clean Markdown with docling, and write the .md files to an output folder that stays in sync with the source" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example walks a directory of local PDF files, converts each one to Markdown using [docling](https://github.com/DS4SD/docling), and writes the resulting `.md` files to an output folder.
+<h1 align="center">Convert a folder of PDFs to <em>Markdown</em>.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Walk a directory of PDFs, convert each one to clean Markdown with <em>docling</em>, and write the <code>.md</code> files to an output folder that stays in sync.</b><br/>
+  No database, no embeddings — just files in, files out, in plain Python.
+</p>
 
-- Python 3.11+
-- No external services required — all processing runs locally on CPU.
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/pdf-to-markdown/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Run
+<div align="center">
 
-Install deps:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Convert a folder of PDFs to Markdown and write the results to a second folder that stays in sync with the source. No database, no embeddings, no API keys — just files in, files out. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed file targets) runs in a Rust engine underneath, so switching parsers or replacing one PDF reprocesses only the minimum.
+
+## How it works
+
+A single docling `DocumentConverter` is built once and pinned to CPU for portability across machines. `process_file` runs once per PDF: it converts the file to Markdown, derives the output name by swapping the extension, and declares the `.md` file as a [target state](https://cocoindex.io/docs/programming_guide/target_state/). Read it in [`main.py`](main.py):
+
+```python
+_converter = DocumentConverter(
+    format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=_pipeline_options)}
+)
+
+@coco.fn(memo=True)
+def process_file(file: localfs.File, outdir: pathlib.Path) -> None:
+    markdown = _converter.convert(file.file_path.resolve()).document.export_to_markdown()
+    outname = file.file_path.path.stem + ".md"
+    localfs.declare_file(outdir / outname, markdown, create_parent_dirs=True)
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
+    files = localfs.walk_dir(
+        sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.pdf"]),
+    )
+    await coco.mount_each(process_file, files.items(), outdir)
+```
+
+`mount_each` runs one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per PDF, so the engine tracks and updates each file independently — it's up to you to pick the granularity (directory, file, or page); file level is the natural choice here.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/pdf-to-markdown/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the App definition, the docling converter, the per-file component, and incremental updates.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Clean Markdown, not raw text dumps.** docling preserves headings, tables, and reading order — the structure that makes the output actually usable.
+- **Managed file targets.** `localfs.declare_file` describes the file you *want to exist*; CocoIndex writes it, overwrites it when the source changes, and deletes its `.md` when the source PDF is gone.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a PDF whose content and code are unchanged, so docling never re-parses a file you've already converted — add one PDF and only that file is processed.
+- **Pick your granularity.** `mount_each` mounts one component per file here, but the same shape works at directory or page level — your choice.
+- **No services, runs anywhere.** Pure local CPU processing, no database or API keys to set up.
+
+## Run it
+
+**1. Install:**
 
 ```sh
 pip install -e .
 ```
 
-Place the PDF files you want to convert in a `pdf_files/` directory (a sample PDF — the "Attention Is All You Need" paper — is already included).
+**2. Add some PDFs** — the example ships a `pdf_files/` folder (the "Attention Is All You Need" paper), or drop your own in. The `.env` sets `COCOINDEX_DB=./cocoindex.db` for internal state.
 
-Build/update the index (converts PDFs and writes Markdown to `out/`):
+**3. Convert** — writes Markdown into `out/`, one `.md` per input PDF:
 
 ```sh
 cocoindex update main
 ```
 
-The converted `.md` files will appear in `./out/`, with each file named after the original PDF (e.g. `1706.03762v7.md`).
+**4. Check the output:**
+
+```sh
+ls out/      # e.g. 1706.03762v7.md
+```
+
+Add, replace, or delete a PDF in `pdf_files/` and re-run `cocoindex update main` — only the changed file is reprocessed, and a removed PDF's `.md` is deleted automatically.
+
+---
+
+<p align="center">
+  If this saved you a parsing pipeline, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/pdf-to-markdown/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/pdf_to_markdown" alt="" width="1" height="1" />

--- a/examples/postgres_source/README.md
+++ b/examples/postgres_source/README.md
@@ -1,53 +1,119 @@
-# PostgreSQL Source Example (v1) 🗄️
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/postgres-source/" title="Use an existing Postgres table as a CocoIndex source — derive fields, embed each row, and write the vectors back to Postgres pgvector, incrementally, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/cover.svg" alt="Postgres as a source with CocoIndex — read product rows from an existing table, derive a description and total_value, embed each row with sentence-transformers, and write the enriched rows plus vectors back to Postgres with pgvector" width="100%" draggable="false"/>
+  </a>
+</p>
 
-[![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
+<h1 align="center">Turn an existing Postgres table into a <em>semantic</em> index.</h1>
 
-This example demonstrates how to use a PostgreSQL table as a source for CocoIndex v1. It reads structured product data from an existing table, computes derived fields, generates embeddings, and stores results in another PostgreSQL table.
+<p align="center">
+  <b>Read product rows from a Postgres table, <em>derive</em> fields and <em>embed</em> each one, and write the enriched rows plus their vectors back to Postgres with pgvector.</b><br/>
+  Your structured data, searchable by meaning — in plain async Python.
+</p>
 
-We appreciate a star ⭐ at [CocoIndex Github](https://github.com/cocoindex-io/cocoindex) if this is helpful.
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/postgres-source/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Prerequisites
+<div align="center">
 
-1. Install dependencies:
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+Most data already lives in a database. This example takes an existing Postgres table of products, reads it row by row, derives a couple of fields, embeds each row, and writes the result — including the vector — back into Postgres with [pgvector](https://github.com/pgvector/pgvector). You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so only the rows that changed get re-embedded and re-upserted.
+
+## How it works
+
+`app_main` wires the source to the target: it mounts the Postgres target table, opens the source table with [`PgTableSource`](https://cocoindex.io/docs/connectors/postgres/), and mounts one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per source row. Passing `row_type=SourceProduct` maps each row straight into the dataclass; `items(...)` tags each one with its `(product_category, product_name)` composite key. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn(memo=True)
+async def process_product(product: SourceProduct, table: postgres.TableTarget[OutputProduct]) -> None:
+    full_description = f"Category: {product.product_category}\nName: {product.product_name}\n\n{product.description}"
+    total_value = product.price * product.amount
+    embedding = await coco.use_context(EMBEDDER).embed(full_description)
+    table.declare_row(row=OutputProduct(..., total_value=total_value, embedding=embedding))
+
+@coco.fn
+async def app_main() -> None:
+    target_table = await postgres.mount_table_target(
+        PG_DB, table_name=TABLE_NAME,
+        table_schema=await postgres.TableSchema.from_class(
+            OutputProduct, primary_key=["product_category", "product_name"]),
+        pg_schema_name=PG_SCHEMA_NAME,
+    )
+    source = postgres.PgTableSource(
+        coco.use_context(SOURCE_POOL), table_name="source_products", row_type=SourceProduct)
+    await coco.mount_each(
+        process_product,
+        source.fetch_rows().items(lambda p: (p.product_category, p.product_name)),
+        target_table,
+    )
+```
+
+We embed the *composed* description — category and name included — so a search for "wireless audio" matches even when the body never says it. `embedding: Annotated[NDArray, EMBEDDER]` ties the vector column to the embedder, so its dimensions are inferred automatically.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/postgres-source/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the source/target row shapes, the derived fields, the embedder wiring, and the SQL query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Your database is the source.** `PgTableSource` reads an existing table directly — point it at any table and you have a semantic index over your structured data, no export step.
+- **Source and target, same engine.** The same Postgres instance can hold both, or set `SOURCE_DATABASE_URL` to read from a separate database. `mount_table_target` creates and manages the target table — schema, idempotent upserts, orphan cleanup.
+- **Embed what matters.** The composed `full_description` carries the category and name into the vector, so meaning-based search works even when the query words never appear in the body.
+- **Incremental by default.** `@coco.fn(memo=True)` skips a row whose content and code are unchanged; the output's primary key is derived from the source row, so only changed rows are re-embedded and upserted and vanished rows are deleted.
+- **Plain Python, your stack.** Local `all-MiniLM-L6-v2` embedder, no API key; swap `EMBED_MODEL` for any of the 12k+ sentence-transformer models on Hugging Face.
+
+## Run it
+
+**1. Start Postgres + pgvector** (the repo ships a compose file):
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set POSTGRES_URL and SOURCE_DATABASE_URL (can be the same instance)
 pip install -e .
 ```
 
-2. A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
-
-   ```sh
-   docker compose -f ../../dev/postgres.yaml up -d
-   ```
-
-3. Create source table `source_products` with sample data:
+**3. Seed the source table** — create `source_products` with the sample rows:
 
 ```sh
-psql "postgres://cocoindex:cocoindex@localhost/cocoindex" -f ./prepare_source_data.sql
+psql "$SOURCE_DATABASE_URL" -f ./prepare_source_data.sql
 ```
 
-For simplicity, we use the same database for source and target. You can also set `SOURCE_DATABASE_URL` to use a separate database.
-
-## Run
-
-Build/update the index (one-shot catch-up; the postgres source does not support live mode):
+**4. Build the index** — the Postgres source runs as a one-shot catch-up (scan the source table, sync the target, exit):
 
 ```sh
 cocoindex update main
 ```
 
-Query:
+**5. Search from the command line:**
 
 ```sh
 python main.py "wireless headphones"
 ```
 
-## Environment
+The most semantically similar products come back ranked — even when they share none of the words in your query. That's the whole point of a vector index.
 
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
+---
 
-```sh
-cp .env.example .env
-```
+<p align="center">
+  If this turned your table into a semantic index, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/postgres-source/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-Set `POSTGRES_URL` (where results are written) and `SOURCE_DATABASE_URL` (the table read as the source) — they can point at the same instance.
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/postgres_source" alt="" width="1" height="1" />

--- a/examples/product_recommendation/README.md
+++ b/examples/product_recommendation/README.md
@@ -1,0 +1,129 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/product-recommendation/" title="Build a product recommendation graph with LLM taxonomy extraction and CocoIndex — Neo4j, incremental, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/product-recommendation/cover.svg" alt="Build a product recommendation graph with CocoIndex and Neo4j — an LLM tags what each product is and what complements it, and the shared taxonomy edges power 'people who bought this also need…' queries" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Turn a product catalog into a <em>recommendation</em> graph.</h1>
+
+<p align="center">
+  <b>An LLM tags what each product <em>is</em> and what <em>pairs</em> with it; the shared taxonomy edges become a "people who bought this also need…" engine — in plain async Python.</b><br/>
+  Point it at a folder of product JSON, and it re-extracts only what changes as you edit the catalog.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/product-recommendation/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+A pile of product listings has the recommendations hiding in plain sight — a *pen* pairs with *ink refills* and a *notebook*; a *monitor* pairs with a *stand* and an *HDMI cable*. But that knowledge is locked in prose. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed graph targets) runs in a Rust engine underneath, so editing one product re-extracts one product, not the catalog.
+
+## How it works
+
+Two node types, two relationship types, and the recommendation falls out of the graph:
+
+- **`Product`** nodes — one per listing (title, price).
+- **`Taxonomy`** nodes — one per distinct label (`gel pen`, `notebook`, `ink refill`), keyed by value and **shared** across products.
+- **`PRODUCT_TAXONOMY`** edges — `Product → Taxonomy`: what the product is.
+- **`PRODUCT_COMPLEMENTARY_TAXONOMY`** edges — `Product → Taxonomy`: what a buyer might also need.
+
+Products whose *complementary* taxonomy matches another product's *is-a* taxonomy are the things to recommend together.
+
+Because taxonomy labels are shared across products, the pipeline runs in two phases — read it top-to-bottom in [`main.py`](main.py):
+
+```python
+@coco.fn(memo=True)  # caches each extraction by content — re-tag only changed products
+async def extract_taxonomy(detail: str) -> ProductTaxonomyInfo:
+    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
+    result = await client.chat.completions.create(
+        model=coco.use_context(LLM_MODEL), response_model=ProductTaxonomyInfo,
+        messages=[{"role": "system", "content": TAXONOMY_PROMPT}, {"role": "user", "content": detail}],
+    )
+    return ProductTaxonomyInfo.model_validate(result.model_dump())
+
+@coco.fn(memo=True)   # Phase 1 — per product: declare the node, extract, carry labels forward
+async def process_file(file: FileLike, product_table: neo4j.TableTarget[Product]) -> ProductTaxonomies:
+    raw = json.loads(await file.read_text())
+    product_id = file.file_path.path.name.removesuffix(".json")
+    product_table.declare_record(row=Product(id=product_id, title=raw["title"], price=...))
+    info = await extract_taxonomy(PRODUCT_TEMPLATE.render(**raw))
+    return ProductTaxonomies(product_id, [t.name for t in info.taxonomies], ...)
+
+@coco.fn              # Phase 2 — one pass owns the shared Taxonomy nodes + both edge types
+async def build_graph(products, taxonomy_table, product_taxonomy_rel, complementary_rel) -> None:
+    for value in {t for p in products for t in (*p.taxonomies, *p.complementary)}:
+        taxonomy_table.declare_record(row=Taxonomy(value=value))
+    for p in products:
+        for t in set(p.taxonomies):    product_taxonomy_rel.declare_relation(from_id=p.product_id, to_id=t)
+        for t in set(p.complementary): complementary_rel.declare_relation(from_id=p.product_id, to_id=t)
+```
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/product-recommendation/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the data model, the two-phase flow, the extraction schema, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Shared nodes, done right.** Taxonomy labels are deduplicated and owned by a single graph pass, so `gel pen` is one node every product can point at — not a copy per product.
+- **Incremental by default.** `@coco.fn(memo=True)` caches each LLM extraction by content; edit one product and only that product re-extracts, then the graph diffs — adding new nodes/edges and removing ones no longer supported anywhere.
+- **The graph IS the recommender.** No separate model. One Cypher query walks *complementary → is-a* edges to surface what to cross-sell.
+- **Plain Python, your stack.** Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/) — swap `LLM_MODEL` for any provider (OpenAI, Ollama, …). No DSL.
+- **Honest cache busting.** `LLM_MODEL` is declared with `detect_change=True`, so swapping the model re-extracts everything against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start Neo4j:**
+
+```sh
+docker run -d -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/cocoindex --name cocoindex-neo4j neo4j:5.26-community
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set OPENAI_API_KEY (or LLM_MODEL=ollama/llama3.2)
+pip install -e .
+```
+
+**3. Build the graph** — the example ships a `products/` folder of sample listings (pens, notebooks, monitors, …):
+
+```sh
+cocoindex update main
+```
+
+On the 9 sample products that's **9 `Product` nodes, ~40 `Taxonomy` nodes**, and the two edge types wired up.
+
+**4. Explore the recommendations** — open [Neo4j Browser](http://localhost:7474) (`neo4j` / `cocoindex`) and ask the graph:
+
+```cypher
+-- Recommend products to pair with anything that is a "gel pen":
+-- find products whose is-a taxonomy matches a pen's complementary taxonomy
+MATCH (:Taxonomy {value: "gel pen"})<-[:PRODUCT_TAXONOMY]-(:Product)
+      -[:PRODUCT_COMPLEMENTARY_TAXONOMY]->(need:Taxonomy)
+MATCH (rec:Product)-[:PRODUCT_TAXONOMY]->(need)
+RETURN DISTINCT rec.title
+```
+
+On the sample data, recommending for a pen surfaces the notepad and the multipurpose paper — exactly the cross-sell you'd want.
+
+---
+
+<p align="center">
+  If this turned your catalog into a recommender, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/product-recommendation/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/product_recommendation" alt="" width="1" height="1" />

--- a/examples/sec_edgar_analytics/README.md
+++ b/examples/sec_edgar_analytics/README.md
@@ -1,0 +1,121 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/sec-edgar-analytics/" title="Index multi-format SEC filings into Apache Doris with CocoIndex — vector + full-text indexes for hybrid search, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/sec-edgar-analytics/cover.svg" alt="Index multi-format SEC filings into Apache Doris with CocoIndex — scrub PII, chunk, embed, and tag 10-K text and XBRL company facts into one table with vector and full-text indexes for hybrid retrieval" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Hybrid search over <em>multi-format</em> SEC filings.</h1>
+
+<p align="center">
+  <b>Scrub, chunk, embed, and tag 10-K text <em>and</em> XBRL JSON into one Apache Doris table — with a vector index <em>and</em> a full-text index, fused with RRF.</b><br/>
+  Semantic relevance and keyword presence combined, not either alone — in plain async Python.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/sec-edgar-analytics/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+SEC filings come in many shapes — narrative 10-K risk factors as text, structured financials as XBRL JSON, exhibits as PDF. This pipeline pulls those formats into a **single** searchable index in [Apache Doris](https://doris.apache.org/), with both a vector index for semantic search and a full-text index for keyword search. You declare the transformation in native Python — `target_state = transformation(source_state)` — and the Rust engine handles incremental processing, so adding a filing embeds and loads only its chunks.
+
+## How it works
+
+Two source formats fan into one chunk table:
+
+1. **Sources** — `*.txt` 10-K filings and `*.json` XBRL company facts (the JSON is rendered to searchable text first).
+2. **Scrub & chunk** — strip SSNs / phones / emails **before** indexing, then split into overlapping chunks.
+3. **Embed & tag** — a sentence-transformer embeds each chunk; a keyword pass tags `RISK:*` / `TOPIC:*` labels.
+4. **Load into Doris** — one row per chunk, into a table with a vector (ANN) index and a full-text (inverted) index.
+
+The magic is in `mount_table_target` — the same table gets a **vector index** (for `l2_distance` semantic search) and an **inverted index** (for `MATCH_ANY` keyword search). Read it in [`main.py`](main.py):
+
+```python
+table = await doris.mount_table_target(
+    DORIS_DB, TABLE,
+    await doris.TableSchema.from_class(FilingChunk, primary_key=["chunk_id"]),
+    vector_indexes=[doris.VectorIndexDef(field_name="embedding", metric_type="l2_distance")],
+    inverted_indexes=[doris.InvertedIndexDef(field_name="text", parser="unicode")],
+)
+
+# PII is redacted *before* chunking, so it never enters the index. Both source
+# formats funnel into one shared path — scrub, chunk, embed, tag, declare a row per chunk:
+async def _index_text(text, source_type, filename, cik, filing_date, form_type, table):
+    embedder = coco.use_context(EMBEDDER)
+    for chunk in _splitter.split(_scrub_pii(text), chunk_size=1000, chunk_overlap=200, language="markdown"):
+        table.declare_row(row=FilingChunk(
+            chunk_id=_chunk_id(filename, chunk.start.char_offset, chunk.end.char_offset),
+            source_type=source_type, doc_filename=filename, cik=cik, filing_date=filing_date,
+            form_type=form_type, text=chunk.text, topics=_extract_topics(chunk.text),
+            embedding=await embedder.embed(chunk.text),
+        ))
+```
+
+Both sources `declare_row` into the **same** Doris table — `chunk_id` is a stable `uuid5` of the file and chunk offsets, so re-running reconciles cleanly instead of duplicating.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/sec-edgar-analytics/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the row schema, the dual-index target, PII scrubbing, and the hybrid RRF query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **One table, two index types.** A single `mount_table_target` declares both a vector (ANN) and a full-text (inverted) index — the foundation for hybrid retrieval, with no second store to keep in sync.
+- **Many formats, one index.** Text 10-Ks and XBRL JSON facts fan into the same chunk table; the PDF path is the same shared `_index_text` (see [Manuals to Structured Data](https://cocoindex.io/docs/examples/manuals-llm-extraction/)).
+- **PII never enters the index.** Scrubbing runs *before* chunking and embedding, so SSNs / phones / emails are gone before anything is stored.
+- **Incremental by default.** Add a filing and only its chunks are scrubbed, embedded, tagged, and stream-loaded; `chunk_id` reconciles edits in place instead of duplicating.
+- **Hybrid search that actually fuses.** `search.py` ranks by vector distance and by keyword match, then combines them with [Reciprocal Rank Fusion](https://en.wikipedia.org/wiki/Learning_to_rank) in one SQL query.
+
+## Run it
+
+> Needs **Apache Doris 4.0+** for vector-index support — a ready `docker-compose.yml` is included.
+
+**1. Start Doris (FE + BE):**
+
+```sh
+docker compose up -d fe be
+```
+
+**2. Fetch sample data, configure & install** — synthetic 10-K filings + XBRL company facts:
+
+```sh
+python download.py
+cp .env.example .env     # Doris host/ports
+pip install -e .
+```
+
+**3. Build the index:**
+
+```sh
+cocoindex update main
+```
+
+On the sample data this loads 4 chunks (2 filings + 2 company-facts) into Doris, creating both `idx_vec_embedding` (ANN) and `idx_inv_text` (INVERTED). Topics come out as you'd expect — Apple tagged `RISK:CYBER, RISK:CLIMATE, RISK:SUPPLY, RISK:REGULATORY, TOPIC:AI`; Microsoft `RISK:CYBER, RISK:REGULATORY, TOPIC:AI, TOPIC:CLOUD`.
+
+**4. Hybrid search** — vector + keyword, fused with RRF:
+
+```sh
+python search.py "cloud computing and AI risk"
+```
+
+On the sample data that ranks **Microsoft's** cloud-and-AI filing first (it carries both `TOPIC:CLOUD` and `TOPIC:AI`), Apple's second, and the company-facts rows below.
+
+---
+
+<p align="center">
+  If this made your filing archive searchable, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/sec-edgar-analytics/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/sec_edgar_analytics" alt="" width="1" height="1" />

--- a/examples/slides_to_speech/README.md
+++ b/examples/slides_to_speech/README.md
@@ -1,0 +1,118 @@
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/slides-to-speech/" title="Turn slide decks into a narrated, searchable index with CocoIndex — vision LLM speaker notes, local Piper TTS, and LanceDB, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.svg" alt="Turn slide decks into narrated, searchable audio with CocoIndex — a vision LLM writes speaker notes for each slide, Piper synthesizes them to MP3 locally, and the notes are embedded into LanceDB for semantic search with playable narration attached" width="100%" draggable="false"/>
+  </a>
+</p>
+
+<h1 align="center">Turn a slide deck into <em>narrated</em>, searchable audio.</h1>
+
+<p align="center">
+  <b>A vision LLM writes speaker notes for each slide, Piper synthesizes them to audio <em>locally</em>, and the notes are embedded into LanceDB — so you search the deck by meaning and play back the narration for any hit.</b><br/>
+  A deck is a great outline and a terrible thing to listen to or search; this fixes both — in plain async Python.
+</p>
+
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/slides-to-speech/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+A slide deck is a great outline and a terrible thing to *listen to* or *search*. This pipeline fixes both: for each slide, a vision LLM writes natural speaker notes, [Piper](https://github.com/OHF-Voice/piper1-gpl) synthesizes them to audio locally, and the notes are embedded into [LanceDB](https://lancedb.com/) so you can search the deck by meaning and play back the narration for any hit. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — the vision and TTS steps run on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/), and the Rust engine handles incremental processing, so adding a deck processes only its slides.
+
+## How it works
+
+A deck fans out to **slides**, and each slide produces text, audio, and a vector:
+
+- **Render** each slide of the PDF to an image (pymupdf).
+- **Narrate** — a vision LLM (instructor over LiteLLM) writes natural speaker notes for the slide image.
+- **Voice + embed** — Piper synthesizes the notes to MP3 while a sentence-transformer embeds them, concurrently.
+- **Store** one LanceDB row per slide — page, notes, audio (a binary column), and the embedding.
+
+`process_slide` runs the vision LLM, then synthesizes audio *and* embeds the notes with `asyncio.gather` before declaring the row. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_slide(slide: SlidePage, filename: str, table: lancedb.TableTarget[SlideRecord]) -> None:
+    notes = (await extract_speaker_notes(slide.image)).speaker_notes   # vision LLM
+    voice, embedding = await asyncio.gather(
+        text_to_speech(notes),                       # Piper TTS — local, no API
+        coco.use_context(EMBEDDER).embed(notes),     # sentence-transformer
+    )
+    table.declare_row(row=SlideRecord(
+        id=f"{filename}#{slide.page_number}", filename=filename, page=slide.page_number,
+        speaker_notes=notes, voice=voice, embedding=embedding,
+    ))
+
+@coco.fn(memo=True)   # unchanged deck is never re-rendered or re-narrated
+async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) -> None:
+    slides = await pdf_to_slides(await file.read())
+    await coco.map(process_slide, slides, str(file.file_path.path), table)
+```
+
+The MP3 audio is stored right in the LanceDB row, so a semantic-search hit comes with playable narration attached.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/slides-to-speech/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the vision-LLM speaker notes, local Piper TTS, the per-slide LanceDB row, and searching the deck by meaning.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Three modalities, one row.** Each slide becomes text (LLM notes), audio (Piper MP3), and a vector (sentence-transformer) — declared as a single LanceDB `SlideRecord`.
+- **Local TTS, no per-character billing.** Piper is a fast, fully local neural voice — no API, no streaming costs; the voice model loads once via `@functools.cache`.
+- **Audio travels with the hit.** The MP3 lives in a binary LanceDB column, so a search result carries its own playable narration.
+- **Concurrent per slide.** `asyncio.gather` runs TTS and embedding side by side; the heavy vision and TTS steps run on a `coco.GPU` runner.
+- **Incremental & swappable.** `@coco.fn(memo=True)` reprocesses only changed slides; `LLM_MODEL` and `EMBEDDER` are declared with `detect_change=True`, so swapping the model or voice re-runs only the affected steps.
+
+## Run it
+
+> Needs **LLM credentials** for the vision model (default `gemini/gemini-2.5-flash` → `GEMINI_API_KEY`), a local **Piper** voice, and **ffmpeg** for MP3 export.
+
+**1. Download a Piper voice** (~60 MB, local):
+
+```sh
+python3 -m piper.download_voices en_US-lessac-medium
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set GEMINI_API_KEY (or swap LLM_MODEL, e.g. OpenAI)
+pip install -e .
+```
+
+**3. Build the index** — drop a slide-deck PDF into `slides/`, then:
+
+```sh
+cocoindex update main        # or: cocoindex update -L main   (keep watching the folder)
+```
+
+On a 3-slide sample deck this produces three LanceDB rows, each with vision-LLM speaker notes and ~170–280 KB of Piper MP3 audio.
+
+**4. Search the deck** — embed a query the same way and search LanceDB:
+
+```sh
+python main.py "reducing latency and reliability"
+```
+
+On the sample deck, that query ranks the **Engineering Priorities** slide first — above the roadmap and go-to-market slides — matching the spoken notes by meaning, not keywords. Each hit carries the slide's MP3 narration, ready to play.
+
+---
+
+<p align="center">
+  If this gave your decks a voice and a search box, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/slides-to-speech/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/slides_to_speech" alt="" width="1" height="1" />

--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -1,47 +1,126 @@
-# Text Embedding (v1) 🔍
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/text-embedding/" title="Build a semantic search index over Markdown with CocoIndex — chunk, embed, and store vectors in Postgres + pgvector, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/cover.svg" alt="Semantic Search 101 with CocoIndex — chunk a folder of Markdown, embed each chunk with a local sentence-transformer, store the vectors in Postgres with pgvector, and search them in plain English" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds local markdown files, stores the chunks + embeddings in Postgres (pgvector), and provides a simple semantic-search query demo.
+<h1 align="center">Turn a folder of Markdown into a <em>searchable</em> vector index.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>Chunk, embed, and store every passage in Postgres + pgvector, then search it in <em>plain English</em> — the foundation under every RAG and semantic-search system.</b><br/>
+  "How does incremental processing work?" finds the right passage even when it shares no keywords — in plain async Python.
+</p>
 
-- A running Postgres with the pgvector extension. If you don't have one, start a local instance with the compose file in this repo:
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/text-embedding/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-  ```sh
-  docker compose -f ../../dev/postgres.yaml up -d
-  ```
+<div align="center">
 
-- `POSTGRES_URL` set, e.g.
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-  ```sh
-  export POSTGRES_URL="postgres://cocoindex:cocoindex@localhost/cocoindex"
-  ```
+</div>
 
-## Run
+<br/>
 
-Install deps:
+A pile of Markdown has the answers hiding in plain sight — but locked behind exact-keyword search. This pipeline reads each file, splits it into overlapping chunks, embeds every chunk with a local sentence-transformer, and stores the vectors in [Postgres + pgvector](https://github.com/pgvector/pgvector) so you can search by *meaning*. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so editing one file re-embeds one file, not the whole folder.
+
+## How it works
+
+The whole pipeline is ordinary `async` Python and the row type is your own dataclass:
+
+1. **Walk** Markdown files from a local directory (`live=True`, so it can watch for changes).
+2. **Chunk** each file into overlapping pieces with `RecursiveSplitter` — small, focused units, with overlap so an idea straddling a boundary still lands whole.
+3. **Embed** every chunk with `all-MiniLM-L6-v2`, a small, fast model that runs locally with no API key.
+4. **Store** one row per chunk in Postgres, with a pgvector index over the embedding.
+
+`process_file` runs once per file; `memo=True` makes it incremental — if a file's content and the function's code are unchanged, the whole file is skipped on the next run. Read it top-to-bottom in [`main.py`](main.py):
+
+```python
+@dataclass
+class DocEmbedding:
+    id: int
+    filename: str
+    chunk_start: int
+    chunk_end: int
+    text: str
+    embedding: Annotated[NDArray, EMBEDDER]   # dimension inferred from the embedder
+
+@coco.fn(memo=True)
+async def process_file(file: FileLike, table: postgres.TableTarget[DocEmbedding]) -> None:
+    text = await file.read_text()
+    chunks = _splitter.split(text, chunk_size=2000, chunk_overlap=500, language="markdown")
+    id_gen = IdGenerator()
+    await coco.map(process_chunk, chunks, file.file_path.path, id_gen, table)
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    target_table = await postgres.mount_table_target(
+        PG_DB, table_name=TABLE_NAME,
+        table_schema=await postgres.TableSchema.from_class(DocEmbedding, primary_key=["id"]),
+        pg_schema_name=PG_SCHEMA_NAME,
+    )
+    target_table.declare_vector_index(column="embedding")
+    files = localfs.walk_dir(sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]), live=True)
+    await coco.mount_each(process_file, files.items(), target_table)
+```
+
+Each row's `id` is derived from its chunk text, so re-running upserts only the rows that actually changed and deletes the ones whose source is gone — you never write update logic.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/text-embedding/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the row schema, the chunk-and-embed flow, the vector index, the SQL query, and exactly what happens on each kind of change.
+</p>
+
+## Why it's worth a star ⭐
+
+- **The simplest end-to-end vector index.** Walk → chunk → embed → store, in one short `main.py` — the canonical foundation under RAG and semantic search.
+- **Incremental by default.** `@coco.fn(memo=True)` caches per file; edit one file and only its changed chunks re-embed, then `mount_table_target` upserts the diff and cleans up orphans — no diff logic to write.
+- **Managed Postgres target.** A single `mount_table_target` owns the table schema, the pgvector index, idempotent upserts, and deletion when a file disappears.
+- **Local, no API key.** Embeddings come from `all-MiniLM-L6-v2` via [sentence-transformers](https://huggingface.co/models?other=sentence-transformers) — swap in any of 12k+ models. The same embedder is reused at query time so indexing and search stay consistent.
+- **Honest cache busting.** `EMBEDDER` is declared with `detect_change=True`, so swapping the model re-embeds everything against it with no cache to clear by hand.
+
+## Run it
+
+**1. Start Postgres + pgvector:**
 
 ```sh
+docker compose -f ../../dev/postgres.yaml up -d
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # set POSTGRES_URL (defaults to the local docker one)
 pip install -e .
 ```
 
-Build/update the index (writes rows into Postgres). Pick one of the two modes:
+**3. Build the index** — the example ships a `markdown_files/` folder of sample docs:
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main          # catch-up: scan, sync, exit
+cocoindex update -L main       # live: keep watching for file changes
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**4. Search** — embeds your query with the *same* model and returns the nearest chunks by pgvector cosine distance:
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-Note: this example **does not create a vector index**; queries will do a sequential scan.
+The most semantically similar chunks come back ranked — even when they share none of the words in your query. That's the whole point of a vector index.
+
+---
+
+<p align="center">
+  If this made your docs searchable by meaning, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/text-embedding/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/text_embedding" alt="" width="1" height="1" />

--- a/examples/text_embedding_lancedb/README.md
+++ b/examples/text_embedding_lancedb/README.md
@@ -1,54 +1,104 @@
-# Text Embedding with LanceDB (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/text-embedding-lancedb/" title="Semantic search over Markdown with CocoIndex and LanceDB — chunk, embed, and store vectors in an embedded, file-based store with zero server to run, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-lancedb/cover.svg" alt="Semantic Search with LanceDB and CocoIndex — chunk a folder of Markdown, embed each chunk locally, and store the vectors in an embedded LanceDB table on disk, with no server to run" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds local markdown files, stores the chunks + embeddings in LanceDB, and provides a simple semantic-search query demo.
+<h1 align="center">Semantic search over Markdown, stored in <em>LanceDB</em>.</h1>
 
-## Key Features
+<p align="center">
+  <b>The Semantic Search 101 pipeline pointed at <em>LanceDB</em> — an embedded, file-based vector store with no server to stand up, no <code>POSTGRES_URL</code>, just a directory on disk you can copy to move.</b><br/>
+  Walk, chunk, embed locally, store — incrementally — in plain async Python.
+</p>
 
-- **No database setup needed**: LanceDB is embedded - no external database required
-- **Vector search**: Semantic text search using sentence embeddings
-- **Full-text search**: FTS index on text content for keyword search
-- **Portable**: Data stored in `./lancedb_data/` directory - just copy to move it
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/text-embedding-lancedb/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-## Data Storage
+<div align="center">
 
-All data is stored in the `./lancedb_data/` directory in your project folder. This directory is created automatically on first run.
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
-To start fresh, simply delete the `./lancedb_data/` directory and re-run the indexing.
+</div>
 
-## Run
+<br/>
 
-Install deps:
+This is [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) with one thing changed: the vectors land in [LanceDB](https://lancedb.github.io/lancedb/) instead of Postgres. LanceDB is an embedded, file-based vector store — no server to stand up, just a `./lancedb_data/` directory created on first run. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so editing one file re-embeds one file, not the whole folder.
+
+## How it works
+
+The chunk-and-embed half is byte-for-byte the base example — `RecursiveSplitter` cuts each file into overlapping Markdown chunks, and a local `SentenceTransformerEmbedder` (`all-MiniLM-L6-v2`, no API key) turns each into a vector. What changes is the resource and the target: a `LanceAsyncConnection` instead of an `asyncpg` pool, and `lancedb.mount_table_target` instead of the Postgres one — same call shape, same `table.declare_row(...)`. Read it in [`main.py`](main.py):
+
+```python
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    conn = await lancedb.connect_async(LANCEDB_URI)   # the "connection" is just a path on disk
+    builder.provide(LANCE_DB, conn)
+    builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
+    yield
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    target_table = await lancedb.mount_table_target(
+        LANCE_DB, table_name=TABLE_NAME,
+        table_schema=await lancedb.TableSchema.from_class(DocEmbedding, primary_key=["id"]),
+    )
+    files = localfs.walk_dir(sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]), live=True)
+    await coco.mount_each(process_file, files.items(), target_table)
+```
+
+`lancedb.mount_table_target` is the LanceDB counterpart to the Postgres `mount_table_target`: it creates and manages the table, handles idempotent upserts keyed on the primary key, and cleans up orphan rows when a file disappears. Only the import changed.
+
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/text-embedding-lancedb/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the LanceDB connection, the managed table target, the row schema, and the async search query.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Zero infrastructure.** No database to install, no `POSTGRES_URL` — LanceDB writes to `./lancedb_data/`, created on first run. To start fresh, delete the directory and re-run.
+- **Portable by design.** Data lives in one directory on disk; copy it to move the whole index.
+- **Managed table target.** `lancedb.mount_table_target` owns the schema, idempotent upserts, and orphan cleanup — the same guarantees the Postgres target gives, against a local store.
+- **Incremental by default.** `@coco.fn(memo=True)` skips files whose content and code are unchanged; each row's `id` is derived from its chunk text, so only changed rows are upserted and vanished ones are deleted.
+- **Same flow, different store.** The chunk-and-embed code is identical to the Postgres version — proof the target is a swappable detail. The same local embedder is reused at query time so indexing and search stay consistent.
+
+## Run it
+
+> No database to install — LanceDB is embedded and writes to `./lancedb_data/`, created on first run.
+
+**1. Configure & install:**
 
 ```sh
+cp .env.example .env     # no required secrets; optional LANCEDB_URI override
 pip install -e .
 ```
 
-Build/update the index (writes rows into LanceDB). Pick one of the two modes:
+**2. Build the index** — the example ships a `markdown_files/` folder of sample docs:
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main          # catch-up: scan, sync, exit
+cocoindex update -L main       # live: keep watching for file changes
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**3. Search** — embeds your query with the *same* model and returns the nearest vectors via LanceDB's async search:
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-## Environment
+The most semantically similar chunks come back ranked — even when they share none of the words in your query.
 
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
+---
 
-```sh
-cp .env.example .env
-```
+<p align="center">
+  If this gave you a portable, server-free vector index, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/text-embedding-lancedb/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-LanceDB is an embedded local store, so there are no required secrets — the file documents the optional `LANCEDB_URI` override.
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/text_embedding_lancedb" alt="" width="1" height="1" />

--- a/examples/text_embedding_qdrant/README.md
+++ b/examples/text_embedding_qdrant/README.md
@@ -1,51 +1,112 @@
-# Text Embedding with Qdrant (v1) 🔍
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/text-embedding-qdrant/" title="Semantic search over Markdown with CocoIndex and Qdrant — chunk, embed, and upsert vectors into a managed Qdrant collection, incrementally, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-qdrant/cover.svg" alt="Semantic Search with Qdrant on CocoIndex — chunk a folder of Markdown, embed each chunk locally, and upsert the vectors into a managed Qdrant collection you can search in plain English" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds local markdown files, stores the chunks + embeddings in Qdrant, and provides a simple semantic-search query demo.
+<h1 align="center">Semantic search over Markdown, stored in <em>Qdrant</em>.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>The Semantic Search 101 pipeline with one thing swapped: the vectors land in a managed <em>Qdrant</em> collection instead of Postgres.</b><br/>
+  Walk, chunk, embed locally, upsert — incrementally — in plain async Python.
+</p>
 
-- Run Qdrant locally (HTTP 6333, gRPC 6334)
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/text-embedding-qdrant/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-```sh
-docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+This is [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) with one thing changed: instead of Postgres + pgvector, the vectors land in a [Qdrant](https://qdrant.tech/) collection. Walk Markdown, chunk, embed locally with `all-MiniLM-L6-v2` — all identical — and only the target differs. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so editing one file re-embeds one file, not the whole folder.
+
+## How it works
+
+Read each file, split into overlapping chunks, embed each chunk, then upsert it as a Qdrant point — text and offsets in the `payload`, the embedding as the `vector`. The one Qdrant-specific call is `mount_collection_target`, which derives the vector dimensions straight from the embedder (`QdrantVectorDef(schema=EMBEDDER)` — no hardcoded `384`) and manages the collection for you. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_chunk(chunk, filename, id_gen, target: qdrant.CollectionTarget) -> None:
+    embedding_vec = await coco.use_context(EMBEDDER).embed(chunk.text)
+    point = qdrant.PointStruct(
+        id=await id_gen.next_id(chunk.text),           # stable id derived from chunk text
+        vector=embedding_vec.tolist(),
+        payload={"filename": str(filename), "chunk_start": chunk.start.char_offset,
+                 "chunk_end": chunk.end.char_offset, "text": chunk.text},
+    )
+    target.declare_point(point)
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    target_collection = await qdrant.mount_collection_target(
+        QDRANT_DB, collection_name=QDRANT_COLLECTION,
+        schema=await qdrant.CollectionSchema.create(vectors=qdrant.QdrantVectorDef(schema=EMBEDDER)),
+    )
+    files = localfs.walk_dir(sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]), live=True)
+    await coco.mount_each(process_file, files.items(), target_collection)
 ```
 
-## Run
+`target.declare_point` declares the point as a target state; CocoIndex inserts, updates, or deletes it to match — you never write upsert calls yourself.
 
-Install deps:
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/text-embedding-qdrant/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the Qdrant client setup, the collection target, the point schema, and the incremental story.
+</p>
+
+## Why it's worth a star ⭐
+
+- **Managed Qdrant target.** A single `mount_collection_target` handles collection creation, idempotent point upserts, and orphan cleanup when a file disappears — the same managed-target guarantees pgvector gets in the base example.
+- **No hardcoded dimensions.** The collection's vector size comes straight from the embedder via `QdrantVectorDef(schema=EMBEDDER)`, so swap the model and the schema follows.
+- **Incremental by default.** `@coco.fn(memo=True)` on `process_file` skips files whose content and code are unchanged; each point's `id` is derived from its chunk text, so only changed points are upserted and vanished ones are deleted.
+- **Same flow, different store.** The chunk-and-embed half is byte-for-byte the Postgres version — proof that the target is a swappable detail, not a rewrite.
+- **gRPC for fast upserts.** The client connects over gRPC (`prefer_grpc=True`); the same local `all-MiniLM-L6-v2` embedder is reused at query time so indexing and search stay consistent.
+
+## Run it
+
+**1. Start Qdrant** — HTTP on `6333`, gRPC on `6334`:
 
 ```sh
+docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+**2. Configure & install:**
+
+```sh
+cp .env.example .env     # no required secrets; optional QDRANT_URL override (default http://localhost:6334/)
 pip install -e .
 ```
 
-Build/update the index (writes points into Qdrant). Pick one of the two modes:
+**3. Build the index** — the example ships a `markdown_files/` folder of sample docs:
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main          # catch-up: scan, sync, exit
+cocoindex update -L main       # live: keep watching for file changes
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**4. Search** — embeds your query with the *same* model and asks Qdrant for the nearest points:
 
 ```sh
 python main.py "what is self-attention?"
 ```
 
-You can also open the Qdrant dashboard at <http://localhost:6333/dashboard>.
+You can also browse the collection in the [Qdrant dashboard](http://localhost:6333/dashboard). The most semantically similar chunks come back ranked — even when they share none of the words in your query.
 
-## Environment
+---
 
-Copy `.env.example` to `.env` and fill in the blanks — it is loaded automatically when you run the example:
+<p align="center">
+  Already running Qdrant and want your docs searchable by meaning? <a href="https://github.com/cocoindex-io/cocoindex"><b>Give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/text-embedding-qdrant/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
 
-```sh
-cp .env.example .env
-```
-
-Stores vectors in Qdrant (defaults to a local container at `http://localhost:6334/`), so no required secrets — the file documents the optional `QDRANT_URL` override.
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/text_embedding_qdrant" alt="" width="1" height="1" />

--- a/examples/text_embedding_turbopuffer/README.md
+++ b/examples/text_embedding_turbopuffer/README.md
@@ -1,42 +1,109 @@
-# Text Embedding with Turbopuffer (v1)
+<p align="center">
+  <a href="https://cocoindex.io/docs/examples/text-embedding-turbopuffer/" title="Semantic search over Markdown with CocoIndex and Turbopuffer — chunk, embed, and upsert vectors into a managed, serverless namespace, incrementally, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-turbopuffer/cover.svg" alt="Semantic Search with Turbopuffer using CocoIndex — chunk a folder of Markdown, embed each chunk locally, and upsert the vectors into a managed, serverless Turbopuffer namespace with no database to run yourself" width="100%" draggable="false"/>
+  </a>
+</p>
 
-This example embeds local markdown files, stores the chunks + embeddings in a [Turbopuffer](https://turbopuffer.com/) namespace, and provides a simple semantic-search query demo.
+<h1 align="center">Semantic search over Markdown, stored in <em>Turbopuffer</em>.</h1>
 
-## Prerequisites
+<p align="center">
+  <b>The Semantic Search 101 pipeline pointed at <em>Turbopuffer</em> — a managed, serverless vector store, so there's no database to run yourself.</b><br/>
+  Walk, chunk, embed locally, upsert — incrementally — in plain async Python.
+</p>
 
-Copy `.env.example` to `.env` and fill in your Turbopuffer API key:
+<p align="center">
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;<a href="https://github.com/cocoindex-io/cocoindex" title="Star CocoIndex on GitHub"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/star-btn-small-light.svg" alt="Star CocoIndex on GitHub" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://cocoindex.io/docs/examples/text-embedding-turbopuffer/" title="Read the full walkthrough"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/docs-inline-light.svg" alt="CocoIndex documentation" height="36" align="absmiddle"/></picture></a> &nbsp;·&nbsp;
+  <a href="https://discord.com/invite/zpA9S2DR7s" title="Join the CocoIndex Discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/discord-inline-light.svg" alt="Join the CocoIndex Discord" height="36" align="absmiddle"/></picture></a>
+</p>
 
-```sh
-cp .env.example .env
-# then edit .env and set TURBOPUFFER_API_KEY=tpuf_...
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex?style=flat-square&label=stars&color=FB6A76)](https://github.com/cocoindex-io/cocoindex)
+[![pypi](https://img.shields.io/pypi/v/cocoindex?style=flat-square&label=pypi&color=E59A63)](https://pypi.org/project/cocoindex/)
+[![discord](https://img.shields.io/discord/1314801574169673738?style=flat-square&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.com/invite/zpA9S2DR7s)
+[![license](https://img.shields.io/badge/license-Apache--2.0-5B5BD6?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
+<br/>
+
+This is [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedding/) with one thing swapped: instead of storing the vectors in Postgres with pgvector, we write them to a [Turbopuffer](https://turbopuffer.com/) namespace — a managed, serverless vector store, so there's no database to run yourself. The chunking and embedding are identical; only the target changes. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — and the heavy lifting (incremental processing, change tracking, managed targets) runs in a Rust engine underneath, so editing one file re-embeds one file, not the whole folder.
+
+## How it works
+
+Turbopuffer is a cloud service, so the shared resource is an `AsyncTurbopuffer` client (keyed off `TURBOPUFFER_API_KEY`) rather than a database pool. A Turbopuffer row is an `id`, a `vector`, and an open bag of `attributes` — the filename, text, and offsets ride along as attributes while the embedding is the indexed vector. Read it in [`main.py`](main.py):
+
+```python
+@coco.fn
+async def process_chunk(chunk, filename, id_gen, target: turbopuffer.NamespaceTarget) -> None:
+    embedding_vec = await coco.use_context(EMBEDDER).embed(chunk.text)
+    target.declare_row(
+        turbopuffer.Row(
+            id=str(await id_gen.next_id(chunk.text)),   # stable id derived from chunk text
+            vector=embedding_vec,
+            attributes={"filename": str(filename), "chunk_start": chunk.start.char_offset,
+                        "chunk_end": chunk.end.char_offset, "text": chunk.text},
+        )
+    )
+
+@coco.fn
+async def app_main(sourcedir: pathlib.Path) -> None:
+    target_namespace = await turbopuffer.mount_namespace_target(
+        TPUF_DB, namespace_name=TPUF_NAMESPACE,
+        schema=await turbopuffer.NamespaceSchema.create(vectors=turbopuffer.VectorDef(schema=EMBEDDER)),
+    )
+    files = localfs.walk_dir(sourcedir, recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]), live=True)
+    await coco.mount_each(process_file, files.items(), target_namespace)
 ```
 
-The example loads variables from `.env` automatically via `python-dotenv`. `TURBOPUFFER_REGION` defaults to `gcp-us-central1` if you don't change it.
+`target.declare_row` declares the row as a target state; CocoIndex handles upserting and deleting it to match. The namespace's dimension comes straight from the embedder, so it always matches what you write.
 
-## Run
+<p align="center">
+  📘 <b><a href="https://cocoindex.io/docs/examples/text-embedding-turbopuffer/">Full Tutorial →</a></b><br/>
+  Step-by-step walkthrough with the Turbopuffer client, the namespace target, the row schema, and the incremental story.
+</p>
 
-Install deps:
+## Why it's worth a star ⭐
+
+- **No database to run.** Turbopuffer is managed and serverless — bring an API key and the namespace is created and managed for you.
+- **Managed namespace target.** A single `mount_namespace_target` handles schema, idempotent upserts, and orphan cleanup when a file disappears.
+- **No hardcoded dimensions.** The namespace's vector size comes from `VectorDef(schema=EMBEDDER)`, so swapping the model carries the schema along.
+- **Incremental by default.** `@coco.fn(memo=True)` skips files whose content and code are unchanged; each row's `id` is derived from its chunk text, so only changed rows are upserted and vanished ones are deleted.
+- **Same flow, different store.** The chunk-and-embed half is identical to the Postgres version; the query reuses the *same* local `all-MiniLM-L6-v2` embedder and asks Turbopuffer for the nearest vectors with `rank_by=("vector", "ANN", ...)`.
+
+## Run it
+
+**1. Get a Turbopuffer API key** — a free key from [turbopuffer.com](https://turbopuffer.com/).
+
+**2. Configure & install:**
 
 ```sh
+cp .env.example .env     # set TURBOPUFFER_API_KEY=tpuf_... (TURBOPUFFER_REGION defaults to gcp-us-central1)
 pip install -e .
 ```
 
-Build/update the index (writes rows into Turbopuffer). Pick one of the two modes:
+**3. Build the index** — the example ships a `markdown_files/` folder of sample docs:
 
-- **Catch-up run** — scan sources, sync changes, exit:
+```sh
+cocoindex update main          # catch-up: scan, sync, exit
+cocoindex update -L main       # live: keep watching for file changes
+```
 
-  ```sh
-  cocoindex update main
-  ```
-
-- **Live run** — catch up, then keep watching for file changes (the source declares `live=True` in `main.py`):
-
-  ```sh
-  cocoindex update -L main
-  ```
-
-Query:
+**4. Search** — embeds your query with the *same* model and asks Turbopuffer for the nearest vectors:
 
 ```sh
 python main.py "what is self-attention?"
 ```
+
+The most semantically similar chunks come back ranked — even when they share none of the words in your query.
+
+---
+
+<p align="center">
+  If this gave you a serverless vector index, <a href="https://github.com/cocoindex-io/cocoindex"><b>give CocoIndex a star ⭐</b></a> — it helps a lot.<br/>
+  <a href="https://cocoindex.io/docs">Docs</a> · <a href="https://cocoindex.io/docs/examples/text-embedding-turbopuffer/">Walkthrough</a> · <a href="https://discord.com/invite/zpA9S2DR7s">Discord</a> · <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all examples →</b></a>
+</p>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7f27e85b-be3a-411a-b612-0b9d53711814&page=examples/text_embedding_turbopuffer" alt="" width="1" height="1" />


### PR DESCRIPTION
Agent-experience pass over the whole `examples/` suite. Companion to **cocoindex-io/blobs#10** (the cover SVGs) — **merge & deploy that first** so the hero images resolve.

## What

**READMEs — all 34 examples to one gold standard.** Each now opens with what the user gets and why it matters, then: a real code snippet, a "why it's worth a star" section, and accurate run steps.
- 6 examples had **no README** (`face_recognition`, `manuals_llm_extraction`, `multi_format_indexing`, `product_recommendation`, `sec_edgar_analytics`, `slides_to_speech`) — now written.
- 2 already-gold READMEs (`code_embedding`, `conversation_to_knowledge`) converted to the new SVG hero.
- Copy/snippets/run-steps verified against each example's actual `main.py`, `.env.example`, and docs walkthrough.

**Images — all SVG, zero PNG.** Every hero is the new self-contained, animated **`cover.svg`** (window-chrome brand style, coconut-sprout mascot, accurate per-example source→transform→target). No raster PNGs in any example README.

**Scarf pixel** added to every README (per-example `&page=examples/<dir>`), matching the root README's pattern.

**Fix:** `openai/gpt-5.4` → `openai/gpt-5-mini` in the 4 knowledge-graph examples (`gpt-5.4` is not a valid model id; each example's resolution step already used `gpt-5-mini`). Left `paper_metadata`'s `"gpt-4o"` untouched — it uses the raw `openai` SDK, where the bare id is correct.

**`examples/AGENTS.md`:** added the 7 examples that were missing from the catalog.

## Notes for review
- Hero image links point at `https://cocoindex.io/blobs/.../cover.svg`, which resolve once **blobs#10** is merged + Pages-deployed. Until then the heroes 404 in preview.
- Two pre-existing bugs surfaced during the pass (not fixed here): a Kafka topic-name mismatch between `csv_to_kafka` (`cocoindex-csv-rows`) and `kafka_to_lancedb` (`csv-rows` / `cocoindex-example-csv-rows`); flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)