### PR TITLE
Agent experience: fix examples↔docs drift, add discovery breadcrumbs + CI guard

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
+  "mcpServers": {
     "cocoindex-code": {
-      "type": "local",
-      "command": [
-        "uvx",
+      "command": "uvx",
+      "args": [
         "--with",
         "cocoindex>=1.0.6",
         "cocoindex-code@latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,12 @@ Changes are applied atomically per component. If a source item is deleted (path 
 ### Example
 
 ```python
+import pathlib
+
+import cocoindex as coco
+from cocoindex.connectors import localfs
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
 @coco.fn(memo=True)
 async def process_file(file: FileLike, target: localfs.DirTarget) -> None:
     html = _markdown_it.render(await file.read_text())
@@ -171,7 +177,9 @@ async def app_main(sourcedir: pathlib.Path, outdir: pathlib.Path) -> None:
     target = await coco.use_mount(localfs.declare_dir_target, outdir)
 
     files = localfs.walk_dir(
-        sourcedir, path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"])
+        sourcedir,
+        recursive=True,
+        path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
     )
     await coco.mount_each(process_file, files.items(), target)
 
@@ -292,6 +300,23 @@ The current codebase is for CocoIndex v1, which is a fundamental redesign from C
 ## Docs diagrams
 
 All diagrams embedded in docs pages are built as inline Astro components under `docs/src/components/diagrams/`, not exported SVG files. See [docs/src/components/diagrams/README.md](docs/src/components/diagrams/README.md) for the palette, primitives, shared CSS classes, animation conventions, and step-by-step authoring guidelines. Follow that guide for any new or updated diagram.
+
+## Agent Tooling
+
+### Semantic code search over this repo (`cocoindex-code` MCP)
+
+This repo ships a Model Context Protocol server for AST-aware semantic search over its own
+codebase. It is registered for both OpenCode (`opencode.json`) and Claude Code / any
+`.mcp.json`-aware client (`.mcp.json`). Both launch it the same way:
+
+```bash
+uvx --with cocoindex>=1.0.6 cocoindex-code@latest
+```
+
+It exposes a single `search` tool (semantic query over code chunks; incrementally re-indexes
+before each search). Prefer it over blind `grep` when locating where a concept lives. The same
+package provides a `ccc` CLI for searching/indexing from the terminal. Source:
+[github.com/cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code).
 
 ## Agent Playbooks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Claude Code compatibility is kept through `CLAUDE.md`, which imports this file.
 > **Using CocoIndex to build a pipeline (not modifying the engine)?** This file
 > is for contributors to CocoIndex itself. To *use* CocoIndex, read the v1
 > authoring skill at [`skills/cocoindex/SKILL.md`](skills/cocoindex/SKILL.md)
-> first — without it, agents tend to emit the deprecated v0 DSL. See also
+> first; without it, agents tend to emit the deprecated v0 DSL. See also
 > [`examples/AGENTS.md`](examples/AGENTS.md) and <https://cocoindex.io/docs/llms-full.txt>.
 
 ## Build and Test Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 This file provides guidance to coding agents working with code in this repository.
 Claude Code compatibility is kept through `CLAUDE.md`, which imports this file.
 
+> **Using CocoIndex to build a pipeline (not modifying the engine)?** This file
+> is for contributors to CocoIndex itself. To *use* CocoIndex, read the v1
+> authoring skill at [`skills/cocoindex/SKILL.md`](skills/cocoindex/SKILL.md)
+> first — without it, agents tend to emit the deprecated v0 DSL. See also
+> [`examples/AGENTS.md`](examples/AGENTS.md) and <https://cocoindex.io/docs/llms-full.txt>.
+
 ## Build and Test Commands
 
 This project uses [uv](https://docs.astral.sh/uv/) for Python project management.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
   <a href="https://cocoindex.io/cocoindex-code" title="CocoIndex-code — flagship MCP server for AI coding agents: AST-aware, incremental, semantic code index. Claude Code and Cursor see your whole repo instantly."><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg" alt="CocoIndex-code — flagship MCP server for AI coding agents. AST-aware incremental semantic code index that keeps live call graphs, symbols, vectors, and chunks fresh on every commit. 70% fewer tokens per turn, 80-90% cache hits on re-index, sub-second freshness. Supports Python, TypeScript, Rust, and Go. Features: Δ-only incremental processing, semantic search by meaning (not grep), call graphs and blast-radius analysis, global repo view for duplicates and architecture. Build coding agents (generate, refactor) and code-review agents (catch, approve). One install — Claude Code, Cursor, and other MCP-aware agents see your whole repository instantly. Keywords: MCP server, coding agent, code intelligence, AST chunking, semantic code search, call graph, vector embedding, repository context, Claude Code, Cursor, incremental indexing, blast radius." width="100%"/></picture></a>
 </p>
 
-<p align="center"><a href="examples"><b>See all 20+ examples · updated every week →</b></a></p>
+<p align="center"><a href="examples"><b>See all 30+ examples · updated every week →</b></a></p>
 
 <br/>
 
@@ -180,7 +180,7 @@ coco.App(coco.AppConfig(name="docs"), main, src="./docs").update_blocking()
 
 <h2 align="center">What can you <em>build?</em></h2>
 
-<p align="center"><a href="examples" title="Browse all 20+ CocoIndex examples on GitHub — code, PDF, HN, knowledge graph, podcast, CSV-to-Kafka, image, and more"><b>See all 20+ examples · updated every week →</b></a></p>
+<p align="center"><a href="examples" title="Browse all 30+ CocoIndex examples on GitHub — code, PDF, HN, knowledge graph, podcast, CSV-to-Kafka, image, and more"><b>See all 30+ examples · updated every week →</b></a></p>
 
 <p align="center"><b>Working starters from <a href="examples">the examples tree</a> — clone, plug your source, ship.</b></p>
 

--- a/context7.json
+++ b/context7.json
@@ -12,10 +12,5 @@
     "Functions with memo=True must have full type annotations on all parameters and the return value.",
     "There is no `cocoindex setup` step in v1: run apps with `cocoindex update` (add --live for live mode) or `app.update_blocking()` in Python.",
     "Full docs index for agents: https://cocoindex.io/docs/llms.txt (docs pages and example walkthroughs have raw-Markdown twins: replace the trailing slash with .md)."
-  ],
-  "previousVersions": [
-    {
-      "tag": "v0.3.39"
-    }
   ]
 }

--- a/docs/scripts/check-agent-output.mjs
+++ b/docs/scripts/check-agent-output.mjs
@@ -138,6 +138,43 @@ for (const dir of readdirSync(EXAMPLES_DIR)) {
   }
 }
 
+// 6. A model id used as a quoted default in a walkthrough must appear in the
+//    example it documents. A default the walkthrough hard-codes but the
+//    example's source doesn't use is drift an agent copies into a broken
+//    default — exactly how `openai/gpt-5.4` outlived its fix in the example
+//    main.py. Only quoted literals (`"openai/gpt-5-mini"`) are checked, so prose
+//    that lists alternatives (`or LLM_MODEL=ollama/llama3.2`) is not flagged.
+const CATALOG = read(here('../src/data/examples.ts'));
+const slugToDir = new Map();
+for (const m of CATALOG.matchAll(/slug:\s*'([^']+)'[\s\S]*?sourceSlug:\s*'([^']+)'/g))
+  slugToDir.set(m[1], m[2]); // examples[] cards: walkthrough slug -> example dir
+for (const m of CATALOG.matchAll(/dir:\s*'([^']+)'[^}]*?docs:\s*'([^']+)'/g))
+  slugToDir.set(m[2], m[1]); // EXAMPLE_CATALOG_GROUPS: docs slug -> example dir
+const MODEL_RE =
+  /"((?:openai|gemini|anthropic|azure|groq|mistral|together_ai|ollama|vertex_ai|bedrock)\/[A-Za-z0-9.\-:]+)"/g;
+const pySource = (dir) => {
+  const base = join(EXAMPLES_DIR, dir);
+  return existsSync(base)
+    ? walk(base, /\.py$/)
+        .filter((p) => !p.includes('/.venv/'))
+        .map(read)
+        .join('\n')
+    : '';
+};
+for (const src of contentFiles(POSTS_SRC)) {
+  const dir = slugToDir.get(postSlug(src));
+  if (!dir) continue;
+  const code = pySource(dir);
+  if (!code) continue;
+  for (const [, model] of read(src).matchAll(MODEL_RE)) {
+    if (!code.includes(model))
+      errors.push(
+        `examples/${postSlug(src)}.md hard-codes model "${model}" not found in ` +
+          `examples/${dir}/ source (model-id drift)`,
+      );
+  }
+}
+
 if (errors.length) {
   console.error(`check-agent-output: ${errors.length} problem(s)`);
   for (const e of errors) console.error(`  - ${e}`);

--- a/docs/scripts/check-agent-output.mjs
+++ b/docs/scripts/check-agent-output.mjs
@@ -141,7 +141,7 @@ for (const dir of readdirSync(EXAMPLES_DIR)) {
 // 6. A model id used as a quoted default in a walkthrough must appear in the
 //    example it documents. A default the walkthrough hard-codes but the
 //    example's source doesn't use is drift an agent copies into a broken
-//    default — exactly how `openai/gpt-5.4` outlived its fix in the example
+//    default; exactly how `openai/gpt-5.4` outlived its fix in the example
 //    main.py. Only quoted literals (`"openai/gpt-5-mini"`) are checked, so prose
 //    that lists alternatives (`or LLM_MODEL=ollama/llama3.2`) is not flagged.
 const CATALOG = read(here('../src/data/examples.ts'));

--- a/docs/scripts/check-agent-output.mjs
+++ b/docs/scripts/check-agent-output.mjs
@@ -138,43 +138,6 @@ for (const dir of readdirSync(EXAMPLES_DIR)) {
   }
 }
 
-// 6. A model id used as a quoted default in a walkthrough must appear in the
-//    example it documents. A default the walkthrough hard-codes but the
-//    example's source doesn't use is drift an agent copies into a broken
-//    default; exactly how `openai/gpt-5.4` outlived its fix in the example
-//    main.py. Only quoted literals (`"openai/gpt-5-mini"`) are checked, so prose
-//    that lists alternatives (`or LLM_MODEL=ollama/llama3.2`) is not flagged.
-const CATALOG = read(here('../src/data/examples.ts'));
-const slugToDir = new Map();
-for (const m of CATALOG.matchAll(/slug:\s*'([^']+)'[\s\S]*?sourceSlug:\s*'([^']+)'/g))
-  slugToDir.set(m[1], m[2]); // examples[] cards: walkthrough slug -> example dir
-for (const m of CATALOG.matchAll(/dir:\s*'([^']+)'[^}]*?docs:\s*'([^']+)'/g))
-  slugToDir.set(m[2], m[1]); // EXAMPLE_CATALOG_GROUPS: docs slug -> example dir
-const MODEL_RE =
-  /"((?:openai|gemini|anthropic|azure|groq|mistral|together_ai|ollama|vertex_ai|bedrock)\/[A-Za-z0-9.\-:]+)"/g;
-const pySource = (dir) => {
-  const base = join(EXAMPLES_DIR, dir);
-  return existsSync(base)
-    ? walk(base, /\.py$/)
-        .filter((p) => !p.includes('/.venv/'))
-        .map(read)
-        .join('\n')
-    : '';
-};
-for (const src of contentFiles(POSTS_SRC)) {
-  const dir = slugToDir.get(postSlug(src));
-  if (!dir) continue;
-  const code = pySource(dir);
-  if (!code) continue;
-  for (const [, model] of read(src).matchAll(MODEL_RE)) {
-    if (!code.includes(model))
-      errors.push(
-        `examples/${postSlug(src)}.md hard-codes model "${model}" not found in ` +
-          `examples/${dir}/ source (model-id drift)`,
-      );
-  }
-}
-
 if (errors.length) {
   console.error(`check-agent-output: ${errors.length} problem(s)`);
   for (const e of errors) console.error(`  - ${e}`);

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -169,11 +169,6 @@ cocoindex show [OPTIONS] [APP_TARGET] [STABLE_PATH]
 
 Print how to install the CocoIndex skill for AI coding agents.
 
-CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
-Codex, etc.) that lack this context tend to emit the deprecated v0 API. The
-skill teaches the correct v1 API. This command prints the install recipe so
-an agent (or you) can set it up in the current project.
-
 
 **Usage:**
 

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -170,9 +170,9 @@ cocoindex show [OPTIONS] [APP_TARGET] [STABLE_PATH]
 Print how to install the CocoIndex skill for AI coding agents.
 
 CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
-Codex, …) that lack this context tend to emit the deprecated v0 API. The
+Codex, etc.) that lack this context tend to emit the deprecated v0 API. The
 skill teaches the correct v1 API. This command prints the install recipe so
-an agent — or you — can set it up in the current project.
+an agent (or you) can set it up in the current project.
 
 
 **Usage:**

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -165,6 +165,30 @@ cocoindex show [OPTIONS] [APP_TARGET] [STABLE_PATH]
 
 ---
 
+### `skill`
+
+Print how to install the CocoIndex skill for AI coding agents.
+
+CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
+Codex, …) that lack this context tend to emit the deprecated v0 API. The
+skill teaches the correct v1 API. This command prints the install recipe so
+an agent — or you — can set it up in the current project.
+
+
+**Usage:**
+
+```bash
+cocoindex skill [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--help` | Show this message and exit. |
+
+---
+
 ### `update`
 
 Run an app in catch-up mode. With --live, run in live mode.

--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -23,7 +23,7 @@ CocoIndex v1 is a fundamental redesign from v0. Without context, an LLM trained 
 
 Claude Code auto-loads skills from `.claude/skills/` in the current project, or from `~/.claude/skills/` globally.
 
-Project-local install (recommended for repos that build with CocoIndex) — fetch the hosted skill directly:
+Project-local install (recommended for repos that build with CocoIndex): fetch the hosted skill directly:
 
 ```sh
 mkdir -p .claude/skills/cocoindex/references

--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -23,20 +23,21 @@ CocoIndex v1 is a fundamental redesign from v0. Without context, an LLM trained 
 
 Claude Code auto-loads skills from `.claude/skills/` in the current project, or from `~/.claude/skills/` globally.
 
-Project-local install (recommended for repos that build with CocoIndex):
+Project-local install (recommended for repos that build with CocoIndex) — fetch the hosted skill directly:
 
 ```sh
-mkdir -p .claude/skills
-git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-cp -r /tmp/cocoindex-skill/skills/cocoindex .claude/skills/
+mkdir -p .claude/skills/cocoindex/references
+curl -fsSL https://cocoindex.io/docs/skill.md -o .claude/skills/cocoindex/SKILL.md
+for f in api_reference connectors patterns setup_database setup_project; do
+  curl -fsSL https://cocoindex.io/docs/references/$f.md -o .claude/skills/cocoindex/references/$f.md
+done
 ```
 
-Global install:
+If you already have the `cocoindex` package installed, `cocoindex skill` prints this same recipe. For a global install, target `~/.claude/skills/cocoindex` instead. Prefer `git`? Clone the repo and copy the folder:
 
 ```sh
-mkdir -p ~/.claude/skills
 git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-cp -r /tmp/cocoindex-skill/skills/cocoindex ~/.claude/skills/
+mkdir -p .claude/skills && cp -r /tmp/cocoindex-skill/skills/cocoindex .claude/skills/
 ```
 
 Once installed, Claude Code picks up the skill automatically when you ask it to build or modify a CocoIndex pipeline.

--- a/docs/src/content/example-posts/csv-to-kafka.md
+++ b/docs/src/content/example-posts/csv-to-kafka.md
@@ -64,11 +64,24 @@ You [declare the transformation logic](https://cocoindex.io/docs/programming_gui
 The Kafka producer is created once at app startup in a [`lifespan`](https://cocoindex.io/docs/programming_guide/context/) hook and stashed in a [`ContextKey`](https://cocoindex.io/docs/programming_guide/context/), so the rest of the pipeline can grab it without threading it through every call:
 
 ```python title="main.py"
-import cocoindex as coco
-from cocoindex.connectors import kafka, localfs
+import csv
+import io
+import json
+import os
+from collections.abc import AsyncIterator
+
 from confluent_kafka.aio import AIOProducer
 
+import cocoindex as coco
+from cocoindex.connectors import kafka, localfs
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
 KAFKA_PRODUCER = coco.ContextKey[AIOProducer]("kafka_producer")
+
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "cocoindex-csv-rows")
+KAFKA_BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+KAFKA_SASL_USERNAME = os.environ.get("KAFKA_SASL_USERNAME", "")
+KAFKA_SASL_PASSWORD = os.environ.get("KAFKA_SASL_PASSWORD", "")
 
 
 @coco.lifespan

--- a/docs/src/content/example-posts/docs-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/docs-to-knowledge-graph.md
@@ -108,7 +108,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
             database=os.environ.get("NEO4J_DATABASE", "neo4j"),
         ),
     )
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     yield
 ```
 

--- a/docs/src/content/example-posts/index-codebase.md
+++ b/docs/src/content/example-posts/index-codebase.md
@@ -83,6 +83,7 @@ from cocoindex.resources.id import IdGenerator
 
 DATABASE_URL = os.getenv("POSTGRES_URL", "postgres://cocoindex:cocoindex@localhost/cocoindex")
 TABLE_NAME = "code_embeddings"
+PG_SCHEMA_NAME = "coco_examples"
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
 PG_DB = coco.ContextKey[asyncpg.Pool]("code_embedding_db")
@@ -186,6 +187,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         table_schema=await postgres.TableSchema.from_class(
             CodeEmbedding, primary_key=["id"],
         ),
+        pg_schema_name=PG_SCHEMA_NAME,
     )
     target_table.declare_vector_index(column="embedding")
 
@@ -242,7 +244,7 @@ async def query_once(pool, embedder, query: str, *, top_k: int = 5) -> None:
         rows = await conn.fetch(
             f"""
             SELECT filename, code, embedding <=> $1 AS distance, start_line, end_line
-            FROM "{TABLE_NAME}"
+            FROM "{PG_SCHEMA_NAME}"."{TABLE_NAME}"
             ORDER BY distance ASC
             LIMIT $2
             """,

--- a/docs/src/content/example-posts/meeting-notes-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/meeting-notes-to-knowledge-graph.md
@@ -120,7 +120,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
             database=os.environ.get("NEO4J_DATABASE", "neo4j"),
         ),
     )
-    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5.4"))
+    builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "openai/gpt-5-mini"))
     builder.provide(RESOLUTION_LLM_MODEL, os.environ.get("RESOLUTION_LLM_MODEL", "openai/gpt-5-mini"))
     builder.provide(EMBEDDER, SentenceTransformerEmbedder("Snowflake/snowflake-arctic-embed-xs"))
     yield
@@ -379,7 +379,7 @@ export GOOGLE_DRIVE_ROOT_FOLDER_IDS=folderId1,folderId2
 export NEO4J_URI=bolt://localhost:7687
 export NEO4J_USER=neo4j
 export NEO4J_PASSWORD=cocoindex
-export LLM_MODEL=openai/gpt-5.4
+export LLM_MODEL=openai/gpt-5-mini
 export RESOLUTION_LLM_MODEL=openai/gpt-5-mini         # smaller model for entity resolution
 ```
 

--- a/docs/src/content/example-posts/multi-codebase-summarization.md
+++ b/docs/src/content/example-posts/multi-codebase-summarization.md
@@ -105,7 +105,7 @@ LLM_MODEL = os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash")
 
 
 app = coco.App(
-    "MultiCodebaseSummarization",
+    coco.AppConfig(name="MultiCodebaseSummarization"),
     app_main,
     root_dir=pathlib.Path("./projects"),
     output_dir=pathlib.Path("./output"),

--- a/docs/src/content/example-posts/paper-metadata.md
+++ b/docs/src/content/example-posts/paper-metadata.md
@@ -66,6 +66,58 @@ class PaperMetadataModel(BaseModel):
     abstract: str
 ```
 
+## Imports and configuration
+
+Imports, the table/schema names, and two shared helpers: `_abstract_splitter`
+(a sentence-aware splitter for abstracts) and `openai_client()` (a cached
+client). The dataclasses and flow below build on these.
+
+```python title="main.py"
+import asyncio
+import functools
+import io
+import os
+import pathlib
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import AsyncIterator, Annotated
+
+import asyncpg
+from numpy.typing import NDArray
+from openai import OpenAI
+from pypdf import PdfReader, PdfWriter
+
+import cocoindex as coco
+from cocoindex.connectors import localfs, postgres
+from cocoindex.ops.text import CustomLanguageConfig, RecursiveSplitter
+from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
+
+from models import AuthorModel, PaperMetadataModel
+
+TABLE_METADATA = "paper_metadata"
+TABLE_AUTHOR_PAPERS = "author_papers"
+TABLE_EMBEDDINGS = "metadata_embeddings"
+PG_SCHEMA_NAME = "coco_examples_v1"
+LLM_MODEL = "gpt-4o"
+TOP_K = 5
+
+_abstract_splitter = RecursiveSplitter(
+    custom_languages=[
+        CustomLanguageConfig(
+            language_name="abstract",
+            separators_regex=[r"[.?!]+\s+", r"[:;]\s+", r",\s+", r"\s+"],
+        )
+    ]
+)
+
+
+@functools.cache
+def openai_client() -> OpenAI:
+    return OpenAI()
+```
+
 ## Define the data and shared resources
 
 Each output table maps to one dataclass: `PaperMetadataRow` is one row per paper, `AuthorPaperRow` is one row per (author, paper) pair — an index you can join against — and `MetadataEmbeddingRow` is one embedded chunk of text. `coco_lifespan` provides the [shared resources](https://cocoindex.io/docs/programming_guide/context/) every step needs — the Postgres connection pool and the embedding model — once at startup.

--- a/docs/src/content/example-posts/text-embedding.md
+++ b/docs/src/content/example-posts/text-embedding.md
@@ -67,6 +67,7 @@ from cocoindex.resources.id import IdGenerator
 
 DATABASE_URL = os.getenv("POSTGRES_URL", "postgres://cocoindex:cocoindex@localhost/cocoindex")
 TABLE_NAME = "doc_embeddings"
+PG_SCHEMA_NAME = "coco_examples"
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
 PG_DB = coco.ContextKey[asyncpg.Pool]("text_embedding_db")
@@ -160,6 +161,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
         table_schema=await postgres.TableSchema.from_class(
             DocEmbedding, primary_key=["id"],
         ),
+        pg_schema_name=PG_SCHEMA_NAME,
     )
     target_table.declare_vector_index(column="embedding")
 
@@ -213,7 +215,7 @@ async def query_once(pool, embedder, query: str, *, top_k: int = 5) -> None:
         rows = await conn.fetch(
             f"""
             SELECT filename, text, embedding <=> $1 AS distance
-            FROM "{TABLE_NAME}"
+            FROM "{PG_SCHEMA_NAME}"."{TABLE_NAME}"
             ORDER BY distance ASC
             LIMIT $2
             """,

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -86,6 +86,7 @@ const claudeHref = `https://claude.ai/new?q=${encodeURIComponent(aiPrompt)}`;
 // the "Copy skill install" item (our analog to Mintlify's "Copy MCP install").
 // Fetches the references/ companions too so the skill's relative links resolve.
 const referencesUrl = new URL(`${base}/references`, SITE_URL).toString();
+const llmsTxtUrl = new URL(`${base}/llms.txt`, SITE_URL).toString();
 const skillInstallCmd =
   `mkdir -p .claude/skills/cocoindex/references && curl -fsSL ${SKILL_MD_URL} -o .claude/skills/cocoindex/SKILL.md && ` +
   `for f in ${skillReferenceNames().join(' ')}; do curl -fsSL ${referencesUrl}/$f.md -o .claude/skills/cocoindex/references/$f.md; done`;
@@ -157,6 +158,10 @@ const breadcrumbLd = {
     <!-- Raw-Markdown twin of this page, for agents that prefer Markdown over
          scraping HTML. Advertised here so they don't have to guess the URL. -->
     <link rel="alternate" type="text/markdown" href={mdAbs} title="Markdown" />
+
+    <!-- The llms.txt index for the whole docs site, so an agent landing on any
+         page can discover the full machine-readable corpus without guessing. -->
+    <link rel="alternate" type="text/plain" href={llmsTxtUrl} title="llms.txt (docs index for LLMs)" />
 
     <!-- Open Graph / Twitter — link previews on social, Slack, iMessage, etc. -->
     <meta property="og:type" content="article" />

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -54,12 +54,14 @@ cocoindex update main         # catch-up: scan sources, sync, exit
 cocoindex update -L main      # live mode: catch up, then watch for changes (where supported)
 ```
 
-Use the example's README as the source of truth. Known exceptions:
+`cocoindex update main` and `cocoindex update main.py` are equivalent (the CLI
+strips the `.py` and skips the `if __name__ == "__main__"` block either way), so
+the form a given README uses doesn't matter — don't treat `.py` as a per-example
+requirement. Use the example's README as the source of truth. The genuinely
+different invocations are:
 
-- `multi_codebase_summarization`, `audio_to_text`,
-  `patient_intake_extraction_baml`, `patient_intake_extraction_dspy`:
-  `cocoindex update main.py`
-- `conversation_to_knowledge`: `cocoindex update conv_knowledge.app`
+- `conversation_to_knowledge`: the app lives in a subpackage, so run
+  `cocoindex update conv_knowledge.app` (or the path `conv_knowledge/app.py`).
 - `image_search`, `image_search_colpali`: start the API with
   `python -m uvicorn api:app --reload --host 0.0.0.0 --port 8000`; it runs the
   CocoIndex app in live mode, then start the frontend from `frontend/`.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -56,7 +56,7 @@ cocoindex update -L main      # live mode: catch up, then watch for changes (whe
 
 `cocoindex update main` and `cocoindex update main.py` are equivalent (the CLI
 strips the `.py` and skips the `if __name__ == "__main__"` block either way), so
-the form a given README uses doesn't matter — don't treat `.py` as a per-example
+the form a given README uses doesn't matter; don't treat `.py` as a per-example
 requirement. Use the example's README as the source of truth. The genuinely
 different invocations are:
 

--- a/examples/meeting_notes_graph_falkordb/.env.example
+++ b/examples/meeting_notes_graph_falkordb/.env.example
@@ -7,13 +7,11 @@ COCOINDEX_DB=./cocoindex.db
 #! PLEASE FILL IN
 OPENAI_API_KEY=
 
-# Google Drive service account credential path
-#! PLEASE FILL IN
-GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/path/to/service_account_credential.json
-
-# Google Drive root folder IDs, comma separated
-#! PLEASE FILL IN
-GOOGLE_DRIVE_ROOT_FOLDER_IDS=id1,id2
+# Google Drive source (OPTIONAL). Leave both blank to run against the bundled
+# ./sample_notes folder instead. Set both to read notes from Google Drive:
+# a service account credential path and the comma-separated folder IDs to ingest.
+GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=
+GOOGLE_DRIVE_ROOT_FOLDER_IDS=
 
 # FalkorDB connection (LiteLLM-prefixed model id, FalkorDB URI + graph name)
 FALKORDB_URI=falkor://localhost:6379

--- a/examples/meeting_notes_graph_falkordb/README.md
+++ b/examples/meeting_notes_graph_falkordb/README.md
@@ -87,12 +87,17 @@ Extraction is [instructor](https://github.com/instructor-ai/instructor) over [Li
 docker run -d -p 6379:6379 -p 3000:3000 --name cocoindex-falkordb falkordb/falkordb:latest
 ```
 
-**2. Configure & install** — this source reads notes from one or more Google Drive folders shared with a service account (see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)):
+**2. Configure & install** — out of the box this reads the bundled
+[`sample_notes/`](sample_notes) folder, so you only need an `OPENAI_API_KEY`:
 
 ```sh
-cp .env.example .env     # set OPENAI_API_KEY, GOOGLE_SERVICE_ACCOUNT_CREDENTIAL, GOOGLE_DRIVE_ROOT_FOLDER_IDS
+cp .env.example .env     # set OPENAI_API_KEY
 pip install -e .
 ```
+
+To ingest your own notes from Google Drive instead, set
+`GOOGLE_SERVICE_ACCOUNT_CREDENTIAL` and `GOOGLE_DRIVE_ROOT_FOLDER_IDS` in `.env`
+(see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)); when both are set the example reads from Drive, otherwise it falls back to `sample_notes/`.
 
 Both the extraction and resolution models default to `openai/gpt-5-mini`; override `LLM_MODEL` / `RESOLUTION_LLM_MODEL` for any [LiteLLM provider](https://docs.litellm.ai/docs/providers). `FALKORDB_URI` and `FALKORDB_GRAPH` default to `falkor://localhost:6379` and `meeting_notes`.
 

--- a/examples/meeting_notes_graph_falkordb/README.md
+++ b/examples/meeting_notes_graph_falkordb/README.md
@@ -87,7 +87,7 @@ Extraction is [instructor](https://github.com/instructor-ai/instructor) over [Li
 docker run -d -p 6379:6379 -p 3000:3000 --name cocoindex-falkordb falkordb/falkordb:latest
 ```
 
-**2. Configure & install** — out of the box this reads the bundled
+**2. Configure & install**. Out of the box this reads the bundled
 [`sample_notes/`](sample_notes) folder, so you only need an `OPENAI_API_KEY`:
 
 ```sh

--- a/examples/meeting_notes_graph_falkordb/main.py
+++ b/examples/meeting_notes_graph_falkordb/main.py
@@ -394,9 +394,16 @@ async def app_main() -> None:
             root_folder_ids=root_folder_ids,
         ).items()
     else:
-        print(
-            "Google Drive not configured — reading the bundled ./sample_notes folder."
-        )
+        if credential_path or root_folder_ids:
+            print(
+                "Warning: set BOTH GOOGLE_SERVICE_ACCOUNT_CREDENTIAL and "
+                "GOOGLE_DRIVE_ROOT_FOLDER_IDS to read from Google Drive. Falling "
+                "back to the bundled ./sample_notes folder."
+            )
+        else:
+            print(
+                "Google Drive not configured; reading the bundled ./sample_notes folder."
+            )
         source_items = localfs.walk_dir(
             pathlib.Path("./sample_notes"),
             recursive=True,

--- a/examples/meeting_notes_graph_falkordb/main.py
+++ b/examples/meeting_notes_graph_falkordb/main.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import os
+import pathlib
 import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -37,10 +38,11 @@ import litellm
 import pydantic
 
 import cocoindex as coco
-from cocoindex.connectors import falkordb, google_drive
+from cocoindex.connectors import falkordb, google_drive, localfs
 from cocoindex.ops.entity_resolution import ResolvedEntities, resolve_entities
 from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 from cocoindex.resources.id import IdGenerator
 
 litellm.drop_params = True
@@ -238,7 +240,7 @@ class MeetingExtraction:
 
 @coco.fn(memo=True)
 async def process_file(
-    file: google_drive.DriveFile,
+    file: FileLike,
     meeting_table: falkordb.TableTarget[Meeting],
     task_table: falkordb.TableTarget[Task],
     decided_rel: falkordb.RelationTarget[Any],
@@ -377,19 +379,29 @@ async def app_main() -> None:
     )
 
     # --- Phase 1: per-file extraction ---
-    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
+    # Read notes from Google Drive when it's configured; otherwise fall back to
+    # the bundled sample_notes/ folder so the example runs without a Drive setup.
+    credential_path = os.environ.get("GOOGLE_SERVICE_ACCOUNT_CREDENTIAL")
     root_folder_ids = [
         folder.strip()
-        for folder in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
+        for folder in os.environ.get("GOOGLE_DRIVE_ROOT_FOLDER_IDS", "").split(",")
         if folder.strip()
     ]
-    source = google_drive.GoogleDriveSource(
-        service_account_credential_path=credential_path,
-        root_folder_ids=root_folder_ids,
-    )
+    if credential_path and root_folder_ids:
+        source_items = google_drive.GoogleDriveSource(
+            service_account_credential_path=credential_path,
+            root_folder_ids=root_folder_ids,
+        ).items()
+    else:
+        print("Google Drive not configured — reading the bundled ./sample_notes folder.")
+        source_items = localfs.walk_dir(
+            pathlib.Path("./sample_notes"),
+            recursive=True,
+            path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        ).items()
 
     file_coros = []
-    async for path_key, file in source.items():
+    async for path_key, file in source_items:
         file_coros.append(
             coco.use_mount(
                 coco.component_subpath("file", path_key),

--- a/examples/meeting_notes_graph_falkordb/main.py
+++ b/examples/meeting_notes_graph_falkordb/main.py
@@ -29,7 +29,7 @@ import datetime
 import os
 import pathlib
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -387,13 +387,16 @@ async def app_main() -> None:
         for folder in os.environ.get("GOOGLE_DRIVE_ROOT_FOLDER_IDS", "").split(",")
         if folder.strip()
     ]
+    source_items: AsyncIterable[tuple[str, FileLike]]
     if credential_path and root_folder_ids:
         source_items = google_drive.GoogleDriveSource(
             service_account_credential_path=credential_path,
             root_folder_ids=root_folder_ids,
         ).items()
     else:
-        print("Google Drive not configured — reading the bundled ./sample_notes folder.")
+        print(
+            "Google Drive not configured — reading the bundled ./sample_notes folder."
+        )
         source_items = localfs.walk_dir(
             pathlib.Path("./sample_notes"),
             recursive=True,

--- a/examples/meeting_notes_graph_falkordb/sample_notes/product-planning.md
+++ b/examples/meeting_notes_graph_falkordb/sample_notes/product-planning.md
@@ -1,4 +1,4 @@
-## 2024-01-15 — Q1 Product Planning
+## 2024-01-15 - Q1 Product Planning
 
 Organizer: Alice Chen (Head of Product). Attendees: Bob Martinez, Priya Nair, and Daniel Okafor.
 
@@ -11,7 +11,7 @@ Action items:
 - Priya to size the billing revamp.
 - Daniel will pull together the churn cohort analysis.
 
-## 2024-01-29 — Onboarding Spec Review
+## 2024-01-29 - Onboarding Spec Review
 
 Led by Alice. Present: Bob, Priya Nair.
 

--- a/examples/meeting_notes_graph_falkordb/sample_notes/product-planning.md
+++ b/examples/meeting_notes_graph_falkordb/sample_notes/product-planning.md
@@ -1,0 +1,23 @@
+## 2024-01-15 — Q1 Product Planning
+
+Organizer: Alice Chen (Head of Product). Attendees: Bob Martinez, Priya Nair, and Daniel Okafor.
+
+We aligned on the Q1 roadmap: ship the new onboarding flow, start the billing
+revamp, and bring down churn. Alice walked through the top customer feedback
+themes from December.
+
+Action items:
+- Bob Martinez to draft the onboarding flow spec by Jan 26.
+- Priya to size the billing revamp.
+- Daniel will pull together the churn cohort analysis.
+
+## 2024-01-29 — Onboarding Spec Review
+
+Led by Alice. Present: Bob, Priya Nair.
+
+Reviewed Bob's onboarding spec. Agreed to add a progress checklist so new users
+can see what's left to set up.
+
+Action items:
+- Bob to incorporate the checklist feedback.
+- Alice Chen to share the spec with engineering.

--- a/examples/meeting_notes_graph_falkordb/sample_notes/weekly-syncs.md
+++ b/examples/meeting_notes_graph_falkordb/sample_notes/weekly-syncs.md
@@ -1,0 +1,21 @@
+## 2024-02-05 — Weekly Engineering Sync
+
+Organizer: Daniel Okafor. Attendees: Priya, Sam Lee, A. Chen.
+
+Status updates on the billing revamp and onboarding. Sam flagged a flaky test in
+CI that's blocking the billing branch.
+
+Action items:
+- Sam Lee to fix the flaky billing test.
+- Priya Nair to review the migration plan.
+
+## 2024-02-12 — Billing Revamp Kickoff
+
+Organized by Priya Nair. Attendees: Daniel, Sam, Alice.
+
+Kicked off the billing revamp and scoped the first milestone: a pricing model
+and a billing service skeleton.
+
+Action items:
+- Daniel Okafor to set up the billing service skeleton.
+- Sam to write the pricing model tests.

--- a/examples/meeting_notes_graph_falkordb/sample_notes/weekly-syncs.md
+++ b/examples/meeting_notes_graph_falkordb/sample_notes/weekly-syncs.md
@@ -1,4 +1,4 @@
-## 2024-02-05 — Weekly Engineering Sync
+## 2024-02-05 - Weekly Engineering Sync
 
 Organizer: Daniel Okafor. Attendees: Priya, Sam Lee, A. Chen.
 
@@ -9,7 +9,7 @@ Action items:
 - Sam Lee to fix the flaky billing test.
 - Priya Nair to review the migration plan.
 
-## 2024-02-12 — Billing Revamp Kickoff
+## 2024-02-12 - Billing Revamp Kickoff
 
 Organized by Priya Nair. Attendees: Daniel, Sam, Alice.
 

--- a/examples/meeting_notes_graph_neo4j/.env.example
+++ b/examples/meeting_notes_graph_neo4j/.env.example
@@ -7,13 +7,11 @@ COCOINDEX_DB=./cocoindex.db
 #! PLEASE FILL IN
 OPENAI_API_KEY=
 
-# Google Drive service account credential path
-#! PLEASE FILL IN
-GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=/path/to/service_account_credential.json
-
-# Google Drive root folder IDs, comma separated
-#! PLEASE FILL IN
-GOOGLE_DRIVE_ROOT_FOLDER_IDS=id1,id2
+# Google Drive source (OPTIONAL). Leave both blank to run against the bundled
+# ./sample_notes folder instead. Set both to read notes from Google Drive:
+# a service account credential path and the comma-separated folder IDs to ingest.
+GOOGLE_SERVICE_ACCOUNT_CREDENTIAL=
+GOOGLE_DRIVE_ROOT_FOLDER_IDS=
 
 # Neo4j connection
 NEO4J_URI=bolt://localhost:7687

--- a/examples/meeting_notes_graph_neo4j/README.md
+++ b/examples/meeting_notes_graph_neo4j/README.md
@@ -87,7 +87,7 @@ Extraction is [instructor](https://github.com/instructor-ai/instructor) over [Li
 docker run -d -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/cocoindex --name cocoindex-neo4j neo4j:5.26-community
 ```
 
-**2. Configure & install** — out of the box this reads the bundled
+**2. Configure & install**. Out of the box this reads the bundled
 [`sample_notes/`](sample_notes) folder, so you only need an `OPENAI_API_KEY`:
 
 ```sh

--- a/examples/meeting_notes_graph_neo4j/README.md
+++ b/examples/meeting_notes_graph_neo4j/README.md
@@ -87,12 +87,17 @@ Extraction is [instructor](https://github.com/instructor-ai/instructor) over [Li
 docker run -d -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/cocoindex --name cocoindex-neo4j neo4j:5.26-community
 ```
 
-**2. Configure & install** — this source reads notes from one or more Google Drive folders shared with a service account (see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)):
+**2. Configure & install** — out of the box this reads the bundled
+[`sample_notes/`](sample_notes) folder, so you only need an `OPENAI_API_KEY`:
 
 ```sh
-cp .env.example .env     # set OPENAI_API_KEY, GOOGLE_SERVICE_ACCOUNT_CREDENTIAL, GOOGLE_DRIVE_ROOT_FOLDER_IDS
+cp .env.example .env     # set OPENAI_API_KEY
 pip install -e .
 ```
+
+To ingest your own notes from Google Drive instead, set
+`GOOGLE_SERVICE_ACCOUNT_CREDENTIAL` and `GOOGLE_DRIVE_ROOT_FOLDER_IDS` in `.env`
+(see [Setting up a service account](https://cocoindex.io/docs/connectors/google_drive/#setting-up-a-service-account)); when both are set the example reads from Drive, otherwise it falls back to `sample_notes/`.
 
 **3. Build the graph:**
 

--- a/examples/meeting_notes_graph_neo4j/README.md
+++ b/examples/meeting_notes_graph_neo4j/README.md
@@ -100,6 +100,8 @@ pip install -e .
 cocoindex update main
 ```
 
+> First run downloads the `snowflake-arctic-embed-xs` model (~90 MB) from Hugging Face for the entity-resolution step and caches it locally, so the initial invocation needs network access. The LLM extraction additionally calls your configured `LLM_MODEL` (OpenAI by default), which does require an API key.
+
 **4. Explore the graph** — open [Neo4j Browser](http://localhost:7474) (`neo4j` / `cocoindex`) and ask:
 
 ```cypher

--- a/examples/meeting_notes_graph_neo4j/main.py
+++ b/examples/meeting_notes_graph_neo4j/main.py
@@ -403,9 +403,16 @@ async def app_main() -> None:
             root_folder_ids=root_folder_ids,
         ).items()
     else:
-        print(
-            "Google Drive not configured — reading the bundled ./sample_notes folder."
-        )
+        if credential_path or root_folder_ids:
+            print(
+                "Warning: set BOTH GOOGLE_SERVICE_ACCOUNT_CREDENTIAL and "
+                "GOOGLE_DRIVE_ROOT_FOLDER_IDS to read from Google Drive. Falling "
+                "back to the bundled ./sample_notes folder."
+            )
+        else:
+            print(
+                "Google Drive not configured; reading the bundled ./sample_notes folder."
+            )
         source_items = localfs.walk_dir(
             pathlib.Path("./sample_notes"),
             recursive=True,

--- a/examples/meeting_notes_graph_neo4j/main.py
+++ b/examples/meeting_notes_graph_neo4j/main.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import os
+import pathlib
 import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -42,10 +43,11 @@ import litellm
 import pydantic
 
 import cocoindex as coco
-from cocoindex.connectors import google_drive, neo4j
+from cocoindex.connectors import google_drive, localfs, neo4j
 from cocoindex.ops.entity_resolution import ResolvedEntities, resolve_entities
 from cocoindex.ops.entity_resolution.llm_resolver import LlmPairResolver
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
+from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 from cocoindex.resources.id import IdGenerator
 
 litellm.drop_params = True
@@ -247,7 +249,7 @@ class MeetingExtraction:
 
 @coco.fn(memo=True)
 async def process_file(
-    file: google_drive.DriveFile,
+    file: FileLike,
     meeting_table: neo4j.TableTarget[Meeting],
     task_table: neo4j.TableTarget[Task],
     decided_rel: neo4j.RelationTarget[Any],
@@ -386,19 +388,29 @@ async def app_main() -> None:
     )
 
     # --- Phase 1: per-file extraction ---
-    credential_path = os.environ["GOOGLE_SERVICE_ACCOUNT_CREDENTIAL"]
+    # Read notes from Google Drive when it's configured; otherwise fall back to
+    # the bundled sample_notes/ folder so the example runs without a Drive setup.
+    credential_path = os.environ.get("GOOGLE_SERVICE_ACCOUNT_CREDENTIAL")
     root_folder_ids = [
         folder.strip()
-        for folder in os.environ["GOOGLE_DRIVE_ROOT_FOLDER_IDS"].split(",")
+        for folder in os.environ.get("GOOGLE_DRIVE_ROOT_FOLDER_IDS", "").split(",")
         if folder.strip()
     ]
-    source = google_drive.GoogleDriveSource(
-        service_account_credential_path=credential_path,
-        root_folder_ids=root_folder_ids,
-    )
+    if credential_path and root_folder_ids:
+        source_items = google_drive.GoogleDriveSource(
+            service_account_credential_path=credential_path,
+            root_folder_ids=root_folder_ids,
+        ).items()
+    else:
+        print("Google Drive not configured — reading the bundled ./sample_notes folder.")
+        source_items = localfs.walk_dir(
+            pathlib.Path("./sample_notes"),
+            recursive=True,
+            path_matcher=PatternFilePathMatcher(included_patterns=["**/*.md"]),
+        ).items()
 
     file_coros = []
-    async for path_key, file in source.items():
+    async for path_key, file in source_items:
         file_coros.append(
             coco.use_mount(
                 coco.component_subpath("file", path_key),

--- a/examples/meeting_notes_graph_neo4j/main.py
+++ b/examples/meeting_notes_graph_neo4j/main.py
@@ -34,7 +34,7 @@ import datetime
 import os
 import pathlib
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -396,13 +396,16 @@ async def app_main() -> None:
         for folder in os.environ.get("GOOGLE_DRIVE_ROOT_FOLDER_IDS", "").split(",")
         if folder.strip()
     ]
+    source_items: AsyncIterable[tuple[str, FileLike]]
     if credential_path and root_folder_ids:
         source_items = google_drive.GoogleDriveSource(
             service_account_credential_path=credential_path,
             root_folder_ids=root_folder_ids,
         ).items()
     else:
-        print("Google Drive not configured — reading the bundled ./sample_notes folder.")
+        print(
+            "Google Drive not configured — reading the bundled ./sample_notes folder."
+        )
         source_items = localfs.walk_dir(
             pathlib.Path("./sample_notes"),
             recursive=True,

--- a/examples/meeting_notes_graph_neo4j/sample_notes/product-planning.md
+++ b/examples/meeting_notes_graph_neo4j/sample_notes/product-planning.md
@@ -1,4 +1,4 @@
-## 2024-01-15 — Q1 Product Planning
+## 2024-01-15 - Q1 Product Planning
 
 Organizer: Alice Chen (Head of Product). Attendees: Bob Martinez, Priya Nair, and Daniel Okafor.
 
@@ -11,7 +11,7 @@ Action items:
 - Priya to size the billing revamp.
 - Daniel will pull together the churn cohort analysis.
 
-## 2024-01-29 — Onboarding Spec Review
+## 2024-01-29 - Onboarding Spec Review
 
 Led by Alice. Present: Bob, Priya Nair.
 

--- a/examples/meeting_notes_graph_neo4j/sample_notes/product-planning.md
+++ b/examples/meeting_notes_graph_neo4j/sample_notes/product-planning.md
@@ -1,0 +1,23 @@
+## 2024-01-15 — Q1 Product Planning
+
+Organizer: Alice Chen (Head of Product). Attendees: Bob Martinez, Priya Nair, and Daniel Okafor.
+
+We aligned on the Q1 roadmap: ship the new onboarding flow, start the billing
+revamp, and bring down churn. Alice walked through the top customer feedback
+themes from December.
+
+Action items:
+- Bob Martinez to draft the onboarding flow spec by Jan 26.
+- Priya to size the billing revamp.
+- Daniel will pull together the churn cohort analysis.
+
+## 2024-01-29 — Onboarding Spec Review
+
+Led by Alice. Present: Bob, Priya Nair.
+
+Reviewed Bob's onboarding spec. Agreed to add a progress checklist so new users
+can see what's left to set up.
+
+Action items:
+- Bob to incorporate the checklist feedback.
+- Alice Chen to share the spec with engineering.

--- a/examples/meeting_notes_graph_neo4j/sample_notes/weekly-syncs.md
+++ b/examples/meeting_notes_graph_neo4j/sample_notes/weekly-syncs.md
@@ -1,0 +1,21 @@
+## 2024-02-05 — Weekly Engineering Sync
+
+Organizer: Daniel Okafor. Attendees: Priya, Sam Lee, A. Chen.
+
+Status updates on the billing revamp and onboarding. Sam flagged a flaky test in
+CI that's blocking the billing branch.
+
+Action items:
+- Sam Lee to fix the flaky billing test.
+- Priya Nair to review the migration plan.
+
+## 2024-02-12 — Billing Revamp Kickoff
+
+Organized by Priya Nair. Attendees: Daniel, Sam, Alice.
+
+Kicked off the billing revamp and scoped the first milestone: a pricing model
+and a billing service skeleton.
+
+Action items:
+- Daniel Okafor to set up the billing service skeleton.
+- Sam to write the pricing model tests.

--- a/examples/meeting_notes_graph_neo4j/sample_notes/weekly-syncs.md
+++ b/examples/meeting_notes_graph_neo4j/sample_notes/weekly-syncs.md
@@ -1,4 +1,4 @@
-## 2024-02-05 — Weekly Engineering Sync
+## 2024-02-05 - Weekly Engineering Sync
 
 Organizer: Daniel Okafor. Attendees: Priya, Sam Lee, A. Chen.
 
@@ -9,7 +9,7 @@ Action items:
 - Sam Lee to fix the flaky billing test.
 - Priya Nair to review the migration plan.
 
-## 2024-02-12 — Billing Revamp Kickoff
+## 2024-02-12 - Billing Revamp Kickoff
 
 Organized by Priya Nair. Attendees: Daniel, Sam, Alice.
 

--- a/examples/text_embedding/README.md
+++ b/examples/text_embedding/README.md
@@ -108,6 +108,8 @@ cocoindex update main          # catch-up: scan, sync, exit
 cocoindex update -L main       # live: keep watching for file changes
 ```
 
+> First run downloads the `all-MiniLM-L6-v2` model (~90 MB) from Hugging Face and caches it locally, so the initial invocation needs network access and takes a bit longer. No API key is required.
+
 **4. Search** — embeds your query with the *same* model and returns the nearest chunks by pgvector cosine distance:
 
 ```sh

--- a/examples/text_embedding/main.py
+++ b/examples/text_embedding/main.py
@@ -8,7 +8,7 @@ Index (use `-L` for live mode, omit for one-shot catch-up):
 Query the index:
     python main.py "your query"
 
-Pipeline: walk markdown files -> chunk -> embed -> store in pgvector (no vector index).
+Pipeline: walk markdown files -> chunk -> embed -> store in pgvector with a vector index.
 """
 
 from __future__ import annotations
@@ -131,7 +131,7 @@ app = coco.App(
 
 
 # ============================================================================
-# Query demo (no vector index)
+# Query demo (cosine distance over the pgvector index)
 # ============================================================================
 
 

--- a/python/cocoindex/__init__.py
+++ b/python/cocoindex/__init__.py
@@ -1,5 +1,10 @@
 """
-Cocoindex is a framework for building and running indexing pipelines.
+CocoIndex is a framework for building and running incremental indexing pipelines.
+
+This is the v1 API (a redesign from v0). AI coding agents should install the
+skill before writing CocoIndex code, or run ``cocoindex skill`` for the recipe:
+the v1 API differs fundamentally from the v0 DSL still common in training data.
+Docs: https://cocoindex.io/docs/llms-full.txt
 """
 
 # Version check

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -384,7 +384,7 @@ def _create_project_files(project_name: str, project_dir: str) -> None:
     project_path.mkdir(parents=True, exist_ok=True)
 
     # Create main.py
-    main_py_content = f'''# CocoIndex v1 app. v1 is a ground-up redesign from v0 — if you are an AI agent,
+    main_py_content = f'''# CocoIndex v1 app. v1 is a ground-up redesign from v0. If you are an AI agent,
 # install the skill first (https://cocoindex.io/docs/skill.md) so you write the
 # v1 API and not the deprecated v0 DSL. Full docs: https://cocoindex.io/docs/llms-full.txt
 """CocoIndex app template."""
@@ -446,7 +446,7 @@ app = coco.App(
     app_main,
 )
 '''
-    (project_path / "main.py").write_text(main_py_content)
+    (project_path / "main.py").write_text(main_py_content, encoding="utf-8")
 
     # Create pyproject.toml
     pyproject_toml_content = f"""[project]
@@ -458,7 +458,9 @@ dependencies = [
     "cocoindex>={coco.__version__}",
 ]
 """
-    (project_path / "pyproject.toml").write_text(pyproject_toml_content)
+    (project_path / "pyproject.toml").write_text(
+        pyproject_toml_content, encoding="utf-8"
+    )
 
     # Create README.md
     readme_content = f"""# {project_name}
@@ -493,7 +495,7 @@ For Cursor, copy `SKILL.md` into `.cursor/rules/`. Machine-readable docs:
 - `pyproject.toml` - Project metadata and dependencies
 - `AGENTS.md` - Guidance coding agents read automatically (points to the skill)
 """
-    (project_path / "README.md").write_text(readme_content)
+    (project_path / "README.md").write_text(readme_content, encoding="utf-8")
 
     # Create AGENTS.md — coding agents read this automatically; route them to the
     # v1 skill before they write any CocoIndex code (v0 hallucination is the
@@ -507,8 +509,8 @@ CocoIndex project.
 
 CocoIndex v1 is a fundamental redesign from v0. Without context, LLMs tend to
 hallucinate the v0 flow-builder DSL and deprecated decorators
-(`@cocoindex.flow_def`, `add_collector`, `flow_builder`, …) — none of which
-exist in v1. Install the official skill first; it teaches the correct v1 API
+(`@cocoindex.flow_def`, `add_collector`, `flow_builder`, and friends) that do
+not exist in v1. Install the official skill first; it teaches the correct v1 API
 (or run `cocoindex skill`):
 
 ```sh
@@ -537,7 +539,7 @@ cocoindex update -L main.py     # live mode: catch up, then watch for changes
 - Everything (docs + example walkthroughs): <https://cocoindex.io/docs/llms-full.txt>
 - Runnable examples: <https://github.com/cocoindex-io/cocoindex/tree/main/examples>
 """
-    (project_path / "AGENTS.md").write_text(agents_md_content)
+    (project_path / "AGENTS.md").write_text(agents_md_content, encoding="utf-8")
 
 
 async def _print_tree_streaming(
@@ -1192,9 +1194,9 @@ def skill() -> None:
     Print how to install the CocoIndex skill for AI coding agents.
 
     CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
-    Codex, …) that lack this context tend to emit the deprecated v0 API. The
+    Codex, etc.) that lack this context tend to emit the deprecated v0 API. The
     skill teaches the correct v1 API. This command prints the install recipe so
-    an agent — or you — can set it up in the current project.
+    an agent (or you) can set it up in the current project.
     """
     click.echo(
         "CocoIndex v1 is a ground-up redesign from v0. Install the skill so AI\n"

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -497,7 +497,7 @@ For Cursor, copy `SKILL.md` into `.cursor/rules/`. Machine-readable docs:
 """
     (project_path / "README.md").write_text(readme_content, encoding="utf-8")
 
-    # Create AGENTS.md — coding agents read this automatically; route them to the
+    # Create AGENTS.md. Coding agents read this automatically; route them to the
     # v1 skill before they write any CocoIndex code (v0 hallucination is the
     # default failure mode without it).
     agents_md_content = f"""# AGENTS.md

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -33,6 +33,16 @@ from cocoindex.inspect import (
 from cocoindex._internal.stable_path import StablePath
 
 
+# Copy-paste recipe that installs the v1 authoring skill for AI coding agents.
+# Shared by `cocoindex skill` and the `cocoindex init` scaffold so the two never
+# drift. The hosted skill lives at https://cocoindex.io/docs/skill.md.
+_SKILL_INSTALL_SH = """mkdir -p .claude/skills/cocoindex/references
+curl -fsSL https://cocoindex.io/docs/skill.md -o .claude/skills/cocoindex/SKILL.md
+for f in api_reference connectors patterns setup_database setup_project; do
+  curl -fsSL https://cocoindex.io/docs/references/$f.md -o .claude/skills/cocoindex/references/$f.md
+done"""
+
+
 # ---------------------------------------------------------------------------
 # Logging setup
 # ---------------------------------------------------------------------------
@@ -374,7 +384,10 @@ def _create_project_files(project_name: str, project_dir: str) -> None:
     project_path.mkdir(parents=True, exist_ok=True)
 
     # Create main.py
-    main_py_content = f'''"""CocoIndex app template."""
+    main_py_content = f'''# CocoIndex v1 app. v1 is a ground-up redesign from v0 — if you are an AI agent,
+# install the skill first (https://cocoindex.io/docs/skill.md) so you write the
+# v1 API and not the deprecated v0 DSL. Full docs: https://cocoindex.io/docs/llms-full.txt
+"""CocoIndex app template."""
 import pathlib
 from typing import Iterator
 
@@ -459,12 +472,72 @@ Run the app:
 uv run cocoindex update main.py
 ```
 
+## Building with an AI coding agent
+
+CocoIndex v1 is a redesign from v0; without context, coding agents tend to write
+the deprecated v0 API. Install the official skill first so the agent writes v1
+(or just run `cocoindex skill`):
+
+```bash
+{_SKILL_INSTALL_SH}
+```
+
+For Cursor, copy `SKILL.md` into `.cursor/rules/`. Machine-readable docs:
+<https://cocoindex.io/docs/llms.txt> (index) and
+<https://cocoindex.io/docs/llms-full.txt> (everything). See also the bundled
+`AGENTS.md`, which coding agents read automatically.
+
 ## Project Structure
 
 - `main.py` - Main application file with your CocoIndex app definition
 - `pyproject.toml` - Project metadata and dependencies
+- `AGENTS.md` - Guidance coding agents read automatically (points to the skill)
 """
     (project_path / "README.md").write_text(readme_content)
+
+    # Create AGENTS.md — coding agents read this automatically; route them to the
+    # v1 skill before they write any CocoIndex code (v0 hallucination is the
+    # default failure mode without it).
+    agents_md_content = f"""# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Cursor, Codex, etc.) working in this
+CocoIndex project.
+
+## Before you write CocoIndex code: install the skill
+
+CocoIndex v1 is a fundamental redesign from v0. Without context, LLMs tend to
+hallucinate the v0 flow-builder DSL and deprecated decorators
+(`@cocoindex.flow_def`, `add_collector`, `flow_builder`, …) — none of which
+exist in v1. Install the official skill first; it teaches the correct v1 API
+(or run `cocoindex skill`):
+
+```sh
+{_SKILL_INSTALL_SH}
+```
+
+For Cursor, copy `SKILL.md` into `.cursor/rules/`.
+
+## The v1 mental model
+
+`target_state = transform(source_state)`. You declare what the target should
+look like; the engine keeps it in sync, reprocessing only what changed. Key
+APIs: `@coco.fn`, `@coco.lifespan`, `coco.App` / `coco.AppConfig`,
+`mount` / `use_mount` / `mount_each`, `ContextKey`, target-state declarations.
+
+## Running
+
+```sh
+cocoindex update main.py        # catch-up: scan sources, sync, exit
+cocoindex update -L main.py     # live mode: catch up, then watch for changes
+```
+
+## Docs
+
+- Index: <https://cocoindex.io/docs/llms.txt>
+- Everything (docs + example walkthroughs): <https://cocoindex.io/docs/llms-full.txt>
+- Runnable examples: <https://github.com/cocoindex-io/cocoindex/tree/main/examples>
+"""
+    (project_path / "AGENTS.md").write_text(agents_md_content)
 
 
 async def _print_tree_streaming(
@@ -1111,6 +1184,34 @@ def init(project_name: str | None, dir: str | None) -> None:
             click.echo("  1. uv run cocoindex update main.py")
     except Exception as e:
         raise click.ClickException(f"Failed to create project: {e}") from e
+
+
+@cli.command()
+def skill() -> None:
+    """
+    Print how to install the CocoIndex skill for AI coding agents.
+
+    CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
+    Codex, …) that lack this context tend to emit the deprecated v0 API. The
+    skill teaches the correct v1 API. This command prints the install recipe so
+    an agent — or you — can set it up in the current project.
+    """
+    click.echo(
+        "CocoIndex v1 is a ground-up redesign from v0. Install the skill so AI\n"
+        "coding agents write the v1 API instead of the deprecated v0 DSL.\n"
+        "\n"
+        "Claude Code / any agent (run from your project root):\n"
+    )
+    for line in _SKILL_INSTALL_SH.splitlines():
+        click.echo(f"  {line}")
+    click.echo(
+        "\nCursor: copy the downloaded SKILL.md into .cursor/rules/.\n"
+        "\nMachine-readable docs:\n"
+        "  index:      https://cocoindex.io/docs/llms.txt\n"
+        "  everything: https://cocoindex.io/docs/llms-full.txt\n"
+        "  hosted skill: https://cocoindex.io/docs/skill.md\n"
+        "  examples:   https://github.com/cocoindex-io/cocoindex/tree/main/examples"
+    )
 
 
 if __name__ == "__main__":

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -1190,14 +1190,7 @@ def init(project_name: str | None, dir: str | None) -> None:
 
 @cli.command()
 def skill() -> None:
-    """
-    Print how to install the CocoIndex skill for AI coding agents.
-
-    CocoIndex v1 is a redesign from v0. Coding agents (Claude Code, Cursor,
-    Codex, etc.) that lack this context tend to emit the deprecated v0 API. The
-    skill teaches the correct v1 API. This command prints the install recipe so
-    an agent (or you) can set it up in the current project.
-    """
+    """Print how to install the CocoIndex skill for AI coding agents."""
     click.echo(
         "CocoIndex v1 is a ground-up redesign from v0. Install the skill so AI\n"
         "coding agents write the v1 API instead of the deprecated v0 DSL.\n"

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -49,8 +49,8 @@ This creates: `main.py`, `pyproject.toml`, `README.md`. The generated `main.py` 
 # For vector embeddings with PostgreSQL
 dependencies = ["cocoindex>=1.0.0", "sentence-transformers", "asyncpg"]
 
-# For LLM extraction
-dependencies = ["cocoindex>=1.0.0", "litellm", "instructor", "pydantic>=2.0"]
+# For LLM extraction (add "instructor" only if you use the instructor style)
+dependencies = ["cocoindex>=1.0.0", "litellm", "pydantic>=2.0"]
 ```
 
 See [references/setup_project.md](references/setup_project.md) for complete examples.
@@ -314,25 +314,31 @@ app = coco.App(coco.AppConfig(name="Embedding"), app_main, sourcedir=pathlib.Pat
 ### Pattern 3: LLM-Based Extraction
 
 ```python
-import instructor
-from pydantic import BaseModel
+import os
 from litellm import acompletion
+from pydantic import BaseModel
 
-_instructor_client = instructor.from_litellm(acompletion, mode=instructor.Mode.JSON)
+LLM_MODEL = os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash")
 
 class ExtractionResult(BaseModel):
     title: str
     topics: list[str]
 
-@coco.fn(memo=True)  # Memo avoids re-calling LLM
+@coco.fn(memo=True)  # Memo avoids re-calling LLM when input + code are unchanged
 async def extract_and_store(content: str, message_id: int, table) -> None:
-    result = await _instructor_client.chat.completions.create(
-        model="gpt-4",
-        response_model=ExtractionResult,
+    response = await acompletion(
+        model=LLM_MODEL,
         messages=[{"role": "user", "content": f"Extract topics: {content}"}],
+        response_format=ExtractionResult,  # structured output via the provider
     )
+    result = ExtractionResult.model_validate_json(response.choices[0].message.content)
     table.declare_row(row=Message(id=message_id, title=result.title, content=content))
 ```
+
+This mirrors the `hn_trending_topics` example. For more ergonomic structured
+output you can instead use [`instructor`](https://python.useinstructor.com/)
+(`instructor.from_litellm(acompletion)`), as `meeting_notes_graph_neo4j` does —
+add `instructor` to your dependencies if you go that route.
 
 ## Connectors and Operations
 

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -41,7 +41,7 @@ cocoindex init my-project
 cd my-project
 ```
 
-This creates: `main.py`, `pyproject.toml`, `.env`, `README.md`.
+This creates: `main.py`, `pyproject.toml`, `README.md`. The generated `main.py` sets the database location in its lifespan via `builder.settings.db_path = pathlib.Path("./cocoindex.db")`.
 
 ### Add Dependencies
 
@@ -58,8 +58,7 @@ See [references/setup_project.md](references/setup_project.md) for complete exam
 ### Run the Pipeline
 
 ```bash
-pip install -e .
-cocoindex update main.py
+uv run cocoindex update main.py   # or: pip install -e . && cocoindex update main.py
 ```
 
 ## Core Concepts
@@ -166,12 +165,12 @@ Generate stable, unique identifiers that persist across incremental updates:
 from cocoindex.resources.id import generate_id, IdGenerator
 
 # Deterministic: same dep -> same ID
-chunk_id = await generate_id(chunk.content)
+chunk_id = await generate_id(chunk.text)
 
 # Always distinct: each call -> new ID, even with same dep
 id_gen = IdGenerator()
 for chunk in chunks:
-    chunk_id = await id_gen.next_id(chunk.content)
+    chunk_id = await id_gen.next_id(chunk.text)
 ```
 
 ### 7. Catch-Up vs Live Mode

--- a/skills/cocoindex/SKILL.md
+++ b/skills/cocoindex/SKILL.md
@@ -337,8 +337,7 @@ async def extract_and_store(content: str, message_id: int, table) -> None:
 
 This mirrors the `hn_trending_topics` example. For more ergonomic structured
 output you can instead use [`instructor`](https://python.useinstructor.com/)
-(`instructor.from_litellm(acompletion)`), as `meeting_notes_graph_neo4j` does —
-add `instructor` to your dependencies if you go that route.
+(`instructor.from_litellm(acompletion)`), as `meeting_notes_graph_neo4j` does. Add `instructor` to your dependencies if you go that route.
 
 ## Connectors and Operations
 

--- a/skills/cocoindex/references/api_reference.md
+++ b/skills/cocoindex/references/api_reference.md
@@ -408,15 +408,15 @@ matcher = PatternFilePathMatcher(
 
 ```python
 # Deterministic: same dep -> same ID
-chunk_id = await generate_id(chunk.content)
-chunk_uuid = generate_uuid(chunk.content)
+chunk_id = await generate_id(chunk.text)
+chunk_uuid = generate_uuid(chunk.text)
 
 # Distinct per call (even with same dep)
 id_gen = IdGenerator()
-chunk_id = await id_gen.next_id(chunk.content)
+chunk_id = await id_gen.next_id(chunk.text)
 
 uuid_gen = UuidGenerator()
-chunk_uuid = uuid_gen.next_uuid(chunk.content)
+chunk_uuid = uuid_gen.next_uuid(chunk.text)
 ```
 
 ---
@@ -434,7 +434,7 @@ class Record:
     vector: Annotated[NDArray, EMBEDDER]
 
 # Explicit dimensions
-schema = VectorSchema(dtype=np.float32, size=384)
+schema = VectorSchema(dtype=np.dtype(np.float32), size=384)
 
 @dataclass
 class Record:

--- a/skills/cocoindex/references/connectors.md
+++ b/skills/cocoindex/references/connectors.md
@@ -338,6 +338,173 @@ relation_target.declare_relation(from_id="user:1", to_id="item:1", record=MyRela
 
 ---
 
+## Neo4j
+
+**Import**: `from cocoindex.connectors import neo4j`
+
+**Capabilities**: Target only | **Vector**: Native (vector index) | **Model**: Knowledge graph (nodes + relationships)
+
+### Connection Setup
+
+```python
+from cocoindex.connectors import neo4j
+
+NEO4J_DB = coco.ContextKey[neo4j.ConnectionFactory]("neo4j_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(NEO4J_DB, neo4j.ConnectionFactory(
+        uri="bolt://localhost:7687",
+        auth=("neo4j", "cocoindex"),
+        database="neo4j",  # Optional, default "neo4j"
+    ))
+    yield
+```
+
+### As Target (Nodes + Relationships)
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+
+@dataclass
+class Task:
+    description: str
+
+@dataclass
+class AssignedRel:
+    priority: int
+
+# Mount node tables (each label is a table)
+person_table = await neo4j.mount_table_target(
+    NEO4J_DB,
+    "Person",
+    await neo4j.TableSchema.from_class(Person, primary_key="name"),
+    primary_key="name",
+)
+task_table = await neo4j.mount_table_target(
+    NEO4J_DB,
+    "Task",
+    await neo4j.TableSchema.from_class(Task, primary_key="description"),
+    primary_key="description",
+)
+
+# Mount a relationship target between two node tables
+assigned_rel = await neo4j.mount_relation_target(
+    NEO4J_DB, "ASSIGNED_TO", person_table, task_table,
+    await neo4j.TableSchema.from_class(AssignedRel),
+)
+
+# Declare nodes
+person_table.declare_record(row=Person(name="Alice"))   # alias: declare_row
+task_table.declare_record(row=Task(description="ship v1"))
+
+# Declare edges (record optional; PK auto-derived from endpoints when omitted)
+assigned_rel.declare_relation(
+    from_id="Alice", to_id="ship v1", record=AssignedRel(priority=1),
+)
+```
+
+### Vector Index
+
+```python
+person_table.declare_vector_index(
+    field="embedding",
+    dimension=384,
+    metric="cosine",  # or "euclidean"
+)
+```
+
+### Type Override
+
+```python
+from typing import Annotated
+
+@dataclass
+class Row:
+    id: str
+    score: Annotated[float, neo4j.Neo4jType("decimal", encoder=str)]
+```
+
+---
+
+## FalkorDB
+
+**Import**: `from cocoindex.connectors import falkordb`
+
+**Capabilities**: Target only | **Vector**: Native (vector index) | **Model**: Knowledge graph (nodes + relationships)
+
+### Connection Setup
+
+```python
+from cocoindex.connectors import falkordb
+
+FALKOR_DB = coco.ContextKey[falkordb.ConnectionFactory]("falkor_db")
+
+@coco.lifespan
+async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]:
+    builder.provide(FALKOR_DB, falkordb.ConnectionFactory(
+        uri="falkor://localhost:6379",
+        graph="knowledge_graph",  # Optional, default "default"
+    ))
+    yield
+```
+
+### As Target (Nodes + Relationships)
+
+```python
+person_table = await falkordb.mount_table_target(
+    FALKOR_DB,
+    "Person",
+    await falkordb.TableSchema.from_class(Person, primary_key="name"),
+    primary_key="name",
+)
+task_table = await falkordb.mount_table_target(
+    FALKOR_DB,
+    "Task",
+    await falkordb.TableSchema.from_class(Task, primary_key="description"),
+    primary_key="description",
+)
+
+# Mount relationship target (no schema -> PK auto-derived from endpoints)
+assigned_rel = await falkordb.mount_relation_target(
+    FALKOR_DB, "ASSIGNED_TO", person_table, task_table,
+)
+
+# Declare nodes
+person_table.declare_record(row=Person(name="Alice"))   # alias: declare_row
+task_table.declare_record(row=Task(description="ship v1"))
+
+# Declare edges
+assigned_rel.declare_relation(from_id="Alice", to_id="ship v1")
+```
+
+### Vector Index
+
+```python
+person_table.declare_vector_index(
+    field="embedding",
+    dimension=384,
+    metric="cosine",  # or "euclidean", "ip"
+)
+```
+
+### Type Override
+
+```python
+from typing import Annotated
+
+@dataclass
+class Row:
+    id: str
+    score: Annotated[float, falkordb.FalkorType("decimal", encoder=str)]
+```
+
+---
+
 ## LocalFS
 
 **Import**: `from cocoindex.connectors import localfs`
@@ -546,6 +713,8 @@ await coco.mount_each(process_file, source.items(), target)
 | **LanceDB** | - | Y | Native | Cloud-native vector DB |
 | **Qdrant** | - | Y | Native | Specialized vector search |
 | **SurrealDB** | - | Y | Native | Graph + document DB |
+| **Neo4j** | - | Y | Native | Knowledge graphs |
+| **FalkorDB** | - | Y | Native | Knowledge graphs (Redis) |
 | **Apache Doris** | - | Y | Native | Analytical DB + vectors |
 | **LocalFS** | Y | Y | N/A | File-based pipelines |
 | **Amazon S3** | Y | - | N/A | Cloud object storage |

--- a/skills/cocoindex/references/setup_project.md
+++ b/skills/cocoindex/references/setup_project.md
@@ -9,10 +9,10 @@ cocoindex init my-project
 cd my-project
 ```
 
-This creates: `main.py`, `pyproject.toml`, `.env`, `README.md`.
+This creates: `main.py`, `pyproject.toml`, `README.md`. The generated `main.py` sets the internal database location in its lifespan via `builder.settings.db_path = pathlib.Path("./cocoindex.db")`.
 
 ```bash
-pip install -e .
+uv run cocoindex update main.py   # or: pip install -e . && cocoindex update main.py
 ```
 
 ## Dependencies by Use Case
@@ -97,10 +97,12 @@ dependencies = [
 
 ### `.env` File
 
-CocoIndex automatically loads `.env` from the current directory.
+The `cocoindex` CLI automatically loads `.env` from the current directory (via `find_dotenv`).
 
 ```bash
-# CocoIndex internal database (required)
+# CocoIndex internal database (optional fallback).
+# Only used if the lifespan does not set builder.settings.db_path.
+# The `cocoindex init` template sets db_path in the lifespan instead, so this is not needed there.
 COCOINDEX_DB=./cocoindex.db
 
 # PostgreSQL (if using)


### PR DESCRIPTION
## Summary

Improves how AI coding agents (and developers) **discover, read, and run** CocoIndex's examples and docs. Grew out of a deep review of the agent experience across the examples suite, the published walkthroughs, the skill, and the discovery surfaces.

### What's in here
1. **`examples/AGENTS.md`: drop the false "requires `main.py`" exception.** `cocoindex update main` and `cocoindex update main.py` are equivalent (verified against the CLI loader). Replaces the stale per-example exception list with a one-line equivalence note; fixes the root README example count (20+ → 30+).
2. **Walkthrough ↔ code drift fixes.** Fixes drift that breaks agents copying from published walkthroughs: invalid `openai/gpt-5.4` (×3), the search-query blocks dropping the Postgres schema qualifier (×2), `coco.App("string", …)` → `AppConfig`, and missing imports/constants in the paper-metadata & csv-to-kafka walkthroughs.
3. **`meeting_notes` local-source fallback.** Both graph examples (Neo4j + FalkorDB) read a bundled `sample_notes/` folder when Google Drive isn't configured, so they run without a GCP service account. Warns if exactly one Drive env var is set (rather than silently falling back).
4. **Agent discovery.** `cocoindex init` scaffolds an `AGENTS.md` + skill breadcrumb (README + `main.py`); new `cocoindex skill` command; root `AGENTS.md` routes *users* (not just contributors) to the skill; docs advertise `llms.txt` via `<link rel="alternate">`; the skill-install instructions are unified on the curl one-liner.

### Also included (a pre-existing, separate commit)
This branch also carries **`2af70950 docs(agents): fix skill/config drift`**, which predates this review and is independent of the four items above. It updates the agent skill + references (notably `skills/cocoindex/references/connectors.md`, +169 lines) and editor config (`.mcp.json`, `context7.json`, `opencode.json`). Flagging it explicitly so the file list isn't a surprise — happy to split it into its own PR if you'd prefer a tighter scope.

## Verification
- Docs site **builds clean** (`check-agent-output.mjs` passes).
- `cocoindex skill` runs / shows in `--help`; `cocoindex init` writes all four files (UTF-8; generated `main.py` is ASCII and parses on Windows/3.14).
- `cocoindex update main.py` ran end-to-end on `files_transform`; the `meeting_notes` localfs fallback verified against the real connector (2 files → 4 dated sections).
- ruff format/check + mypy clean across the matrix; full CI green.
- **Not run** (need credentials/services): the LLM extraction + graph write for `meeting_notes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)