### PR TITLE
fix: reject rows with missing or null primary keys

### DIFF
--- a/docs/src/content/docs/connectors/sqlite.mdx
+++ b/docs/src/content/docs/connectors/sqlite.mdx
@@ -141,7 +141,7 @@ def TableTarget.declare_row(
 
 **Parameters:**
 
-- `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
+- `row` — A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns with non-`None` values. Dict rows may omit nullable non-primary-key columns; omitted values are written as SQL `NULL`.
 
 ### Table schema: from Python class
 

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -1055,7 +1055,9 @@ class TableTarget(
 
         Args:
             row: A row object (dict, dataclass, NamedTuple, or Pydantic model).
-                 Must include all primary key columns.
+                 Must include all primary key columns with non-None values.
+                 Dict rows may omit nullable non-primary-key columns; omitted values
+                 are written as NULL.
         """
         row_dict = self._row_to_dict(row)
         pk_values: list[Any] = []

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -1058,9 +1058,17 @@ class TableTarget(
                  Must include all primary key columns.
         """
         row_dict = self._row_to_dict(row)
-        # Extract primary key values
-        pk_values = tuple(row_dict[pk] for pk in self._table_schema.primary_key)
-        coco.declare_target_state(self._provider.target_state(pk_values, row_dict))
+        pk_values: list[Any] = []
+        for pk in self._table_schema.primary_key:
+            if isinstance(row, dict) and pk not in row:
+                raise ValueError(f"SQLite row is missing primary key column {pk!r}")
+            pk_value = row_dict[pk]
+            if pk_value is None:
+                raise ValueError(f"SQLite primary key column {pk!r} cannot be None")
+            pk_values.append(pk_value)
+        coco.declare_target_state(
+            self._provider.target_state(tuple(pk_values), row_dict)
+        )
 
     def _row_to_dict(self, row: RowT) -> dict[str, Any]:
         """

--- a/python/tests/connectors/test_sqlite_target.py
+++ b/python/tests/connectors/test_sqlite_target.py
@@ -7,7 +7,7 @@ import struct
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Iterator
+from typing import Annotated, Any, Iterator, cast
 
 import numpy as np
 import pytest
@@ -282,6 +282,42 @@ def test_delete_row(sqlite_db: tuple[sqlite.ManagedConnection, Path]) -> None:
     assert not any(row["id"] == "2" for row in data)
 
 
+def test_dataclass_row_null_primary_key_raises(
+    sqlite_db: tuple[sqlite.ManagedConnection, Path],
+) -> None:
+    """Test dataclass rows cannot declare NULL primary keys."""
+    managed_conn, _ = sqlite_db
+    global _source_rows, _row_type, _table_name
+
+    old_source_rows = _source_rows
+    old_row_type = _row_type
+    old_table_name = _table_name
+    try:
+        _row_type = SimpleRow
+        _table_name = "test_dataclass_null_pk"
+        _source_rows = [SimpleRow(id=cast(Any, None), name="No id", value=1)]
+
+        test_env = make_test_env(
+            managed_conn, "test_dataclass_row_null_primary_key_raises"
+        )
+        app = coco.App(
+            coco.AppConfig(
+                name="test_dataclass_row_null_primary_key_raises",
+                environment=test_env,
+            ),
+            declare_table_and_rows,
+        )
+
+        with pytest.raises(
+            ValueError, match="SQLite primary key column 'id' cannot be None"
+        ):
+            app.update_blocking()
+    finally:
+        _source_rows = old_source_rows
+        _row_type = old_row_type
+        _table_name = old_table_name
+
+
 def test_different_schema_types(
     sqlite_db: tuple[sqlite.ManagedConnection, Path],
 ) -> None:
@@ -508,6 +544,139 @@ def test_dict_rows(sqlite_db: tuple[sqlite.ManagedConnection, Path]) -> None:
     data = read_table_data(managed_conn, "dict_table")
     assert len(data) == 2
     assert {"id": "1", "name": "Item1", "count": 10} in data
+
+
+def test_dict_row_missing_primary_key_raises(
+    sqlite_db: tuple[sqlite.ManagedConnection, Path],
+) -> None:
+    """Test dict rows missing primary keys are rejected."""
+    managed_conn, _ = sqlite_db
+
+    dict_rows: list[dict[str, Any]] = []
+
+    test_env = make_test_env(managed_conn, "test_dict_row_missing_primary_key_raises")
+
+    async def declare_dict_table() -> None:
+        table = await coco.use_mount(
+            coco.component_subpath("setup", "table"),
+            sqlite.declare_table_target,
+            SQLITE_DB,
+            "dict_missing_pk",
+            sqlite.TableSchema(
+                {
+                    "id": sqlite.ColumnDef(type="TEXT", nullable=False),
+                    "name": sqlite.ColumnDef(type="TEXT"),
+                    "count": sqlite.ColumnDef(type="INTEGER"),
+                },
+                primary_key=["id"],
+            ),
+        )
+
+        for row in dict_rows:
+            table.declare_row(row=row)
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_dict_row_missing_primary_key_raises", environment=test_env
+        ),
+        declare_dict_table,
+    )
+
+    dict_rows.extend([{"name": "Item1", "count": 1}])
+    with pytest.raises(
+        ValueError, match="SQLite row is missing primary key column 'id'"
+    ):
+        app.update_blocking()
+
+
+def test_dict_row_null_primary_key_raises(
+    sqlite_db: tuple[sqlite.ManagedConnection, Path],
+) -> None:
+    """Test dict rows with NULL primary keys are rejected."""
+    managed_conn, _ = sqlite_db
+
+    dict_rows: list[dict[str, Any]] = []
+
+    test_env = make_test_env(managed_conn, "test_dict_row_null_primary_key_raises")
+
+    async def declare_dict_table() -> None:
+        table = await coco.use_mount(
+            coco.component_subpath("setup", "table"),
+            sqlite.declare_table_target,
+            SQLITE_DB,
+            "dict_null_pk",
+            sqlite.TableSchema(
+                {
+                    "id": sqlite.ColumnDef(type="TEXT", nullable=False),
+                    "name": sqlite.ColumnDef(type="TEXT"),
+                    "count": sqlite.ColumnDef(type="INTEGER"),
+                },
+                primary_key=["id"],
+            ),
+        )
+
+        for row in dict_rows:
+            table.declare_row(row=row)
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_dict_row_null_primary_key_raises", environment=test_env
+        ),
+        declare_dict_table,
+    )
+
+    dict_rows.extend([{"id": None, "name": "Item1", "count": 1}])
+    with pytest.raises(
+        ValueError, match="SQLite primary key column 'id' cannot be None"
+    ):
+        app.update_blocking()
+
+
+def test_dict_row_missing_nullable_non_key_writes_null(
+    sqlite_db: tuple[sqlite.ManagedConnection, Path],
+) -> None:
+    """Test missing nullable non-key dict fields are written as NULL."""
+    managed_conn, _ = sqlite_db
+
+    dict_rows: list[dict[str, Any]] = []
+
+    test_env = make_test_env(
+        managed_conn, "test_dict_row_missing_nullable_non_key_writes_null"
+    )
+
+    async def declare_dict_table() -> None:
+        table = await coco.use_mount(
+            coco.component_subpath("setup", "table"),
+            sqlite.declare_table_target,
+            SQLITE_DB,
+            "dict_missing_nullable",
+            sqlite.TableSchema(
+                {
+                    "id": sqlite.ColumnDef(type="TEXT", nullable=False),
+                    "name": sqlite.ColumnDef(type="TEXT"),
+                    "count": sqlite.ColumnDef(type="INTEGER"),
+                },
+                primary_key=["id"],
+            ),
+        )
+
+        for row in dict_rows:
+            table.declare_row(row=row)
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_dict_row_missing_nullable_non_key_writes_null",
+            environment=test_env,
+        ),
+        declare_dict_table,
+    )
+
+    dict_rows.extend([{"id": "1", "name": "Item1"}])
+    app.update_blocking()
+
+    assert read_table_data(managed_conn, "dict_missing_nullable") == [
+        {"id": "1", "name": "Item1", "count": None}
+    ]
 
 
 def test_user_managed_table(sqlite_db: tuple[sqlite.ManagedConnection, Path]) -> None:


### PR DESCRIPTION
## Summary

Reject SQLite target rows whose primary-key values are missing or `None` before declaring target state.

## Why

Dict rows are projected with `row.get(column)`. That is correct for nullable non-key columns, but it allowed a missing primary-key field to become `None` and enter CocoIndex as the row identity before SQLite validation ran.

Without early validation, CocoIndex can compute a target-state identity from `None` even though SQLite would later reject or mishandle the row. The fix makes the connector reject invalid identities at the user-facing boundary while keeping nullable non-key fields unchanged.

## What changed

- Validate every configured primary-key column in `TableTarget.declare_row()` after `_row_to_dict(row)` and before target-state declaration.
- Raise `ValueError` when a dict row omits a primary-key column.
- Raise `ValueError` when any projected primary-key value is `None`.
- Preserve the existing missing-to-`NULL` behavior for nullable non-primary-key dict fields.
- Clarify SQLite row documentation so primary-key values must be present and non-`None`, while nullable non-key dict omissions still write SQL `NULL`.

## Breaking changes

None for valid rows. Invalid rows that already violated the documented primary-key contract now fail earlier, before target-state declaration.

## Follow-up

A similar missing-or-null primary-key risk appears in the PostgreSQL target path (`row.get(col_name)` projection, then primary keys derived from `row_dict`). This PR stays scoped to SQLite and leaves PostgreSQL as a separate follow-up.

## Tests

- `uv run pytest python/` 
- `uv run ruff format --check python/cocoindex/connectors/sqlite/_target.py python/tests/connectors/test_sqlite_target.py` 
- `uv run mypy` 
