### PR TITLE
docs: Core Concepts prerequisite notes + mount vs use_mount diagram

### DIFF
--- a/docs/src/components/diagrams/concepts/MountVsUseMount.astro
+++ b/docs/src/components/diagrams/concepts/MountVsUseMount.astro
@@ -1,0 +1,67 @@
+---
+import DiagramFrame from '../primitives/DiagramFrame.astro';
+import ProcessingComponent from '../primitives/ProcessingComponent.astro';
+import FlowArrow from '../primitives/FlowArrow.astro';
+
+// Two ways a parent component brings a child into being:
+//   mount()     → parent takes no value back; child runs & refreshes independently.
+//   use_mount() → parent consumes the child's return value; the two are coupled.
+// The visual story is the edge: use_mount has a value returning up; mount doesn't.
+const MARGIN = 20;
+const BOX_W = 140, BOX_H = 50;
+
+const PARENT_Y = 48;
+const VGAP = 54;
+const CHILD_Y = PARENT_Y + BOX_H + VGAP;          // 152
+const TITLE_Y = PARENT_Y - 18;                    // 30
+const CAP_Y = CHILD_Y + BOX_H + 26;               // 228
+
+const P1_CX = MARGIN + BOX_W / 2;                 // 90  (mount panel center)
+const PANEL_GAP = 86;
+const BOX2_X = P1_CX + BOX_W / 2 + PANEL_GAP;     // 246
+const P2_CX = BOX2_X + BOX_W / 2;                 // 316 (use_mount panel center)
+const DIVIDER_X = (P1_CX + BOX_W / 2 + BOX2_X) / 2; // 203
+
+// value-return curve (use_mount only), bowing to the right of the boxes
+const BOX2_R = P2_CX + BOX_W / 2;                 // 386
+const RET_BOW = 32;
+const RET_X = BOX2_R + RET_BOW;                   // 418
+const PARENT_MID = PARENT_Y + BOX_H / 2;          // 73
+const CHILD_MID = CHILD_Y + BOX_H / 2;            // 177
+const RET_MID_Y = (PARENT_MID + CHILD_MID) / 2;   // 125
+const VALUE_LABEL_X = RET_X + 10;                 // 428
+
+const VB_W = VALUE_LABEL_X + 54;                  // ~482
+const VB_H = CAP_Y + 14;                          // 242
+
+const box1L = P1_CX - BOX_W / 2;                  // 20
+---
+<DiagramFrame
+  viewBox={`0 0 ${VB_W} ${VB_H}`}
+  maxWidth={540}
+  title="mount() versus use_mount()"
+  desc="With mount, the parent takes no value from the child, so the child runs and refreshes independently. With use_mount, the parent consumes the child's returned value, which couples the two."
+>
+  {/* soft divider between the two cases */}
+  <line
+    x1={DIVIDER_X} y1={TITLE_Y - 6} x2={DIVIDER_X} y2={CAP_Y}
+    stroke="var(--rule-strong, rgba(42,18,27,0.35))"
+    stroke-width="1" stroke-dasharray="2 6" opacity="0.45"
+  />
+
+  {/* ── mount(): nothing returns, child is independent ── */}
+  <text class="dg-label dg-label--mono" x={P1_CX} y={TITLE_Y}>mount()</text>
+  <ProcessingComponent x={box1L} y={PARENT_Y} w={BOX_W} h={BOX_H} label="parent" />
+  <FlowArrow d={`M ${P1_CX} ${PARENT_Y + BOX_H} L ${P1_CX} ${CHILD_Y}`} />
+  <ProcessingComponent x={box1L} y={CHILD_Y} w={BOX_W} h={BOX_H} label="child" />
+  <text class="dg-label dg-label--small" x={P1_CX} y={CAP_Y}>refreshes independently</text>
+
+  {/* ── use_mount(): value flows back up, the two are coupled ── */}
+  <text class="dg-label dg-label--mono" x={P2_CX} y={TITLE_Y}>use_mount()</text>
+  <ProcessingComponent x={BOX2_X} y={PARENT_Y} w={BOX_W} h={BOX_H} label="parent" />
+  <FlowArrow d={`M ${P2_CX} ${PARENT_Y + BOX_H} L ${P2_CX} ${CHILD_Y}`} />
+  <ProcessingComponent x={BOX2_X} y={CHILD_Y} w={BOX_W} h={BOX_H} label="child" />
+  <FlowArrow d={`M ${BOX2_R} ${CHILD_MID} C ${RET_X} ${CHILD_MID}, ${RET_X} ${PARENT_MID}, ${BOX2_R} ${PARENT_MID}`} />
+  <text class="dg-label dg-label--caps dg-label--left" x={VALUE_LABEL_X} y={RET_MID_Y}>value</text>
+  <text class="dg-label dg-label--small" x={P2_CX} y={CAP_Y}>coupled to parent</text>
+</DiagramFrame>

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -5,6 +5,10 @@ description: >
   trigger updates, configure the database path, and wire up lifespan-managed
   resources.
 ---
