### PR TITLE
fix(localfs): add periodic rescan + watcher recreation for live mode

### DIFF
--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as _datetime
 import os
 from datetime import datetime
 from pathlib import Path
@@ -66,7 +67,7 @@ class File(_file.FileLike[pathlib.Path]):
         return await asyncio.to_thread(self._read_sync, size)
 
 
-_DEFAULT_RESCAN_INTERVAL: float = 3600.0
+_DEFAULT_RESCAN_INTERVAL: _datetime.timedelta = _datetime.timedelta(hours=1)
 
 
 class DirWalker:
@@ -85,7 +86,7 @@ class DirWalker:
     _recursive: bool
     _path_matcher: FilePathMatcher
     _live: bool
-    _rescan_interval: float | None
+    _rescan_interval: _datetime.timedelta | None
 
     def __init__(
         self,
@@ -94,7 +95,7 @@ class DirWalker:
         live: bool = False,
         recursive: bool = False,
         path_matcher: FilePathMatcher | None = None,
-        rescan_interval: float | None = _DEFAULT_RESCAN_INTERVAL,
+        rescan_interval: _datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
     ) -> None:
         self._root_path = to_file_path(path)
         self._live = live
@@ -175,10 +176,22 @@ class DirWalker:
             yield file
 
 
-def _stop_observer(observer: object) -> None:
-    """Stop a watchdog observer, suppressing TypeError during interpreter shutdown."""
+def _stop_observer(observer: object, *, join_timeout: float = 5.0) -> None:
+    """Stop and join a watchdog observer.
+
+    All blocking work lives here so callers can offload the entire
+    shutdown to a thread via ``asyncio.to_thread(_stop_observer, obs)``.
+
+    TypeError is suppressed because during interpreter shutdown watchdog's
+    platform observer may already have its C-library globals torn down
+    (e.g. macOS FSEvents calling a function that's been GC'd to None).
+    """
     try:
         observer.stop()  # type: ignore[union-attr]
+    except TypeError:
+        pass
+    try:
+        observer.join(timeout=join_timeout)  # type: ignore[union-attr]
     except TypeError:
         pass
 
@@ -216,7 +229,8 @@ class _LiveDirItems:
 
         root_resolved = self._resolved_root
         loop = asyncio.get_running_loop()
-        rescan_interval = self._walker._rescan_interval
+        td = self._walker._rescan_interval
+        rescan_seconds: float | None = td.total_seconds() if td is not None else None
         # Watchdog dispatches events from a background thread; we forward
         # them into this asyncio.Queue via call_soon_threadsafe.
         events_queue: asyncio.Queue[FileSystemEvent] = asyncio.Queue()
@@ -245,22 +259,15 @@ class _LiveDirItems:
 
             while True:
                 # Compute timeout until next periodic rescan.
-                if rescan_interval is not None:
-                    remaining = rescan_interval - (loop.time() - last_rescan)
+                if rescan_seconds is not None:
+                    remaining = rescan_seconds - (loop.time() - last_rescan)
                     if remaining <= 0:
                         # Periodic rescan cycle: tear down the old
                         # OS-level watcher, drain stale events, create a
                         # fresh watcher (new FSEvents/inotify stream),
                         # then do a full rescan to catch anything the old
                         # watcher may have silently dropped.
-                        _stop_observer(observer)
-                        try:
-                            await asyncio.to_thread(observer.join, 5.0)
-                        except (RuntimeError, TypeError):
-                            try:
-                                observer.join(timeout=5.0)
-                            except TypeError:
-                                pass
+                        await asyncio.to_thread(_stop_observer, observer)
 
                         while not events_queue.empty():
                             try:
@@ -332,28 +339,14 @@ class _LiveDirItems:
                     handle = await subscriber.update(key, file)
                     await handle.ready()
         finally:
-            # During interpreter shutdown, watchdog's platform observer
-            # may already have its C-library globals torn down, so
-            # `observer.stop()` can raise a `TypeError` from inside
-            # watchdog (e.g. macOS FSEvents trying to call a function
-            # that's been GC'd to None). Suppress that specific case
-            # only — we're already exiting, the OS will reclaim the
-            # watcher. Real bugs (AttributeError etc.) still propagate.
-            _stop_observer(observer)
-            # Wait for the observer thread to exit. Prefer the
-            # non-blocking thread-pool path; during interpreter shutdown
-            # the asyncio default executor may already be closed
-            # ("cannot schedule new futures after shutdown"), in which
-            # case fall back to a bounded synchronous join (also wrapped
-            # in TypeError-suppression for the same FSEvents-teardown
-            # reason).
+            # Offload the blocking stop+join to a thread. During
+            # interpreter shutdown the default executor may already be
+            # closed, so fall back to a synchronous call (TypeError /
+            # RuntimeError are suppressed inside _stop_observer).
             try:
