### PR TITLE
fix(postgres): recursively strip NUL (U+0000) from array and composite bindings

### DIFF
--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -1301,15 +1301,10 @@ class TableTarget(
 
             if value is not None and col.encoder is not None:
                 value = col.encoder(value)
-            # Strip NUL from values bound to Postgres.  Scalar strings hit
-            # the fast path; lists/tuples (array and composite columns) are
-            # walked recursively.  jsonb columns are already handled inside
-            # `_json_encoder`, so the recursive walk is a harmless no-op on
-            # the encoded JSON string.
-            if isinstance(value, str):
-                value = _strip_nul(value)
-            elif isinstance(value, (list, tuple)):
-                value = _sanitize_nul(value)
+            # Strip NUL from values bound to Postgres recursively. jsonb columns
+            # are already handled inside `_json_encoder`, so the recursive walk
+            # is a harmless no-op on the encoded JSON string.
+            value = _sanitize_nul(value)
             out[col_name] = value
         return out
 

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -135,15 +135,20 @@ def _strip_nul(s: str) -> str:
 def _sanitize_nul(value: Any) -> Any:
     """Recursively strip NUL from strings, dict keys, and nested containers.
 
-    Applied to jsonb payloads before ``json.dumps`` so nested strings — and
-    dict keys — don't surface as ``\\u0000`` escapes in the serialized JSON
-    (which Postgres rejects when parsing ``jsonb``).
+    Applied to jsonb payloads before ``json.dumps`` and to array / composite
+    column values before they are bound to asyncpg.  Nested strings — and
+    dict keys — are cleaned so Postgres never sees ``U+0000``.
+
+    ``tuple`` inputs are returned as ``tuple`` (asyncpg relies on ``tuple``
+    for Postgres composite types); ``list`` inputs remain ``list``.
     """
     if isinstance(value, str):
         return _strip_nul(value)
     if isinstance(value, dict):
         return {_sanitize_nul(k): _sanitize_nul(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, tuple):
+        return tuple(_sanitize_nul(v) for v in value)
+    if isinstance(value, list):
         return [_sanitize_nul(v) for v in value]
     return value
 
@@ -1296,14 +1301,15 @@ class TableTarget(
 
             if value is not None and col.encoder is not None:
                 value = col.encoder(value)
-            # Strip NUL from any string bound directly to Postgres. Text-family
-            # columns reject it; jsonb columns are already handled inside
-            # `_json_encoder` (nested strings + dict keys), so this is a no-op
-            # on the encoded JSON string but catches `text`/`varchar`/`citext`/
-            # custom-typed str columns regardless of whether the user supplied
-            # an encoder.
+            # Strip NUL from values bound to Postgres.  Scalar strings hit
+            # the fast path; lists/tuples (array and composite columns) are
+            # walked recursively.  jsonb columns are already handled inside
+            # `_json_encoder`, so the recursive walk is a harmless no-op on
+            # the encoded JSON string.
             if isinstance(value, str):
                 value = _strip_nul(value)
+            elif isinstance(value, (list, tuple)):
+                value = _sanitize_nul(value)
             out[col_name] = value
         return out
 

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -1108,3 +1108,12 @@ def test_sanitize_nul_preserves_list() -> None:
     assert result == ["xy", ["nestedz"]]
     assert isinstance(result, list)
     assert isinstance(result[1], list)
+
+
+def test_sanitize_nul_preserves_dict() -> None:
+    """``_sanitize_nul`` must return ``dict`` when given ``dict`` input, with keys and values sanitized."""
+    inp = {"a\x00b": "c\x00d", "e": {"f\x00g": "h"}}
+    result = postgres._target._sanitize_nul(inp)
+    assert result == {"ab": "cd", "e": {"fg": "h"}}
+    assert isinstance(result, dict)
+    assert isinstance(result["e"], dict)

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -1023,3 +1023,88 @@ async def test_schema_evolution_incompatible_fallback(
 
     finally:
         await _drop_table(pool, table_name)
+
+
+@pytest.mark.asyncio
+async def test_postgres_strips_nul_in_array_columns(pg_env: _PgEnv) -> None:
+    """U+0000 (NUL) inside array element strings must be stripped before asyncpg
+    binds them to Postgres.
+
+    Prior to the fix, ``_row_to_dict`` only called ``_strip_nul`` on scalar
+    ``str`` values.  A ``list[str]`` bound to a ``text[]`` column bypassed
+    sanitization entirely, causing asyncpg to raise ``ValueError: string
+    cannot contain NUL (0x00) characters``.
+    """
+    pool = pg_env.pool
+    coco_env = pg_env.coco_env
+    table_name = _unique_name("test_arr_nul")
+
+    schema: postgres.TableSchema[dict[str, Any]] = postgres.TableSchema(
+        columns={
+            "id": postgres.ColumnDef("text", nullable=False),
+            "tags": postgres.ColumnDef("text[]"),
+        },
+        primary_key=["id"],
+    )
+
+    rows: list[dict[str, Any]] = [
+        {"id": "row1", "tags": ["clean", "has\x00nul", "also\x00bad"]},
+        {"id": "row2", "tags": ["all", "clean"]},
+    ]
+
+    try:
+
+        async def declare_fn() -> None:
+            table = await coco.use_mount(
+                coco.component_subpath("setup", "table"),
+                postgres.declare_table_target,
+                _PG_DB_KEY,
+                table_name,
+                schema,
+            )
+            for row in rows:
+                table.declare_row(row=row)
+
+        app = coco.App(
+            coco.AppConfig(name=f"test_arr_nul_{table_name}", environment=coco_env),
+            declare_fn,
+        )
+        await app.update()
+
+        async with pool.acquire() as conn:
+            row1 = await conn.fetchrow(
+                f'SELECT "tags" FROM "{table_name}" WHERE "id" = $1', "row1"
+            )
+            row2 = await conn.fetchrow(
+                f'SELECT "tags" FROM "{table_name}" WHERE "id" = $1', "row2"
+            )
+
+        assert row1 is not None
+        assert list(row1["tags"]) == ["clean", "hasnul", "alsobad"]
+        assert row2 is not None
+        assert list(row2["tags"]) == ["all", "clean"]
+
+    finally:
+        await _drop_table(pool, table_name)
+
+
+def test_sanitize_nul_preserves_tuple() -> None:
+    """``_sanitize_nul`` must return ``tuple`` when given ``tuple`` input.
+
+    asyncpg uses ``tuple`` to represent Postgres composite (record) types.
+    Converting to ``list`` silently changes the wire encoding.
+    """
+    inp = ("a\x00b", "c", ("inner\x00d",))
+    result = postgres._target._sanitize_nul(inp)
+    assert result == ("ab", "c", ("innerd",))
+    assert isinstance(result, tuple)
+    assert isinstance(result[2], tuple)
+
+
+def test_sanitize_nul_preserves_list() -> None:
+    """``_sanitize_nul`` must return ``list`` when given ``list`` input."""
+    inp = ["x\x00y", ["nested\x00z"]]
+    result = postgres._target._sanitize_nul(inp)
+    assert result == ["xy", ["nestedz"]]
+    assert isinstance(result, list)
+    assert isinstance(result[1], list)


### PR DESCRIPTION
## Summary

Fixes a bug where strings containing NUL (`U+0000`) inside Postgres array (`text[]`) or composite values bypass sanitization and cause `asyncpg` to fail with:
```
ValueError: string cannot contain NUL (0x00) characters
```

### Root Cause
In `postgres/_target.py`, `_row_to_dict` only stripped NUL from scalar string values and JSONB column payloads. Strings bound within native array columns (`text[]`, `varchar[]`) and composite types (`tuple`) bypassed sanitization completely.

### Fix
1. **Extend `_sanitize_nul`:** Updated the walker to recursively strip NUL from lists and tuples, ensuring that `tuple` objects return `tuple` (crucial for `asyncpg` composite type adapters) and `list` objects return `list`.
2. **Apply to Containers in `_row_to_dict`:** Updated parameter mapping to apply `_sanitize_nul` to list and tuple structures.
3. **Tests:** Added comprehensive regression tests to verify that `text[]` columns correctly strip NUL from array strings and unit tests to ensure collections retain correct type structures.

Refs #933
