### PR TITLE
feat(lancedb): optimize table maintenance from LanceDB stats

### DIFF
--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -71,7 +71,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 #### Tables (parent state)
 
-Declares a table as a target state. Returns a `TableTarget` for declaring rows.
+Declares a table as a target state. Returns a pending `TableTarget` for declaring rows.
 
 ```python
 def declare_table_target(
@@ -79,7 +79,7 @@ def declare_table_target(
     table_name: str,
     table_schema: TableSchema[RowT],
     *,
-    managed_by: Literal["system", "user"] = "system",
+    managed_by: ManagedBy = ManagedBy.SYSTEM,
 ) -> TableTarget[RowT, coco.PendingS]
 ```
 
@@ -89,8 +89,34 @@ def declare_table_target(
 - `table_name` — Name of the table.
 - `table_schema` — Schema definition including columns and primary key (see [Table Schema](#table-schema-from-python-class)).
 - `managed_by` — Whether CocoIndex manages the table lifecycle (`"system"`) or assumes it exists (`"user"`).
+  `ManagedBy` is exported from `cocoindex.connectorkits.target`.
 
-**Returns:** A pending `TableTarget`. Use the convenience wrapper `await lancedb.mount_table_target(LANCE_DB, table_name, table_schema)` to resolve.
+**Returns:** A pending `TableTarget`. Resolve it with `await target`.
+
+For the common case where you want a ready-to-use target immediately, use `mount_table_target()`:
+
+```python
+async def mount_table_target(
+    db: ContextKey[LanceAsyncConnection],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    managed_by: ManagedBy = ManagedBy.SYSTEM,
+) -> TableTarget[RowT]
+```
+
+For lower-level composition with `coco.mount_target()`, `table_target()` returns the raw target
+state:
+
+```python
+def table_target(
+    db: ContextKey[LanceAsyncConnection],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    managed_by: ManagedBy = ManagedBy.SYSTEM,
+) -> coco.TargetState
+```
 
 CocoIndex automatically runs LanceDB `table.optimize()` when durable table and index statistics
 cross internal maintenance thresholds, such as small fragments, deletion files, or unindexed
@@ -265,6 +291,12 @@ class MyRow:
     value: Annotated[float, LanceType(pa.float32())]
 ```
 
+`LanceType` also accepts an optional encoder for values that need conversion before writing:
+
+```python
+LanceType(pa.string(), encoder=lambda value: json.dumps(value))
+```
+
 #### VectorSchemaProvider
 
 For `NDArray` fields, a `VectorSchemaProvider` annotation specifies the vector dimension and dtype. The annotation accepts a `VectorSchemaProvider`, a `ContextKey`, or an explicit `VectorSchema`. See [Vector Schema](../common_resources/vector_schema#vectorschemaprovider) for details.
@@ -278,8 +310,23 @@ def TableSchema.__init__(
     self,
     columns: dict[str, ColumnDef],
     primary_key: list[str],
+    *,
+    row_type: type[RowT] | None = None,
 ) -> None
 ```
+
+`ColumnDef` has the following fields:
+
+```python
+class ColumnDef(NamedTuple):
+    type: pa.DataType
+    nullable: bool = True
+    encoder: Callable[[Any], Any] | None = None
+```
+
+- `type` — PyArrow type stored in LanceDB.
+- `nullable` — Whether the column may contain null values.
+- `encoder` — Optional function to convert values before writing them.
 
 **Example:**
 

--- a/docs/src/content/docs/connectors/lancedb.mdx
+++ b/docs/src/content/docs/connectors/lancedb.mdx
@@ -80,7 +80,6 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: Literal["system", "user"] = "system",
-    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT, coco.PendingS]
 ```
 
@@ -90,9 +89,24 @@ def declare_table_target(
 - `table_name` — Name of the table.
 - `table_schema` — Schema definition including columns and primary key (see [Table Schema](#table-schema-from-python-class)).
 - `managed_by` — Whether CocoIndex manages the table lifecycle (`"system"`) or assumes it exists (`"user"`).
-- `num_transactions_before_optimize` — Number of successful row mutation batches before scheduling a background LanceDB `table.optimize()` call.
 
 **Returns:** A pending `TableTarget`. Use the convenience wrapper `await lancedb.mount_table_target(LANCE_DB, table_name, table_schema)` to resolve.
+
+CocoIndex automatically runs LanceDB `table.optimize()` when durable table and index statistics
+cross internal maintenance thresholds, such as small fragments, deletion files, or unindexed
+index tails. This is stats-driven rather than transaction-count-driven, so it works across
+many short incremental runs as well as long-running updates.
+
+Table optimization compacts small fragments, cleans up deletion files, and reindexes new data so
+the freshest rows are available through declared indexes; see LanceDB's
+[compaction and cleanup](https://docs.lancedb.com/performance#compaction-and-cleanup) guidance.
+
+:::note
+Automatic optimize runs inline with CocoIndex's row-mutation path. To avoid LanceDB optimistic
+commit conflicts, use CocoIndex as the owner of writes that sync source data into the table.
+External LanceDB connections outside CocoIndex should generally be read-only while CocoIndex is
+updating the table.
+:::
 
 #### Rows (child states)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ editable-profile = "dev" # local editable builds
 litellm = ["litellm>=1.81.0"]
 sentence_transformers = ["sentence-transformers>=3.3.1"]
 colpali = ["colpali-engine"]
-lancedb = ["lancedb>=0.33.0", "pyarrow>=23.0.0"]
+lancedb = ["lancedb>=0.34.0", "pyarrow>=23.0.0"]
 postgres = ["asyncpg>=0.31.0"]
 qdrant = ["qdrant-client>=1.6.0"]
 snowflake = ["snowflake-connector-python>=3.0.0"]
@@ -105,7 +105,7 @@ all = [
     "litellm>=1.81.0",
     "sentence-transformers>=3.3.1",
     "colpali-engine",
-    "lancedb>=0.33.0",
+    "lancedb>=0.34.0",
     "pyarrow>=23.0.0",
     "asyncpg>=0.31.0",
     "pgvector>=0.4.2",

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -8,7 +8,7 @@ This module provides a two-level target state system for LanceDB:
 
 from __future__ import annotations
 
-import asyncio
+import datetime as _datetime
 import json
 import logging
 from dataclasses import dataclass
@@ -56,6 +56,17 @@ import msgspec
 from cocoindex._internal.context_keys import ContextKey, ContextProvider
 
 _logger = logging.getLogger(__name__)
+
+_MAX_SMALL_FRAGMENTS = 200
+_MAX_DELETION_FILES = 64
+_MAX_UNINDEXED_ROWS = 20_000
+_UNINDEXED_FRACTION = 0.05
+_MIN_UNINDEXED_ROWS_FOR_FRACTION = 50
+_MAX_PRUNABLE_OLD_VERSIONS = 1_000
+_DEFAULT_VERSION_PRUNE_AGE = _datetime.timedelta(days=7)
+_VERSION_PRUNE_MARGIN = _datetime.timedelta(days=1)
+_MUTATED_ROWS_BETWEEN_STATS_CHECKS = 25
+_MIN_MUTATED_ROWS_BETWEEN_OPTIMIZE_ATTEMPTS = 1_000
 
 # Type aliases
 _RowKey = tuple[Any, ...]  # Primary key values as tuple
@@ -330,8 +341,7 @@ async def _drop_index_if_exists(
     """Drop an index by name if it currently exists on the table.
 
     LanceDB's ``drop_index`` only detaches the index from the table; the storage
-    is reclaimed on the next ``table.optimize()``, which the row handler already
-    schedules periodically after mutation batches.
+    is reclaimed on a later stats-driven ``table.optimize()`` from the row handler.
     """
     existing = {idx.name for idx in await table.list_indices()}
     if index_name not in existing:
@@ -350,16 +360,48 @@ class _RowAction(NamedTuple):
     track_only: bool = False  # True means advance tracking without mutating LanceDB.
 
 
+class _OptimizeDecision(NamedTuple):
+    should: bool
+    reasons: tuple[str, ...]
+
+
+def _metadata_int(metadata: dict[str, Any], key: str) -> int:
+    value = metadata.get(key)
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _count_prunable_old_versions(versions: Sequence[dict[str, Any]]) -> int:
+    cutoff = _datetime.datetime.now(_datetime.timezone.utc) - (
+        _DEFAULT_VERSION_PRUNE_AGE + _VERSION_PRUNE_MARGIN
+    )
+    count = 0
+    for version in versions:
+        timestamp = version.get("timestamp")
+        if not isinstance(timestamp, _datetime.datetime):
+            continue
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.astimezone(_datetime.timezone.utc)
+        else:
+            timestamp = timestamp.astimezone(_datetime.timezone.utc)
+        if timestamp <= cutoff:
+            count += 1
+    return count
+
+
 class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
     """Handler for row-level target states within a table."""
 
     _conn: LanceAsyncConnection
     _table_name: str
     _table_schema: TableSchema
-    _num_transactions_before_optimize: int
-    _num_applied_mutations: int
-    _optimize_lock: asyncio.Lock
-    _optimize_task: asyncio.Task[None] | None
+    _mutated_rows_since_check: int
+    _mutated_rows_since_optimize_attempt: int
+    _stats_checked_once: bool
     _sink: coco.TargetActionSink[_RowAction]
     _null_backfilled_columns: frozenset[str]
 
@@ -368,16 +410,16 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         conn: LanceAsyncConnection,
         table_name: str,
         table_schema: TableSchema,
-        num_transactions_before_optimize: int,
         null_backfilled_columns: Collection[str] = (),
     ) -> None:
         self._conn = conn
         self._table_name = table_name
         self._table_schema = table_schema
-        self._num_transactions_before_optimize = num_transactions_before_optimize
-        self._num_applied_mutations = 0
-        self._optimize_lock = asyncio.Lock()
-        self._optimize_task = None
+        self._mutated_rows_since_check = 0
+        self._mutated_rows_since_optimize_attempt = (
+            _MIN_MUTATED_ROWS_BETWEEN_OPTIMIZE_ATTEMPTS
+        )
+        self._stats_checked_once = False
         self._sink = coco.TargetActionSink.from_async_fn(self._apply_actions)
         self._null_backfilled_columns = frozenset(null_backfilled_columns)
 
@@ -413,7 +455,7 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         if deletes:
             await self._execute_deletes(table, deletes)
 
-        await self._maybe_optimize(table)
+        await self._maybe_optimize(table, mutation_count=len(upserts) + len(deletes))
 
     def _legacy_fingerprint_for_null_backfill(
         self, desired_state: _RowValue
@@ -442,51 +484,103 @@ class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
             return None
         return fingerprint_object(legacy_state)
 
-    async def _maybe_optimize(self, table: lancedb.table.AsyncTable) -> None:
-        """Periodically optimize the table after successful mutation batches."""
-        async with self._optimize_lock:
-            self._num_applied_mutations += 1
-            if self._num_applied_mutations >= self._num_transactions_before_optimize:
-                self._schedule_optimize_locked(table)
-
-    def _schedule_optimize_locked(self, table: lancedb.table.AsyncTable) -> None:
-        if self._optimize_task is not None and not self._optimize_task.done():
-            return
-        num_mutations_to_consume = self._num_applied_mutations
-        self._optimize_task = asyncio.create_task(
-            self._run_optimize(table, num_mutations_to_consume)
-        )
-
-    async def _run_optimize(
-        self, table: lancedb.table.AsyncTable, num_mutations_to_consume: int
+    async def _maybe_optimize(
+        self, table: lancedb.table.AsyncTable, *, mutation_count: int
     ) -> None:
-        succeeded = False
+        """Optimize the table when durable table stats cross maintenance thresholds."""
+        self._mutated_rows_since_check += mutation_count
+        self._mutated_rows_since_optimize_attempt += mutation_count
+
+        if (
+            self._stats_checked_once
+            and self._mutated_rows_since_check < _MUTATED_ROWS_BETWEEN_STATS_CHECKS
+        ):
+            return
+
+        if (
+            self._mutated_rows_since_optimize_attempt
+            < _MIN_MUTATED_ROWS_BETWEEN_OPTIMIZE_ATTEMPTS
+        ):
+            self._mutated_rows_since_check = 0
+            return
+
+        self._stats_checked_once = True
+        self._mutated_rows_since_check = 0
+
         try:
-            await table.optimize()
-            succeeded = True
+            decision = await self._evaluate_optimize(table)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.exception(
+                "Exception evaluating LanceDB optimize decision for table %s",
+                self._table_name,
+            )
+            return
+
+        if not decision.should:
+            return
+
+        self._mutated_rows_since_optimize_attempt = 0
+        try:
+            result = await table.optimize()
+            _logger.info(
+                "Optimized LanceDB table %s (%s): %s",
+                self._table_name,
+                ", ".join(decision.reasons),
+                result,
+            )
         except Exception:  # pylint: disable=broad-exception-caught
             _logger.exception(
                 "Exception in optimizing LanceDB table %s", self._table_name
             )
-        finally:
-            async with self._optimize_lock:
-                if asyncio.current_task() is self._optimize_task:
-                    self._optimize_task = None
-                    if succeeded:
-                        self._num_applied_mutations = max(
-                            0,
-                            self._num_applied_mutations - num_mutations_to_consume,
-                        )
-                        if (
-                            self._num_applied_mutations
-                            >= self._num_transactions_before_optimize
-                        ):
-                            self._schedule_optimize_locked(table)
-                    else:
-                        self._num_applied_mutations = max(
-                            self._num_applied_mutations,
-                            self._num_transactions_before_optimize,
-                        )
+
+    async def _evaluate_optimize(
+        self, table: lancedb.table.AsyncTable
+    ) -> _OptimizeDecision:
+        reasons: list[str] = []
+        stats = await table.stats()
+        fragment_stats = stats["fragment_stats"]
+        num_small_fragments = fragment_stats["num_small_fragments"]
+
+        if num_small_fragments >= _MAX_SMALL_FRAGMENTS:
+            reasons.append(
+                f"small_fragments={num_small_fragments}>={_MAX_SMALL_FRAGMENTS}"
+            )
+
+        if stats["num_indices"]:
+            for idx in await table.list_indices():
+                index_stats = await table.index_stats(idx.name)
+                if index_stats is None:
+                    continue
+
+                unindexed = index_stats.num_unindexed_rows
+                indexed = index_stats.num_indexed_rows
+                relative_threshold_exceeded = (
+                    indexed > 0
+                    and unindexed >= _MIN_UNINDEXED_ROWS_FOR_FRACTION
+                    and unindexed >= _UNINDEXED_FRACTION * indexed
+                )
+                if unindexed >= _MAX_UNINDEXED_ROWS or relative_threshold_exceeded:
+                    reasons.append(
+                        f"unindexed[{idx.name}]={unindexed} (indexed={indexed})"
+                    )
+
+        versions = await table.list_versions()
+        if versions:
+            latest_metadata = versions[-1].get("metadata", {})
+            deletion_files = _metadata_int(latest_metadata, "total_deletion_files")
+            if deletion_files >= _MAX_DELETION_FILES:
+                reasons.append(
+                    f"deletion_files={deletion_files}>={_MAX_DELETION_FILES}"
+                )
+
+        prunable_versions = _count_prunable_old_versions(versions)
+        if prunable_versions >= _MAX_PRUNABLE_OLD_VERSIONS:
+            reasons.append(
+                f"prunable_old_versions={prunable_versions}>="
+                f"{_MAX_PRUNABLE_OLD_VERSIONS}"
+            )
+
+        return _OptimizeDecision(should=bool(reasons), reasons=tuple(reasons))
 
     async def _execute_upserts(
         self,
@@ -823,7 +917,6 @@ class _TableSpec:
 
     table_schema: TableSchema[Any]
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
-    num_transactions_before_optimize: int = 50
 
 
 class _ColumnState(msgspec.Struct, frozen=True, array_like=True):
@@ -932,7 +1025,6 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                     conn=conn,
                     table_name=key.table_name,
                     table_schema=spec.table_schema,
-                    num_transactions_before_optimize=spec.num_transactions_before_optimize,
                     null_backfilled_columns=null_backfilled_columns,
                 )
                 outputs[i] = coco.ChildTargetDef(handler=handler)
@@ -1283,7 +1375,6 @@ def table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
-    num_transactions_before_optimize: int = 50,
 ) -> coco.TargetState[_RowHandler]:
     """
     Create a TargetState for a LanceDB table target.
@@ -1296,20 +1387,14 @@ def table_target(
         table_name: Name of the table.
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" or "user".
-        num_transactions_before_optimize: Number of successful row mutation batches
-            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TargetState that can be passed to ``mount_target()``.
     """
-    if num_transactions_before_optimize <= 0:
-        raise ValueError("num_transactions_before_optimize must be positive")
-
     key = _TableKey(db_key=db.key, table_name=table_name)
     spec = _TableSpec(
         table_schema=table_schema,
         managed_by=managed_by,
-        num_transactions_before_optimize=num_transactions_before_optimize,
     )
     return _table_provider.target_state(key, spec)
 
@@ -1320,7 +1405,6 @@ def declare_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
-    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT, coco.PendingS]:
     """
     Create a TableTarget for writing rows to a LanceDB table.
@@ -1331,8 +1415,6 @@ def declare_table_target(
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" (CocoIndex creates/drops it)
                     or "user" (table must exist, CocoIndex only manages rows).
-        num_transactions_before_optimize: Number of successful row mutation batches
-            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TableTarget that can be used to declare rows.
@@ -1343,7 +1425,6 @@ def declare_table_target(
             table_name,
             table_schema,
             managed_by=managed_by,
-            num_transactions_before_optimize=num_transactions_before_optimize,
         )
     )
     return TableTarget(provider, table_schema)
@@ -1355,7 +1436,6 @@ async def mount_table_target(
     table_schema: TableSchema[RowT],
     *,
     managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
-    num_transactions_before_optimize: int = 50,
 ) -> TableTarget[RowT]:
     """
     Mount a table target and return a ready-to-use TableTarget.
@@ -1367,8 +1447,6 @@ async def mount_table_target(
         table_name: Name of the table.
         table_schema: Schema definition including columns and primary key.
         managed_by: Whether the table is managed by "system" or "user".
-        num_transactions_before_optimize: Number of successful row mutation batches
-            before scheduling a background ``table.optimize()``.
 
     Returns:
         A TableTarget that can be used to declare rows.
@@ -1379,7 +1457,6 @@ async def mount_table_target(
             table_name,
             table_schema,
             managed_by=managed_by,
-            num_transactions_before_optimize=num_transactions_before_optimize,
         )
     )
     return TableTarget(provider, table_schema)

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
+import datetime as _datetime
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, Iterator, NamedTuple, cast
 
 import pytest
 
@@ -61,21 +61,72 @@ def lancedb_dir() -> Iterator[Path]:
 
 if HAS_LANCEDB:
 
+    class _FakeIndexConfig(NamedTuple):
+        name: str
+        columns: list[str]
+
+    class _FakeIndexStats(NamedTuple):
+        num_indexed_rows: int
+        num_unindexed_rows: int
+
+    def _fake_version(
+        *,
+        timestamp: _datetime.datetime | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "timestamp": timestamp or _datetime.datetime.now(),
+            "metadata": metadata or {},
+        }
+
     class _FakeAsyncTable:
         def __init__(
             self,
             *,
-            block: asyncio.Event | None = None,
             fail_once: bool = False,
+            stats_failure: bool = False,
+            num_small_fragments: int = 0,
+            index_stats: dict[str, _FakeIndexStats] | None = None,
+            versions: list[dict[str, Any]] | None = None,
         ) -> None:
             self.optimize_count = 0
-            self._block = block
+            self.stats_count = 0
             self._fail_once = fail_once
+            self._stats_failure = stats_failure
+            self._num_small_fragments = num_small_fragments
+            self._index_stats = index_stats or {}
+            self._versions = versions if versions is not None else [_fake_version()]
+
+        async def stats(self) -> dict[str, Any]:
+            self.stats_count += 1
+            if self._stats_failure:
+                raise RuntimeError("stats failed")
+            return {
+                "total_bytes": 0,
+                "num_rows": 0,
+                "num_indices": len(self._index_stats),
+                "fragment_stats": {
+                    "num_fragments": self._num_small_fragments,
+                    "num_small_fragments": self._num_small_fragments,
+                    "lengths": {},
+                },
+            }
+
+        async def list_indices(self) -> list[_FakeIndexConfig]:
+            return [
+                _FakeIndexConfig(name=name, columns=[name])
+                for name in self._index_stats
+            ]
+
+        async def index_stats(self, index_name: str) -> _FakeIndexStats | None:
+            return self._index_stats.get(index_name)
+
+        async def list_versions(self) -> list[dict[str, Any]]:
+            return self._versions
 
         async def optimize(self) -> None:
             self.optimize_count += 1
-            if self._block is not None:
-                await self._block.wait()
             if self._fail_once:
                 self._fail_once = False
                 raise RuntimeError("optimize failed")
@@ -157,11 +208,6 @@ if HAS_LANCEDB:
             },
             primary_key=["id"],
         )
-
-    async def _wait_for_optimize_task(handler: _target._RowHandler) -> None:
-        task = handler._optimize_task
-        if task is not None:
-            await task
 
 
 @pytest.mark.asyncio
@@ -331,7 +377,6 @@ def test_row_reconcile_tracks_only_nulls_from_new_nullable_columns() -> None:
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
         null_backfilled_columns={"extra"},
     )
 
@@ -364,7 +409,6 @@ def test_row_reconcile_upserts_non_null_value_for_new_nullable_column() -> None:
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
         null_backfilled_columns={"extra"},
     )
 
@@ -397,7 +441,6 @@ def test_row_reconcile_upserts_existing_column_change_with_new_null_column() -> 
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
         null_backfilled_columns={"extra"},
     )
 
@@ -430,7 +473,6 @@ def test_row_reconcile_upserts_when_previous_row_may_be_missing() -> None:
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
         null_backfilled_columns={"extra"},
     )
 
@@ -463,7 +505,6 @@ def test_row_reconcile_upserts_non_nullable_added_column() -> None:
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
     )
 
     old_row = {"id": "1", "name": "Alice"}
@@ -489,7 +530,6 @@ async def test_row_handler_track_only_actions_do_not_open_table_or_optimize() ->
         conn=cast(Any, conn),
         table_name="test_table",
         table_schema=_make_table_schema(),
-        num_transactions_before_optimize=1,
     )
 
     await handler._apply_actions(
@@ -607,107 +647,213 @@ async def test_add_multiple_columns_in_place(lancedb_dir: Path) -> None:
 
 @pytest.mark.asyncio
 @requires_lancedb
-async def test_row_handler_optimizes_after_configured_mutation_count() -> None:
-    table_schema = lancedb.TableSchema(
-        columns={
-            "id": lancedb.ColumnDef(type=pa.string(), nullable=False),
-            "name": lancedb.ColumnDef(type=pa.string()),
-        },
-        primary_key=["id"],
-    )
+async def test_row_handler_optimizes_for_small_fragments() -> None:
     handler = _target._RowHandler(
         conn=cast(Any, None),
         table_name="test_table",
-        table_schema=table_schema,
-        num_transactions_before_optimize=2,
+        table_schema=_make_table_schema(),
+    )
+    table = _FakeAsyncTable(num_small_fragments=_target._MAX_SMALL_FRAGMENTS)
+
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+
+    assert table.optimize_count == 1
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_optimizes_for_deletion_files() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+    )
+    table = _FakeAsyncTable(
+        versions=[
+            _fake_version(
+                metadata={
+                    "total_deletion_files": str(_target._MAX_DELETION_FILES),
+                }
+            )
+        ]
+    )
+
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+
+    assert table.optimize_count == 1
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_optimizes_for_unindexed_tail_on_all_index_types() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+    )
+    table = _FakeAsyncTable(
+        index_stats={
+            "vector_idx": _FakeIndexStats(
+                num_indexed_rows=100_000,
+                num_unindexed_rows=_target._MAX_UNINDEXED_ROWS,
+            ),
+            "fts_idx": _FakeIndexStats(
+                num_indexed_rows=100_000,
+                num_unindexed_rows=_target._MAX_UNINDEXED_ROWS,
+            ),
+        }
+    )
+
+    decision = await handler._evaluate_optimize(cast(Any, table))
+    assert decision.should is True
+    assert any(
+        reason.startswith("unindexed[vector_idx]=") for reason in decision.reasons
+    )
+    assert any(reason.startswith("unindexed[fts_idx]=") for reason in decision.reasons)
+
+
+@requires_lancedb
+def test_count_prunable_old_versions_ignores_young_versions() -> None:
+    now = _datetime.datetime.now(_datetime.timezone.utc)
+    old_enough = now - (
+        _target._DEFAULT_VERSION_PRUNE_AGE
+        + _target._VERSION_PRUNE_MARGIN
+        + _datetime.timedelta(seconds=1)
+    )
+    too_young = now - _target._DEFAULT_VERSION_PRUNE_AGE
+    versions = [
+        _fake_version(timestamp=old_enough),
+        _fake_version(timestamp=too_young),
+    ]
+
+    assert _target._count_prunable_old_versions(versions) == 1
+
+
+@requires_lancedb
+def test_count_prunable_old_versions_treats_naive_timestamps_as_local() -> None:
+    cutoff = _datetime.datetime.now(_datetime.timezone.utc) - (
+        _target._DEFAULT_VERSION_PRUNE_AGE + _target._VERSION_PRUNE_MARGIN
+    )
+    local_tz = _datetime.datetime.now().astimezone().tzinfo
+    assert local_tz is not None
+    old_enough_local = (cutoff - _datetime.timedelta(seconds=1)).astimezone(local_tz)
+
+    versions = [_fake_version(timestamp=old_enough_local.replace(tzinfo=None))]
+
+    assert _target._count_prunable_old_versions(versions) == 1
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_checks_stats_after_large_mutation_batch() -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
     )
     table = _FakeAsyncTable()
 
-    await handler._maybe_optimize(cast(Any, table))
-    assert table.optimize_count == 0
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+    table._num_small_fragments = _target._MAX_SMALL_FRAGMENTS
 
-    await handler._maybe_optimize(cast(Any, table))
-    await _wait_for_optimize_task(handler)
-    assert table.optimize_count == 1
+    await handler._maybe_optimize(
+        cast(Any, table),
+        mutation_count=_target._MUTATED_ROWS_BETWEEN_STATS_CHECKS,
+    )
 
-    await handler._maybe_optimize(cast(Any, table))
-    await _wait_for_optimize_task(handler)
     assert table.optimize_count == 1
 
 
 @pytest.mark.asyncio
 @requires_lancedb
-async def test_row_handler_does_not_overlap_optimize_tasks() -> None:
+async def test_row_handler_skips_stats_until_mutated_row_threshold() -> None:
     handler = _target._RowHandler(
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=_make_table_schema(),
-        num_transactions_before_optimize=1,
     )
-    unblock = asyncio.Event()
-    table = _FakeAsyncTable(block=unblock)
+    table = _FakeAsyncTable()
 
-    await handler._maybe_optimize(cast(Any, table))
-    await asyncio.sleep(0)
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+    table._num_small_fragments = _target._MAX_SMALL_FRAGMENTS
+    await handler._maybe_optimize(
+        cast(Any, table),
+        mutation_count=_target._MUTATED_ROWS_BETWEEN_STATS_CHECKS - 1,
+    )
+
+    assert table.optimize_count == 0
+    assert table.stats_count == 1
+
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
     assert table.optimize_count == 1
-
-    await handler._maybe_optimize(cast(Any, table))
-    await asyncio.sleep(0)
-    assert table.optimize_count == 1
-
-    unblock.set()
-    await _wait_for_optimize_task(handler)
 
 
 @pytest.mark.asyncio
 @requires_lancedb
-async def test_row_handler_preserves_mutations_during_optimize() -> None:
+async def test_row_handler_throttles_optimize_attempts_after_trigger() -> None:
     handler = _target._RowHandler(
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=_make_table_schema(),
-        num_transactions_before_optimize=2,
     )
-    unblock = asyncio.Event()
-    table = _FakeAsyncTable(block=unblock)
+    table = _FakeAsyncTable(num_small_fragments=_target._MAX_SMALL_FRAGMENTS)
 
-    await handler._maybe_optimize(cast(Any, table))
-    assert table.optimize_count == 0
-
-    await handler._maybe_optimize(cast(Any, table))
-    await asyncio.sleep(0)
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
     assert table.optimize_count == 1
 
-    await handler._maybe_optimize(cast(Any, table))
-    await asyncio.sleep(0)
+    await handler._maybe_optimize(
+        cast(Any, table),
+        mutation_count=_target._MUTATED_ROWS_BETWEEN_STATS_CHECKS,
+    )
     assert table.optimize_count == 1
 
-    unblock.set()
-    await _wait_for_optimize_task(handler)
-
-    await handler._maybe_optimize(cast(Any, table))
-    await _wait_for_optimize_task(handler)
+    await handler._maybe_optimize(
+        cast(Any, table),
+        mutation_count=(
+            _target._MIN_MUTATED_ROWS_BETWEEN_OPTIMIZE_ATTEMPTS
+            - _target._MUTATED_ROWS_BETWEEN_STATS_CHECKS
+        ),
+    )
     assert table.optimize_count == 2
 
 
 @pytest.mark.asyncio
 @requires_lancedb
-async def test_row_handler_retries_after_optimize_failure() -> None:
+async def test_row_handler_stats_failure_is_non_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     handler = _target._RowHandler(
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=_make_table_schema(),
-        num_transactions_before_optimize=1,
     )
-    table = _FakeAsyncTable(fail_once=True)
+    table = _FakeAsyncTable(stats_failure=True)
 
-    await handler._maybe_optimize(cast(Any, table))
-    await _wait_for_optimize_task(handler)
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+
+    assert table.optimize_count == 0
+    assert "Exception evaluating LanceDB optimize decision" in caplog.text
+
+
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_row_handler_optimize_failure_is_non_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler = _target._RowHandler(
+        conn=cast(Any, None),
+        table_name="test_table",
+        table_schema=_make_table_schema(),
+    )
+    table = _FakeAsyncTable(
+        fail_once=True,
+        num_small_fragments=_target._MAX_SMALL_FRAGMENTS,
+    )
+
+    await handler._maybe_optimize(cast(Any, table), mutation_count=1)
+
     assert table.optimize_count == 1
-
-    await handler._maybe_optimize(cast(Any, table))
-    await _wait_for_optimize_task(handler)
-    assert table.optimize_count == 2
+    assert "Exception in optimizing LanceDB table" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -720,14 +866,12 @@ async def test_table_handler_skips_optimize_for_existing_table() -> None:
         spec=_target._TableSpec(
             table_schema=_make_table_schema(),
             managed_by=target.ManagedBy.USER,
-            num_transactions_before_optimize=50,
         ),
         main_action=None,
         column_actions={},
     )
 
     await handler._apply_actions(cast(Any, _FakeContextProvider(conn)), [action])
-    await asyncio.sleep(0)
 
     assert conn.open_table_count == 0
     assert conn.table.optimize_count == 0
@@ -743,31 +887,16 @@ async def test_table_handler_does_not_optimize_new_table_before_row_mutations() 
         spec=_target._TableSpec(
             table_schema=_make_table_schema(),
             managed_by=target.ManagedBy.SYSTEM,
-            num_transactions_before_optimize=50,
         ),
         main_action="insert",
         column_actions={},
     )
 
     await handler._apply_actions(cast(Any, _FakeContextProvider(conn)), [action])
-    await asyncio.sleep(0)
 
     assert conn.create_table_count == 1
     assert conn.open_table_count == 0
     assert conn.table.optimize_count == 0
-
-
-@requires_lancedb
-def test_table_target_rejects_non_positive_optimize_interval() -> None:
-    with pytest.raises(
-        ValueError, match="num_transactions_before_optimize must be positive"
-    ):
-        lancedb.table_target(
-            db=cast(Any, None),
-            table_name="test_table",
-            table_schema=_make_table_schema(),
-            num_transactions_before_optimize=0,
-        )
 
 
 @requires_lancedb
@@ -1233,7 +1362,6 @@ async def test_execute_deletes_escapes_string_pk() -> None:
         conn=cast(Any, None),
         table_name="test_table",
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
     )
     await handler._execute_deletes(
         cast(Any, fake_table),
@@ -1283,7 +1411,6 @@ async def test_execute_deletes_with_real_lancedb(lancedb_dir: Path) -> None:
         conn=conn,
         table_name=table_name,
         table_schema=table_schema,
-        num_transactions_before_optimize=50,
     )
     await handler._execute_deletes(
         table,

--- a/uv.lock
+++ b/uv.lock
@@ -769,8 +769,8 @@ requires-dist = [
     { name = "httplib2", marker = "extra == 'google-drive'", specifier = ">=0.22.0" },
     { name = "instructor", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "instructor", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.0" },
-    { name = "lancedb", marker = "extra == 'all'", specifier = ">=0.33.0" },
-    { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.33.0" },
+    { name = "lancedb", marker = "extra == 'all'", specifier = ">=0.34.0" },
+    { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.34.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'entity-resolution-llm'", specifier = ">=1.81.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0" },
@@ -1717,7 +1717,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.33.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1730,12 +1730,10 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115, upload-time = "2026-05-28T20:37:55.88Z" },
-    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262, upload-time = "2026-05-28T20:37:59.101Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368, upload-time = "2026-05-28T20:38:02.2Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986, upload-time = "2026-05-28T20:38:05.375Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958, upload-time = "2026-05-28T20:38:08.474Z" },
-    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944, upload-time = "2026-05-28T20:38:11.549Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR changes the LanceDB connector's automatic table maintenance from a transaction-count trigger to a stats-driven trigger.

Previously, the connector ran `table.optimize()` after `num_transactions_before_optimize` mutation batches. That was a weak proxy for actual table/index maintenance debt: it's incredibly common to see scenarios where there are many small updates across short runs might never reach the threshold, while one large batch could leave a large unindexed tail until a later run.

### UX improvement
The connector now decides based on LanceDB's own table/index state. The user no longer needs to worry about a `num_transactions_before_optimize` kwarg (this has been removed in this version).

## Why Is This Change Needed?

In LanceDB, table optimization involves physical maintenance of the underlying files: it compacts small fragments, cleans up deletion files, and reindexes new data so the freshest rows are available through declared indexes.

A transaction-count trigger does not reliably represent that physical maintenance debt. Batch counts vary widely depending on runtime scheduling: a tiny update can be one batch, and a large backfill can also arrive as only one or two batches. That means the old design could miss both important ends of the workload spectrum:

- many small, sporadic updates across short runs could build up fragments and unindexed rows indefinitely
- a large update into an existing indexed table could leave a big unindexed tail until some later run happened to cross the transaction threshold

The new design implemented here uses _durable LanceDB stats_ instead: fragment counts, deletion file counts, old prunable versions, and per-index unindexed row counts. Checks are driven by mutated row count rather than batch count, so the cadence tracks actual write volume.

## What Changed

- Replace `num_transactions_before_optimize` with internal stats-driven optimize thresholds.
- Trigger `table.optimize()` from:
  - small fragment count from `table.stats()`
  - deletion file count from latest version metadata
  - prunable old version count
  - `num_unindexed_rows` from every declared index
- Use mutation-row count, not batch count, to decide when to re-check stats.
- Add an internal cooldown between optimize attempts to avoid repeated optimize calls during high-write streams.
- Treat optimize evaluation/execute failures as non-fatal: mutations still succeed and failures are logged.
- Handle LanceDB version timestamps correctly when timestamps are naive local datetimes.
- Update docs to explain optimize behavior and external concurrency guidance.
- Bump LanceDB Python SDK dependency to `>=0.34.0`.

## Breaking Change

This removes the optional `num_transactions_before_optimize` kwarg.

I think removing it without a deprecation period is acceptable here because:

- It was an optional tuning kwarg that most users likely never touched
- This is still a relatively new connector with limited usage
- Keeping the option would preserve the wrong mental model: optimize should be driven by physical table/index state, not by transaction count

## Validation

Verified against the most recent LanceDB Python SDK `0.34.0`.

- `uv run --extra lancedb python -c 'import lancedb; print(lancedb.__version__)'`
  - confirmed `0.34.0`
- `uv run --extra lancedb pytest python/tests/connectors/test_lancedb_target.py`
  - `40 passed`
- `uv run ruff check python/cocoindex/connectors/lancedb/_target.py python/tests/connectors/test_lancedb_target.py`
  - passed
- `uv run maturin build --out target/wheels`
  - passed

Also ran a real smoke test through [cocoindex-v1-intro](https://github.com/thedataquarry/cocoindex-v1-intro) with LanceDB `0.34.0`:

- bulk ingested 1000 records
- then sporadically updated 10, 20, and 30 records
- optimize triggered once the cumulative unindexed index tail crossed the internal threshold
- after optimize, fragments dropped to 3 and unindexed rows dropped to 4

## Scenarios This Protects Against

I went through multiple iterations to stress-test the design with Fable 5, and I think it should be way more robust than the earlier version. Here's a summary of various scenarios users may experience in the wild that this design protects against.

| # | Scenario | What happens with stats-driven optimize | Outcome |
|---|---|---|---|
| 1. | **Initial bulk ingest** (10K+ rows, new table) | Rows land in 1-2 large batches; index is created *after* rows, so `create_index` covers everything | No tail; no optimize needed |
| 2. | **Sporadic updates** (10-20 rows, months apart) | Fresh `_RowHandler` per run, so the first batch of every run always evaluates stats, repaying any debt from prior runs | Nothing accumulates indefinitely, regardless of run frequency |
| 3. | **Bulk backfill into existing indexed table** | Stats checks are row-count-driven (every >=25 mutated rows): the bulk batch itself crosses the threshold, so the post-backfill state is evaluated and optimized in the same run | Tail integrated immediately; at most ~1K rows can remain unindexed at exit (bounded by the optimize floor) |
| 4. | **Long-lived watcher, tiny updates** | Stats round-trip only per >=25 mutated rows, and after any optimize attempt a 1,000-row floor gates further attempts | Check overhead scales with mutation volume; optimize frequency bounded even on small tables |
| 5. | **High-throughput continuous writes** | Batches coalesce large; 20K absolute / 5% relative unindexed caps bound cadence; optimize runs inline, serialized with row writes; 1,000-row floor between attempts prevents thrash | Backpressure instead of commit conflicts; every trigger is physically cleared by optimize |
| 6. | **Concurrent readers during optimize** | MVCC snapshots; default 7-day cleanup horizon retains recent versions | Reads unaffected, long-lived checkouts safe |
| 7. | **Stats/optimize failure** (e.g. remote table) | Exception logged, row mutations succeed; retried after 1,000 more mutated rows or on next run's first batch | Non-fatal with natural retry, no failure-retry loop |

Trigger design: checks are driven by **mutated row count** (not batch count), so cadence tracks actual write volume at both extremes: a 10K-row backfill is evaluated as soon as it lands, while a trickle of single-row updates only pays a stats check per 25 mutated rows. The 1,000-row floor between optimize attempts caps worst-case optimize frequency independently of table size.

## Documentation

Updated the docs page to better describe this change, and briefly explain this in case the user wants to learn more.