-                await asyncio.to_thread(observer.join)
+                await asyncio.to_thread(_stop_observer, observer)
             except RuntimeError:
-                try:
-                    observer.join(timeout=5.0)
-                except TypeError:
-                    pass
+                _stop_observer(observer)
 
 
 def walk_dir(
@@ -362,7 +355,7 @@ def walk_dir(
     live: bool = False,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
-    rescan_interval: float | None = _DEFAULT_RESCAN_INTERVAL,
+    rescan_interval: _datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
 ) -> DirWalker:
     """
     Walk through a directory and yield file entries.
@@ -379,10 +372,10 @@ def walk_dir(
             in the immediate directory.
         path_matcher: Optional file path matcher to filter files and directories.
             If not provided, all files and directories are included.
-        rescan_interval: When ``live=True``, seconds between periodic full
+        rescan_interval: When ``live=True``, interval between periodic full
             rescans that recreate the OS-level file watcher. Defends against
             platform-specific watcher failures (e.g. macOS FSEvents silently
-            stopping). Defaults to 3600 (1 hour). Set to ``None`` to disable.
+            stopping). Defaults to 1 hour. Set to ``None`` to disable.
             Ignored when ``live=False``.
 
     Returns:

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -186,11 +186,11 @@ def _stop_observer(observer: object, *, join_timeout: float = 5.0) -> None:
     (e.g. macOS FSEvents calling a function that's been GC'd to None).
     """
     try:
-        observer.stop()  # type: ignore[union-attr]
+        observer.stop()  # type: ignore[attr-defined]
     except TypeError:
         pass
     try:
-        observer.join(timeout=join_timeout)  # type: ignore[union-attr]
+        observer.join(timeout=join_timeout)  # type: ignore[attr-defined]
     except TypeError:
         pass
 
@@ -225,6 +225,7 @@ class _LiveDirItems:
             FileSystemEventHandler,
         )
         from watchdog.observers import Observer
+        from watchdog.observers.api import BaseObserver
 
         root_resolved = self._resolved_root
         loop = asyncio.get_running_loop()
@@ -240,7 +241,7 @@ class _LiveDirItems:
 
         handler = _Handler()
 
-        def _start_observer() -> Observer:
+        def _start_observer() -> BaseObserver:
             obs = Observer()
             obs.schedule(handler, str(root_resolved), recursive=self._walker._recursive)
             # Observer.start() is synchronous and arms the OS-level watch

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -66,6 +66,9 @@ class File(_file.FileLike[pathlib.Path]):
         return await asyncio.to_thread(self._read_sync, size)
 
 
