### PR TITLE
fix(core): round-trip StableKey::Bytes through serde msgpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serde_with",
  "storekey 0.9.0",
@@ -10172,6 +10173,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ rmp = { version = "0.8.14" }
 rmp-serde = { version = "1.3.0" }
 rpds = { version = "1.2.0" }
 serde = { version = "1.0.228" }
+serde_bytes = "0.11.19"
 serde_json = "1.0.145"
 serde_path_to_error = "0.1.20"
 serde_with = { version = "3.16.0", features = ["base64"] }

--- a/benchmarks/file_summarization/rust/Cargo.lock
+++ b/benchmarks/file_summarization/rust/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1845,6 +1846,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/amazon_s3_embedding/Cargo.lock
+++ b/examples/rust/amazon_s3_embedding/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -4319,6 +4320,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/audio_to_text/Cargo.lock
+++ b/examples/rust/audio_to_text/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2400,6 +2401,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding/Cargo.lock
+++ b/examples/rust/code_embedding/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3414,6 +3415,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding_lancedb/Cargo.lock
+++ b/examples/rust/code_embedding_lancedb/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -5896,6 +5897,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/conversation_to_knowledge/Cargo.lock
+++ b/examples/rust/conversation_to_knowledge/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey 0.9.0",
  "tokio",
@@ -5096,6 +5097,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/csv_to_iggy/Cargo.lock
+++ b/examples/rust/csv_to_iggy/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3858,6 +3859,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/csv_to_kafka/Cargo.lock
+++ b/examples/rust/csv_to_kafka/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1990,6 +1991,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/files_to_sqlite/Cargo.lock
+++ b/examples/rust/files_to_sqlite/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2185,6 +2186,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/files_transform/Cargo.lock
+++ b/examples/rust/files_transform/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1872,6 +1873,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/gdrive_text_embedding/Cargo.lock
+++ b/examples/rust/gdrive_text_embedding/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3419,6 +3420,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/hn_trending_topics/Cargo.lock
+++ b/examples/rust/hn_trending_topics/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2390,6 +2391,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/image_search/Cargo.lock
+++ b/examples/rust/image_search/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3276,6 +3277,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/image_search_colpali/Cargo.lock
+++ b/examples/rust/image_search_colpali/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2376,6 +2377,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/kafka_consume/Cargo.lock
+++ b/examples/rust/kafka_consume/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1965,6 +1966,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1918,6 +1919,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2112,6 +2113,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/multi_codebase_summarization/Cargo.lock
+++ b/examples/rust/multi_codebase_summarization/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2067,6 +2068,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/oci_object_storage_embedding/Cargo.lock
+++ b/examples/rust/oci_object_storage_embedding/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3419,6 +3420,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/paper_metadata/Cargo.lock
+++ b/examples/rust/paper_metadata/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3585,6 +3586,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/pdf_embedding/Cargo.lock
+++ b/examples/rust/pdf_embedding/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3583,6 +3584,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/pdf_to_markdown/Cargo.lock
+++ b/examples/rust/pdf_to_markdown/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2124,6 +2125,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/postgres_source/Cargo.lock
+++ b/examples/rust/postgres_source/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3367,6 +3368,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding/Cargo.lock
+++ b/examples/rust/text_embedding/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3403,6 +3404,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_lancedb/Cargo.lock
+++ b/examples/rust/text_embedding_lancedb/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -5886,6 +5887,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_qdrant/Cargo.lock
+++ b/examples/rust/text_embedding_qdrant/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3312,6 +3313,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_turbopuffer/Cargo.lock
+++ b/examples/rust/text_embedding_turbopuffer/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
+ "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3114,6 +3115,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -23,6 +23,7 @@ tokio-stream = { workspace = true }
 rmp = { workspace = true }
 rmp-serde = { workspace = true }
 rpds = { workspace = true }
+serde_bytes = { workspace = true }
 serde_with = { workspace = true }
 uuid = { workspace = true }
 indexmap = { workspace = true }

--- a/rust/core/src/state/stable_path.rs
+++ b/rust/core/src/state/stable_path.rs
@@ -56,10 +56,20 @@ impl<'de> Deserialize<'de> for StableKey {
             Str(String),
             // Intentionally before Array to preserve StableKey::Bytes roundtrip in formats
             // (like JSON) where bytes can be represented as a sequence of integers.
+            // `serde_bytes` makes this consume a native byte string too (msgpack
+            // `bin`, the state-store format) — a plain `Vec<u8>` only deserializes
+            // via `deserialize_seq`, so a `bin` would fail to match any variant.
+            #[serde(with = "serde_bytes")]
             Bytes(Vec<u8>),
-            Uuid { uuid: uuid::Uuid },
-            Fp { fp: utils::fingerprint::Fingerprint },
-            Sym { sym: String },
+            Uuid {
+                uuid: uuid::Uuid,
+            },
+            Fp {
+                fp: utils::fingerprint::Fingerprint,
+            },
+            Sym {
+                sym: String,
+            },
             Array(Vec<Repr>),
         }
 
@@ -462,5 +472,29 @@ mod tests {
 
         let roundtrip: StablePath = serde_json::from_value(got).expect("deserialize");
         assert_eq!(roundtrip, path);
+    }
+
+    #[test]
+    fn serde_msgpack_bytes_roundtrip() {
+        // `StableKey::Bytes` must survive a serde msgpack round-trip — it rides
+        // inside component paths and target-state keys, which may embed raw
+        // bytes. msgpack serializes a `Vec<u8>` as a native `bin`, so the
+        // deserializer has to accept a `bin` (not just an int sequence).
+        for key in [
+            StableKey::Bytes(Arc::from(&b"\x00\x01\xff sha"[..])),
+            // A nested array carrying a symbol, strings, and a raw-bytes key.
+            StableKey::Array(Arc::from(vec![
+                StableKey::Array(Arc::from(vec![
+                    StableKey::Symbol(Arc::from("obj")),
+                    StableKey::Str(Arc::from("tenant")),
+                ])),
+                StableKey::Str(Arc::from("src/main.rs")),
+                StableKey::Bytes(Arc::from(&[0xde, 0xad, 0xbe, 0xef][..])),
+            ])),
+        ] {
+            let bytes = rmp_serde::to_vec_named(&key).expect("encode");
+            let decoded: StableKey = rmp_serde::from_slice(&bytes).expect("decode bytes key");
+            assert_eq!(decoded, key);
+        }
     }
 }


### PR DESCRIPTION
## Problem

`StableKey`'s `Deserialize` impl routes through an untagged `Repr` enum. The
`Bytes(Vec<u8>)` variant only deserializes via `deserialize_seq` (an integer
sequence), so a serde msgpack `bin` — which is how the state store encodes
byte slices — matched **no** variant and failed with:

> data did not match any variant of untagged enum Repr

Any `StableKey` embedding raw bytes (component paths, target-state keys) could
not round-trip through the state store's msgpack format.

## Fix

Annotate `Repr::Bytes` with `#[serde(with = "serde_bytes")]` so it consumes a
native byte string (msgpack `bin`) while still accepting the JSON int-array
representation, preserving existing behavior. Adds `serde_bytes` as a workspace
dependency and a serde-msgpack round-trip test covering a raw `Bytes` key and a
nested-array key carrying raw bytes.

## Testing

`cargo test -p cocoindex_core` passes (new `serde_msgpack_bytes_roundtrip` test
plus existing stable_path/db_schema serde tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
