### PR TITLE
fix(postgres): schema-qualify DROP INDEX when reconciling vector indexes

### DIFF
--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -515,12 +515,21 @@ class _VectorIndexHandler:
     ) -> None:
         async with self._pool.acquire() as conn:
             for action in actions:
-                index_name = f'"{self._table_name}__vector__{action.name}"'
+                index_base_name = f"{self._table_name}__vector__{action.name}"
+                # `CREATE INDEX` takes an *unqualified* index name (it is created in
+                # the table's schema); `DROP INDEX` must be *schema-qualified* to
+                # find that index — an unqualified name resolves via `search_path`,
+                # which need not include the table's schema, so the drop would
+                # silently no-op and a later create would collide.
+                create_index_name = f'"{index_base_name}"'
+                drop_index_name = _qualified_table_name(
+                    index_base_name, self._schema_name
+                )
                 if action.spec is None:
-                    await conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+                    await conn.execute(f"DROP INDEX IF EXISTS {drop_index_name}")
                 else:
                     # Drop + recreate
-                    await conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+                    await conn.execute(f"DROP INDEX IF EXISTS {drop_index_name}")
                     table_name = _qualified_table_name(
                         self._table_name, self._schema_name
                     )
@@ -539,7 +548,7 @@ class _VectorIndexHandler:
                         f" WITH ({', '.join(with_params)})" if with_params else ""
                     )
                     sql = (
-                        f"CREATE INDEX {index_name} ON {table_name} "
+                        f"CREATE INDEX {create_index_name} ON {table_name} "
                         f'USING {action.spec.method} ("{action.spec.column}" {action.spec.op_class})'
                         f"{with_clause}"
                     )

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -297,6 +297,79 @@ async def test_postgres_declare_vector_index(pg_env: _PgEnv) -> None:
 
 
 @pytest.mark.asyncio
+async def test_postgres_declare_vector_index_recreate_in_non_default_schema(
+    pg_env: _PgEnv,
+) -> None:
+    """Re-creating a vector index in a NON-default schema must not collide.
+
+    Regression: `_apply_actions` dropped the index with an *unqualified* name,
+    which resolves through the connection's `search_path` (default `"$user",
+    public`, excluding a custom schema), so the `DROP INDEX IF EXISTS` silently
+    no-opped while the following `CREATE INDEX ... ON "<schema>"."<table>"` always
+    targets the table's schema — raising `DuplicateTableError`. The method change
+    (ivfflat → hnsw) is what triggers the drop+recreate. The default-schema test
+    above doesn't catch this because `public` is on `search_path`.
+    """
+    pool = pg_env.pool
+    coco_env = pg_env.coco_env
+    schema_name = _unique_name("vecidx_sch")
+    table_name = _unique_name("test_vec_sch")
+    logical_name = "idx1"
+    pg_index_name = f"{table_name}__vector__{logical_name}"
+    index_method = "ivfflat"
+
+    async with pool.acquire() as conn:
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema_name}"')
+
+    try:
+
+        async def declare_fn() -> None:
+            table = await coco.use_mount(
+                coco.component_subpath("setup", "table"),
+                postgres.declare_table_target,
+                _PG_DB_KEY,
+                table_name,
+                await postgres.TableSchema.from_class(VectorRow, primary_key=["id"]),
+                pg_schema_name=schema_name,
+            )
+            table.declare_row(
+                row=VectorRow(
+                    id="1",
+                    content="hello",
+                    embedding=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+                )
+            )
+            table.declare_vector_index(
+                name=logical_name,
+                column="embedding",
+                metric="cosine",
+                method=index_method,
+            )
+
+        app = coco.App(
+            coco.AppConfig(name=f"test_vec_sch_{table_name}", environment=coco_env),
+            declare_fn,
+        )
+
+        # Run 1: create the ivfflat index in the custom schema.
+        await app.update()
+        info = await _index_info(pool, pg_index_name)
+        assert info is not None and info["amname"] == "ivfflat"
+
+        # Run 2: change the method → drop + recreate. Before the fix this raised
+        # DuplicateTableError because the unqualified DROP missed the custom-schema
+        # index.
+        index_method = "hnsw"
+        await app.update()
+        info = await _index_info(pool, pg_index_name)
+        assert info is not None and info["amname"] == "hnsw"
+
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE')
+
+
+@pytest.mark.asyncio
 async def test_postgres_declare_vector_index_fingerprint_no_change(
     pg_env: _PgEnv,
 ) -> None:


### PR DESCRIPTION
## Summary
- `_VectorIndexHandler._apply_actions` dropped the vector index with an **unqualified** name, which Postgres resolves via the connection's `search_path` (default `"$user", public`). For a table in a **non-default schema**, that schema isn't on `search_path`, so `DROP INDEX IF EXISTS "<name>"` silently matched nothing while the following `CREATE INDEX "<name>" ON "<schema>"."<table>"` always targets the table's schema — raising `DuplicateTableError: relation "…__vector__…" already exists` whenever an index action ran with the index already present (a method change like ivfflat→hnsw, or a recreate after a prior failed run).
- Fix: schema-qualify the `DROP INDEX` with the table's schema (via `_qualified_table_name`, already used for the CREATE's table reference); keep the CREATE's index name unqualified (Postgres places the index in the table's schema and rejects a schema-qualified name there). No behavior change for the default-schema case.
- Add a regression test driving the ivfflat→hnsw recreate in a non-default schema — it reproduces the `DuplicateTableError` before the fix and passes after. The existing vector-index test only used `public`, where the unqualified drop happens to resolve, so it didn't catch this.

## Test plan
- New test `test_postgres_declare_vector_index_recreate_in_non_default_schema` (testcontainers + pgvector): fails on `main` with `DuplicateTableError`, passes with the fix.
- Full `test_postgres_target.py` vector-index group green; ruff + mypy clean; CI.
