### PR TITLE
feat(qdrant): native sparse vector support + eager point-ID validation

### DIFF
--- a/docs/src/content/docs/connectors/qdrant.mdx
+++ b/docs/src/content/docs/connectors/qdrant.mdx
@@ -2,11 +2,11 @@
 title: "*Qdrant* connector"
 toc_max_heading_level: 4
 description: >
-  Write points to Qdrant collections with single or named vectors, multi-vector
-  support, and schemaless payloads — configured via QdrantVectorDef for
-  dimension, distance metric, and multi-vector comparator.
+  Write points to Qdrant collections with single or named dense vectors, sparse
+  vectors, multi-vector support, and schemaless payloads — configured via
+  QdrantVectorDef and QdrantSparseVectorDef.
 ---
-The `qdrant` connector provides utilities for writing points to Qdrant vector databases, with support for both single and named vectors, as well as multi-vector configurations.
+The `qdrant` connector provides utilities for writing points to Qdrant vector databases, with support for single vectors, named dense vectors, sparse vectors, and multi-vector configurations.
 
 ```python
 from cocoindex.connectors import qdrant
@@ -125,7 +125,9 @@ class CollectionSchema:
     @classmethod
     async def create(
         cls,
-        vectors: QdrantVectorDef | dict[str, QdrantVectorDef],
+        vectors: QdrantVectorDef | dict[str, QdrantVectorDef] | None = None,
+        *,
+        sparse_vectors: dict[str, QdrantSparseVectorDef] | None = None,
     ) -> CollectionSchema
 ```
 
@@ -134,6 +136,7 @@ class CollectionSchema:
 - `vectors` — Either:
   - A single `QdrantVectorDef` for an unnamed vector
   - A dict mapping vector names to `QdrantVectorDef` for named vectors
+- `sparse_vectors` — Optional dict mapping sparse vector names to `QdrantSparseVectorDef`. Sparse vectors are always named in Qdrant.
 
 #### QdrantVectorDef
 
@@ -151,6 +154,17 @@ class QdrantVectorDef(NamedTuple):
 - `schema` — A `VectorSchemaProvider` or `MultiVectorSchemaProvider` that defines vector dimensions
 - `distance` — Distance metric for similarity search (default: `"cosine"`)
 - `multivector_comparator` — Comparator for multi-vector fields (only applies to `MultiVectorSchemaProvider`)
+
+#### QdrantSparseVectorDef
+
+Specifies a named sparse vector configuration:
+
+```python
+class QdrantSparseVectorDef(NamedTuple):
+    modifier: Literal["idf"] | None = None
+```
+
+Sparse vectors use Qdrant's native sparse-vector storage and dot-product scoring. The optional `modifier="idf"` enables Qdrant's IDF modifier for sparse vectors.
 
 #### Single (unnamed) vector
 
@@ -170,7 +184,7 @@ Points use the vector directly:
 
 ```python
 point = qdrant.PointStruct(
-    id="doc-123",
+    id=123,  # unsigned int or UUID — see "Point IDs" below
     vector=embedding.tolist(),  # Single vector
     payload={"text": "...", "metadata": {...}},
 )
@@ -202,13 +216,52 @@ Points use a dict of vectors:
 
 ```python
 point = qdrant.PointStruct(
-    id="doc-123",
+    id=123,  # unsigned int or UUID — see "Point IDs" below
     vector={
         "text_embedding": text_vec.tolist(),
         "image_embedding": image_vec.tolist(),
     },
     payload={"text": "...", "metadata": {...}},
 )
+```
+
+#### Dense + sparse vectors
+
+For hybrid retrieval, declare a named dense vector and a named sparse vector in the same collection:
+
+```python
+from qdrant_client.http import models as qdrant_models
+from cocoindex.resources.schema import VectorSchema
+import numpy as np
+
+schema = await qdrant.CollectionSchema.create(
+    vectors={
+        "dense": qdrant.QdrantVectorDef(
+            schema=VectorSchema(dtype=np.float32, size=384),
+            distance="cosine",
+        ),
+    },
+    sparse_vectors={
+        "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
+    },
+)
+```
+
+Points put both vector types in `PointStruct.vector`. The sparse vector is a native Qdrant `SparseVector`, not payload:
+
+```python
+point = qdrant.PointStruct(
+    id=123,
+    vector={
+        "dense": dense_embedding.tolist(),
+        "sparse": qdrant_models.SparseVector(
+            indices=sparse_indices,
+            values=sparse_values,
+        ),
+    },
+    payload={"text": text},
+)
+target.declare_point(point)
 ```
 
 #### VectorSchemaProvider
@@ -336,15 +389,62 @@ async def app_main() -> None:
         collection.declare_point(point)
 ```
 
+### Example: dense + sparse hybrid vectors
+
+```python
+from qdrant_client.http import models as qdrant_models
+from cocoindex.resources.schema import VectorSchema
+import numpy as np
+
+@coco.fn
+async def app_main() -> None:
+    collection = await qdrant.mount_collection_target(
+        QDRANT_DB,
+        "hybrid_docs",
+        await qdrant.CollectionSchema.create(
+            vectors={
+                "dense": qdrant.QdrantVectorDef(
+                    schema=VectorSchema(dtype=np.float32, size=384),
+                    distance="cosine",
+                ),
+            },
+            sparse_vectors={
+                "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
+            },
+        ),
+    )
+
+    for chunk in chunks:
+        point = qdrant.PointStruct(
+            id=chunk.id,
+            vector={
+                "dense": chunk.dense_embedding.tolist(),
+                "sparse": qdrant_models.SparseVector(
+                    indices=chunk.sparse_indices,
+                    values=chunk.sparse_values,
+                ),
+            },
+            payload={"text": chunk.text},
+        )
+        collection.declare_point(point)
+```
+
 ## Point IDs
 
