### PR TITLE
docs: bump @cocoindex/brand to v0.4.29 (footer layout fix)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.27",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.29",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.27",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#d8f7a271d57fc9a9804a7eb86c6e4038f0ad7992",
+      "version": "0.4.29",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#0525e4cef3aef8a96342aa1fe048411041fc1652",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.27",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.29",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",


### PR DESCRIPTION
Bumps the docs site's shared design-system package to **v0.4.29**, which rebalances the footer layout.

### What changed in the footer
The meta row used `grid-template-columns: auto 1fr 1fr 1fr`, smearing the three short link columns across the row with uneven internal voids. It's now flex with `margin-right: auto` on the brand, so the columns group on the right with the cluster width balanced against the gap after the brand. Footer links also get `white-space: nowrap` to stay one line on the 2-up tablet band.

Verified at 1440 / 768 / 375px: balanced cluster on desktop, 2-up on tablet, single-column stack with no horizontal scroll on mobile.

Only `docs/package.json` + `docs/package-lock.json` change here (lockfile re-resolved to the v0.4.29 commit so `npm ci` installs the new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)