+_DEFAULT_RESCAN_INTERVAL: float = 3600.0
+
+
 class DirWalker:
     """An async directory walker.
 
@@ -82,6 +85,7 @@ class DirWalker:
     _recursive: bool
     _path_matcher: FilePathMatcher
     _live: bool
+    _rescan_interval: float | None
 
     def __init__(
         self,
@@ -90,11 +94,13 @@ class DirWalker:
         live: bool = False,
         recursive: bool = False,
         path_matcher: FilePathMatcher | None = None,
+        rescan_interval: float | None = _DEFAULT_RESCAN_INTERVAL,
     ) -> None:
         self._root_path = to_file_path(path)
         self._live = live
         self._recursive = recursive
         self._path_matcher = path_matcher or MatchAllFilePathMatcher()
+        self._rescan_interval = rescan_interval
 
     def _walk_sync(self) -> Iterator[File]:
         """Synchronously walk the directory and yield File objects (internal helper)."""
@@ -169,6 +175,14 @@ class DirWalker:
             yield file
 
 
+def _stop_observer(observer: object) -> None:
+    """Stop a watchdog observer, suppressing TypeError during interpreter shutdown."""
+    try:
+        observer.stop()  # type: ignore[union-attr]
+    except TypeError:
+        pass
+
+
 class _LiveDirItems:
     """``LiveMapView`` returned by ``DirWalker.items()`` when ``live=True``."""
 
@@ -202,6 +216,7 @@ class _LiveDirItems:
 
         root_resolved = self._resolved_root
         loop = asyncio.get_running_loop()
+        rescan_interval = self._walker._rescan_interval
         # Watchdog dispatches events from a background thread; we forward
         # them into this asyncio.Queue via call_soon_threadsafe.
         events_queue: asyncio.Queue[FileSystemEvent] = asyncio.Queue()
@@ -210,20 +225,63 @@ class _LiveDirItems:
             def on_any_event(self, event: FileSystemEvent) -> None:
                 loop.call_soon_threadsafe(events_queue.put_nowait, event)
 
-        observer = Observer()
-        observer.schedule(
-            _Handler(), str(root_resolved), recursive=self._walker._recursive
-        )
-        # Observer.start() is synchronous and arms the OS-level watch
-        # (e.g. inotify) before returning, so the initial scan that
-        # follows cannot miss events that occur after this point.
-        observer.start()
+        handler = _Handler()
+
+        def _start_observer() -> Observer:
+            obs = Observer()
+            obs.schedule(handler, str(root_resolved), recursive=self._walker._recursive)
+            # Observer.start() is synchronous and arms the OS-level watch
+            # (e.g. inotify / FSEvents) before returning, so a scan that
+            # follows cannot miss events that occur after this point.
+            obs.start()
+            return obs
+
+        observer = _start_observer()
         try:
             await subscriber.update_all()
             await subscriber.mark_ready()
 
+            last_rescan = loop.time()
+
             while True:
-                event = await events_queue.get()
+                # Compute timeout until next periodic rescan.
+                if rescan_interval is not None:
+                    remaining = rescan_interval - (loop.time() - last_rescan)
+                    if remaining <= 0:
+                        # Periodic rescan cycle: tear down the old
+                        # OS-level watcher, drain stale events, create a
+                        # fresh watcher (new FSEvents/inotify stream),
+                        # then do a full rescan to catch anything the old
+                        # watcher may have silently dropped.
+                        _stop_observer(observer)
+                        try:
+                            await asyncio.to_thread(observer.join, 5.0)
+                        except (RuntimeError, TypeError):
+                            try:
+                                observer.join(timeout=5.0)
+                            except TypeError:
+                                pass
+
+                        while not events_queue.empty():
+                            try:
+                                events_queue.get_nowait()
+                            except asyncio.QueueEmpty:
+                                break
+
+                        observer = _start_observer()
+                        await subscriber.update_all()
+                        last_rescan = loop.time()
+                        continue
+                    timeout: float | None = remaining
+                else:
+                    timeout = None
+
+                try:
+                    event = await asyncio.wait_for(events_queue.get(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    # Rescan interval elapsed; loop back to trigger rescan.
+                    continue
+
                 # On a move event with a dest_path, treat as
                 # delete(src) + create(dest). All other events carry the
                 # affected path in src_path. src_path/dest_path are typed
@@ -281,10 +339,7 @@ class _LiveDirItems:
             # that's been GC'd to None). Suppress that specific case
             # only — we're already exiting, the OS will reclaim the
             # watcher. Real bugs (AttributeError etc.) still propagate.
-            try:
-                observer.stop()
-            except TypeError:
-                pass
+            _stop_observer(observer)
             # Wait for the observer thread to exit. Prefer the
             # non-blocking thread-pool path; during interpreter shutdown
             # the asyncio default executor may already be closed
@@ -307,6 +362,7 @@ def walk_dir(
     live: bool = False,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
+    rescan_interval: float | None = _DEFAULT_RESCAN_INTERVAL,
 ) -> DirWalker:
     """
     Walk through a directory and yield file entries.