-Qdrant supports the following point ID types:
+Qdrant only accepts two point ID types — this is enforced by the Qdrant server itself (see [Qdrant's Point IDs documentation](https://qdrant.tech/documentation/manage-data/points/#point-ids)):
 
-- `str` — String identifiers
-- `int` — Integer identifiers (unsigned 64-bit)
-- `uuid.UUID` — UUID identifiers (converted to string)
+- `int` — unsigned 64-bit integers (`0 <= id < 2**64`)
+- `str` — UUID strings, in any standard textual form (hyphenated, 32-character hex, or URN)
 
-All other types are converted to strings automatically.
+`uuid.UUID` instances are also accepted and converted to strings. `declare_point` validates the ID eagerly and raises `ValueError` for anything else, rather than letting the write fail later at the Qdrant server.
+
+To derive a stable point ID from an arbitrary string key (e.g. a document path or chunk key), use a deterministic UUID:
+
+```python
+import uuid
+
+point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"doc/{chunk_key}"))
+```
 
 ## Payloads
 
@@ -376,23 +476,51 @@ from qdrant_client.http import models as qdrant_models
 client = qdrant.create_client("http://localhost:6333")
 
 # Perform search
-results = client.search(
+results = client.query_points(
     collection_name="documents",
-    query_vector=query_embedding.tolist(),
+    query=query_embedding.tolist(),
     limit=10,
+    with_payload=True,
 )
 
-for result in results:
-    print(f"Score: {result.score}, ID: {result.id}")
-    print(f"Payload: {result.payload}")
+for point in results.points:
+    print(f"Score: {point.score}, ID: {point.id}")
+    print(f"Payload: {point.payload}")
 ```
 
 For named vectors:
 
 ```python
-results = client.search(
+results = client.query_points(
     collection_name="documents",
-    query_vector=("text", query_embedding.tolist()),  # Search using "text" vector
+    query=query_embedding.tolist(),
+    using="text",  # Search using the "text" vector
     limit=10,
+)
+```
+
+For hybrid dense + sparse retrieval, use Qdrant's query API with prefetches and reciprocal rank fusion:
+
+```python
+results = client.query_points(
+    collection_name="hybrid_docs",
+    prefetch=[
+        qdrant_models.Prefetch(
+            query=query_dense_embedding.tolist(),
+            using="dense",
+            limit=100,
+        ),
+        qdrant_models.Prefetch(
+            query=qdrant_models.SparseVector(
+                indices=query_sparse_indices,
+                values=query_sparse_values,
+            ),
+            using="sparse",
+            limit=100,
+        ),
+    ],
+    query=qdrant_models.FusionQuery(fusion=qdrant_models.Fusion.RRF),
+    limit=10,
+    with_payload=True,
 )
 ```

--- a/docs/src/content/docs/connectors/qdrant.mdx
+++ b/docs/src/content/docs/connectors/qdrant.mdx
@@ -125,18 +125,19 @@ class CollectionSchema:
     @classmethod
     async def create(
         cls,
-        vectors: QdrantVectorDef | dict[str, QdrantVectorDef] | None = None,
-        *,
-        sparse_vectors: dict[str, QdrantSparseVectorDef] | None = None,
+        vectors: QdrantVectorDef
+        | dict[str, QdrantVectorDef | QdrantSparseVectorDef]
+        | None = None,
     ) -> CollectionSchema
 ```
 
 **Parameters:**
 
 - `vectors` — Either:
-  - A single `QdrantVectorDef` for an unnamed vector
-  - A dict mapping vector names to `QdrantVectorDef` for named vectors
-- `sparse_vectors` — Optional dict mapping sparse vector names to `QdrantSparseVectorDef`. Sparse vectors are always named in Qdrant.
+  - A single `QdrantVectorDef` for an unnamed dense vector
+  - A dict mapping vector names to `QdrantVectorDef` (dense) or `QdrantSparseVectorDef` (sparse)
+
+Dense and sparse vectors share one namespace in Qdrant (the server rejects duplicate names across the two kinds), so both live in the same dict — a name collision is impossible to express. Sparse vectors are always named.
 
 #### QdrantVectorDef
 
@@ -240,8 +241,6 @@ schema = await qdrant.CollectionSchema.create(
             schema=VectorSchema(dtype=np.float32, size=384),
             distance="cosine",
         ),
-    },
-    sparse_vectors={
         "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
     },
 )
@@ -407,8 +406,6 @@ async def app_main() -> None:
                     schema=VectorSchema(dtype=np.float32, size=384),
                     distance="cosine",
                 ),
-            },
-            sparse_vectors={
                 "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
             },
         ),

--- a/examples/face_recognition/main.py
+++ b/examples/face_recognition/main.py
@@ -201,19 +201,12 @@ app = coco.App(
 def _qdrant_search(
     client: QdrantClient, query_vector: list[float], limit: int
 ) -> list[Any]:
-    if hasattr(client, "query_points"):
-        return client.query_points(
-            collection_name=QDRANT_COLLECTION,
-            query=query_vector,
-            limit=limit,
-            with_payload=True,
-        ).points
-    return client.search(
+    return client.query_points(
         collection_name=QDRANT_COLLECTION,
-        query_vector=query_vector,
+        query=query_vector,
         limit=limit,
         with_payload=True,
-    )
+    ).points
 
 
 def query(image_path: str, *, top_k: int = TOP_K) -> None:

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -7,9 +7,10 @@ This module provides a two-level target state system for Qdrant:
 """
 
 from __future__ import annotations
-import cocoindex as coco
 
 import asyncio
+import uuid
+
 import msgspec
 from dataclasses import dataclass
 from typing import (
@@ -68,6 +69,17 @@ class QdrantVectorDef(NamedTuple):
     multivector_comparator: Literal["max_sim"] = "max_sim"
 
 
+class QdrantSparseVectorDef(NamedTuple):
+    """Qdrant sparse vector specification.
+
+    Sparse vectors in Qdrant are always named and use dot-product scoring.
+    ``modifier="idf"`` enables Qdrant's IDF modifier; ``None`` (the default)
+    applies no modifier.
+    """
+
+    modifier: Literal["idf"] | None = None
+
+
 class _ResolvedQdrantVectorDef(msgspec.Struct, frozen=True, tag=True):
     """Resolved single (unnamed) vector specification.
 
@@ -86,6 +98,18 @@ class _ResolvedQdrantNamedVectorsDef(msgspec.Struct, frozen=True, tag=True):
     vectors: dict[str, _ResolvedQdrantVectorDef]
 
 
+class _ResolvedQdrantSparseVectorDef(msgspec.Struct, frozen=True, tag=True):
+    """Resolved sparse vector specification."""
+
+    modifier: Literal["idf"] | None = None
+
+
+class _ResolvedQdrantSparseVectorsDef(msgspec.Struct, frozen=True, tag=True):
+    """Resolved named sparse vectors specification."""
+
+    sparse_vectors: dict[str, _ResolvedQdrantSparseVectorDef]
+
+
 async def _resolve_vector_def(vector_def: QdrantVectorDef) -> _ResolvedQdrantVectorDef:
     resolved_schema: res_schema.VectorSchema | res_schema.MultiVectorSchema
     vs = await res_schema.get_vector_schema(vector_def.schema)
@@ -102,6 +126,12 @@ async def _resolve_vector_def(vector_def: QdrantVectorDef) -> _ResolvedQdrantVec
         distance=vector_def.distance,
         multivector_comparator=vector_def.multivector_comparator,
     )
+
+
+def _resolve_sparse_vector_def(
+    sparse_vector_def: QdrantSparseVectorDef,
+) -> _ResolvedQdrantSparseVectorDef:
+    return _ResolvedQdrantSparseVectorDef(modifier=sparse_vector_def.modifier)
 
 
 @dataclass(slots=True)
