### PR TITLE
fix(docs): tolerate commented-out keys in .env.example check

### DIFF
--- a/docs/scripts/check-agent-output.mjs
+++ b/docs/scripts/check-agent-output.mjs
@@ -116,10 +116,16 @@ for (const src of contentFiles(POSTS_SRC)) {
 // 5. Each example's .env.example is a superset of its tracked .env — the
 //    documented `cp .env.example .env` step must never drop a default
 //    (COCOINDEX_DB regressions were shipped exactly this way).
-const envKeys = (text) =>
+// Keys assigned in a .env-style file. For the .env.example template, pass
+// `includeCommented` to also count commented-out assignments (e.g.
+// `# OCI_STREAMING_TOPIC=...`): a copied template still carries that line, so
+// the key is documented even when its default is intentionally left disabled.
+// The real .env is read strictly — only keys it actively sets must be documented.
+const envKeys = (text, { includeCommented = false } = {}) =>
   new Set(
     text
       .split('\n')
+      .map((l) => (includeCommented ? l.replace(/^\s*#+\s*/, '') : l))
       .map((l) => l.replace(/^export\s+/, ''))
       .filter((l) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(l))
       .map((l) => l.split('=')[0]),
@@ -128,7 +134,7 @@ for (const dir of readdirSync(EXAMPLES_DIR)) {
   const env = join(EXAMPLES_DIR, dir, '.env');
   const tmpl = join(EXAMPLES_DIR, dir, '.env.example');
   if (!existsSync(env) || !existsSync(tmpl)) continue;
-  const tmplKeys = envKeys(read(tmpl));
+  const tmplKeys = envKeys(read(tmpl), { includeCommented: true });
   for (const key of envKeys(read(env))) {
     if (!tmplKeys.has(key))
       errors.push(

--- a/examples/conversation_to_knowledge/.env.example
+++ b/examples/conversation_to_knowledge/.env.example
@@ -18,3 +18,5 @@ INPUT_DIR=./input
 # Models (optional, shown with defaults)
 LLM_MODEL=openai/gpt-5-mini
 RESOLUTION_LLM_MODEL=openai/gpt-5-mini
+
+KMP_DUPLICATE_LIB_OK=TRUE


### PR DESCRIPTION
## Summary
- `docs/scripts/check-agent-output.mjs`: the `.env.example` superset check now counts **commented-out** assignments (e.g. `# OCI_STREAMING_TOPIC=...`) as documented, so optional keys a developer enables in their local `.env` no longer trip false positives that fail the docs build. The real `.env` is still read strictly — a key set in `.env` but absent *entirely* from `.env.example` (the `COCOINDEX_DB`-regression case the check guards against) is still flagged.
- `examples/conversation_to_knowledge/.env.example`: add `KMP_DUPLICATE_LIB_OK`.

## Test plan
- CI.
- Verified locally: `node docs/scripts/check-agent-output.mjs` reports "all agent-facing artifacts OK", and the full `npm run build` in `docs/` passes (Astro build + check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