+:::note[Prerequisite]
+This page builds on [Core Concepts](./core_concepts), which introduces the App and the source → transform → target-state model **with diagrams**. If the App model feels abstract, start there.
+:::
+
 An **App** is the top-level runnable unit in CocoIndex.
 It names your pipeline and binds a main function with its parameters. When you call `app.update()`, CocoIndex runs that main function as the root [processing component](./processing_component) which can mount child processing components to do work and declare target states.
 
@@ -80,7 +84,7 @@ An App is the top-level runner and entry point. A **processing component** is th
 
 This is why `app.update()` does not "run everything from scratch": CocoIndex uses the component path tree to decide what can be reused and what must re-run.
 
-For example, an app that processes files might mount one component per file:
+For example, an app that processes files might mount one component per file — the per-file fan-out from [Core Concepts](./core_concepts#processing-component), shown here as a path tree:
 
 ```text
 (root)                         ← app_main component

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -5,6 +5,10 @@ description: >
   detection, memoization, and execution pipeline — with async adapters, batching,
   and GPU-aware runners included.
 ---
+:::note[Prerequisite]
+This page builds on [Core Concepts](./core_concepts), which introduces change detection and function memoization **with diagrams**. If memoization feels abstract, start there.
+:::
+
 It's common to factor work into helper functions (for parsing, chunking, embedding, formatting, etc.). In CocoIndex, you can decorate any Python function with `@coco.fn` when you want to add incremental capabilities to it. The decorated function is still a normal Python function: its signature stays the same, and you can call it normally.
 
 ```python
@@ -31,7 +35,7 @@ If you don't need any of the above for a helper, keep it as a plain Python funct
 
 ## Change detection and memoization
 
-Every `@coco.fn` function participates in CocoIndex's change detection system. With `memo=True`, the function's results are cached and reused when nothing has changed. These two mechanisms — detecting changes and acting on them — work together to enable incremental updates.
+Every `@coco.fn` function participates in CocoIndex's change detection system. With `memo=True`, the function's results are cached and reused when nothing has changed. These two mechanisms — detecting changes and acting on them — work together to enable incremental updates. For the big-picture view — how memoization skips unchanged work across both input and code changes — see the [Function memoization section in Core Concepts](./core_concepts#function-memoization-skip-unchanged-computations).
 
 :::tip[Mental model]
 A function's behavior is determined by its **logic** (source code, [`deps`](#deps), [`version`](#version)), its **inputs** (arguments), and the **context values** it reads via [`use_context()`](./context#retrieving-values). If none of those have changed, a memoized function returns its cached result without re-executing. You don't need to reason about *how* CocoIndex tracks any of this; just trust the contract.

--- a/docs/src/content/docs/programming_guide/processing_component.mdx
+++ b/docs/src/content/docs/programming_guide/processing_component.mdx
@@ -5,6 +5,12 @@ description: >
   boundaries for target states. Covers mounting APIs (mount, use_mount,
   mount_each, mount_target), component paths, and granularity tradeoffs.
 ---
+import MountVsUseMount from '/src/components/diagrams/concepts/MountVsUseMount.astro';
+
+:::note[Prerequisite]
+This page builds on [Core Concepts](./core_concepts), which introduces processing components, target states, and incremental sync **with diagrams** — the per-file fan-out and the chunk-embedding pipeline it walks through are referenced throughout this page. If the mounting APIs below feel abstract, start there.
+:::
+
 Most apps process many independent source items — files, rows, or entities. A **Processing Component** is the unit of execution for one: it runs that item's transformation logic and declares the set of **target states** produced for it.
 
 ## Component path
@@ -35,12 +41,16 @@ See [StableKey](./sdk_overview#stablekey) in the SDK Overview for details on wha
 
 ## Mount
 
-Mounting is how you declare (instantiate) a processing component within an app at a specific path, so CocoIndex knows that component exists, should run, and owns a set of target states.
+Mounting is how you declare (instantiate) a processing component within an app at a specific path, so CocoIndex knows that component exists, should run, and owns a set of target states — and can match it against its previous run to sync only what changed.
 
 CocoIndex provides two core mounting APIs:
 
 - **`mount()`** — sets up a processing component in a child path without depending on data from it. This allows the component to refresh independently in live mode.
 - **`use_mount()`** — returns a value from the component's execution to the caller. The component at that path cannot refresh independently without re-executing the caller.
+
+<MountVsUseMount />
+
+**Which one you reach for comes down to a single question: does the caller need a value back?** `use_mount()` consumes the child's return value, which *couples* the two — the call blocks until the child finishes and commits its target states, and the child can't refresh on its own without re-running the caller. `mount()` takes nothing back and returns as soon as the child is scheduled, so the child runs on its own and can [refresh independently in live mode](./live_mode) when its inputs change.
 
 And two sugar APIs that simplify common patterns:
 
@@ -124,6 +134,8 @@ await coco.mount_each(process_file, files.items(), target)
 
 Each item in the iterable is a `(key, value)` tuple. The value is passed as the first argument to the function, and any additional arguments are passed through. Items are mounted under an [auto-derived subpath](#automatic-subpath-derivation) (`Symbol(fn.__name__)`), so the component path for each item is `parent / Symbol("process_file") / key`.
 
+In the static case this is just the keyed-loop form of [`mount()`](#mount) — the same per-file fan-out shown in [Core Concepts](./core_concepts#processing-component). The snippet above is equivalent to looping over the items and calling `mount(coco.component_subpath(coco.Symbol("process_file"), key), process_file, value, target)` for each one. The per-item `key` is what keeps each component's path stable across runs, so the engine matches, updates, and cleans up each item individually.
+
 You can provide an explicit subpath as the first argument:
 
 ```python
@@ -132,7 +144,7 @@ await coco.mount_each(coco.component_subpath("files"), process_file, files.items
 
 Source connectors provide an `items()` method that returns `(StableKey, T)` pairs. For example, `localfs.walk_dir(...).items()` yields `(relative_path, File)` tuples.
 
-When a source connector supports live watching, its `items()` returns a `LiveMapView` or `LiveMapFeed` instead of a plain iterable. `mount_each()` detects this and automatically handles incremental updates — no changes to `mount_each()` itself are needed. See [Live Mode](./live_mode).
+It also does one thing a hand-written loop can't: when a source connector supports live watching, its `items()` returns a `LiveMapView` or `LiveMapFeed` instead of a plain iterable, and `mount_each()` detects this and automatically adds, updates, and removes per-item components as the source changes — no changes to `mount_each()` itself are needed. See [Live Mode](./live_mode).
 
 ### `mount_target()`
 `mount_target()` mounts a target without requiring an explicit subpath.
@@ -292,4 +304,4 @@ The first argument to the function receives each item; additional arguments are 
 #### When to use `map()` vs `mount_each()`
 
 - Use **`mount_each()`** when each item should be its own processing component — with its own component path, target state ownership, and target states sync boundary.
-- Use **`map()`** when you want to process items concurrently *within* the current component, without creating new component boundaries. This is common for sub-item work like processing chunks within a file.
+- Use **`map()`** when you want to process items concurrently *within* the current component, without creating new component boundaries. This is common for sub-item work like processing chunks within a file — the same within-component chunk work the [chunk-embedding pipeline in Core Concepts](./core_concepts#processing-component) walks through.

--- a/docs/src/content/docs/programming_guide/target_state.mdx
+++ b/docs/src/content/docs/programming_guide/target_state.mdx
@@ -5,6 +5,10 @@ description: >
   embeddings. Learn how to declare them through connector APIs, nest container
   targets, and rely on CocoIndex to sync minimal creates, updates, and deletes.
 ---
+:::note[Prerequisite]
+This page builds on [Core Concepts](./core_concepts), which introduces target states and the declarative *target state = transform(source state)* model **with diagrams**. If the ideas below feel abstract, start there.
+:::
+
 A **target state** represents what you want to exist in an external system. You *declare* target states in your code; CocoIndex keeps them in sync with your intent — creating, updating, or removing them as needed.
 
 :::note[Terminology]
@@ -95,7 +99,7 @@ Targets like `DirTarget` and `TableTarget` have two statuses: **pending** (just 
 
 ## How CocoIndex syncs target states
 
-Under the hood, CocoIndex compares your declared target states with the previous run and applies the minimal changes needed:
+Under the hood, CocoIndex compares your declared target states with the previous run and applies the minimal changes needed — the same create/update/delete sync the [change-scenario diagrams in Core Concepts](./core_concepts#processing-component) walk through, viewed per target state:
 
 <table>
   <thead>


### PR DESCRIPTION
## Summary
- Add a **Prerequisite** admonition pointing to [Core Concepts](https://cocoindex.io/docs/programming_guide/core_concepts/) on the `processing_component`, `app`, `function`, and `target_state` programming-guide pages, each with a callback to the relevant Core Concepts diagram/example (per-file fan-out, change-scenario sync, function memoization) — so the abstract API pages connect to the concrete pictures instead of duplicating them.
- Add a `MountVsUseMount` inline SVG diagram on the processing component page contrasting `mount()` (nothing returned → child refreshes independently) with `use_mount()` (value returned → child coupled to parent). This is the model the page previously left implicit.
- Frame the `mount` vs `use_mount` choice as a single question — *does the caller need a value back?* — i.e. a data-dependency/coupling tradeoff, and gloss "refresh independently in live mode".
- Reconcile the `mount_each` "sugar" framing: a static keyed loop over `mount()`, **plus** live-feed handling a hand-written loop can't replicate.
- Make cross-run reconciliation explicit in the mount definition.

## Test plan
- CI (docs build).
- Verified locally: `npm run build` in `docs/` passes (Astro build + `check-agent-output`), and the new diagram renders correctly (headless-Chrome screenshot of the rendered page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