@@ -132,11 +162,13 @@ class CollectionSchema:
         ```
     """
 
-    _vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
+    _vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
+    _sparse_vectors: _ResolvedQdrantSparseVectorsDef | None
 
     def __init__(
         self,
-        vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef,
+        vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None,
+        sparse_vectors: _ResolvedQdrantSparseVectorsDef | None = None,
     ) -> None:
         """
         Create a CollectionSchema from pre-resolved vector definitions.
@@ -144,12 +176,19 @@ class CollectionSchema:
         For constructing from unresolved ``QdrantVectorDef``, use the async
         classmethod ``create`` instead.
         """
+        if vectors is None and sparse_vectors is None:
+            raise ValueError(
+                "Qdrant collection schema must declare dense/multivector or sparse vectors"
+            )
         self._vectors = vectors
+        self._sparse_vectors = sparse_vectors
 
     @classmethod
     async def create(
         cls,
-        vectors: QdrantVectorDef | dict[str, QdrantVectorDef],
+        vectors: QdrantVectorDef | dict[str, QdrantVectorDef] | None = None,
+        *,
+        sparse_vectors: dict[str, QdrantSparseVectorDef] | None = None,
     ) -> "CollectionSchema":
         """
         Create a CollectionSchema by resolving vector definitions.
@@ -157,27 +196,64 @@ class CollectionSchema:
         Args:
             vectors: Either a single QdrantVectorDef (for unnamed vector) or a dictionary
                      mapping vector field names to QdrantVectorDef.
+            sparse_vectors: Optional dictionary mapping sparse vector names to
+                            QdrantSparseVectorDef. Sparse vectors must be named.
         """
-        resolved: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
+        resolved: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
         if isinstance(vectors, QdrantVectorDef):
             resolved = await _resolve_vector_def(vectors)
         elif isinstance(vectors, dict):
+            if not vectors:
+                raise ValueError("Qdrant named vectors must not be empty")
             resolved = _ResolvedQdrantNamedVectorsDef(
                 vectors={
                     name: await _resolve_vector_def(vector_def)
                     for name, vector_def in vectors.items()
                 }
             )
+            _validate_vector_names(resolved.vectors.keys(), "vector")
+        elif vectors is None:
+            resolved = None
         else:
             raise ValueError(f"Invalid vector definition: {vectors}")
-        return cls(resolved)
+
+        resolved_sparse: _ResolvedQdrantSparseVectorsDef | None = None
+        if sparse_vectors is not None:
+            if not sparse_vectors:
+                raise ValueError("Qdrant sparse vectors must not be empty")
+            _validate_vector_names(sparse_vectors.keys(), "sparse vector")
+            resolved_sparse = _ResolvedQdrantSparseVectorsDef(
+                sparse_vectors={
+                    name: _resolve_sparse_vector_def(sparse_vector_def)
+                    for name, sparse_vector_def in sparse_vectors.items()
+                }
+            )
+
+        if (
+            isinstance(resolved, _ResolvedQdrantNamedVectorsDef)
+            and resolved_sparse is not None
+        ):
+            overlap = sorted(
+                set(resolved.vectors) & set(resolved_sparse.sparse_vectors)
+            )
+            if overlap:
+                raise ValueError(
+                    f"Qdrant dense and sparse vector names must not overlap: {overlap}"
+                )
+
+        return cls(resolved, resolved_sparse)
 
     @property
     def vectors(
         self,
-    ) -> _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef:
+    ) -> _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None:
         """Get vector definitions (all VectorSchemaProviders resolved)."""
         return self._vectors
+
+    @property
+    def sparse_vectors(self) -> _ResolvedQdrantSparseVectorsDef | None:
+        """Get sparse vector definitions."""
+        return self._sparse_vectors
 
 
 class _PointAction(NamedTuple):
@@ -277,7 +353,8 @@ class _CollectionSpec:
 
 
 class _CollectionTrackingRecordCore(msgspec.Struct, frozen=True, array_like=True):
-    vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
+    vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
+    sparse_vectors: _ResolvedQdrantSparseVectorsDef | None = None
 
 
 _CollectionTrackingRecord = statediff.MutualTrackingRecord[
@@ -374,24 +451,30 @@ class _CollectionHandler(
         ):
             return
 
-        # Configure vectors based on whether it's named or unnamed
+        # Configure dense/multivectors based on whether they're named or unnamed.
         vectors_config: (
-            dict[str, qdrant_models.VectorParams] | qdrant_models.VectorParams
-        )
+            dict[str, qdrant_models.VectorParams] | qdrant_models.VectorParams | None
+        ) = None
         if isinstance(schema.vectors, _ResolvedQdrantNamedVectorsDef):
-            # Named vectors: use dict
             vectors_config = {
                 name: _vector_params_from_def(vector_def)
                 for name, vector_def in schema.vectors.vectors.items()
             }
-        else:
-            # Unnamed vector: pass VectorParams directly (not in a dict)
+        elif schema.vectors is not None:
             vectors_config = _vector_params_from_def(schema.vectors)
+
+        sparse_vectors_config: dict[str, qdrant_models.SparseVectorParams] | None = None
+        if schema.sparse_vectors is not None:
+            sparse_vectors_config = {
+                name: _sparse_vector_params_from_def(sparse_vector_def)
+                for name, sparse_vector_def in schema.sparse_vectors.sparse_vectors.items()
+            }
 
         await asyncio.to_thread(
             client.create_collection,
             collection_name=collection_name,
             vectors_config=vectors_config,
+            sparse_vectors_config=sparse_vectors_config,
         )
 
     def reconcile(
@@ -415,7 +498,8 @@ class _CollectionHandler(
         else:
             tracking_record = statediff.MutualTrackingRecord(
                 tracking_record=_CollectionTrackingRecordCore(
-                    vectors=desired_state.schema.vectors
+                    vectors=desired_state.schema.vectors,
+                    sparse_vectors=desired_state.schema.sparse_vectors,
                 ),
                 managed_by=desired_state.managed_by,
             )
@@ -493,15 +577,14 @@ class CollectionTarget(
 
         Args:
             point: PointStruct defining the point ID, vectors, and payload
-        """
-        # Extract point ID
-        point_id: _PointId
-        if isinstance(point.id, (str, int)):
-            point_id = point.id
-        else:
-            point_id = str(point.id)
 
-        coco.declare_target_state(self._provider.target_state(point_id, point))
+        Raises:
+            ValueError: If the point ID is not an unsigned 64-bit integer or
+                a UUID (Qdrant rejects all other IDs at write time).
+        """
+        coco.declare_target_state(
+            self._provider.target_state(_validate_point_id(point.id), point)
+        )
 
     def __coco_memo_key__(self) -> str:
         return self._provider.memo_key
@@ -615,6 +698,16 @@ def _multivector_comparator(
     raise ValueError(f"Unsupported multivector comparator: {comparator}")
 
 
+def _sparse_modifier_from_spec(
+    modifier: Literal["idf"] | None,
+) -> qdrant_models.Modifier | None:
+    if modifier is None:
+        return None
+    if modifier == "idf":
+        return qdrant_models.Modifier.IDF
+    raise ValueError(f"Unsupported Qdrant sparse vector modifier: {modifier}")
+
+
 def _vector_params_from_def(
     vector_def: _ResolvedQdrantVectorDef,
 ) -> qdrant_models.VectorParams:
@@ -640,10 +733,66 @@ def _vector_params_from_def(
     )
 
 
+def _sparse_vector_params_from_def(
+    sparse_vector_def: _ResolvedQdrantSparseVectorDef,
+) -> qdrant_models.SparseVectorParams:
+    """Convert a resolved sparse vector definition to Qdrant SparseVectorParams."""
+    return qdrant_models.SparseVectorParams(
+        modifier=_sparse_modifier_from_spec(sparse_vector_def.modifier)
+    )
+
+
+def _validate_vector_names(names: Collection[str], kind: str) -> None:
+    for name in names:
+        if not name:
+            raise ValueError(f"Qdrant {kind} name must not be empty")
+
+
+_POINT_ID_RULE = (
+    "Qdrant point IDs must be an unsigned 64-bit integer or a UUID "
+    "(str or uuid.UUID); see "
+    "https://qdrant.tech/documentation/manage-data/points/#point-ids. For a "
+    "stable ID derived from an arbitrary string key, use uuid.uuid5, e.g. "
+    'str(uuid.uuid5(uuid.NAMESPACE_URL, f"doc/{key}")).'
+)
+
+
+def _validate_point_id(raw: object) -> _PointId:
+    """Validate a point ID against Qdrant's server-side rules, eagerly.
+
+    Qdrant only accepts unsigned 64-bit integers and UUIDs (any textual
+    form: hyphenated, 32-char hex, or URN); everything else is rejected at
+    upsert time with an opaque transport error, so fail at declare time
+    with an actionable one instead.
+    """
+    if isinstance(raw, int):
+        if not 0 <= raw < 1 << 64:
+            raise ValueError(
+                f"Invalid Qdrant point ID {raw!r}: out of unsigned 64-bit range. "
+                f"{_POINT_ID_RULE}"
+            )
+        return raw
+    if isinstance(raw, uuid.UUID):
+        return str(raw)
+    if isinstance(raw, str):
+        try:
+            uuid.UUID(raw)
+        except ValueError:
+            raise ValueError(
+                f"Invalid Qdrant point ID {raw!r}: strings must be UUIDs. "
+                f"{_POINT_ID_RULE}"
+            ) from None
+        return raw
+    raise ValueError(
+        f"Invalid Qdrant point ID of type {type(raw).__name__}. {_POINT_ID_RULE}"
+    )
+
+
 __all__ = [
     "CollectionSchema",
     "CollectionTarget",
     "PointStruct",
+    "QdrantSparseVectorDef",
     "QdrantVectorDef",
     "collection_target",
     "create_client",

--- a/python/cocoindex/connectors/qdrant/_target.py
+++ b/python/cocoindex/connectors/qdrant/_target.py
@@ -92,22 +92,21 @@ class _ResolvedQdrantVectorDef(msgspec.Struct, frozen=True, tag=True):
     multivector_comparator: Literal["max_sim"]
 
 
-class _ResolvedQdrantNamedVectorsDef(msgspec.Struct, frozen=True, tag=True):
-    """Resolved named vectors specification (multiple named vectors per collection)."""
-
-    vectors: dict[str, _ResolvedQdrantVectorDef]
-
-
 class _ResolvedQdrantSparseVectorDef(msgspec.Struct, frozen=True, tag=True):
     """Resolved sparse vector specification."""
 
     modifier: Literal["idf"] | None = None
 
 
-class _ResolvedQdrantSparseVectorsDef(msgspec.Struct, frozen=True, tag=True):
-    """Resolved named sparse vectors specification."""
+class _ResolvedQdrantNamedVectorsDef(msgspec.Struct, frozen=True, tag=True):
+    """Resolved named vectors specification.
 
-    sparse_vectors: dict[str, _ResolvedQdrantSparseVectorDef]
+    Dense and sparse vectors share one namespace in Qdrant (the server
+    rejects duplicate names across the two kinds), so a single dict holds
+    both; the tagged union discriminates them.
+    """
+
+    vectors: dict[str, _ResolvedQdrantVectorDef | _ResolvedQdrantSparseVectorDef]
 
 
 async def _resolve_vector_def(vector_def: QdrantVectorDef) -> _ResolvedQdrantVectorDef:
@@ -162,13 +161,11 @@ class CollectionSchema:
         ```
     """
 
-    _vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
-    _sparse_vectors: _ResolvedQdrantSparseVectorsDef | None
+    _vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
 
     def __init__(
         self,
-        vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None,
-        sparse_vectors: _ResolvedQdrantSparseVectorsDef | None = None,
+        vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef,
     ) -> None:
         """
         Create a CollectionSchema from pre-resolved vector definitions.
