### PR TITLE
Add portable Agent Skills discovery

### DIFF
--- a/.agents/skills/cocoindex
+++ b/.agents/skills/cocoindex
@@ -1,0 +1,1 @@
+../../skills/cocoindex

--- a/.agents/skills/cocoindex-diagrams
+++ b/.agents/skills/cocoindex-diagrams
@@ -1,0 +1,1 @@
+../../dev/agent-skills/cocoindex-diagrams

--- a/.agents/skills/target-connector
+++ b/.agents/skills/target-connector
@@ -1,0 +1,1 @@
+../../dev/agent-skills/target-connector

--- a/.agents/skills/upgrade-examples
+++ b/.agents/skills/upgrade-examples
@@ -1,0 +1,1 @@
+../../dev/agent-skills/upgrade-examples

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,8 @@ Reusable task-specific agent guidance lives under `dev/agent-skills/`. These pla
 - For new target connectors, read `dev/agent-skills/target-connector/SKILL.md`.
 - For upgrading example package versions, read `dev/agent-skills/upgrade-examples/SKILL.md`.
 
-Claude-specific runtime configuration, hooks, and compatibility symlinks remain under `.claude/`. Do not put portable project guidance there; keep it in this file or under `dev/agent-skills/`.
+Agent Skills-compatible clients, including Codex, discover the checked-in symlinks under `.agents/skills/`. The public CocoIndex skill is exposed there as `cocoindex`, and contributor playbooks are exposed there from `dev/agent-skills/`.
+
+Claude Code compatibility remains under `.claude/`: hooks/settings live there, and `.claude/skills/` mirrors the contributor playbooks with symlinks. Do not duplicate skill content under `.agents/skills/` or `.claude/skills/`; edit the source directories (`skills/cocoindex/` for the public skill, `dev/agent-skills/` for contributor playbooks) and keep dot-directory entries as symlinks.
 
 Portable agent checks live under `dev/agent-checks/`. Claude Code hooks in `.claude/hooks/` are thin adapters that call these scripts when relevant files changed.

--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -19,6 +19,29 @@ CocoIndex v1 is a fundamental redesign from v0. Without context, an LLM trained 
 - **Connectors** — PostgreSQL, SQLite, LanceDB, Qdrant, SurrealDB, Apache Doris, LocalFS, S3, Kafka, Google Drive.
 - **Best practices** — memoization, stable component paths, vector schema with `Annotated[NDArray, KEY]`.
 
+## Use with agent clients
+
+| Client / workflow | Recommended setup |
+| --- | --- |
+| **Codex / Agent Skills-compatible clients** | Use `.agents/skills/cocoindex` for repo-local discovery. In this CocoIndex repo, checked-in `.agents/skills` symlinks expose the public skill and contributor playbooks automatically. |
+| **Claude Code** | Use `.claude/skills/cocoindex` in a project, or `~/.claude/skills/cocoindex` globally. |
+| **Cursor** | Copy `skills/cocoindex/SKILL.md` into `.cursor/rules/cocoindex.md`. |
+| **Generic AGENTS.md / CLAUDE.md** | Link to, import, or summarize `skills/cocoindex/SKILL.md` from your top-level agent instructions. |
+| **Context7** | This repo's `context7.json` already indexes `skills/cocoindex`; custom stacks can index the same folder. |
+| **Custom RAG / agent stack** | Index the `skills/cocoindex/` directory, including `references/`, as regular documentation. |
+
+Agent Skills-compatible clients load a skill directory that contains `SKILL.md`.
+If `.agents/skills/cocoindex` is checked into your project, no extra install step is
+needed for clients that scan that path.
+
+Project-local install for Codex or other Agent Skills-compatible clients:
+
+```sh
+mkdir -p .agents/skills
+git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
+cp -r /tmp/cocoindex-skill/skills/cocoindex .agents/skills/
+```
+
 ## Use with Claude Code
 
 Claude Code auto-loads skills from `.claude/skills/` in the current project, or from `~/.claude/skills/` globally.
@@ -47,6 +70,7 @@ The skill is plain Markdown — `SKILL.md` plus a few reference files. Any agent
 
 - **Cursor** — copy `skills/cocoindex/SKILL.md` into `.cursor/rules/cocoindex.md`.
 - **Generic AGENTS.md / CLAUDE.md** — concatenate or `@import` `SKILL.md` from your top-level agent instructions file.
+- **Context7** — use this repo's `context7.json` shape as a reference; it indexes `skills/cocoindex` alongside docs and examples.
 - **Custom RAG / agent stack** — index the `skills/cocoindex/` directory like any other documentation source.
 
 ## What's inside

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -8,14 +8,14 @@ CocoIndex **v1** apps; `rust/` contains Rust ports with per-example READMEs.
 
 CocoIndex v1 is a fundamental redesign from v0. Without context, LLMs tend to
 hallucinate the v0 flow-builder DSL and deprecated decorators. Install the
