### PR TITLE
feat: add type_hint to use_state for typed state deserialization (#2198)

### DIFF
--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -93,6 +93,8 @@ from .serde import (
     unpickle_safe,
     serialize_by_pickle,
     make_deserialize_fn,
+    get_deserialize_fn,
+    DeserializeFn,
 )
 
 from .pending_marker import PendingS, ResolvedS, MaybePendingS
@@ -648,22 +650,24 @@ class StateHandle(Generic[_StateT]):
     assign to `.value` to persist a new value for the next run.
     """
 
-    __slots__ = ("_key", "_stored", "_core_processor_ctx")
+    __slots__ = ("_key", "_stored", "_deserializer", "_core_processor_ctx")
 
     def __init__(
         self,
         key: StableKey,
         stored: core.StoredValue,
+        deserializer: DeserializeFn,
         core_processor_ctx: core.ComponentProcessorContext,
     ) -> None:
         self._key = key
         self._stored = stored
+        self._deserializer = deserializer
         self._core_processor_ctx = core_processor_ctx
 
     @property
     def value(self) -> _StateT:
         # Lazy read: object-backed returns directly; bytes-backed deserializes once, cached.
-        return self._stored.get(_DESERIALIZE_ANY)  # type: ignore[no-any-return]
+        return self._stored.get(self._deserializer)  # type: ignore[no-any-return]
 
     @value.setter
     def value(self, new_value: _StateT) -> None:
@@ -674,10 +678,20 @@ class StateHandle(Generic[_StateT]):
 
 
 @overload
-def use_state(key: StableKey) -> StateHandle[Any]: ...
+def use_state(key: StableKey, initial_value: Any = None) -> StateHandle[Any]: ...
 @overload
-def use_state(key: StableKey, initial_value: _StateT) -> StateHandle[_StateT]: ...
-def use_state(key: StableKey, initial_value: Any = None) -> StateHandle[Any]:
+def use_state(
+    key: StableKey,
+    initial_value: _StateT | None = None,
+    *,
+    type_hint: type[_StateT],
+) -> StateHandle[_StateT]: ...
+def use_state(
+    key: StableKey,
+    initial_value: Any = None,
+    *,
+    type_hint: type[Any] | None = None,
+) -> StateHandle[Any]:
     """
     Declare a persistent state for the current component.
 
@@ -698,6 +712,14 @@ def use_state(key: StableKey, initial_value: Any = None) -> StateHandle[Any]:
              at most once per component run.
         initial_value: Value to use when no stored state exists for `key`.
                        Defaults to `None`.
+        type_hint: Optional type to deserialize the stored value into. When
+                   provided, `.value` is decoded via the registered
+                   serialization framework (msgspec for dataclasses /
+                   NamedTuples / msgspec.Structs / primitives, pickle for
+                   types decorated with ``@coco.serialize_by_pickle``, pydantic
+                   for ``BaseModel`` subclasses). When omitted, the value is
+                   decoded generically (``Any``) — i.e. whatever object the
+                   deserializer produces from the stored bytes.
 
     Returns:
         A StateHandle wrapping the current value.
@@ -717,6 +739,21 @@ def use_state(key: StableKey, initial_value: Any = None) -> StateHandle[Any]:
                       - If `key` is declared more than once in the same component
                         run: each key maps to exactly one state slot; a second
                         declaration would be ambiguous.
+
+    Example::
+
+        # Plain (value typed as Any)
+        counter = coco.use_state("counter", 0)
+
+        # Typed — handle.value is Cursor, with full type inference
+        @dataclass
+        class Cursor:
+            pos: int
+            tag: str
+
+        cur = coco.use_state("cursor", type_hint=Cursor, initial_value=Cursor(0, "init"))
+        cur.value.pos += 1
+        cur.value = Cursor(cur.value.pos, "next")
     """
     ctx = get_context_from_ctx()
     if ctx._core_path != ctx._core_processor_ctx.stable_path:
@@ -736,7 +773,14 @@ def use_state(key: StableKey, initial_value: Any = None) -> StateHandle[Any]:
         # Rust client errors surface as ValueError; normalize to RuntimeError so
         # all use_state usage errors have a consistent type for callers.
         raise RuntimeError(str(e)) from None
-    return StateHandle(key, stored, ctx._core_processor_ctx)
+    if type_hint is not None:
+        deserializer = get_deserialize_fn(
+            type_hint,  # type: ignore[arg-type]  # type objects are hashable at runtime
+            source_label=f"use_state key {key!r}",
+        )
+    else:
+        deserializer = _DESERIALIZE_ANY
+    return StateHandle(key, stored, deserializer, ctx._core_processor_ctx)
 
 
 # ============================================================================

--- a/python/cocoindex/_internal/serde.py
+++ b/python/cocoindex/_internal/serde.py
@@ -459,13 +459,15 @@ def serialize(value: Any) -> bytes:
 
 
 @functools.cache
-def _get_deserialize_fn(type_hint: Any) -> DeserializeFn:
-    return make_deserialize_fn(type_hint)
+def get_deserialize_fn(
+    type_hint: Any, source_label: str | None = None
+) -> DeserializeFn:
+    return make_deserialize_fn(type_hint, source_label=source_label)
 
 
 def deserialize(data: bytes, type_hint: Any = Any) -> Any:
     """Deserialize data using the routing-byte protocol."""
-    return _get_deserialize_fn(type_hint)(data)
+    return get_deserialize_fn(type_hint)(data)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/core/test_use_state.py
+++ b/python/tests/core/test_use_state.py
@@ -1,5 +1,9 @@
 """Integration tests for coco.use_state() — persistent per-component state."""
 
+import dataclasses
+from typing import NamedTuple
+
+import msgspec
 import pytest
 import cocoindex as coco
 
@@ -595,3 +599,293 @@ def test_use_state_raises_inside_component_subpath_block() -> None:
     _source_items[:] = ["a"]
     app.update_blocking()
     assert _raised["a"] is True
+
+
+@dataclasses.dataclass
+class _Cursor:
+    pos: int
+    tag: str
+
+
+def test_use_state_type_hint_deserializes_into_dataclass() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        s = coco.use_state("cur", type_hint=_Cursor, initial_value=_Cursor(0, "init"))
+        v = s.value
+        assert isinstance(v, _Cursor), f"expected _Cursor, got {type(v)}"
+        _captured[item] = v
+        s.value = _Cursor(v.pos + 1, "next")
+
+    @coco.fn
+    async def _root_typed(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint", environment=coco_env),
+        _root_typed,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Cursor)
+    assert (loaded.pos, loaded.tag) == (0, "init")
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Cursor)
+    assert (loaded.pos, loaded.tag) == (1, "next")
+
+
+def test_use_state_type_hint_without_initial() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        s = coco.use_state("cur", type_hint=_Cursor)
+        v = s.value
+        _captured[item] = v
+        s.value = _Cursor(42, "set")
+
+    @coco.fn
+    async def _root_no_initial(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint_no_initial", environment=coco_env),
+        _root_no_initial,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    assert _captured["a"] is None
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Cursor)
+    assert (loaded.pos, loaded.tag) == (42, "set")
+
+
+def test_use_state_type_hint_with_positional_none_initial() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        # Exercises the overload: use_state(key, None, *, type_hint=...)
+        s = coco.use_state("cur", None, type_hint=_Cursor)
+        v = s.value
+        _captured[item] = v
+        s.value = _Cursor(99, "pos")
+
+    @coco.fn
+    async def _root(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(
+            name="use_state_type_hint_positional_none", environment=coco_env
+        ),
+        _root,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    assert _captured["a"] is None
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Cursor)
+    assert (loaded.pos, loaded.tag) == (99, "pos")
+
+
+class _Point(NamedTuple):
+    x: int
+    y: int
+
+
+def test_use_state_type_hint_deserializes_into_namedtuple() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        s = coco.use_state("pt", type_hint=_Point, initial_value=_Point(1, 2))
+        v = s.value
+        assert isinstance(v, _Point), f"expected _Point, got {type(v)}"
+        _captured[item] = v
+        s.value = _Point(v.x + 1, v.y + 1)
+
+    @coco.fn
+    async def _root_typed(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint_namedtuple", environment=coco_env),
+        _root_typed,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Point)
+    assert loaded == _Point(1, 2)
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _Point)
+    assert loaded == _Point(2, 3)
+
+
+class _MsgSpecPoint(msgspec.Struct):
+    x: int
+    y: int
+
+
+def test_use_state_type_hint_deserializes_into_msgspec_struct() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        s = coco.use_state(
+            "pt", type_hint=_MsgSpecPoint, initial_value=_MsgSpecPoint(1, 2)
+        )
+        v = s.value
+        assert isinstance(v, _MsgSpecPoint), f"expected _MsgSpecPoint, got {type(v)}"
+        _captured[item] = v
+        s.value = _MsgSpecPoint(v.x + 1, v.y + 1)
+
+    @coco.fn
+    async def _root_typed(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint_msgspec", environment=coco_env),
+        _root_typed,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _MsgSpecPoint)
+    assert (loaded.x, loaded.y) == (1, 2)
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _MsgSpecPoint)
+    assert (loaded.x, loaded.y) == (2, 3)
+
+
+def test_use_state_type_hint_deserializes_into_pydantic_model() -> None:
+    pydantic = pytest.importorskip("pydantic")
+
+    class _PydanticPoint(pydantic.BaseModel):  # type: ignore[name-defined, misc]
+        x: int
+        y: int
+
+    _source_items.clear()
+    _captured.clear()
+
+    @coco.fn
+    def _process(item: str) -> None:
+        s = coco.use_state(
+            "pt", type_hint=_PydanticPoint, initial_value=_PydanticPoint(x=1, y=2)
+        )
+        v = s.value
+        assert isinstance(v, _PydanticPoint), f"expected _PydanticPoint, got {type(v)}"
+        _captured[item] = v
+        s.value = _PydanticPoint(x=v.x + 1, y=v.y + 1)
+
+    @coco.fn
+    async def _root_typed(items: list[str]) -> None:
+        for item in items:
+            await coco.mount(coco.component_subpath(item), _process, item)
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint_pydantic", environment=coco_env),
+        _root_typed,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _PydanticPoint)
+    assert (loaded.x, loaded.y) == (1, 2)
+
+    app.update_blocking()
+    loaded = _captured["a"]
+    assert isinstance(loaded, _PydanticPoint)
+    assert (loaded.x, loaded.y) == (2, 3)
+
+
+def test_use_state_type_hint_mismatch_raises_deserialization_error() -> None:
+    _source_items.clear()
+    _captured.clear()
+
+    captured: list[BaseException] = []
+    _store_mode: list[bool] = [True]  # mutable flag to switch behavior between runs
+
+    @coco.fn
+    def _process_store_int(item: str) -> None:
+        # Store an int without any type hint.
+        s = coco.use_state("cur", 123)
+        _captured[item] = s.value
+
+    @coco.fn
+    def _process_load_as_cursor(item: str) -> None:
+        # On the next run, try to deserialize the stored int as a _Cursor.
+        s = coco.use_state("cur", type_hint=_Cursor)
+        _captured[item] = s.value  # should raise DeserializationError
+
+    @coco.fn
+    async def _root_mismatch(items: list[str]) -> None:
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            captured.append(exc)
+
+        async with coco.exception_handler(handler):
+            for item in items:
+                if _store_mode[0]:
+                    await coco.mount(
+                        coco.component_subpath(item), _process_store_int, item
+                    )
+                else:
+                    await coco.mount(
+                        coco.component_subpath(item), _process_load_as_cursor, item
+                    )
+
+    app = coco.App(  # type: ignore[type-arg]
+        coco.AppConfig(name="use_state_type_hint_mismatch", environment=coco_env),
+        _root_mismatch,
+        items=_source_items,
+    )
+    _source_items[:] = ["a"]
+
+    # First run: store the int.
+    app.update_blocking()
+    assert _captured["a"] == 123
+
+    # Second run: attempt to load as _Cursor; should fail with DeserializationError.
+    _store_mode[0] = False
+    _captured.clear()
+    captured.clear()
+    app.update_blocking()
+    assert len(captured) == 1
+    exc_text = str(captured[0])
+    assert "DeserializationError" in exc_text
+    assert "use_state key 'cur'" in exc_text


### PR DESCRIPTION
Allow users to pass a `type_hint` to `coco.use_state()` so stored values are deserialized into a concrete type (dataclass, NamedTuple, msgspec.Struct, pydantic BaseModel) instead of the generic Any returned by the default decoder. This brings type-safe access to persistent component state, with IDE auto-complete and static type checking on `.value`.

Changes:
- `use_state()` gains an optional keyword-only `type_hint` parameter
- `StateHandle` holds a per-instance deserializer; `.value` delegates to it instead of the module-level `_DESERIALIZE_ANY` fallback
- New overload covers `use_state(key, initial_value, *, type_hint)` call pattern
- Deserialization errors include the state key via `source_label` for debugging
- 7 new tests: dataclass / NamedTuple / msgspec.Struct / pydantic round-trips, no-initial edge case, overload resolution, and type-mismatch error path

Closes #2198.