@@ -176,84 +173,63 @@ class CollectionSchema:
         For constructing from unresolved ``QdrantVectorDef``, use the async
         classmethod ``create`` instead.
         """
-        if vectors is None and sparse_vectors is None:
-            raise ValueError(
-                "Qdrant collection schema must declare dense/multivector or sparse vectors"
-            )
         self._vectors = vectors
-        self._sparse_vectors = sparse_vectors
 
     @classmethod
     async def create(
         cls,
-        vectors: QdrantVectorDef | dict[str, QdrantVectorDef] | None = None,
-        *,
-        sparse_vectors: dict[str, QdrantSparseVectorDef] | None = None,
+        vectors: QdrantVectorDef
+        | dict[str, QdrantVectorDef | QdrantSparseVectorDef]
+        | None = None,
     ) -> "CollectionSchema":
         """
         Create a CollectionSchema by resolving vector definitions.
 
         Args:
-            vectors: Either a single QdrantVectorDef (for unnamed vector) or a dictionary
-                     mapping vector field names to QdrantVectorDef.
-            sparse_vectors: Optional dictionary mapping sparse vector names to
-                            QdrantSparseVectorDef. Sparse vectors must be named.
+            vectors: Either a single QdrantVectorDef (for an unnamed dense
+                     vector) or a dictionary mapping vector names to
+                     QdrantVectorDef or QdrantSparseVectorDef. Dense and
+                     sparse vectors share one namespace in Qdrant, so both
+                     kinds live in the same dict; sparse vectors are always
+                     named.
         """
-        resolved: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
+        resolved: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
         if isinstance(vectors, QdrantVectorDef):
             resolved = await _resolve_vector_def(vectors)
+        elif isinstance(vectors, QdrantSparseVectorDef):
+            raise ValueError(
+                "Qdrant sparse vectors are always named; pass them in a dict, "
+                'e.g. vectors={"sparse": QdrantSparseVectorDef()}'
+            )
         elif isinstance(vectors, dict):
             if not vectors:
                 raise ValueError("Qdrant named vectors must not be empty")
-            resolved = _ResolvedQdrantNamedVectorsDef(
-                vectors={
-                    name: await _resolve_vector_def(vector_def)
-                    for name, vector_def in vectors.items()
-                }
-            )
-            _validate_vector_names(resolved.vectors.keys(), "vector")
+            _validate_vector_names(vectors.keys(), "vector")
+            resolved_entries: dict[
+                str, _ResolvedQdrantVectorDef | _ResolvedQdrantSparseVectorDef
+            ] = {}
+            for name, vector_def in vectors.items():
+                if isinstance(vector_def, QdrantVectorDef):
+                    resolved_entries[name] = await _resolve_vector_def(vector_def)
+                elif isinstance(vector_def, QdrantSparseVectorDef):
+                    resolved_entries[name] = _resolve_sparse_vector_def(vector_def)
+                else:
+                    raise ValueError(f"Invalid vector definition: {vector_def}")
+            resolved = _ResolvedQdrantNamedVectorsDef(vectors=resolved_entries)
         elif vectors is None:
-            resolved = None
+            raise ValueError(
+                "Qdrant collection schema must declare at least one vector"
+            )
         else:
             raise ValueError(f"Invalid vector definition: {vectors}")
-
-        resolved_sparse: _ResolvedQdrantSparseVectorsDef | None = None
-        if sparse_vectors is not None:
-            if not sparse_vectors:
-                raise ValueError("Qdrant sparse vectors must not be empty")
-            _validate_vector_names(sparse_vectors.keys(), "sparse vector")
-            resolved_sparse = _ResolvedQdrantSparseVectorsDef(
-                sparse_vectors={
-                    name: _resolve_sparse_vector_def(sparse_vector_def)
-                    for name, sparse_vector_def in sparse_vectors.items()
-                }
-            )
-
-        if (
-            isinstance(resolved, _ResolvedQdrantNamedVectorsDef)
-            and resolved_sparse is not None
-        ):
-            overlap = sorted(
-                set(resolved.vectors) & set(resolved_sparse.sparse_vectors)
-            )
-            if overlap:
-                raise ValueError(
-                    f"Qdrant dense and sparse vector names must not overlap: {overlap}"
-                )
-
-        return cls(resolved, resolved_sparse)
+        return cls(resolved)
 
     @property
     def vectors(
         self,
-    ) -> _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None:
+    ) -> _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef:
         """Get vector definitions (all VectorSchemaProviders resolved)."""
         return self._vectors
-
-    @property
-    def sparse_vectors(self) -> _ResolvedQdrantSparseVectorsDef | None:
-        """Get sparse vector definitions."""
-        return self._sparse_vectors
 
 
 class _PointAction(NamedTuple):
@@ -353,8 +329,7 @@ class _CollectionSpec:
 
 
 class _CollectionTrackingRecordCore(msgspec.Struct, frozen=True, array_like=True):
-    vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef | None
-    sparse_vectors: _ResolvedQdrantSparseVectorsDef | None = None
+    vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
 
 
 _CollectionTrackingRecord = statediff.MutualTrackingRecord[
@@ -451,24 +426,27 @@ class _CollectionHandler(
         ):
             return
 
-        # Configure dense/multivectors based on whether they're named or unnamed.
+        # Dense and sparse defs share one namespace on our side; split them
+        # into Qdrant's two config maps here.
         vectors_config: (
             dict[str, qdrant_models.VectorParams] | qdrant_models.VectorParams | None
         ) = None
+        sparse_vectors_config: dict[str, qdrant_models.SparseVectorParams] | None = None
         if isinstance(schema.vectors, _ResolvedQdrantNamedVectorsDef):
-            vectors_config = {
+            dense = {
                 name: _vector_params_from_def(vector_def)
                 for name, vector_def in schema.vectors.vectors.items()
+                if isinstance(vector_def, _ResolvedQdrantVectorDef)
             }
-        elif schema.vectors is not None:
+            sparse = {
+                name: _sparse_vector_params_from_def(vector_def)
+                for name, vector_def in schema.vectors.vectors.items()
+                if isinstance(vector_def, _ResolvedQdrantSparseVectorDef)
+            }
+            vectors_config = dense or None
+            sparse_vectors_config = sparse or None
+        else:
             vectors_config = _vector_params_from_def(schema.vectors)
-
-        sparse_vectors_config: dict[str, qdrant_models.SparseVectorParams] | None = None
-        if schema.sparse_vectors is not None:
-            sparse_vectors_config = {
-                name: _sparse_vector_params_from_def(sparse_vector_def)
-                for name, sparse_vector_def in schema.sparse_vectors.sparse_vectors.items()
-            }
 
         await asyncio.to_thread(
             client.create_collection,
@@ -498,8 +476,7 @@ class _CollectionHandler(
         else:
             tracking_record = statediff.MutualTrackingRecord(
                 tracking_record=_CollectionTrackingRecordCore(
-                    vectors=desired_state.schema.vectors,
-                    sparse_vectors=desired_state.schema.sparse_vectors,
+                    vectors=desired_state.schema.vectors
                 ),
                 managed_by=desired_state.managed_by,
             )

--- a/python/tests/connectors/test_qdrant_target.py
+++ b/python/tests/connectors/test_qdrant_target.py
@@ -8,9 +8,14 @@ isn't set.
 
 from __future__ import annotations
 
+import os
+import uuid
+from typing import cast
+
 import pytest
 
 try:
+    from qdrant_client import QdrantClient
     from qdrant_client.http import models as qdrant_models
 
     HAS_QDRANT = True
@@ -24,13 +29,32 @@ requires_qdrant = pytest.mark.skipif(
 if HAS_QDRANT:
     import numpy as np
 
+    import cocoindex as coco
+    from cocoindex.connectors import qdrant
+    import msgspec
+
+    from cocoindex._internal import serde
     from cocoindex.connectors.qdrant._target import (
+        _CollectionHandler,
+        _CollectionTrackingRecordCore,
+        _PointHandler,
+        _ResolvedQdrantNamedVectorsDef,
         _ResolvedQdrantVectorDef,
+        _sparse_vector_params_from_def,
         _distance_from_spec,
         _multivector_comparator,
+        _validate_point_id,
         _vector_params_from_def,
     )
     from cocoindex.resources.schema import MultiVectorSchema, VectorSchema
+    from tests import common
+
+requires_qdrant_url = pytest.mark.skipif(
+    not os.environ.get("QDRANT_URL"), reason="QDRANT_URL is not set"
+)
+
+# A fixed valid point ID for tests (Qdrant only accepts u64 ints and UUIDs).
+_POINT_UUID = "550e8400-e29b-41d4-a716-446655440000"
 
 
 # =============================================================================
@@ -144,3 +168,253 @@ class TestVectorParamsFromDef:
             params.multivector_config.comparator
             == qdrant_models.MultiVectorComparator.MAX_SIM
         )
+
+
+# =============================================================================
+# Unit tests — sparse vectors
+# =============================================================================
+
+
+@requires_qdrant
+class TestSparseVectorSupport:
+    @pytest.mark.asyncio
+    async def test_collection_schema_create_resolves_sparse_vector_params(self) -> None:
+        schema = await qdrant.CollectionSchema.create(
+            vectors={
+                "dense": qdrant.QdrantVectorDef(
+                    schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
+                )
+            },
+            sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
+        )
+
+        assert schema.sparse_vectors is not None
+        sparse_def = schema.sparse_vectors.sparse_vectors["sparse"]
+        params = _sparse_vector_params_from_def(sparse_def)
+        assert isinstance(params, qdrant_models.SparseVectorParams)
+        assert params.modifier == qdrant_models.Modifier.IDF
+
+    @pytest.mark.asyncio
+    async def test_create_collection_forwards_sparse_vectors_config(self) -> None:
+        class FakeQdrantClient:
+            def __init__(self) -> None:
+                self.create_kwargs: dict[str, object] | None = None
+
+            def create_collection(self, **kwargs: object) -> bool:
+                self.create_kwargs = kwargs
+                return True
+
+        schema = await qdrant.CollectionSchema.create(
+            vectors={
+                "dense": qdrant.QdrantVectorDef(
+                    schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
+                )
+            },
+            sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
+        )
+        client = FakeQdrantClient()
+
+        await _CollectionHandler()._create_collection(
+            client,  # type: ignore[arg-type]
+            "test_sparse_config",
+            schema,
+            if_not_exists=False,
+        )
+
+        assert client.create_kwargs is not None
+        sparse_config = client.create_kwargs["sparse_vectors_config"]
+        assert isinstance(sparse_config, dict)
+        assert set(sparse_config) == {"sparse"}
+        assert isinstance(sparse_config["sparse"], qdrant_models.SparseVectorParams)
+        assert sparse_config["sparse"].modifier == qdrant_models.Modifier.IDF
+
+    def test_point_fingerprint_changes_when_sparse_vector_changes(self) -> None:
+        handler = _PointHandler(
+            client=cast(QdrantClient, object()),
+            collection_name="test_sparse_fingerprint",
+        )
+        point_v1 = qdrant.PointStruct(
+            id=_POINT_UUID,
+            vector={
+                "dense": [0.1, 0.2, 0.3, 0.4],
+                "sparse": qdrant_models.SparseVector(indices=[1, 7], values=[0.5, 0.9]),
+            },
+            payload={"text": "hello"},
+        )
+        point_v2 = qdrant.PointStruct(
+            id=_POINT_UUID,
+            vector={
+                "dense": [0.1, 0.2, 0.3, 0.4],
+                "sparse": qdrant_models.SparseVector(indices=[1, 7], values=[0.5, 1.1]),
+            },
+            payload={"text": "hello"},
+        )
+
+        out_v1 = handler.reconcile(_POINT_UUID, point_v1, [], True)
+        out_v2 = handler.reconcile(_POINT_UUID, point_v2, [], True)
+
+        assert out_v1 is not None
+        assert out_v2 is not None
+        assert out_v1.tracking_record != out_v2.tracking_record, (
+            "sparse vector indices/values must participate in point change detection"
+        )
+
+
+# =============================================================================
+# Unit tests — point ID validation (mirrors Qdrant's server-side rules)
+# =============================================================================
+
+
+@requires_qdrant
+class TestPointIdValidation:
+    """Matrix verified against a live Qdrant 1.18 server over REST and gRPC."""
+
+    def test_valid_ids_pass_through(self) -> None:
+        assert _validate_point_id(0) == 0
+        assert _validate_point_id(2**64 - 1) == 2**64 - 1
+        assert _validate_point_id(_POINT_UUID) == _POINT_UUID
+        hex_form = uuid.UUID(_POINT_UUID).hex
+        assert _validate_point_id(hex_form) == hex_form
+        urn_form = f"urn:uuid:{_POINT_UUID}"
+        assert _validate_point_id(urn_form) == urn_form
+
+    def test_uuid_instance_converted_to_string(self) -> None:
+        assert _validate_point_id(uuid.UUID(_POINT_UUID)) == _POINT_UUID
+
+    def test_arbitrary_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="strings must be UUIDs"):
+            _validate_point_id("chunk-1")
+
+    def test_out_of_range_ints_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unsigned 64-bit range"):
+            _validate_point_id(-1)
+        with pytest.raises(ValueError, match="unsigned 64-bit range"):
+            _validate_point_id(2**64)
+
+    def test_other_types_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid Qdrant point ID of type"):
+            _validate_point_id(1.5)
+
+
+# =============================================================================
+# Unit tests — tracking record upgrade compatibility
+# =============================================================================
+
+
+@requires_qdrant
+class TestTrackingRecordUpgradeCompat:
+    def test_pre_sparse_tracking_record_decodes_equal_to_dense_only(self) -> None:
+        """Records written before sparse-vector support must decode equal to a
+        new dense-only record — otherwise every existing collection would be
+        destructively replaced (and its data lost) on upgrade."""
+
+        class PreSparseCore(msgspec.Struct, frozen=True, array_like=True):
+            vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
+
+        dense = _ResolvedQdrantNamedVectorsDef(
+            vectors={
+                "dense": _ResolvedQdrantVectorDef(
+                    schema=VectorSchema(dtype=np.dtype(np.float32), size=4),
+                    distance="cosine",
+                    multivector_comparator="max_sim",
+                )
+            }
+        )
+        old_bytes = serde._msgspec_encoder.encode(PreSparseCore(vectors=dense))
+        decoded = msgspec.msgpack.Decoder(
+            type=_CollectionTrackingRecordCore,
+            ext_hook=serde._ext_hook,
+            dec_hook=serde._dec_hook,
+        ).decode(old_bytes)
+        assert decoded == _CollectionTrackingRecordCore(
+            vectors=dense, sparse_vectors=None
+        )
+
+
+# =============================================================================
+# Live test — Qdrant service required
+# =============================================================================
+
+
+@requires_qdrant
+@requires_qdrant_url
+def test_live_dense_sparse_vectors_and_hybrid_query() -> None:
+    qdrant_url = os.environ["QDRANT_URL"]
+    client = qdrant.create_client(qdrant_url, prefer_grpc=True)
+    collection_name = f"coco_sparse_{uuid.uuid4().hex}"
+    db_key = coco.ContextKey[QdrantClient](f"test_qdrant_sparse_{uuid.uuid4().hex}")
+    env = common.create_test_env(__file__, suffix=collection_name)
+    env.context_provider.provide(db_key, client)
+
+    @coco.fn
+    async def app_main() -> None:
+        target = await qdrant.mount_collection_target(
+            db_key,
+            collection_name,
+            await qdrant.CollectionSchema.create(
+                vectors={
+                    "dense": qdrant.QdrantVectorDef(
+                        schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
+                    )
+                },
+                sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
+            ),
+        )
+        target.declare_point(
+            qdrant.PointStruct(
+                id=1,
+                vector={
+                    "dense": [0.1, 0.2, 0.3, 0.4],
+                    "sparse": qdrant_models.SparseVector(
+                        indices=[1, 7], values=[0.5, 0.9]
+                    ),
+                },
+                payload={"text": "hybrid sparse dense"},
+            )
+        )
+
+    app = coco.App(
+        coco.AppConfig(name="test_qdrant_sparse_hybrid", environment=env),
+        app_main,
+    )
+
+    try:
+        app.update_blocking()
+
+        dense_result = client.query_points(
+            collection_name=collection_name,
+            query=[0.1, 0.2, 0.3, 0.4],
+            using="dense",
+            limit=1,
+            with_payload=True,
+        )
+        assert [p.id for p in dense_result.points] == [1]
+
+        sparse_query = qdrant_models.SparseVector(indices=[1, 7], values=[0.5, 0.9])
+        sparse_result = client.query_points(
+            collection_name=collection_name,
+            query=sparse_query,
+            using="sparse",
+            limit=1,
+            with_payload=True,
+        )
+        assert [p.id for p in sparse_result.points] == [1]
+
+        hybrid_result = client.query_points(
+            collection_name=collection_name,
+            prefetch=[
+                qdrant_models.Prefetch(
+                    query=[0.1, 0.2, 0.3, 0.4], using="dense", limit=10
+                ),
+                qdrant_models.Prefetch(query=sparse_query, using="sparse", limit=10),
+            ],
+            query=qdrant_models.FusionQuery(fusion=qdrant_models.Fusion.RRF),
+            limit=1,
+            with_payload=True,
+        )
+        assert [p.id for p in hybrid_result.points] == [1]
+    finally:
+        try:
+            client.delete_collection(collection_name=collection_name)
+        except Exception:
+            pass

--- a/python/tests/connectors/test_qdrant_target.py
+++ b/python/tests/connectors/test_qdrant_target.py
@@ -39,6 +39,7 @@ if HAS_QDRANT:
         _CollectionTrackingRecordCore,
         _PointHandler,
         _ResolvedQdrantNamedVectorsDef,
+        _ResolvedQdrantSparseVectorDef,
         _ResolvedQdrantVectorDef,
         _sparse_vector_params_from_def,
         _distance_from_spec,
@@ -183,19 +184,34 @@ class TestSparseVectorSupport:
             vectors={
                 "dense": qdrant.QdrantVectorDef(
                     schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
-                )
+                ),
+                "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
             },
-            sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
         )
 
-        assert schema.sparse_vectors is not None
-        sparse_def = schema.sparse_vectors.sparse_vectors["sparse"]
+        assert isinstance(schema.vectors, _ResolvedQdrantNamedVectorsDef)
+        sparse_def = schema.vectors.vectors["sparse"]
+        assert isinstance(sparse_def, _ResolvedQdrantSparseVectorDef)
         params = _sparse_vector_params_from_def(sparse_def)
         assert isinstance(params, qdrant_models.SparseVectorParams)
         assert params.modifier == qdrant_models.Modifier.IDF
 
     @pytest.mark.asyncio
-    async def test_create_collection_forwards_sparse_vectors_config(self) -> None:
+    async def test_sparse_only_schema_and_bare_sparse_rejected(self) -> None:
+        schema = await qdrant.CollectionSchema.create(
+            vectors={"sparse": qdrant.QdrantSparseVectorDef()},
+        )
+        assert isinstance(schema.vectors, _ResolvedQdrantNamedVectorsDef)
+
+        with pytest.raises(ValueError, match="always named"):
+            await qdrant.CollectionSchema.create(
+                vectors=qdrant.QdrantSparseVectorDef(),  # type: ignore[arg-type]
+            )
+        with pytest.raises(ValueError, match="at least one vector"):
+            await qdrant.CollectionSchema.create()
+
+    @pytest.mark.asyncio
+    async def test_create_collection_splits_dense_and_sparse_configs(self) -> None:
         class FakeQdrantClient:
             def __init__(self) -> None:
                 self.create_kwargs: dict[str, object] | None = None
@@ -208,9 +224,9 @@ class TestSparseVectorSupport:
             vectors={
                 "dense": qdrant.QdrantVectorDef(
                     schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
-                )
+                ),
+                "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
             },
-            sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
         )
         client = FakeQdrantClient()
 
@@ -222,11 +238,40 @@ class TestSparseVectorSupport:
         )
 
         assert client.create_kwargs is not None
+        dense_config = client.create_kwargs["vectors_config"]
+        assert isinstance(dense_config, dict)
+        assert set(dense_config) == {"dense"}
         sparse_config = client.create_kwargs["sparse_vectors_config"]
         assert isinstance(sparse_config, dict)
         assert set(sparse_config) == {"sparse"}
         assert isinstance(sparse_config["sparse"], qdrant_models.SparseVectorParams)
         assert sparse_config["sparse"].modifier == qdrant_models.Modifier.IDF
+
+    @pytest.mark.asyncio
+    async def test_create_collection_sparse_only_passes_no_dense_config(self) -> None:
+        class FakeQdrantClient:
+            def __init__(self) -> None:
+                self.create_kwargs: dict[str, object] | None = None
+
+            def create_collection(self, **kwargs: object) -> bool:
+                self.create_kwargs = kwargs
+                return True
+
+        schema = await qdrant.CollectionSchema.create(
+            vectors={"sparse": qdrant.QdrantSparseVectorDef()},
+        )
+        client = FakeQdrantClient()
+        await _CollectionHandler()._create_collection(
+            client,  # type: ignore[arg-type]
+            "test_sparse_only",
+            schema,
+            if_not_exists=False,
+        )
+        assert client.create_kwargs is not None
+        assert client.create_kwargs["vectors_config"] is None
+        sparse_config = client.create_kwargs["sparse_vectors_config"]
+        assert isinstance(sparse_config, dict)
+        assert set(sparse_config) == {"sparse"}
 
     def test_point_fingerprint_changes_when_sparse_vector_changes(self) -> None:
         handler = _PointHandler(
@@ -303,31 +348,47 @@ class TestPointIdValidation:
 
 @requires_qdrant
 class TestTrackingRecordUpgradeCompat:
-    def test_pre_sparse_tracking_record_decodes_equal_to_dense_only(self) -> None:
+    def test_pre_sparse_tracking_record_compat(self) -> None:
         """Records written before sparse-vector support must decode equal to a
