### PR TITLE
test: explicit AtMost(N) sentinel for nondeterministic sink counts

### DIFF
--- a/python/tests/common/target_states.py
+++ b/python/tests/common/target_states.py
@@ -26,7 +26,7 @@ class Metrics:
         with self._lock:
             m = self.data
             self.data = {}
-            return _MetricCounts(m)
+            return m
 
     def __repr__(self) -> str:
         return f"Metrics{self.data}"
@@ -50,29 +50,25 @@ class Metrics:
             self.data.clear()
 
 
-class _MetricCounts(dict[str, int]):
-    """Collected metric counts whose equality tolerates the per-batch ``sink`` count.
+class AtMost:
+    """Expected metric value that compares equal to any actual count up to ``bound``.
 
-    Operation counts (``insert``/``upsert``/``delete``) are deterministic and
-    compared exactly. The number of ``sink`` (batch) invocations depends on how
-    aggressively the engine's shared target-action batcher coalesces leaf
-    actions, which can vary with concurrency. The ``sink`` value in an expected
-    literal is therefore treated as an upper bound rather than an exact count.
+    Use in an expected metric dict literal for nondeterministic counts. The
+    number of ``sink`` (batch) invocations depends on how aggressively the
+    engine's shared target-action batcher coalesces leaf actions, which can vary
+    with concurrency, so ``sink`` is asserted as an upper bound rather than an
+    exact count. Operation counts (``insert``/``upsert``/``delete``) stay
+    deterministic and are compared exactly as plain ints.
     """
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, dict):
-            return False
-        actual_ops = {k: v for k, v in self.items() if k != "sink"}
-        expected_ops = {k: v for k, v in other.items() if k != "sink"}
-        if actual_ops != expected_ops:
-            return False
-        if "sink" not in other:
-            return True
-        return bool(self.get("sink", 0) <= other["sink"])
+    def __init__(self, bound: int) -> None:
+        self.bound = bound
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, int) and other <= self.bound
+
+    def __repr__(self) -> str:
+        return f"AtMost({self.bound})"
 
     __hash__ = None  # type: ignore[assignment]
 
@@ -301,12 +297,10 @@ class DictsTargetStateStore:
         self.child_invalidation = None
 
     def collect_child_metrics(self) -> dict[str, int]:
-        return _MetricCounts(
-            sum(
-                (Metrics(store.metrics.collect()) for store in self._stores.values()),
-                Metrics(),
-            ).data
-        )
+        return sum(
+            (Metrics(store.metrics.collect()) for store in self._stores.values()),
+            Metrics(),
+        ).data
 
     @property
     def data(self) -> dict[str, dict[str, DictDataWithPrev]]:
@@ -482,16 +476,14 @@ class AttachmentDictsTargetStateStore:
         self.child_invalidation = None
 
     def collect_attachment_metrics(self, att_type: str) -> dict[str, int]:
-        return _MetricCounts(
-            sum(
-                (
-                    Metrics(handler._attachment_stores[att_type].metrics.collect())
-                    for handler in self._handlers.values()
-                    if att_type in handler._attachment_stores
-                ),
-                Metrics(),
-            ).data
-        )
+        return sum(
+            (
+                Metrics(handler._attachment_stores[att_type].metrics.collect())
+                for handler in self._handlers.values()
+                if att_type in handler._attachment_stores
+            ),
+            Metrics(),
+        ).data
 
     @property
     def attachment_data(

--- a/python/tests/core/test_attachment_target_states.py
+++ b/python/tests/core/test_attachment_target_states.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from tests import common
 from tests.common.target_states import (
+    AtMost,
     AttachmentDictsTarget,
     MultiAttachmentDictsTarget,
     DictsTarget,
@@ -53,9 +54,12 @@ def test_attachment_basic_lifecycle() -> None:
             },
         },
     }
-    assert AttachmentDictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
+    assert AttachmentDictsTarget.store.metrics.collect() == {
+        "sink": AtMost(1),
+        "insert": 1,
+    }
     assert AttachmentDictsTarget.store.collect_attachment_metrics("items") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "upsert": 2,
     }
 
@@ -71,9 +75,9 @@ def test_attachment_basic_lifecycle() -> None:
             },
         },
     }
-    assert AttachmentDictsTarget.store.metrics.collect() == {"sink": 1}
+    assert AttachmentDictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
     assert AttachmentDictsTarget.store.collect_attachment_metrics("items") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "delete": 1,
         "upsert": 1,
     }
@@ -82,7 +86,10 @@ def test_attachment_basic_lifecycle() -> None:
     _source_data.clear()
     app.update_blocking()
     assert AttachmentDictsTarget.store.attachment_data == {}
-    assert AttachmentDictsTarget.store.metrics.collect() == {"sink": 1, "delete": 1}
+    assert AttachmentDictsTarget.store.metrics.collect() == {
+        "sink": AtMost(1),
+        "delete": 1,
+    }
 
 
 def test_attachment_idempotent_provider() -> None:
@@ -168,11 +175,11 @@ def test_attachment_independent_types() -> None:
         },
     }
     assert MultiAttachmentDictsTarget.store.collect_attachment_metrics("items") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "upsert": 2,
     }
     assert MultiAttachmentDictsTarget.store.collect_attachment_metrics("tags") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "upsert": 2,
     }
 
@@ -254,7 +261,7 @@ def test_attachment_destructive_change_invalidates_memo() -> None:
     app.update_blocking()
     assert _memo_exec_count == 1
     assert AttachmentDictsTarget.store.collect_attachment_metrics("items") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "upsert": 1,
     }
 
@@ -274,7 +281,7 @@ def test_attachment_destructive_change_invalidates_memo() -> None:
         AttachmentDictsTarget.store.child_invalidation = None
     assert _memo_exec_count == 1
     assert AttachmentDictsTarget.store.collect_attachment_metrics("items") == {
-        "sink": 1,
+        "sink": AtMost(1),
         "upsert": 1,
     }
 

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -8,7 +8,12 @@ import dataclasses
 from typing import Any, Collection, Generic
 
 from tests import common
-from tests.common.target_states import DictsTarget, DictDataWithPrev, AsyncDictsTarget
+from tests.common.target_states import (
+    DictsTarget,
+    DictDataWithPrev,
+    AsyncDictsTarget,
+    AtMost,
+)
 
 coco_env = common.create_test_env(__file__)
 
@@ -49,8 +54,8 @@ def test_dicts_data_together_insert() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -67,8 +72,8 @@ def test_dicts_data_together_insert() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -99,8 +104,8 @@ def test_dicts_data_together_delete_dict() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -120,8 +125,12 @@ def test_dicts_data_together_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1, "delete": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {
+        "sink": AtMost(3),
+        "insert": 1,
+        "delete": 1,
+    }
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -144,8 +153,8 @@ def test_dicts_data_together_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -174,8 +183,8 @@ def test_dicts_data_together_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     del _source_data["D1"]["a"]
     app.update_blocking()
@@ -184,8 +193,8 @@ def test_dicts_data_together_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "delete": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -198,8 +207,8 @@ def test_dicts_data_together_delete_entry() -> None:
             "c": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -244,8 +253,8 @@ def test_dicts_in_sub_components_insert() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -262,8 +271,8 @@ def test_dicts_in_sub_components_insert() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -296,8 +305,8 @@ def test_dicts_in_sub_components_delete_dict() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -318,8 +327,12 @@ def test_dicts_in_sub_components_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1, "delete": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {
+        "sink": AtMost(3),
+        "insert": 1,
+        "delete": 1,
+    }
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D2",
@@ -343,8 +356,8 @@ def test_dicts_in_sub_components_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -375,8 +388,8 @@ def test_dicts_in_sub_components_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     del _source_data["D1"]["a"]
     app.update_blocking()
@@ -385,8 +398,8 @@ def test_dicts_in_sub_components_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "delete": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -399,8 +412,8 @@ def test_dicts_in_sub_components_delete_entry() -> None:
             "c": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -461,8 +474,8 @@ async def test_dicts_containers_together_insert() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -479,8 +492,8 @@ async def test_dicts_containers_together_insert() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -506,8 +519,8 @@ async def test_dicts_containers_together_delete_dict() -> None:
     _source_data["D1"] = {"a": 1, "b": 2}
     _source_data["D2"] = {}
     await app.update()
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -527,8 +540,12 @@ async def test_dicts_containers_together_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1, "delete": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {
+        "sink": AtMost(1),
+        "insert": 1,
+        "delete": 1,
+    }
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D2",
@@ -551,8 +568,8 @@ async def test_dicts_containers_together_delete_dict() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -583,8 +600,8 @@ async def test_dicts_containers_together_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     del _source_data["D1"]["a"]
     await app.update()
@@ -593,8 +610,8 @@ async def test_dicts_containers_together_delete_entry() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "delete": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -607,8 +624,8 @@ async def test_dicts_containers_together_delete_entry() -> None:
             "c": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "D1",
@@ -643,7 +660,7 @@ def test_proceed_with_failed_creation() -> None:
             "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -872,8 +889,8 @@ async def test_mount_each_insert() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -890,8 +907,8 @@ async def test_mount_each_insert() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 2}
     _me = coco.Symbol("_declare_one_dict")
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
@@ -918,7 +935,7 @@ async def test_mount_each_delete() -> None:
     _source_data["D1"] = {"a": 1, "b": 2}
     _source_data["D2"] = {}
     await app.update()
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
 
     del _source_data["D1"]
     _source_data["D2"]["c"] = 3
@@ -932,7 +949,11 @@ async def test_mount_each_delete() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1, "delete": 1}
+    assert DictsTarget.store.metrics.collect() == {
+        "sink": AtMost(3),
+        "insert": 1,
+        "delete": 1,
+    }
     _me = coco.Symbol("_declare_one_dict")
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
@@ -958,7 +979,7 @@ async def test_mount_each_delete() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / _me,
@@ -1006,8 +1027,11 @@ async def test_async_dicts() -> None:
         },
         "D2": {},
     }
-    assert AsyncDictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert AsyncDictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert AsyncDictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert AsyncDictsTarget.store.collect_child_metrics() == {
+        "sink": AtMost(1),
+        "upsert": 2,
+    }
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -1024,8 +1048,11 @@ async def test_async_dicts() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert AsyncDictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert AsyncDictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert AsyncDictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert AsyncDictsTarget.store.collect_child_metrics() == {
+        "sink": AtMost(2),
+        "upsert": 2,
+    }
     assert await coco_inspect.list_stable_paths(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -1054,8 +1081,11 @@ def test_async_dicts_sync_app() -> None:
         },
         "D2": {},
     }
-    assert AsyncDictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert AsyncDictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert AsyncDictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert AsyncDictsTarget.store.collect_child_metrics() == {
+        "sink": AtMost(1),
+        "upsert": 2,
+    }
 
     _source_data["D2"]["c"] = 3
     _source_data["D3"] = {"a": 4}
@@ -1072,8 +1102,11 @@ def test_async_dicts_sync_app() -> None:
             "a": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert AsyncDictsTarget.store.metrics.collect() == {"sink": 3, "insert": 1}
-    assert AsyncDictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 2}
+    assert AsyncDictsTarget.store.metrics.collect() == {"sink": AtMost(3), "insert": 1}
+    assert AsyncDictsTarget.store.collect_child_metrics() == {
+        "sink": AtMost(2),
+        "upsert": 2,
+    }
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict",
@@ -1120,8 +1153,8 @@ def test_mount_target_insert() -> None:
         },
         "D2": {},
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     # Verify stable paths contain the mount_target symbol
     paths = coco_inspect.list_stable_paths_sync(app)
@@ -1150,8 +1183,8 @@ def test_mount_target_delete() -> None:
             "c": DictDataWithPrev(data=3, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "insert": 2}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 2, "upsert": 3}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 3}
 
     # Delete D2, modify D1
     del _mount_target_source_data["D2"]
@@ -1164,8 +1197,8 @@ def test_mount_target_delete() -> None:
             "c": DictDataWithPrev(data=4, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 2, "delete": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "delete": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
 
 
 ##################################################################################

--- a/python/tests/core/test_flat_target_states.py
+++ b/python/tests/core/test_flat_target_states.py
@@ -6,6 +6,7 @@ import cocoindex as coco
 
 from tests import common
 from tests.common.target_states import (
+    AtMost,
     GlobalDictTarget,
     AsyncGlobalDictTarget,
     DictDataWithPrev,
@@ -37,7 +38,7 @@ def test_global_dict_target_state_insert() -> None:
     assert GlobalDictTarget.store.data == {
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     _source_data["b"] = 2
     app.update_blocking()
@@ -45,7 +46,7 @@ def test_global_dict_target_state_insert() -> None:
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
 
 def test_global_dict_target_state_upsert() -> None:
@@ -66,7 +67,7 @@ def test_global_dict_target_state_upsert() -> None:
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 2}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 2}
 
     _source_data["a"] = 3
     app.update_blocking()
@@ -74,7 +75,7 @@ def test_global_dict_target_state_upsert() -> None:
         "a": DictDataWithPrev(data=3, prev=[1], prev_may_be_missing=False),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
 
 def test_global_dict_target_state_delete() -> None:
@@ -91,14 +92,14 @@ def test_global_dict_target_state_delete() -> None:
     _source_data["a"] = 1
     _source_data["b"] = 2
     app.update_blocking()
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 2}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 2}
 
     del _source_data["a"]
     app.update_blocking()
     assert GlobalDictTarget.store.data == {
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "delete": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
 
 
 def test_global_dict_target_state_no_change() -> None:
@@ -120,7 +121,7 @@ def test_global_dict_target_state_no_change() -> None:
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 2}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 2}
 
     app.update_blocking()
     assert GlobalDictTarget.store.data == {
@@ -136,7 +137,7 @@ def test_global_dict_target_state_no_change() -> None:
         "a": DictDataWithPrev(data=3, prev=[1], prev_may_be_missing=False),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     app.update_blocking()
     assert GlobalDictTarget.store.data == {
@@ -167,7 +168,10 @@ def test_async_global_dict_target_state_insert() -> None:
     assert AsyncGlobalDictTarget.store.data == {
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
     }
-    assert AsyncGlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert AsyncGlobalDictTarget.store.metrics.collect() == {
+        "sink": AtMost(1),
+        "upsert": 1,
+    }
 
     _source_data["b"] = 2
     app.update_blocking()
@@ -175,7 +179,10 @@ def test_async_global_dict_target_state_insert() -> None:
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert AsyncGlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert AsyncGlobalDictTarget.store.metrics.collect() == {
+        "sink": AtMost(1),
+        "upsert": 1,
+    }
 
 
 def test_global_dict_preview_returns_actions_without_writing() -> None:
@@ -203,7 +210,7 @@ def test_global_dict_preview_returns_actions_without_writing() -> None:
         "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
         "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 2}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 2}
 
 
 @pytest.mark.asyncio
@@ -250,14 +257,14 @@ def test_global_dict_target_state_proceed_with_exception() -> None:
     assert GlobalDictTarget.store.data == {
         "a": DictDataWithPrev(data=2, prev=[1], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     _source_data["a"] = 3
     app.update_blocking()
     assert GlobalDictTarget.store.data == {
         "a": DictDataWithPrev(data=3, prev=[2], prev_may_be_missing=False),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     del _source_data["a"]
     try:
@@ -268,4 +275,4 @@ def test_global_dict_target_state_proceed_with_exception() -> None:
         GlobalDictTarget.store.sink_exception = False
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "delete": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import cocoindex as coco
 
 from tests import common
-from tests.common.target_states import GlobalDictTarget, DictDataWithPrev
+from tests.common.target_states import GlobalDictTarget, DictDataWithPrev, AtMost
 
 coco_env = common.create_test_env(__file__)
 
@@ -101,7 +101,7 @@ def test_ownership_transfer_then_delete() -> None:
     _source_data["C2"] = {}
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "delete": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
 
 
 def test_ownership_transfer_ordering_independence() -> None:
@@ -216,7 +216,7 @@ def test_ownership_transfer_preempt_strict() -> None:
     assert GlobalDictTarget.store.data == {
         "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
     }
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 2: Ownership transfers from C1 to C2
     _source_data.clear()
@@ -226,7 +226,7 @@ def test_ownership_transfer_preempt_strict() -> None:
         "x": DictDataWithPrev(data=2, prev=[1], prev_may_be_missing=False),
     }
     # Should be 1 upsert (update), NOT a delete + insert
-    assert GlobalDictTarget.store.metrics.collect() == {"sink": 1, "upsert": 1}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 3: Same value transfer — no action needed
     _source_data.clear()

--- a/python/tests/core/test_provider_generation.py
+++ b/python/tests/core/test_provider_generation.py
@@ -3,7 +3,7 @@ from typing import Any
 import cocoindex as coco
 
 from tests import common
-from tests.common.target_states import DictsTarget, DictDataWithPrev
+from tests.common.target_states import DictsTarget, DictDataWithPrev, AtMost
 
 _inner_exec_count: int = 0
 
@@ -71,8 +71,8 @@ def test_destructive_change_ignores_stale_children() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
-    assert DictsTarget.store.metrics.collect() == {"sink": 1, "insert": 1}
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 2}
+    assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1), "insert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 2}
 
     # Run 2: Destructive change with same data — children re-inserted (stale tracking ignored)
     DictsTarget.store.child_invalidation = "destructive"
@@ -235,7 +235,7 @@ def test_destructive_change_invalidates_memo() -> None:
     # Run 1: Initial insert — inner function executes
     app.update_blocking()
     assert _inner_exec_count == 1
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 2: Same data, no invalidation — inner function skipped (memo hit)
     _inner_exec_count = 0
@@ -251,7 +251,7 @@ def test_destructive_change_invalidates_memo() -> None:
     finally:
         DictsTarget.store.child_invalidation = None
     assert _inner_exec_count == 1
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 4: Same data, no invalidation — memo hit again (new provider_id is stable)
     _inner_exec_count = 0
@@ -268,7 +268,7 @@ def test_lossy_change_invalidates_memo() -> None:
     # Run 1: Initial insert — inner function executes
     app.update_blocking()
     assert _inner_exec_count == 1
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 2: Same data, no invalidation — inner function skipped (memo hit)
     _inner_exec_count = 0
@@ -285,7 +285,7 @@ def test_lossy_change_invalidates_memo() -> None:
         DictsTarget.store.child_invalidation = None
     assert _inner_exec_count == 1
     # Lossy forces upsert (prev_may_be_missing=True) for child rows
-    assert DictsTarget.store.collect_child_metrics() == {"sink": 1, "upsert": 1}
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
 
     # Run 4: Same data, no invalidation — memo hit again (schema_version is stable)
     _inner_exec_count = 0


### PR DESCRIPTION
## Summary
- Replace the implicit `_MetricCounts` dict subclass (from #2233) with an explicit `AtMost(N)` sentinel used in expected metric dict literals.
- `collect()` and the child/attachment aggregators return plain dicts again; callsites wrap nondeterministic values as `{"sink": AtMost(2), ...}` so the upper bound is visible at the callsite instead of hidden in an overridden `dict.__eq__`.
- Nothing special-cases the `"sink"` string anymore — the bound generalizes to any metric — and deterministic op counts stay exact plain-int comparisons.

## Background
The per-batch `sink` count became nondeterministic in #2221, which routed leaf target actions through a shared batcher. #2233 tolerated this by making `== {"sink": 2, ...}` read like exact equality while silently treating `sink` as an upper bound. This makes that tolerance explicit and honest at each callsite.

## Test plan
CI. All affected core target-state tests pass locally; `ruff` and `mypy` clean on changed files.
