### PR TITLE
Agent experience: fix skill/config drift, add MCP discoverability

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
+  "mcpServers": {
     "cocoindex-code": {
-      "type": "local",
-      "command": [
-        "uvx",
+      "command": "uvx",
+      "args": [
         "--with",
         "cocoindex>=1.0.6",
         "cocoindex-code@latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,12 @@ Changes are applied atomically per component. If a source item is deleted (path 
 ### Example
 
 ```python
+import pathlib
+
+import cocoindex as coco
+from cocoindex.connectors import localfs
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
 @coco.fn(memo=True)
 async def process_file(file: FileLike, target: localfs.DirTarget) -> None:
     html = _markdown_it.render(await file.read_text())
@@ -171,7 +177,9 @@ async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
     target = await coco.use_mount(localfs.declare_dir_target, outdir)
 
     files = localfs.walk_dir(
-        sourcedir, path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"])
+        sourcedir,
+        recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
     )
     await coco.mount_each(process_file, files.items(), target)
 
@@ -292,6 +300,23 @@ The current codebase is for CocoIndex v1, which is a fundamental redesign from C
 ## Docs diagrams
 
 All diagrams embedded in docs pages are built as inline Astro components under `docs/src/components/diagrams/`, not exported SVG files. See [docs/src/components/diagrams/README.md](docs/src/components/diagrams/README.md) for the palette, primitives, shared CSS classes, animation conventions, and step-by-step authoring guidelines. Follow that guide for any new or updated diagram.
+
+## Agent Tooling
+
+### Semantic code search over this repo (`cocoindex-code` MCP)
+
+This repo ships a Model Context Protocol server for AST-aware semantic search over its own
+codebase. It is registered for both OpenCode (`opencode.json`) and Claude Code / any
+`.mcp.json`-aware client (`.mcp.json`). Both launch it the same way:
+
+```bash
+uvx --with cocoindex>=1.0.6 cocoindex-code@latest
+```
+
+It exposes a single `search` tool (semantic query over code chunks; incrementally re-indexes
+before each search). Prefer it over blind `grep` when locating where a concept lives. The same
+package provides a `ccc` CLI for searching/indexing from the terminal. Source:
+[github.com/cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code).
 
 ## Agent Playbooks
 

--- a/context7.json
+++ b/context7.json
@@ -12,10 +12,5 @@
     "Functions with memo=True must have full type annotations on all parameters and the return value.",
     "There is no `cocoindex setup` step in v1: run apps with `cocoindex update` (add --live for live mode) or `app.update_blocking()` in Python.",
     "Full docs index for agents: https://cocoindex.io/docs/llms.txt (docs pages and example walkthroughs have raw-Markdown twins: replace the trailing slash with .md)."
-  ],
-  "previousVersions": [
-    {
-      "tag": "v0.3.39"
-    }
   ]
 }

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -41,7 +41,7 @@ cocoindex init my-project
 cd my-project
 ```
 
-This creates: `main.py`, `pyproject.toml`, `.env`, `README.md`.
+This creates: `main.py`, `pyproject.toml`, `README.md`. The generated `main.py` sets the database location in its lifespan via `builder.settings.db_path = pathlib.Path("./cocoindex.db")`.
 
 ### Add Dependencies
 
@@ -58,8 +58,7 @@ See [references/setup_project.md](references/setup_project.md) for complete exam
 ### Run the Pipeline
 
 ```bash
-pip install -e .
-cocoindex update main.py
+uv run cocoindex update main.py   # or: pip install -e . && cocoindex update main.py
 ```
 
 ## Core Concepts
@@ -166,12 +165,12 @@ Generate stable, unique identifiers that persist across incremental updates:
 from cocoindex.resources.id import generate_id, IdGenerator
 
 # Deterministic: same dep -> same ID
-chunk_id = await generate_id(chunk.content)
+chunk_id = await generate_id(chunk.text)
 
 # Always distinct: each call -> new ID, even with same dep
 id_gen = IdGenerator()
 for chunk in chunks:
-    chunk_id = await id_gen.next_id(chunk.content)
+    chunk_id = await id_gen.next_id(chunk.text)
 ```
 
 ### 7. Catch-Up vs Live Mode

--- a/skills/cocoindex/references/api_reference.md
+++ b/skills/cocoindex/references/api_reference.md
@@ -408,15 +408,15 @@ matcher = PatternFilePathMatcher(
 
 ```python
 # Deterministic: same dep -> same ID
-chunk_id = await generate_id(chunk.content)
-chunk_uuid = generate_uuid(chunk.content)
+chunk_id = await generate_id(chunk.text)
+chunk_uuid = generate_uuid(chunk.text)
 
 # Distinct per call (even with same dep)
 id_gen = IdGenerator()
-chunk_id = await id_gen.next_id(chunk.content)
+chunk_id = await id_gen.next_id(chunk.text)
 
 uuid_gen = UuidGenerator()
-chunk_uuid = uuid_gen.next_uuid(chunk.content)
+chunk_uuid = uuid_gen.next_uuid(chunk.text)
 ```
 
 ---
@@ -434,7 +434,7 @@ class Record:
     vector: Annotated[NDArray, EMBEDDER]
 
 # Explicit dimensions
-schema = VectorSchema(dtype=np.float32, size=384)
+schema = VectorSchema(dtype=np.dtype(np.float32), size=384)
 
 @dataclass
 class Record:

--- a/skills/cocoindex/references/connectors.md
+++ b/skills/cocoindex/references/connectors.md
@@ -338,6 +338,173 @@ relation_target.declare_relation(from_id="user:1", to_id="item:1", record=MyRela
 
 ---
 
+## Neo4j
+
+**Import**: `from cocoindex.connectors import neo4j`
+
+**Capabilities**: Target only | **Vector**: Native (vector index) | **Model**: Knowledge graph (nodes + relationships)
+
+### Connection Setup
+
+```python
+from cocoindex.connectors import neo4j
+
+NEO4J_DB = coco.ContextKey[neo4j.ConnectionFactory]("neo4j_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(NEO4J_DB, neo4j.ConnectionFactory(
+        uri="bolt://localhost:7687",
+        auth=("neo4j", "cocoindex"),
+        database="neo4j",  # Optional, default "neo4j"
+    ))
+    yield
+```
+
+### As Target (Nodes + Relationships)
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+
+@dataclass
+class Task:
+    description: str
+
+@dataclass
+class AssignedRel:
+    priority: int
+
+# Mount node tables (each label is a table)
+person_table = await neo4j.mount_table_target(
+    NEO4J_DB,
+    "Person",
+    await neo4j.TableSchema.from_class(Person, primary_key="name"),
+    primary_key="name",
+)
+task_table = await neo4j.mount_table_target(
+    NEO4J_DB,
+    "Task",
+    await neo4j.TableSchema.from_class(Task, primary_key="description"),
+    primary_key="description",
+)
+
+# Mount a relationship target between two node tables
+assigned_rel = await neo4j.mount_relation_target(
+    NEO4J_DB, "ASSIGNED_TO", person_table, task_table,
+    await neo4j.TableSchema.from_class(AssignedRel),
+)
+
+# Declare nodes
+person_table.declare_record(row=Person(name="Alice"))   # alias: declare_row
+task_table.declare_record(row=Task(description="ship v1"))
+
+# Declare edges (record optional; PK auto-derived from endpoints when omitted)
+assigned_rel.declare_relation(
+    from_id="Alice", to_id="ship v1", record=AssignedRel(priority=1),
+)
+```
+
+### Vector Index
+
+```python
+person_table.declare_vector_index(
+    field="embedding",
+    dimension=384,
+    metric="cosine",  # or "euclidean"
+)
+```
+
+### Type Override
+
+```python
+from typing import Annotated
+
+@dataclass
+class Row:
+    id: str
+    score: Annotated[float, neo4j.Neo4jType("decimal", encoder=str)]
+```
+
+---
+
+## FalkorDB
+
+**Import**: `from cocoindex.connectors import falkordb`
+
+**Capabilities**: Target only | **Vector**: Native (vector index) | **Model**: Knowledge graph (nodes + relationships)
+
+### Connection Setup
+
+```python
+from cocoindex.connectors import falkordb
+
+FALKOR_DB = coco.ContextKey[falkordb.ConnectionFactory]("falkor_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(FALKOR_DB, falkordb.ConnectionFactory(
+        uri="falkor://localhost:6379",
+        graph="knowledge_graph",  # Optional, default "default"
+    ))
+    yield
+```
+
+### As Target (Nodes + Relationships)
+
+```python
+person_table = await falkordb.mount_table_target(
+    FALKOR_DB,
+    "Person",
+    await falkordb.TableSchema.from_class(Person, primary_key="name"),
+    primary_key="name",
+)
+task_table = await falkordb.mount_table_target(
+    FALKOR_DB,
+    "Task",
+    await falkordb.TableSchema.from_class(Task, primary_key="description"),
+    primary_key="description",
+)
+
+# Mount relationship target (no schema -> PK auto-derived from endpoints)
+assigned_rel = await falkordb.mount_relation_target(
+    FALKOR_DB, "ASSIGNED_TO", person_table, task_table,
+)
+
+# Declare nodes
+person_table.declare_record(row=Person(name="Alice"))   # alias: declare_row
+task_table.declare_record(row=Task(description="ship v1"))
+
+# Declare edges
+assigned_rel.declare_relation(from_id="Alice", to_id="ship v1")
+```
+
+### Vector Index
+
+```python
+person_table.declare_vector_index(
+    field="embedding",
+    dimension=384,
+    metric="cosine",  # or "euclidean", "ip"
+)
+```
+
+### Type Override
+
+```python
+from typing import Annotated
+
+@dataclass
+class Row:
+    id: str
+    score: Annotated[float, falkordb.FalkorType("decimal", encoder=str)]
+```
+
+---
+
 ## LocalFS
 
 **Import**: `from cocoindex.connectors import localfs`
@@ -546,6 +713,8 @@ await coco.mount_each(process_file, source.items(), target)
 | **LanceDB** | - | Y | Native | Cloud-native vector DB |
 | **Qdrant** | - | Y | Native | Specialized vector search |
 | **SurrealDB** | - | Y | Native | Graph + document DB |
+| **Neo4j** | - | Y | Native | Knowledge graphs |
+| **FalkorDB** | - | Y | Native | Knowledge graphs (Redis) |
 | **Apache Doris** | - | Y | Native | Analytical DB + vectors |
 | **LocalFS** | Y | Y | N/A | File-based pipelines |
 | **Amazon S3** | Y | - | N/A | Cloud object storage |

--- a/skills/cocoindex/references/setup_project.md
+++ b/skills/cocoindex/references/setup_project.md
@@ -9,10 +9,10 @@ cocoindex init my-project
 cd my-project
 ```
 
-This creates: `main.py`, `pyproject.toml`, `.env`, `README.md`.
+This creates: `main.py`, `pyproject.toml`, `README.md`. The generated `main.py` sets the internal database location in its lifespan via `builder.settings.db_path = pathlib.Path("./cocoindex.db")`.
 
 ```bash
-pip install -e .
+uv run cocoindex update main.py   # or: pip install -e . && cocoindex update main.py
 ```
 
 ## Dependencies by Use Case
@@ -97,10 +97,12 @@ dependencies = [
 
 ### `.env` File
 
-CocoIndex automatically loads `.env` from the current directory.
+The `cocoindex` CLI automatically loads `.env` from the current directory (via `find_dotenv`).
 
 ```bash
-# CocoIndex internal database (required)
+# CocoIndex internal database (optional fallback).
+# Only used if the lifespan does not set builder.settings.db_path.
+# The `cocoindex init` template sets db_path in the lifespan instead, so this is not needed there.
 COCOINDEX_DB=./cocoindex.db
 
 # PostgreSQL (if using)


### PR DESCRIPTION
## What this is

A deep review of CocoIndex's **AI-coding-agent surface** and the accuracy/discoverability fixes it surfaced. Scope reviewed: `AGENTS.md`, the bundled `skills/cocoindex/` skill, the `llms.txt` docs surface, `examples/`, and the MCP / Context7 / OpenCode configs.

**Verdict:** the agent-experience setup here is unusually strong. `AGENTS.md` is accurate against the real v1 API, the `llms.txt` `.md`-twin mechanism is genuinely implemented, all examples are on the v1 API with zero dead pre-1.0 leakage, and the hooks/skills are honest thin adapters. No P0s. These are targeted accuracy and discoverability fixes, not a rescue.

## Changes

**Skill (`skills/cocoindex/`)**
- `chunk.content` → `chunk.text` (the real `Chunk` field) in the ID-generation snippets of `SKILL.md` and `api_reference.md`. The skill already used `chunk.text` everywhere else, so this was self-inconsistent and would `AttributeError` if copied.
- Corrected project setup: `cocoindex init` does **not** create a `.env`, and `COCOINDEX_DB` is an optional fallback, not "required" (the scaffold sets `builder.settings.db_path` in the lifespan). Kept the accurate "CLI auto-loads `.env`" note.
- Documented the **Neo4j** and **FalkorDB** knowledge-graph target connectors (the skill advertises KG use cases but never documented them). Signatures ground-truthed against the connector source.
- `VectorSchema(dtype=np.dtype(np.float32))` — the field expects a `np.dtype` instance.

**Configs**
- `opencode.json`: bump pin `cocoindex>=1.0.0a16` → `>=1.0.6` and drop `--prerelease=explicit` (`cocoindex-code` already requires `>=1.0.6`).
- **Added `.mcp.json`** so Claude Code / any `.mcp.json`-aware client also gets the `cocoindex-code` semantic-search server (was OpenCode-only — Claude Code clones never got the tool).
- `context7.json`: dropped `previousVersions: v0.3.39`, a pre-v1 tag that would re-surface the dead `FlowBuilder`/`sources` API the file's own rules forbid.

**`AGENTS.md`**
- Added an "Agent Tooling" section documenting the `cocoindex-code` MCP `search` server + `ccc` CLI (previously undiscoverable from the repo).
- Made the worked example copy-runnable: added the import header and `recursive=True` on `walk_dir`.

## Notes for the reviewer
- Every API symbol in the new connector docs and the skill edits was verified against the real source (`python/cocoindex/connectors/{neo4j,falkordb}/_target.py`, `resources/chunk.py`, `cli.py`, `setting.py`).
- An earlier draft also touched ~25 docs/example files via an over-eager `cocoindex update main` → `main.py` rewrite and added 6 example READMEs. Both were dropped: `user_app_loader.py` accepts both run forms by design (`examples.ts` keeps `RUN_MAIN`/`RUN_MAIN_PY` on purpose), and `main` already has canonical READMEs for those 6 examples. This PR is scoped to the 8 files above only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)