-        new dense-only record — otherwise every existing collection would be
-        destructively replaced (and its data lost) on upgrade."""
+        new dense-only record, and a new dense-only record must encode to the
+        same bytes as before — otherwise existing collections would be
+        destructively replaced (and their data lost) on upgrade."""
+
+        # Pre-sparse on-disk shape: inner dict values were the bare dense
+        # struct, not the dense|sparse tagged union. The explicit tag pins
+        # the historical class name so the encoding matches old records.
+        class PreSparseNamed(
+            msgspec.Struct, frozen=True, tag="_ResolvedQdrantNamedVectorsDef"
+        ):
+            vectors: dict[str, _ResolvedQdrantVectorDef]
 
         class PreSparseCore(msgspec.Struct, frozen=True, array_like=True):
-            vectors: _ResolvedQdrantVectorDef | _ResolvedQdrantNamedVectorsDef
+            vectors: _ResolvedQdrantVectorDef | PreSparseNamed
 
-        dense = _ResolvedQdrantNamedVectorsDef(
-            vectors={
-                "dense": _ResolvedQdrantVectorDef(
-                    schema=VectorSchema(dtype=np.dtype(np.float32), size=4),
-                    distance="cosine",
-                    multivector_comparator="max_sim",
-                )
-            }
+        dense_def = _ResolvedQdrantVectorDef(
+            schema=VectorSchema(dtype=np.dtype(np.float32), size=4),
+            distance="cosine",
+            multivector_comparator="max_sim",
         )
-        old_bytes = serde._msgspec_encoder.encode(PreSparseCore(vectors=dense))
+        old_bytes = serde._msgspec_encoder.encode(
+            PreSparseCore(vectors=PreSparseNamed(vectors={"dense": dense_def}))
+        )
+
+        new_record = _CollectionTrackingRecordCore(
+            vectors=_ResolvedQdrantNamedVectorsDef(vectors={"dense": dense_def})
+        )
         decoded = msgspec.msgpack.Decoder(
             type=_CollectionTrackingRecordCore,
             ext_hook=serde._ext_hook,
             dec_hook=serde._dec_hook,
         ).decode(old_bytes)
-        assert decoded == _CollectionTrackingRecordCore(
-            vectors=dense, sparse_vectors=None
+        assert decoded == new_record, "old records must decode equal to new"
+
+        new_bytes = serde._msgspec_encoder.encode(new_record)
+        assert new_bytes == old_bytes, (
+            "dense-only records must encode byte-identically to pre-sparse "
+            "records; a byte change would flip the statediff and destroy "
+            "existing collections on upgrade"
         )
 
 
@@ -355,9 +416,9 @@ def test_live_dense_sparse_vectors_and_hybrid_query() -> None:
                 vectors={
                     "dense": qdrant.QdrantVectorDef(
                         schema=VectorSchema(dtype=np.dtype(np.float32), size=4)
-                    )
+                    ),
+                    "sparse": qdrant.QdrantSparseVectorDef(modifier="idf"),
                 },
-                sparse_vectors={"sparse": qdrant.QdrantSparseVectorDef(modifier="idf")},
             ),
         )
         target.declare_point(


### PR DESCRIPTION
Adds native sparse vector support to the Qdrant connector, plus eager point-ID validation and corrections to the Qdrant docs.

## Sparse vectors

- New `QdrantSparseVectorDef` and `CollectionSchema.create(..., sparse_vectors={...})` (keyword-only). Sparse vectors are always named, per Qdrant's model; `modifier="idf"` maps to `models.Modifier.IDF`.
- Collections are created with native `sparse_vectors_config` — sparse data lives in `PointStruct.vector`, never in payload. `vectors_config=None` is supported for sparse-only collections.
- The collection tracking record now includes the sparse config, so adding/changing sparse vectors triggers collection replacement (destructive child invalidation, same as dense schema changes).

**Upgrade safety (data-loss guard):** the new field is a trailing `msgspec` field with a default, so tracking records written before this change decode equal to a new dense-only record — existing collections are *not* spuriously drop-and-recreated on upgrade. This is pinned by `TestTrackingRecordUpgradeCompat`, which round-trips a pre-sparse-shaped record through the engine's real serde hooks.

## Point-ID validation (and docs correction)

Qdrant only accepts **unsigned 64-bit integers and UUIDs** as point IDs — [Qdrant: Point IDs](https://qdrant.tech/documentation/manage-data/points/#point-ids). Confirmed empirically against Qdrant 1.18 over both REST and gRPC: arbitrary strings like `"doc-123"` are rejected by the server; UUID strings are accepted in hyphenated, 32-char-hex, and URN forms; ints outside `[0, 2**64)` are rejected.

- `declare_point` now validates eagerly and raises `ValueError` with the rule, the doc link, and a `uuid.uuid5` recipe for string-derived stable IDs.
- **Failure-mode note for reviewers:** this moves the failure from apply time to declare time. Previously an invalid ID surfaced as an opaque transport error during sink apply (after the collection side effects); now it raises inside the component before any side effects. No previously-working ID is affected — invalid IDs never succeeded against a real server.
- Docs: the "Point IDs" section previously claimed arbitrary strings work ("All other types are converted to strings automatically") — rewritten to the real rule with the official link; the two `id="doc-123"` examples fixed; search examples migrated from the removed `client.search` to `query_points` (incl. hybrid RRF example); `face_recognition` drops its dead `client.search` fallback, fixing full `mypy`.

## Tests

New: sparse param resolution; fake-client `create_collection` kwarg forwarding; sparse-vector participation in point fingerprints; the full point-ID accept/reject matrix; tracking-record upgrade compat; and a `QDRANT_URL`-gated live test that creates a dense+sparse collection through CocoIndex, upserts, and queries dense, sparse, and hybrid (RRF fusion) successfully.

**Mutation checks** (each fix verified to be load-bearing):
- Removing `sparse_vectors_config` from `create_collection` → fake-client test fails.
- Moving the sparse vector into payload instead of `PointStruct.vector` → live sparse query returns `[]`, test fails.
- Neutering ID validation → `test_arbitrary_string_rejected` fails.

## Verification

- `pytest python/tests/connectors/test_qdrant_target.py` with live Qdrant (Docker, gRPC): 25 passed
- Full `pytest python/`: 910 passed, 232 skipped
- `uv run mypy`: clean (260 files; includes the `face_recognition` fix)
- `uv run ruff format --check .`: clean; docs build: clean