-official skill first — it teaches the correct v1 API. Quickest path is the
-hosted single file:
+official skill first — it teaches the correct v1 API. Quickest portable path
+for Codex and other Agent Skills-compatible clients is the hosted skill:
 
 ```sh
-mkdir -p .claude/skills/cocoindex/references
-curl -fsSL https://cocoindex.io/docs/skill.md -o .claude/skills/cocoindex/SKILL.md
+mkdir -p .agents/skills/cocoindex/references
+curl -fsSL https://cocoindex.io/docs/skill.md -o .agents/skills/cocoindex/SKILL.md
 for f in api_reference connectors patterns setup_database setup_project; do
-  curl -fsSL https://cocoindex.io/docs/references/$f.md -o .claude/skills/cocoindex/references/$f.md
+  curl -fsSL https://cocoindex.io/docs/references/$f.md -o .agents/skills/cocoindex/references/$f.md
 done
 ```
 
@@ -23,8 +23,11 @@ Or clone the repo and copy the folder:
 
 ```sh
 git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-mkdir -p .claude/skills && cp -r /tmp/cocoindex-skill/skills/cocoindex .claude/skills/
+mkdir -p .agents/skills && cp -r /tmp/cocoindex-skill/skills/cocoindex .agents/skills/
 ```
+
+For Claude Code's native project path, use `.claude/skills/cocoindex` instead
+of `.agents/skills/cocoindex`; the skill format is the same.
 
 The skill itself lives at [`skills/cocoindex/`](../skills/cocoindex) (SKILL.md +
 `references/`). For Cursor, copy `SKILL.md` into `.cursor/rules/`. Full machine-readable


### PR DESCRIPTION
I heard Linghua Jin speak about CocoIndex at AWS Builder Lounge and was grateful to learn about the project. I wanted to contribute a small improvement that helps more coding agents discover the existing CocoIndex skills.

## Summary

This PR adds repo-local `.agents/skills` discovery for Agent Skills-compatible clients, including Codex, while preserving the existing Claude Code setup.

The new `.agents/skills` entries are symlinks back to the existing source-of-truth skill directories, so this does not duplicate skill content or change the `.claude/skills` compatibility path.

## Changes

- Add `.agents/skills` symlinks for:
  - `cocoindex`
  - `cocoindex-diagrams`
  - `target-connector`
  - `upgrade-examples`
- Update repo agent guidance to document `.agents/skills`, `.claude/skills`, and source-of-truth skill directories.
- Update AI coding agent docs with setup guidance for Codex / Agent Skills-compatible clients, Claude Code, Cursor, AGENTS.md / CLAUDE.md, Context7, and custom RAG.
- Update examples agent guidance to prefer the portable `.agents/skills/cocoindex` install path while keeping Claude Code and Cursor alternatives.

## References Used

- OpenAI Codex Agent Skills docs: confirms Codex skills use `SKILL.md`, are available in Codex CLI/IDE/app, and build on the open Agent Skills standard. It also confirms Codex scans repo/user `.agents/skills` locations and supports symlinked skill folders. https://developers.openai.com/codex/skills
- Agent Skills specification: confirms the portable skill package shape: directory containing `SKILL.md`, optional `scripts/`, `references/`, `assets/`, and required frontmatter fields like `name` and `description`. https://agentskills.io/specification
- Agent Skills implementor guide: confirms `.agents/skills/` is the cross-client convention, while client-native paths like `.<client>/skills/` remain valid. It also notes some implementations may additionally scan `.claude/skills/` for compatibility. https://agentskills.io/client-implementation/adding-skills-support
- Claude Code skills docs: confirms Claude Code's native project path is `.claude/skills/<skill-name>/SKILL.md`, personal path is `~/.claude/skills/`, and Claude Code skills follow the Agent Skills open standard with Claude-specific extensions. https://docs.anthropic.com/en/docs/claude-code/skills

## Conflict Check

- Codex side: official Codex docs say Codex scans `.agents/skills` and supports symlinked skill folders.
- Claude side: official Claude Code docs describe `.claude/skills`, not `.agents/skills`, as Claude's native project path, so adding `.agents/skills` does not alter Claude Code's existing discovery path.
- Cross-client caveat: clients that scan both `.agents/skills` and `.claude/skills` could theoretically see duplicate skill names. This PR mitigates that by using symlinks to the same source directories instead of duplicate checked-in content, and by documenting `.agents/skills` as portable discovery rather than a replacement for `.claude/skills`.
- Repo check: `git ls-files -s .agents/skills .claude/skills` confirms both directories contain separate symlink entries; contributor playbooks point to the same `dev/agent-skills/*` sources. The public `cocoindex` skill is exposed only under `.agents/skills`.

## Verification

- `git diff --cached --check`
- `test -f .agents/skills/cocoindex/SKILL.md`
- `test -f .agents/skills/target-connector/SKILL.md`
- `npm --prefix docs ci`
- `npm --prefix docs run build`
- `uv run prek run --all-files --show-diff-on-failure`