@@ -323,11 +379,22 @@ def walk_dir(
             in the immediate directory.
         path_matcher: Optional file path matcher to filter files and directories.
             If not provided, all files and directories are included.
+        rescan_interval: When ``live=True``, seconds between periodic full
+            rescans that recreate the OS-level file watcher. Defends against
+            platform-specific watcher failures (e.g. macOS FSEvents silently
+            stopping). Defaults to 3600 (1 hour). Set to ``None`` to disable.
+            Ignored when ``live=False``.
 
     Returns:
         A DirWalker that can be used with ``async for`` loops.
     """
-    return DirWalker(path, live=live, recursive=recursive, path_matcher=path_matcher)
+    return DirWalker(
+        path,
+        live=live,
+        recursive=recursive,
+        path_matcher=path_matcher,
+        rescan_interval=rescan_interval,
+    )
 
 
 __all__ = ["walk_dir", "File", "DirWalker"]

--- a/python/cocoindex/connectors/localfs/_source.py
+++ b/python/cocoindex/connectors/localfs/_source.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import datetime as _datetime
+import datetime
 import os
-from datetime import datetime
 from pathlib import Path
 from collections.abc import AsyncIterable as _AsyncIterable
 from typing import AsyncIterator, Iterator
@@ -29,7 +28,7 @@ from ._common import FilePath, to_file_path
 def _stat_to_metadata(stat: os.stat_result) -> FileMetadata:
     """Convert an os.stat_result to FileMetadata."""
     seconds, us = divmod(stat.st_mtime_ns // 1_000, 1_000_000)
-    mtime = datetime.fromtimestamp(seconds).replace(microsecond=us)
+    mtime = datetime.datetime.fromtimestamp(seconds).replace(microsecond=us)
     return FileMetadata(size=stat.st_size, modified_time=mtime)
 
 
@@ -67,7 +66,7 @@ class File(_file.FileLike[pathlib.Path]):
         return await asyncio.to_thread(self._read_sync, size)
 
 
-_DEFAULT_RESCAN_INTERVAL: _datetime.timedelta = _datetime.timedelta(hours=1)
+_DEFAULT_RESCAN_INTERVAL: datetime.timedelta = datetime.timedelta(hours=1)
 
 
 class DirWalker:
@@ -86,7 +85,7 @@ class DirWalker:
     _recursive: bool
     _path_matcher: FilePathMatcher
     _live: bool
-    _rescan_interval: _datetime.timedelta | None
+    _rescan_interval: datetime.timedelta | None
 
     def __init__(
         self,
@@ -95,7 +94,7 @@ class DirWalker:
         live: bool = False,
         recursive: bool = False,
         path_matcher: FilePathMatcher | None = None,
-        rescan_interval: _datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
+        rescan_interval: datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
     ) -> None:
         self._root_path = to_file_path(path)
         self._live = live
@@ -355,7 +354,7 @@ def walk_dir(
     live: bool = False,
     recursive: bool = False,
     path_matcher: FilePathMatcher | None = None,
-    rescan_interval: _datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
+    rescan_interval: datetime.timedelta | None = _DEFAULT_RESCAN_INTERVAL,
 ) -> DirWalker:
     """
     Walk through a directory and yield file entries.

--- a/python/tests/connectors/test_localfs_live.py
+++ b/python/tests/connectors/test_localfs_live.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from pathlib import Path
 from typing import Any
 
@@ -137,7 +138,9 @@ async def test_localfs_live_rescan_interval(tmp_path: Path) -> None:
 
     @coco.fn
     async def app_main() -> None:
-        files = localfs.walk_dir(tmp_path, live=True, rescan_interval=2.0)
+        files = localfs.walk_dir(
+            tmp_path, live=True, rescan_interval=datetime.timedelta(seconds=2)
+        )
         await coco.mount_each(process_file, files.items())
 
     app = coco.App(

--- a/python/tests/connectors/test_localfs_live.py
+++ b/python/tests/connectors/test_localfs_live.py
@@ -129,6 +129,87 @@ async def test_localfs_live_add_edit_delete(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_localfs_live_rescan_interval(tmp_path: Path) -> None:
+    """Periodic rescan detects files even with a short rescan interval."""
+    GlobalDictTarget.store.clear()
+
+    (tmp_path / "file1.txt").write_text("content1")
+
+    @coco.fn
+    async def app_main() -> None:
+        files = localfs.walk_dir(tmp_path, live=True, rescan_interval=2.0)
+        await coco.mount_each(process_file, files.items())
+
+    app = coco.App(
+        coco.AppConfig(name="test_localfs_live_rescan", environment=coco_env),
+        app_main,
+    )
+
+    handle = app.update(live=True)
+    update_task = asyncio.create_task(handle.result())
+    await asyncio.sleep(0.5)
+
+    try:
+        file1_key = "file1.txt"
+        await _wait_for_target_keys({file1_key})
+        assert GlobalDictTarget.store.data[file1_key].data == "content1"
+
+        # Add a file — picked up by events or the periodic rescan.
+        (tmp_path / "file2.txt").write_text("content2")
+        file2_key = "file2.txt"
+        await _wait_for_target_keys({file1_key, file2_key})
+        assert GlobalDictTarget.store.data[file2_key].data == "content2"
+
+        # Edit after a rescan cycle should still be detected.
+        await asyncio.sleep(2.5)
+        (tmp_path / "file1.txt").write_text("content1_v2")
+        await _wait_for_value(file1_key, "content1_v2")
+    finally:
+        update_task.cancel()
+        try:
+            await update_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_localfs_live_rescan_none_disables(tmp_path: Path) -> None:
+    """Setting rescan_interval=None disables periodic rescanning."""
+    GlobalDictTarget.store.clear()
+
+    (tmp_path / "a.txt").write_text("aaa")
+
+    @coco.fn
+    async def app_main() -> None:
+        files = localfs.walk_dir(tmp_path, live=True, rescan_interval=None)
+        await coco.mount_each(process_file, files.items())
+
+    app = coco.App(
+        coco.AppConfig(name="test_localfs_live_rescan_none", environment=coco_env),
+        app_main,
+    )
+
+    handle = app.update(live=True)
+    update_task = asyncio.create_task(handle.result())
+    await asyncio.sleep(0.5)
+
+    try:
+        await _wait_for_target_keys({"a.txt"})
+        assert GlobalDictTarget.store.data["a.txt"].data == "aaa"
+
+        # Events still work when periodic rescan is disabled.
+        (tmp_path / "b.txt").write_text("bbb")
+        await _wait_for_target_keys({"a.txt", "b.txt"})
+        assert GlobalDictTarget.store.data["b.txt"].data == "bbb"
+    finally:
+        update_task.cancel()
+        try:
+            await update_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
 async def test_localfs_live_single_watcher(tmp_path: Path) -> None:
     """A second concurrent watch() on one live view fails loudly."""
     items: Any = localfs.walk_dir(tmp_path, live=True).items()

--- a/python/tests/connectors/test_localfs_source.py
+++ b/python/tests/connectors/test_localfs_source.py
@@ -288,3 +288,34 @@ class TestDirWalkerWalkSync:
         walker = DirWalker(tmp_path)
         files = list(walker._walk_sync())
         assert files == []
+
+
+# =============================================================================
+# rescan_interval parameter
+# =============================================================================
+
+
+class TestRescanInterval:
+    def test_default_rescan_interval(self, tmp_path: Path) -> None:
+        walker = DirWalker(tmp_path, live=True)
+        assert walker._rescan_interval == 3600.0
+
+    def test_custom_rescan_interval(self, tmp_path: Path) -> None:
+        walker = DirWalker(tmp_path, live=True, rescan_interval=120.0)
+        assert walker._rescan_interval == 120.0
+
+    def test_none_disables_rescan(self, tmp_path: Path) -> None:
+        walker = DirWalker(tmp_path, live=True, rescan_interval=None)
+        assert walker._rescan_interval is None
+
+    def test_walk_dir_passes_rescan_interval(self, tmp_path: Path) -> None:
+        from cocoindex.connectors.localfs._source import walk_dir
+
+        walker = walk_dir(tmp_path, live=True, rescan_interval=300.0)
+        assert walker._rescan_interval == 300.0
+
+    def test_walk_dir_default_rescan_interval(self, tmp_path: Path) -> None:
+        from cocoindex.connectors.localfs._source import walk_dir
+
+        walker = walk_dir(tmp_path, live=True)
+        assert walker._rescan_interval == 3600.0

--- a/python/tests/connectors/test_localfs_source.py
+++ b/python/tests/connectors/test_localfs_source.py
@@ -9,10 +9,10 @@ Tests cover:
 
 from __future__ import annotations
 
+import datetime
 import os
 import pathlib
 from pathlib import Path, PurePath
-from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -55,14 +55,14 @@ class TestStatToMetadata:
         # 1_000_000_500_000 us = 1_000_000 seconds + 500_000 microseconds
         stat = self._make_stat(size=0, mtime_ns=1_000_000_500_000_000)
         meta = _stat_to_metadata(stat)
-        assert isinstance(meta.modified_time, datetime)
+        assert isinstance(meta.modified_time, datetime.datetime)
         assert meta.modified_time.microsecond == 500_000
 
     def test_mtime_zero(self) -> None:
         stat = self._make_stat(size=0, mtime_ns=0)
         meta = _stat_to_metadata(stat)
         assert meta.size == 0
-        assert isinstance(meta.modified_time, datetime)
+        assert isinstance(meta.modified_time, datetime.datetime)
 
     def test_real_stat(self, tmp_path: Path) -> None:
         f = tmp_path / "sample.txt"
@@ -70,7 +70,7 @@ class TestStatToMetadata:
         stat = f.stat()
         meta = _stat_to_metadata(stat)
         assert meta.size == 11
-        assert isinstance(meta.modified_time, datetime)
+        assert isinstance(meta.modified_time, datetime.datetime)
 
 
 # =============================================================================
@@ -298,11 +298,13 @@ class TestDirWalkerWalkSync:
 class TestRescanInterval:
     def test_default_rescan_interval(self, tmp_path: Path) -> None:
         walker = DirWalker(tmp_path, live=True)
-        assert walker._rescan_interval == 3600.0
+        assert walker._rescan_interval == datetime.timedelta(hours=1)
 
     def test_custom_rescan_interval(self, tmp_path: Path) -> None:
-        walker = DirWalker(tmp_path, live=True, rescan_interval=120.0)
-        assert walker._rescan_interval == 120.0
+        walker = DirWalker(
+            tmp_path, live=True, rescan_interval=datetime.timedelta(minutes=2)
+        )
+        assert walker._rescan_interval == datetime.timedelta(minutes=2)
 
     def test_none_disables_rescan(self, tmp_path: Path) -> None:
         walker = DirWalker(tmp_path, live=True, rescan_interval=None)
@@ -311,11 +313,13 @@ class TestRescanInterval:
     def test_walk_dir_passes_rescan_interval(self, tmp_path: Path) -> None:
         from cocoindex.connectors.localfs._source import walk_dir
 
-        walker = walk_dir(tmp_path, live=True, rescan_interval=300.0)
-        assert walker._rescan_interval == 300.0
+        walker = walk_dir(
+            tmp_path, live=True, rescan_interval=datetime.timedelta(minutes=5)
+        )
+        assert walker._rescan_interval == datetime.timedelta(minutes=5)
 
     def test_walk_dir_default_rescan_interval(self, tmp_path: Path) -> None:
         from cocoindex.connectors.localfs._source import walk_dir
 
         walker = walk_dir(tmp_path, live=True)
-        assert walker._rescan_interval == 3600.0
+        assert walker._rescan_interval == datetime.timedelta(hours=1)


### PR DESCRIPTION
## Summary

Implements the periodic rescan + watcher recreation approach discussed in #2227 with @georgeh0.

On macOS (and potentially other platforms), FSEvents can silently stop delivering events after days of continuous operation. The live file watcher had no recovery path — it blocked indefinitely on `events_queue.get()`.

This adds a configurable `rescan_interval` parameter to `walk_dir()` (default: 3600s / 1 hour) that periodically:

1. **Stops** the current watchdog Observer (releases the FSEvents stream)
2. **Drains** stale events from the queue
3. **Creates** a fresh Observer (new FSEvents/inotify stream from the OS)
4. **Runs** a full rescan via `subscriber.update_all()`

### Design decisions

- **Fixed-cadence rescan, decoupled from event flow** — as @georgeh0 suggested, the rescan fires on a timer regardless of whether events are being received. This catches both failure modes: watcher completely dead (no events) and watcher dropping individual events while the stream is alive.
- **Watcher recreation** — each cycle tears down the old Observer and creates a new one, getting a fresh OS-level watch stream. This is the definitive fix for `CFRunLoop`/`fseventsd` staleness.
- **`rescan_interval=None` disables** — for callers who don't want periodic rescanning (e.g. short-lived processes).
- **Backward compatible** — the default 1-hour interval is enabled automatically; existing callers get the safety net without code changes.

### Changes

- `python/cocoindex/connectors/localfs/_source.py` — core implementation
- `python/tests/connectors/test_localfs_source.py` — unit tests for `rescan_interval` parameter
- `python/tests/connectors/test_localfs_live.py` — e2e tests validating rescan + disable behavior

### Test plan

- [x] All existing unit tests pass (`test_localfs_source.py` — 37 tests)
- [x] All existing e2e live tests pass (`test_localfs_live.py` — 4 tests)
- [x] New `test_localfs_live_rescan_interval` — validates files are detected with a short rescan interval, including after a rescan cycle
- [x] New `test_localfs_live_rescan_none_disables` — validates `rescan_interval=None` disables rescanning while events still work
- [x] New `TestRescanInterval` unit tests — validates parameter defaults, custom values, None, and pass-through from `walk_dir()`
- [x] `ruff check` and `ruff format` pass

Closes #2227

Made with [Cursor](https://cursor.com)