### PR TITLE
examples(kafka_to_lancedb): align Kafka topic name with the producer

### DIFF
--- a/examples/kafka_to_lancedb/.env.example
+++ b/examples/kafka_to_lancedb/.env.example
@@ -4,8 +4,8 @@ COCOINDEX_DB=./cocoindex.db
 # Kafka broker address
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 
-# Kafka topic to consume from (must match csv_to_kafka producer)
-KAFKA_TOPIC=cocoindex-example-csv-rows
+# Kafka topic to consume from (must match csv_to_kafka producer's default)
+KAFKA_TOPIC=cocoindex-csv-rows
 
 # Kafka consumer group ID
 KAFKA_GROUP_ID=kafka-to-lancedb

--- a/examples/kafka_to_lancedb/README.md
+++ b/examples/kafka_to_lancedb/README.md
@@ -85,7 +85,7 @@ The line worth pausing on is `declare_row` — deliberately *not* `upsert()`. A 
 
 > Needs a running Kafka broker with a topic to consume. The easy way to populate it: run [csv-to-kafka](https://github.com/cocoindex-io/cocoindex/tree/main/examples/csv_to_kafka) first.
 
-**1. Configure & install** — point `KAFKA_TOPIC` at the topic csv-to-kafka produced (its default is `cocoindex-csv-rows`):
+**1. Configure & install** — both examples default to the same `KAFKA_TOPIC` (`cocoindex-csv-rows`), so the producer and consumer line up out of the box; override it in `.env` only if you changed it on the producer side:
 
 ```sh
 cp .env.example .env     # set KAFKA_BOOTSTRAP_SERVERS / KAFKA_TOPIC / LANCEDB_URI (+ SASL for a managed broker)

--- a/examples/kafka_to_lancedb/main.py
+++ b/examples/kafka_to_lancedb/main.py
@@ -20,7 +20,7 @@ from confluent_kafka.aio import AIOConsumer
 import cocoindex as coco
 from cocoindex.connectors import kafka, lancedb
 
-KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "csv-rows")
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "cocoindex-csv-rows")
 KAFKA_BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
 KAFKA_GROUP_ID = os.environ.get("KAFKA_GROUP_ID", "kafka-to-lancedb")
 KAFKA_SASL_USERNAME = os.environ.get("KAFKA_SASL_USERNAME", "")


### PR DESCRIPTION
## Problem

`kafka_to_lancedb` is the consumer for the `csv_to_kafka` producer (its `.env.example` comment even says *"must match csv_to_kafka producer"*), but the topic name disagreed in **three** places, so the demo consumes an empty topic out of the box:

| File | Was | Now |
|---|---|---|
| `csv_to_kafka/main.py` (producer) | `cocoindex-csv-rows` | unchanged ✓ |
| `csv_to_kafka/.env.example` | `cocoindex-csv-rows` | unchanged ✓ |
| `kafka_to_lancedb/main.py` (consumer default) | `csv-rows` | **`cocoindex-csv-rows`** |
| `kafka_to_lancedb/.env.example` | `cocoindex-example-csv-rows` | **`cocoindex-csv-rows`** |

The consumer was also inconsistent **with itself** — its code default (`csv-rows`) and its `.env.example` (`cocoindex-example-csv-rows`) differed, so behavior depended on whether you ran `cp .env.example .env`.

## Fix

Align everything on the producer's default `cocoindex-csv-rows` (code + env), and reword the consumer README's run step to note the two examples now line up automatically (override via `KAFKA_TOPIC` only if you changed the producer side). The `csv-to-kafka` docs walkthrough already used the correct name — no change needed there.

Sharing one topic across the pair is intended: they're a producer→consumer demo, and `KAFKA_TOPIC` stays env-overridable for isolation.

Verified: all topic references now read `cocoindex-csv-rows`; `python -m py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)