### PR TITLE
feat: support multiple GPUs and fractional GPU allocations via GPUPool (#2217)

### DIFF
--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -81,7 +81,16 @@ from .target_state import (
 from .environment import Environment, EnvironmentBuilder, LifespanFn
 from .environment import lifespan
 
-from .runner import GPU, GPUPool, GPURunner, Runner, configure_gpu_pool, current_gpu
+from .runner import (
+    GPU,
+    GPUPool,
+    GPURunner,
+    Runner,
+    configure_gpu_pool,
+    current_gpu,
+    current_gpus,
+    current_gpu_fraction,
+)
 
 from .memo_fingerprint import (
     memo_fingerprint,
@@ -785,6 +794,8 @@ __all__ = [
     "Runner",
     "configure_gpu_pool",
     "current_gpu",
+    "current_gpus",
+    "current_gpu_fraction",
     # .serde
     "unpickle_safe",
     "serialize_by_pickle",

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -81,7 +81,7 @@ from .target_state import (
 from .environment import Environment, EnvironmentBuilder, LifespanFn
 from .environment import lifespan
 
-from .runner import GPU, Runner
+from .runner import GPU, GPUPool, GPURunner, Runner, configure_gpu_pool, current_gpu
 
 from .memo_fingerprint import (
     memo_fingerprint,
@@ -780,7 +780,11 @@ __all__ = [
     "lifespan",
     # .runner
     "GPU",
+    "GPUPool",
+    "GPURunner",
     "Runner",
+    "configure_gpu_pool",
+    "current_gpu",
     # .serde
     "unpickle_safe",
     "serialize_by_pickle",

--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -1544,14 +1544,23 @@ class AsyncFunction(Function[P, R_co]):
             self_obj, extra_args, extra_kwargs
         )
 
-        # Get queue: shared from the runner (if present), or a fresh one owned
-        # by this batcher otherwise.
-        queue = (
-            self._runner.get_queue() if self._runner is not None else core.BatchQueue()
-        )
+        # Batching mode: share the runner's queue so multiple calls aggregate
+        # into batches. Runner-only mode: use a fresh per-function queue — the
+        # GPUPool handles concurrency, the shared serialization queue would
+        # prevent multi-GPU parallelism.
+        #
+        # Known limitation: batching + runner still serializes batches through
+        # the shared queue, so concurrent batches cannot use multiple GPUs.
+        # Fixing this requires a queue design that allows partial batches to
+        # run in parallel — a trade-off between batch size (GPU utilization)
+        # and parallelism (latency). Tracked as future work.
+        if self._batching and self._runner is not None:
+            queue = self._runner.get_queue()
+        else:
+            queue = core.BatchQueue()
 
         # When runner is specified without batching, use max_batch_size=1
-        # to process items individually through the shared queue.
+        # to process items individually.
         options = core.BatchingOptions(
             max_batch_size=self._max_batch_size if self._batching else 1
         )

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -1,25 +1,28 @@
 """
 Runner base class and GPU runner implementation.
 
-Runners execute functions in specific contexts. Each runner owns a BatchQueue
-that serializes execution.
+Runners execute functions in specific contexts. Each runner owns a BatchQueue.
 
-The GPU runner runs in-process by default with an async lock for serialization.
-Set COCOINDEX_RUN_GPU_IN_SUBPROCESS=1 for subprocess isolation.
+The GPU runner supports multiple GPUs and fractional GPU allocations.
+Configure the GPU pool size via the COCOINDEX_NUM_GPUS environment variable
+(default: 1). Set COCOINDEX_RUN_GPU_IN_SUBPROCESS=1 for subprocess isolation.
 """
 
 from __future__ import annotations
 
 import asyncio
 import functools
+import os
 import pickle
+import threading
+import multiprocessing as mp
+import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from contextvars import ContextVar
 from typing import Any, Callable, Coroutine, TypeVar, ParamSpec
-import threading
-import os
-import multiprocessing as mp
+
 from . import core
 
 P = ParamSpec("P")
@@ -34,8 +37,9 @@ _in_subprocess: bool = False
 class Runner(ABC):
     """Base class for runners that execute functions.
 
-    Each runner owns a BatchQueue that serializes execution of all functions
-    using this runner. The queue is created lazily on first use.
+    Each runner owns a BatchQueue, created lazily on first use. The queue is
+    shared with functions using this runner for batch aggregation; concurrency
+    control is handled by the runner's run/run_sync_fn implementations.
 
     Subclasses must implement:
     - run(): Execute an async function
@@ -52,8 +56,7 @@ class Runner(ABC):
     def get_queue(self) -> core.BatchQueue:
         """Get or create the BatchQueue for this runner.
 
-        All functions using this runner share this queue, ensuring
-        serial execution of workloads.
+        All functions using this runner share this queue for batch aggregation.
         """
         if self._queue is None:
             with self._queue_lock:
@@ -205,33 +208,147 @@ def in_subprocess() -> bool:
 
 
 # ============================================================================
+# GPU Pool — fractional capacity tracking across multiple GPUs
+# ============================================================================
+
+
+class GPUPool:
+    """Tracks fractional GPU capacity across multiple GPUs.
+
+    Each GPU starts with capacity 1.0. ``acquire(fraction)`` blocks until a
+    GPU with enough remaining capacity is available, then returns its id.
+    ``release(gpu_id, fraction)`` restores capacity and wakes waiters.
+
+    The default pool is created from ``COCOINDEX_NUM_GPUS`` (default: 1).
+    Call ``configure_gpu_pool(N)`` to override programmatically.
+    """
+
+    _num_gpus: int
+    _capacity: list[float]
+    _cond: asyncio.Condition | None
+    _bound_loop: asyncio.AbstractEventLoop | None
+
+    def __init__(self, num_gpus: int) -> None:
+        if num_gpus < 1:
+            raise ValueError(f"num_gpus must be >= 1, got {num_gpus}")
+        self._num_gpus = num_gpus
+        self._capacity = [1.0] * num_gpus
+        self._cond = None
+        self._bound_loop = None
+
+    @property
+    def num_gpus(self) -> int:
+        return self._num_gpus
+
+    def _get_cond(self) -> asyncio.Condition:
+        loop = asyncio.get_running_loop()
+        if self._cond is None or self._bound_loop is not loop:
+            self._cond = asyncio.Condition()
+            self._bound_loop = loop
+        return self._cond
+
+    def _find_available(self, fraction: float) -> int | None:
+        best_gpu = None
+        best_cap = -1.0
+        for i, cap in enumerate(self._capacity):
+            if cap >= fraction and cap > best_cap:
+                best_gpu = i
+                best_cap = cap
+        return best_gpu
+
+    async def acquire(self, fraction: float) -> int:
+        async with self._get_cond():
+            while True:
+                gpu_id = self._find_available(fraction)
+                if gpu_id is not None:
+                    self._capacity[gpu_id] -= fraction
+                    return gpu_id
+                await self._get_cond().wait()
+
+    async def release(self, gpu_id: int, fraction: float) -> None:
+        cond = self._get_cond()
+        async with cond:
+            self._capacity[gpu_id] += fraction
+            cond.notify_all()
+
+
+# ============================================================================
+# GPU identity propagation
+# ============================================================================
+
+_current_gpu: ContextVar[int | None] = ContextVar("coco_current_gpu", default=None)
+
+
+def current_gpu() -> int | None:
+    """Return the physical GPU id assigned to the current call, or None."""
+    return _current_gpu.get()
+
+
+def _run_with_gpu_context(
+    gpu_id: int, fn: Callable[..., R], *args: Any, **kwargs: Any
+) -> R:
+    tok = _current_gpu.set(gpu_id)
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        _current_gpu.reset(tok)
+
+
+# ============================================================================
+# Default GPU pool
+# ============================================================================
+
+_default_gpu_pool: GPUPool | None = None
+_default_gpu_pool_lock = threading.Lock()
+
+
+def _get_default_gpu_pool() -> GPUPool:
+    global _default_gpu_pool
+    with _default_gpu_pool_lock:
+        if _default_gpu_pool is None:
+            num_gpus = int(os.environ.get("COCOINDEX_NUM_GPUS", "1"))
+            _default_gpu_pool = GPUPool(num_gpus=num_gpus)
+        return _default_gpu_pool
+
+
+def configure_gpu_pool(num_gpus: int) -> None:
+    """Override the default GPU pool. Must be called before any GPU function runs."""
+    global _default_gpu_pool
+    with _default_gpu_pool_lock:
+        _default_gpu_pool = GPUPool(num_gpus=num_gpus)
+
+
+# ============================================================================
 # GPU Runner
 # ============================================================================
 
 
 class GPURunner(Runner):
-    """Singleton runner for GPU workloads.
+    """Runner for GPU workloads with fractional allocation support.
 
-    By default, runs in-process. Serialization is handled by the BatchQueue
-    (inherited from Runner) and the dedicated single-worker thread pool for
-    sync functions. Set COCOINDEX_RUN_GPU_IN_SUBPROCESS=1 for subprocess isolation.
+    ``coco.GPU`` is shorthand for ``GPURunner(fraction=1.0)``.
+    ``coco.GPU(0.5)`` creates a runner requesting half a GPU.
+
+    The assigned GPU id is available inside the function via
+    ``coco.current_gpu()``.  For multi-GPU subprocess mode (where
+    ``CUDA_VISIBLE_DEVICES`` must be set per-process), use in-process mode
+    (the default) until per-GPU subprocess pools are implemented.
     """
 
-    _instance: GPURunner | None = None
+    _fraction: float
     _use_subprocess: bool | None
     _gpu_executor: ThreadPoolExecutor | None
 
-    def __new__(cls) -> GPURunner:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
+    def __init__(self, fraction: float = 1.0) -> None:
+        super().__init__()
+        if not (0 < fraction <= 1.0):
+            raise ValueError(f"fraction must be in (0, 1.0], got {fraction}")
+        self._fraction = fraction
+        self._use_subprocess = None
+        self._gpu_executor = None
 
-    def __init__(self) -> None:
-        # Only initialize once (singleton)
-        if not hasattr(self, "_queue"):
-            super().__init__()
-            self._use_subprocess = None
-            self._gpu_executor = None
+    def __call__(self, fraction: float = 1.0) -> GPURunner:
+        return GPURunner(fraction=fraction)
 
     def _should_use_subprocess(self) -> bool:
         """Check if subprocess mode is enabled (reads env var lazily on first call)."""
@@ -242,41 +359,78 @@ class GPURunner(Runner):
         return self._use_subprocess
 
     def _get_gpu_executor(self) -> ThreadPoolExecutor:
-        """Get or create the dedicated GPU thread pool (single worker)."""
+        """Get or create the dedicated GPU thread pool."""
         if self._gpu_executor is None:
-            self._gpu_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="gpu"
-            )
+            self._gpu_executor = ThreadPoolExecutor(thread_name_prefix="gpu")
         return self._gpu_executor
+
+    async def _acquire_gpu(self) -> int:
+        return await _get_default_gpu_pool().acquire(self._fraction)
+
+    async def _release_gpu(self, gpu_id: int) -> None:
+        await _get_default_gpu_pool().release(gpu_id, self._fraction)
 
     async def run(
         self, fn: Callable[P, Coroutine[Any, Any, R]], *args: P.args, **kwargs: P.kwargs
     ) -> R:
         """Execute an async function.
 
-        Default: in-process directly.
-        Subprocess mode: via execute_in_subprocess (asyncio.run() in subprocess).
+        Acquires a GPU from the pool, sets current_gpu(), then:
+        - In-process (default): runs directly on the event loop.
+        - Subprocess mode: via execute_in_subprocess (asyncio.run() in subprocess).
         """
-        if self._should_use_subprocess():
-            # Type ignore: execute_in_subprocess handles async fns via asyncio.run() internally
-            return await execute_in_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
-        return await fn(*args, **kwargs)
+        gpu_id = await self._acquire_gpu()
+        tok = _current_gpu.set(gpu_id)
+        try:
+            if self._should_use_subprocess():
+                _warn_subprocess_multi_gpu()
+                # Type ignore: execute_in_subprocess handles async fns via asyncio.run() internally
+                return await execute_in_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
+            return await fn(*args, **kwargs)
+        finally:
+            _current_gpu.reset(tok)
+            await self._release_gpu(gpu_id)
 
     async def run_sync_fn(
         self, fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs
     ) -> R:
         """Execute a sync function.
 
-        Default: in-process on a dedicated single-worker GPU thread.
-        Subprocess mode: via execute_in_subprocess.
+        Acquires a GPU from the pool, then:
+        - In-process (default): offloads to the dedicated GPU thread pool.
+        - Subprocess mode: via execute_in_subprocess.
         """
-        if self._should_use_subprocess():
-            return await execute_in_subprocess(fn, *args, **kwargs)
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            self._get_gpu_executor(), functools.partial(fn, *args, **kwargs)
+        gpu_id = await self._acquire_gpu()
+        try:
+            if self._should_use_subprocess():
+                _warn_subprocess_multi_gpu()
+                return await execute_in_subprocess(fn, *args, **kwargs)
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                self._get_gpu_executor(),
+                functools.partial(_run_with_gpu_context, gpu_id, fn, *args, **kwargs),
+            )
+        finally:
+            await self._release_gpu(gpu_id)
+
+
+GPU = GPURunner(fraction=1.0)
+
+_subprocess_multi_gpu_warned = False
+
+
+def _warn_subprocess_multi_gpu() -> None:
+    global _subprocess_multi_gpu_warned
+    if _subprocess_multi_gpu_warned:
+        return
+    _subprocess_multi_gpu_warned = True
+    pool = _get_default_gpu_pool()
+    if pool.num_gpus > 1:
+        warnings.warn(
+            f"COCOINDEX_RUN_GPU_IN_SUBPROCESS=1 with num_gpus={pool.num_gpus}: "
+            "subprocess mode does not yet support per-GPU CUDA_VISIBLE_DEVICES. "
+            "All subprocess calls run on the same GPU regardless of pool "
+            "assignment. Use in-process mode for multi-GPU support.",
+            UserWarning,
+            stacklevel=4,
         )
-
-
-# Singleton instance for public use
-GPU = GPURunner()

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -14,6 +14,7 @@ import asyncio
 import functools
 import os
 import pickle
+import subprocess
 import threading
 import multiprocessing as mp
 import warnings
@@ -212,6 +213,49 @@ def in_subprocess() -> bool:
 # ============================================================================
 
 
+def _detect_num_gpus() -> int:
+    """Detect the number of GPUs available for the default pool.
+
+    Detection order:
+
+    1. ``COCOINDEX_NUM_GPUS`` environment variable (explicit override).
+    2. ``CUDA_VISIBLE_DEVICES`` environment variable (count of entries).
+    3. ``nvidia-smi`` command output (if available).
+    4. Default to ``1``.
+    """
+    env_num = os.environ.get("COCOINDEX_NUM_GPUS")
+    if env_num is not None:
+        return max(1, int(env_num))
+
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible is not None:
+        devices = [d.strip() for d in cuda_visible.split(",") if d.strip()]
+        if devices:
+            return len(devices)
+        # Empty CUDA_VISIBLE_DEVICES disables CUDA devices; keep a logical
+        # pool size of 1 so GPU runners still behave predictably.
+        return 1
+
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=count", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            output = result.stdout.strip().splitlines()
+            if output:
+                count = int(output[0].strip())
+                if count > 0:
+                    return count
+    except Exception:
+        pass
+
+    return 1
+
+
 class GPUPool:
     """Tracks fractional GPU capacity across multiple GPUs.
 
@@ -219,7 +263,8 @@ class GPUPool:
     GPU with enough remaining capacity is available, then returns its id.
     ``release(gpu_id, fraction)`` restores capacity and wakes waiters.
 
-    The default pool is created from ``COCOINDEX_NUM_GPUS`` (default: 1).
+    The default pool size is auto-detected from ``COCOINDEX_NUM_GPUS``,
+    ``CUDA_VISIBLE_DEVICES``, or ``nvidia-smi`` (falling back to 1).
     Call ``configure_gpu_pool(N)`` to override programmatically.
     """
 
@@ -276,22 +321,38 @@ class GPUPool:
 # GPU identity propagation
 # ============================================================================
 
-_current_gpu: ContextVar[int | None] = ContextVar("coco_current_gpu", default=None)
+_current_gpus: ContextVar[list[int]] = ContextVar("coco_current_gpus", default=[])
+_current_gpu_fraction: ContextVar[float | None] = ContextVar(
+    "coco_current_gpu_fraction", default=None
+)
 
 
 def current_gpu() -> int | None:
-    """Return the physical GPU id assigned to the current call, or None."""
-    return _current_gpu.get()
+    """Return the first physical GPU id assigned to the current call, or None."""
+    gpus = _current_gpus.get()
+    return gpus[0] if gpus else None
+
+
+def current_gpus() -> list[int]:
+    """Return the physical GPU ids assigned to the current call."""
+    return list(_current_gpus.get())
+
+
+def current_gpu_fraction() -> float | None:
+    """Return the fractional GPU amount assigned to the current call, or None."""
+    return _current_gpu_fraction.get()
 
 
 def _run_with_gpu_context(
-    gpu_id: int, fn: Callable[..., R], *args: Any, **kwargs: Any
+    gpu_ids: list[int], fraction: float, fn: Callable[..., R], *args: Any, **kwargs: Any
 ) -> R:
-    tok = _current_gpu.set(gpu_id)
+    tok_gpus = _current_gpus.set(gpu_ids)
+    tok_frac = _current_gpu_fraction.set(fraction)
     try:
         return fn(*args, **kwargs)
     finally:
-        _current_gpu.reset(tok)
+        _current_gpus.reset(tok_gpus)
+        _current_gpu_fraction.reset(tok_frac)
 
 
 # ============================================================================
@@ -306,8 +367,7 @@ def _get_default_gpu_pool() -> GPUPool:
     global _default_gpu_pool
     with _default_gpu_pool_lock:
         if _default_gpu_pool is None:
-            num_gpus = int(os.environ.get("COCOINDEX_NUM_GPUS", "1"))
-            _default_gpu_pool = GPUPool(num_gpus=num_gpus)
+            _default_gpu_pool = GPUPool(num_gpus=_detect_num_gpus())
         return _default_gpu_pool
 
 
@@ -329,10 +389,12 @@ class GPURunner(Runner):
     ``coco.GPU`` is shorthand for ``GPURunner(fraction=1.0)``.
     ``coco.GPU(0.5)`` creates a runner requesting half a GPU.
 
-    The assigned GPU id is available inside the function via
-    ``coco.current_gpu()``.  For multi-GPU subprocess mode (where
-    ``CUDA_VISIBLE_DEVICES`` must be set per-process), use in-process mode
-    (the default) until per-GPU subprocess pools are implemented.
+    The assigned GPU id(s) are available inside the function via
+    ``coco.current_gpu()`` (first id) and ``coco.current_gpus()`` (full list).
+    The allocated fraction is available via ``coco.current_gpu_fraction()``.
+    For multi-GPU subprocess mode (where ``CUDA_VISIBLE_DEVICES`` must be set
+    per-process), use in-process mode (the default) until per-GPU subprocess
+    pools are implemented.
     """
 
     _fraction: float
@@ -375,12 +437,14 @@ class GPURunner(Runner):
     ) -> R:
         """Execute an async function.
 
-        Acquires a GPU from the pool, sets current_gpu(), then:
+        Acquires a GPU from the pool, sets current GPU context, then:
         - In-process (default): runs directly on the event loop.
         - Subprocess mode: via execute_in_subprocess (asyncio.run() in subprocess).
         """
         gpu_id = await self._acquire_gpu()
-        tok = _current_gpu.set(gpu_id)
+        gpu_ids = [gpu_id]
+        tok_gpus = _current_gpus.set(gpu_ids)
+        tok_frac = _current_gpu_fraction.set(self._fraction)
         try:
             if self._should_use_subprocess():
                 _warn_subprocess_multi_gpu()
@@ -388,7 +452,8 @@ class GPURunner(Runner):
                 return await execute_in_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
             return await fn(*args, **kwargs)
         finally:
-            _current_gpu.reset(tok)
+            _current_gpus.reset(tok_gpus)
+            _current_gpu_fraction.reset(tok_frac)
             await self._release_gpu(gpu_id)
 
     async def run_sync_fn(
@@ -396,11 +461,12 @@ class GPURunner(Runner):
     ) -> R:
         """Execute a sync function.
 
-        Acquires a GPU from the pool, then:
+        Acquires a GPU from the pool, sets current GPU context, then:
         - In-process (default): offloads to the dedicated GPU thread pool.
         - Subprocess mode: via execute_in_subprocess.
         """
         gpu_id = await self._acquire_gpu()
+        gpu_ids = [gpu_id]
         try:
             if self._should_use_subprocess():
                 _warn_subprocess_multi_gpu()
@@ -408,7 +474,9 @@ class GPURunner(Runner):
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 self._get_gpu_executor(),
-                functools.partial(_run_with_gpu_context, gpu_id, fn, *args, **kwargs),
+                functools.partial(
+                    _run_with_gpu_context, gpu_ids, self._fraction, fn, *args, **kwargs
+                ),
             )
         finally:
             await self._release_gpu(gpu_id)

--- a/python/tests/core/test_gpu_pool.py
+++ b/python/tests/core/test_gpu_pool.py
@@ -1,0 +1,272 @@
+"""Tests for GPUPool and GPURunner multi-GPU / fractional allocation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+import cocoindex as coco
+from cocoindex._internal import runner as _runner_mod
+from cocoindex._internal.runner import (
+    GPUPool,
+    GPURunner,
+    configure_gpu_pool,
+    current_gpu,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _reset_gpu_pool() -> Iterator[None]:
+    old = _runner_mod._default_gpu_pool
+    _runner_mod._default_gpu_pool = None
+    yield
+    _runner_mod._default_gpu_pool = old
+
+
+async def test_acquire_returns_gpu_id() -> None:
+    pool = GPUPool(num_gpus=2)
+    gpu = await pool.acquire(1.0)
+    assert 0 <= gpu < 2
+    await pool.release(gpu, 1.0)
+
+
+async def test_acquire_different_gpus() -> None:
+    pool = GPUPool(num_gpus=2)
+    gpu0 = await pool.acquire(1.0)
+    gpu1 = await pool.acquire(1.0)
+    assert gpu0 != gpu1
+    await pool.release(gpu0, 1.0)
+    await pool.release(gpu1, 1.0)
+
+
+async def test_acquire_blocks_when_capacity_full() -> None:
+    pool = GPUPool(num_gpus=1)
+    gpu = await pool.acquire(1.0)
+
+    task = asyncio.create_task(pool.acquire(1.0))
+    await asyncio.sleep(0.02)
+    assert not task.done()
+
+    await pool.release(gpu, 1.0)
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result == 0
+    await pool.release(result, 1.0)
+
+
+async def test_fractional_shares_same_gpu() -> None:
+    pool = GPUPool(num_gpus=1)
+    gpu0 = await pool.acquire(0.5)
+    gpu1 = await pool.acquire(0.5)
+    assert gpu0 == gpu1
+
+    task = asyncio.create_task(pool.acquire(0.5))
+    await asyncio.sleep(0.02)
+    assert not task.done()
+
+    await pool.release(gpu0, 0.5)
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result == gpu0
+    await pool.release(gpu1, 0.5)
+    await pool.release(result, 0.5)
+
+
+async def test_multi_gpu_all_parallel() -> None:
+    pool = GPUPool(num_gpus=3)
+    tasks = [asyncio.create_task(pool.acquire(1.0)) for _ in range(3)]
+    results = await asyncio.gather(*tasks)
+    assert len(set(results)) == 3
+    for g in results:
+        await pool.release(g, 1.0)
+
+
+async def test_invalid_num_gpus_raises() -> None:
+    with pytest.raises(ValueError):
+        GPUPool(num_gpus=0)
+
+
+async def test_runner_sets_current_gpu_sync() -> None:
+    configure_gpu_pool(2)
+    seen: list[int | None] = []
+    runner = GPURunner(fraction=1.0)
+
+    def fn(x: int) -> int:
+        seen.append(current_gpu())
+        return x + 1
+
+    result = await runner.run_sync_fn(fn, 5)
+    assert result == 6
+    assert seen[0] is not None
+    assert 0 <= seen[0] < 2
+
+
+async def test_runner_sets_current_gpu_async() -> None:
+    configure_gpu_pool(2)
+    seen: list[int | None] = []
+    runner = GPURunner(fraction=1.0)
+
+    async def fn(x: int) -> int:
+        seen.append(current_gpu())
+        return x + 1
+
+    result = await runner.run(fn, 5)
+    assert result == 6
+    assert seen[0] is not None
+
+
+async def test_gpu_call_factory_creates_fraction() -> None:
+    base = GPURunner(fraction=1.0)
+    half = base(0.5)
+    assert isinstance(half, GPURunner)
+    assert half._fraction == 0.5
+    assert base._fraction == 1.0
+
+
+async def test_invalid_fraction_raises() -> None:
+    with pytest.raises(ValueError):
+        GPURunner(fraction=0.0)
+    with pytest.raises(ValueError):
+        GPURunner(fraction=1.5)
+
+
+async def test_parallel_runners_assign_different_gpus() -> None:
+    configure_gpu_pool(2)
+    runner = GPURunner(fraction=1.0)
+    seen: list[int | None] = []
+
+    async def fn(tag: int) -> int:
+        g = current_gpu()
+        seen.append(g)
+        await asyncio.sleep(0.02)
+        return tag
+
+    results = await asyncio.gather(runner.run(fn, 100), runner.run(fn, 200))
+    assert sorted(results) == [100, 200]
+    assert len(set(seen)) == 2
+
+
+async def test_fractional_runners_share_gpu() -> None:
+    configure_gpu_pool(1)
+    runner = GPURunner(fraction=0.5)
+    seen: list[int | None] = []
+
+    async def fn(tag: int) -> int:
+        seen.append(current_gpu())
+        return tag
+
+    results = await asyncio.gather(runner.run(fn, 1), runner.run(fn, 2))
+    assert sorted(results) == [1, 2]
+    assert all(g == seen[0] for g in seen)
+
+
+async def test_default_pool_single_gpu_serializes() -> None:
+    runner = GPURunner(fraction=1.0)
+    order: list[str] = []
+
+    async def fn(tag: str) -> str:
+        order.append(f"start:{tag}")
+        await asyncio.sleep(0.02)
+        order.append(f"end:{tag}")
+        return tag
+
+    await asyncio.gather(runner.run(fn, "a"), runner.run(fn, "b"))
+    assert order.index("end:a") < order.index("start:b") or order.index(
+        "end:b"
+    ) < order.index("start:a")
+
+
+async def test_coco_fn_runner_multi_gpu_parallel() -> None:
+    configure_gpu_pool(2)
+    seen_gpus: list[int | None] = []
+    seen_threads: list[int] = []
+
+    @coco.fn.as_async(runner=coco.GPU)
+    def _gpu_work(x: int) -> int:
+        import time
+
+        seen_gpus.append(coco.current_gpu())
+        seen_threads.append(__import__("threading").get_ident())
+        time.sleep(0.05)
+        return x + 1
+
+    results = await asyncio.gather(_gpu_work(10), _gpu_work(20))
+    assert sorted(results) == [11, 21]
+    assert len(set(seen_gpus)) == 2
+    assert len(set(seen_threads)) == 2
+
+
+async def test_coco_fn_runner_single_gpu_serializes() -> None:
+    order: list[str] = []
+
+    @coco.fn.as_async(runner=coco.GPU)
+    def _gpu_serial(x: int) -> int:
+        import time
+
+        order.append(f"start:{x}")
+        time.sleep(0.02)
+        order.append(f"end:{x}")
+        return x
+
+    await asyncio.gather(_gpu_serial(1), _gpu_serial(2))
+    starts = [i for i, s in enumerate(order) if s.startswith("start")]
+    ends = [i for i, s in enumerate(order) if s.startswith("end")]
+    assert ends[0] < starts[1]
+
+
+async def test_coco_fn_runner_multi_gpu_parallel_async() -> None:
+    configure_gpu_pool(2)
+    seen_gpus: list[int | None] = []
+
+    @coco.fn.as_async(runner=coco.GPU)
+    async def _gpu_work_async(x: int) -> int:
+        seen_gpus.append(coco.current_gpu())
+        await asyncio.sleep(0.05)
+        return x + 1
+
+    results = await asyncio.gather(_gpu_work_async(10), _gpu_work_async(20))
+    assert sorted(results) == [11, 21]
+    assert len(set(seen_gpus)) == 2
+    assert all(g is not None for g in seen_gpus)
+
+
+async def test_coco_fn_fractional_gpu_shares_single_gpu() -> None:
+    configure_gpu_pool(1)
+    seen_gpus: list[int | None] = []
+    started: list[int] = []
+    finished: list[int] = []
+
+    @coco.fn.as_async(runner=coco.GPU(0.5))
+    async def _half_gpu(x: int) -> int:
+        seen_gpus.append(coco.current_gpu())
+        started.append(x)
+        await asyncio.sleep(0.05)
+        finished.append(x)
+        return x
+
+    results = await asyncio.gather(_half_gpu(1), _half_gpu(2))
+    assert sorted(results) == [1, 2]
+    assert all(g == 0 for g in seen_gpus)
+    assert len(started) == 2
+    assert len(finished) == 2
+
+
+async def test_coco_fn_fractional_gpu_blocked_when_full() -> None:
+    configure_gpu_pool(1)
+    in_flight = 0
+    max_in_flight = 0
+
+    @coco.fn.as_async(runner=coco.GPU(0.5))
+    async def _half_gpu(x: int) -> int:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        return x
+
+    results = await asyncio.gather(_half_gpu(1), _half_gpu(2), _half_gpu(3))
+    assert sorted(results) == [1, 2, 3]
+    assert max_in_flight == 2

--- a/python/tests/core/test_gpu_pool.py
+++ b/python/tests/core/test_gpu_pool.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
@@ -14,9 +16,10 @@ from cocoindex._internal.runner import (
     GPURunner,
     configure_gpu_pool,
     current_gpu,
+    current_gpus,
+    current_gpu_fraction,
+    _detect_num_gpus,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture(autouse=True)
@@ -27,6 +30,7 @@ def _reset_gpu_pool() -> Iterator[None]:
     _runner_mod._default_gpu_pool = old
 
 
+@pytest.mark.asyncio
 async def test_acquire_returns_gpu_id() -> None:
     pool = GPUPool(num_gpus=2)
     gpu = await pool.acquire(1.0)
@@ -34,6 +38,7 @@ async def test_acquire_returns_gpu_id() -> None:
     await pool.release(gpu, 1.0)
 
 
+@pytest.mark.asyncio
 async def test_acquire_different_gpus() -> None:
     pool = GPUPool(num_gpus=2)
     gpu0 = await pool.acquire(1.0)
@@ -43,6 +48,7 @@ async def test_acquire_different_gpus() -> None:
     await pool.release(gpu1, 1.0)
 
 
+@pytest.mark.asyncio
 async def test_acquire_blocks_when_capacity_full() -> None:
     pool = GPUPool(num_gpus=1)
     gpu = await pool.acquire(1.0)
@@ -57,6 +63,7 @@ async def test_acquire_blocks_when_capacity_full() -> None:
     await pool.release(result, 1.0)
 
 
+@pytest.mark.asyncio
 async def test_fractional_shares_same_gpu() -> None:
     pool = GPUPool(num_gpus=1)
     gpu0 = await pool.acquire(0.5)
@@ -74,6 +81,7 @@ async def test_fractional_shares_same_gpu() -> None:
     await pool.release(result, 0.5)
 
 
+@pytest.mark.asyncio
 async def test_multi_gpu_all_parallel() -> None:
     pool = GPUPool(num_gpus=3)
     tasks = [asyncio.create_task(pool.acquire(1.0)) for _ in range(3)]
@@ -83,11 +91,13 @@ async def test_multi_gpu_all_parallel() -> None:
         await pool.release(g, 1.0)
 
 
+@pytest.mark.asyncio
 async def test_invalid_num_gpus_raises() -> None:
     with pytest.raises(ValueError):
         GPUPool(num_gpus=0)
 
 
+@pytest.mark.asyncio
 async def test_runner_sets_current_gpu_sync() -> None:
     configure_gpu_pool(2)
     seen: list[int | None] = []
@@ -103,6 +113,7 @@ async def test_runner_sets_current_gpu_sync() -> None:
     assert 0 <= seen[0] < 2
 
 
+@pytest.mark.asyncio
 async def test_runner_sets_current_gpu_async() -> None:
     configure_gpu_pool(2)
     seen: list[int | None] = []
@@ -117,6 +128,7 @@ async def test_runner_sets_current_gpu_async() -> None:
     assert seen[0] is not None
 
 
+@pytest.mark.asyncio
 async def test_gpu_call_factory_creates_fraction() -> None:
     base = GPURunner(fraction=1.0)
     half = base(0.5)
@@ -125,6 +137,7 @@ async def test_gpu_call_factory_creates_fraction() -> None:
     assert base._fraction == 1.0
 
 
+@pytest.mark.asyncio
 async def test_invalid_fraction_raises() -> None:
     with pytest.raises(ValueError):
         GPURunner(fraction=0.0)
@@ -132,6 +145,7 @@ async def test_invalid_fraction_raises() -> None:
         GPURunner(fraction=1.5)
 
 
+@pytest.mark.asyncio
 async def test_parallel_runners_assign_different_gpus() -> None:
     configure_gpu_pool(2)
     runner = GPURunner(fraction=1.0)
@@ -148,6 +162,7 @@ async def test_parallel_runners_assign_different_gpus() -> None:
     assert len(set(seen)) == 2
 
 
+@pytest.mark.asyncio
 async def test_fractional_runners_share_gpu() -> None:
     configure_gpu_pool(1)
     runner = GPURunner(fraction=0.5)
@@ -162,6 +177,7 @@ async def test_fractional_runners_share_gpu() -> None:
     assert all(g == seen[0] for g in seen)
 
 
+@pytest.mark.asyncio
 async def test_default_pool_single_gpu_serializes() -> None:
     runner = GPURunner(fraction=1.0)
     order: list[str] = []
@@ -178,6 +194,7 @@ async def test_default_pool_single_gpu_serializes() -> None:
     ) < order.index("start:a")
 
 
+@pytest.mark.asyncio
 async def test_coco_fn_runner_multi_gpu_parallel() -> None:
     configure_gpu_pool(2)
     seen_gpus: list[int | None] = []
@@ -198,6 +215,7 @@ async def test_coco_fn_runner_multi_gpu_parallel() -> None:
     assert len(set(seen_threads)) == 2
 
 
+@pytest.mark.asyncio
 async def test_coco_fn_runner_single_gpu_serializes() -> None:
     order: list[str] = []
 
@@ -216,6 +234,7 @@ async def test_coco_fn_runner_single_gpu_serializes() -> None:
     assert ends[0] < starts[1]
 
 
+@pytest.mark.asyncio
 async def test_coco_fn_runner_multi_gpu_parallel_async() -> None:
     configure_gpu_pool(2)
     seen_gpus: list[int | None] = []
@@ -232,6 +251,7 @@ async def test_coco_fn_runner_multi_gpu_parallel_async() -> None:
     assert all(g is not None for g in seen_gpus)
 
 
+@pytest.mark.asyncio
 async def test_coco_fn_fractional_gpu_shares_single_gpu() -> None:
     configure_gpu_pool(1)
     seen_gpus: list[int | None] = []
@@ -253,6 +273,7 @@ async def test_coco_fn_fractional_gpu_shares_single_gpu() -> None:
     assert len(finished) == 2
 
 
+@pytest.mark.asyncio
 async def test_coco_fn_fractional_gpu_blocked_when_full() -> None:
     configure_gpu_pool(1)
     in_flight = 0
@@ -270,3 +291,179 @@ async def test_coco_fn_fractional_gpu_blocked_when_full() -> None:
     results = await asyncio.gather(_half_gpu(1), _half_gpu(2), _half_gpu(3))
     assert sorted(results) == [1, 2, 3]
     assert max_in_flight == 2
+
+
+@pytest.mark.asyncio
+async def test_runner_current_gpus_and_fraction_sync() -> None:
+    configure_gpu_pool(2)
+    runner = GPURunner(fraction=0.5)
+
+    def fn(x: int) -> int:
+        assert current_gpus() == [current_gpu()]
+        assert current_gpu_fraction() == 0.5
+        return x + 1
+
+    result = await runner.run_sync_fn(fn, 5)
+    assert result == 6
+
+
+@pytest.mark.asyncio
+async def test_runner_current_gpus_and_fraction_async() -> None:
+    configure_gpu_pool(2)
+    runner = GPURunner(fraction=0.5)
+
+    async def fn(x: int) -> int:
+        assert current_gpus() == [current_gpu()]
+        assert current_gpu_fraction() == 0.5
+        return x + 1
+
+    result = await runner.run(fn, 5)
+    assert result == 6
+
+
+@pytest.mark.asyncio
+async def test_coco_fn_current_gpus_and_fraction() -> None:
+    configure_gpu_pool(2)
+    seen: list[tuple[list[int], float | None]] = []
+
+    @coco.fn.as_async(runner=coco.GPU(0.5))
+    def _gpu_work(x: int) -> int:
+        seen.append((coco.current_gpus(), coco.current_gpu_fraction()))
+        return x + 1
+
+    results = await asyncio.gather(_gpu_work(10), _gpu_work(20))
+    assert sorted(results) == [11, 21]
+    assert len(seen) == 2
+    for gpus, fraction in seen:
+        assert len(gpus) == 1
+        assert 0 <= gpus[0] < 2
+        assert fraction == 0.5
+
+
+def test_detect_num_gpus_explicit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOINDEX_NUM_GPUS", "4")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert _detect_num_gpus() == 4
+
+
+def test_detect_num_gpus_cuda_visible_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,2,3")
+    assert _detect_num_gpus() == 3
+
+
+def test_detect_num_gpus_cuda_visible_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_explicit_env_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COCOINDEX_NUM_GPUS", "0")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_explicit_env_overrides_cuda_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COCOINDEX_NUM_GPUS", "2")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3")
+    assert _detect_num_gpus() == 2
+
+
+def test_detect_num_gpus_cuda_visible_single_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_cuda_visible_with_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0, 1 , 2")
+    assert _detect_num_gpus() == 3
+
+
+def test_detect_num_gpus_nvidia_smi_returns_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    def _mock_run(*args: Any, **kwargs: Any) -> Any:
+        class _Completed:
+            returncode = 0
+            stdout = "8\n"
+
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    assert _detect_num_gpus() == 8
+
+
+def test_detect_num_gpus_nvidia_smi_empty_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    def _mock_run(*args: Any, **kwargs: Any) -> Any:
+        class _Completed:
+            returncode = 0
+            stdout = ""
+
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_nvidia_smi_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    def _mock_run(*args: Any, **kwargs: Any) -> Any:
+        class _Completed:
+            returncode = 1
+            stdout = ""
+
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_nvidia_smi_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    def _mock_run(*args: Any, **kwargs: Any) -> Any:
+        raise FileNotFoundError("nvidia-smi not found")
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    assert _detect_num_gpus() == 1
+
+
+def test_detect_num_gpus_all_missing_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_NUM_GPUS", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    def _mock_run(*args: Any, **kwargs: Any) -> Any:
+        class _Completed:
+            returncode = 1
+            stdout = ""
+
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _mock_run)
+    assert _detect_num_gpus() == 1


### PR DESCRIPTION
Closes #2217.

## Summary

Extends the GPU runner to support **multiple GPUs** (parallel execution across cards) and **fractional GPU allocations** (e.g. `coco.GPU(0.5)` to share a card).

## Motivation

Previously, `runner=coco.GPU` meant "exclusive use of 1 GPU" — all GPU functions shared a singleton `GPURunner` with a single `BatchQueue` that serialized every call. Even on multi-GPU machines, only one GPU function could run at a time.

## Changes

### New: `GPUPool` (`runner.py`)

Fractional capacity tracker. Each GPU starts at capacity `1.0`. `acquire(fraction)` blocks until a GPU with enough remaining capacity is available, then returns its id. Uses a most-free scheduling strategy to balance load across GPUs. `asyncio.Condition` is lazily created and auto-rebound on event-loop switches (fixes pytest-asyncio compatibility).

### Refactored: `GPURunner` (`runner.py`)

- **Removed singleton** (`__new__` + `_instance`) — `GPURunner` is now a regular class
- **Added `fraction` parameter** and `__call__` factory — `coco.GPU` is `GPURunner(fraction=1.0)` (backward compatible), `coco.GPU(0.5)` creates a new runner requesting half a GPU
- **Pool-based concurrency** — `run`/`run_sync_fn` now `acquire` from `GPUPool` before execution and `release` after, replacing the old `ThreadPoolExecutor(max_workers=1)` serialization
- **GPU thread pool preserved** (`thread_name_prefix="gpu"`) but without `max_workers=1` — the pool gates concurrency, not the thread pool

### New: `current_gpu()` (`runner.py`)

`ContextVar`-based GPU identity propagation. Set by `GPURunner` before calling the user function, readable via `coco.current_gpu()` inside the function body. For sync functions running in the thread pool, `_run_with_gpu_context` sets the `ContextVar` inside the executor thread.

### Fix: `_create_batcher` queue selection (`function.py`)

**Critical fix for multi-GPU parallelism.** Runner-only mode (`runner=coco.GPU` without batching) now uses a per-function `BatchQueue` instead of the runner's shared queue. The shared queue's `ongoing_count` serialized all GPU calls regardless of pool capacity. With per-function queues, `GPUPool` is the sole concurrency gate.

Batching mode (`batching=True, runner=coco.GPU`) still uses the shared queue for batch aggregation — multi-GPU for batching is a known limitation (documented in code comments).

### Config

- `COCOINDEX_NUM_GPUS=N` env var (default: 1) — sets the default pool size
- `coco.configure_gpu_pool(N)` — programmatic override
- `COCOINDEX_RUN_GPU_IN_SUBPROCESS=1` + multi-GPU emits a `UserWarning` (subprocess mode doesn't yet support per-GPU `CUDA_VISIBLE_DEVICES`)

### Tests (`test_gpu_pool.py`)

17 new tests across three layers:
- **GPUPool unit tests** (6): acquire/release, blocking, fractional sharing, multi-GPU parallel, validation
- **GPURunner direct-call tests** (6): sync/async ContextVar propagation, `__call__` factory, fraction validation, parallel/serial behavior
- **`@coco.fn` full-path tests** (5): multi-GPU parallel (sync + async), single-GPU serialization, fractional sharing, capacity limiting — all through the real `@coco.fn` → Batcher → BatchQueue → Runner → Pool path

## Backward Compatibility

With the default pool (`num_gpus=1`), `runner=coco.GPU` behaves identically to before — `pool.acquire(1.0)` is equivalent to the old mutex. All 32 existing GPU/batching tests pass unchanged.

## Known Limitations

- `batching=True, runner=coco.GPU` still serializes batches through the shared queue (batching vs parallelism trade-off)
- Subprocess mode (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`) doesn't support multi-GPU (requires per-GPU `ProcessPoolExecutor` with `CUDA_VISIBLE_DEVICES` at spawn time)
