### PR TITLE
Add BigQuery target connector

### DIFF
--- a/docs/src/content/docs/connectors/bigquery.mdx
+++ b/docs/src/content/docs/connectors/bigquery.mdx
@@ -1,0 +1,220 @@
+---
+title: "*BigQuery* connector"
+toc_max_heading_level: 4
+description: >
+  Write CocoIndex target rows into BigQuery tables with managed DDL, MERGE
+  upserts, deletes, and automatic mapping from Python row types.
+---
+The `bigquery` connector provides target state APIs for writing rows to BigQuery tables. CocoIndex tracks the rows that should exist and applies table creation, upserts, updates, and deletes incrementally.
+
+```python
+from cocoindex.connectors import bigquery
+```
+
+:::note[Install]
+Install the optional BigQuery dependency before using this connector:
+
+```bash
+pip install cocoindex[bigquery]
+```
+:::
+
+## Connection setup
+
+Create a `ContextKey[bigquery.ConnectionConfig]` to identify the BigQuery connection, then provide it in your lifespan:
+
+:::note
+The key name is load-bearing across runs. It is the stable identity CocoIndex uses to track managed rows. See [ContextKey as stable identity](../programming_guide/context#contextkey-as-stable-identity) before renaming.
+:::
+
+```python
+import os
+from collections.abc import Iterator
+
+import cocoindex as coco
+from cocoindex.connectors import bigquery
+
+BIGQUERY = coco.ContextKey[bigquery.ConnectionConfig]("bigquery")
+
+@coco.lifespan
+def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+    builder.provide(
+        BIGQUERY,
+        bigquery.ConnectionConfig(
+            project=os.environ.get("BIGQUERY_PROJECT"),
+            credentials_path=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or None,
+            location=os.environ.get("BIGQUERY_LOCATION"),
+        ),
+    )
+    yield
+```
+
+If `credentials_path` is omitted, the Google client uses Application Default Credentials.
+
+### ConnectionConfig
+
+```python
+@dataclass(frozen=True)
+class ConnectionConfig:
+    project: str | None = None
+    credentials_path: str | None = None
+    location: str | None = None
+```
+
+**Parameters:**
+
+- `project` - Optional Google Cloud project used by the BigQuery client.
+- `credentials_path` - Optional path to a service account JSON key file. If omitted, Application Default Credentials are used.
+- `location` - Optional BigQuery job location, for example `US` or `EU`.
+
+## As target
+
+The `bigquery` connector provides target state APIs for writing rows to tables.
+
+### Tables
+
+Declares a table as a target state. Returns a `TableTarget` for declaring rows.
+
+```python
+def declare_table_target(
+    db: ContextKey[ConnectionConfig],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    dataset: str,
+    project: str | None = None,
+    managed_by: Literal["system", "user"] = "system",
+) -> TableTarget[RowT, coco.PendingS]
+```
+
+**Parameters:**
+
+- `db` - A `ContextKey[ConnectionConfig]` identifying the connection to use.
+- `table_name` - Name of the table.
+- `table_schema` - Schema definition including columns and primary key.
+- `dataset` - BigQuery dataset name.
+- `project` - Optional project that owns the target table. If omitted, BigQuery uses the client project.
+- `managed_by` - Whether CocoIndex manages the table lifecycle (`"system"`) or assumes it exists (`"user"`).
+
+When `managed_by="system"`, CocoIndex creates the dataset and table if needed. Table changes use BigQuery DDL, and row changes use BigQuery `MERGE` for upserts.
+
+:::note
+BigQuery primary key constraints are not enforced by BigQuery. CocoIndex still uses the primary key list to reconcile rows and generate `MERGE` and `DELETE` statements.
+:::
+
+### Rows
+
+Once a `TableTarget` is resolved, declare rows to be upserted:
+
+```python
+def TableTarget.declare_row(
+    self,
+    *,
+    row: RowT,
+) -> None
+```
+
+**Parameters:**
+
+- `row` - A row object (dict, dataclass, NamedTuple, or Pydantic model). Must include all primary key columns.
+
+## Table schema: from Python class
+
+Define the table structure using a Python class:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class ProductRow:
+    id: str
+    name: str
+    price: float
+    metadata: dict[str, object]
+
+schema = await bigquery.TableSchema.from_class(
+    ProductRow,
+    primary_key=["id"],
+)
+```
+
+Python types are automatically mapped to BigQuery column types:
+
+| Python Type | BigQuery Type |
+|-------------|---------------|
+| `bool` | `BOOL` |
+| `int` | `INT64` |
+| `float` | `FLOAT64` |
+| `decimal.Decimal` | `NUMERIC` |
+| `str` | `STRING` |
+| `bytes` | `BYTES` |
+| `uuid.UUID` | `STRING` |
+| `datetime.date` | `DATE` |
+| `datetime.time` | `TIME` |
+| `datetime.datetime` | `TIMESTAMP` |
+| `datetime.timedelta` | `FLOAT64` |
+| `list`, `dict`, nested structs | `JSON` |
+
+`JSON` values are JSON-serialized and written with `PARSE_JSON`.
+
+### BigQueryType
+
+Use `BigQueryType` to specify a custom BigQuery type and optional encoder:
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from cocoindex.connectors.bigquery import BigQueryType
+
+@dataclass
+class ProductRow:
+    id: Annotated[int, BigQueryType("NUMERIC")]
+    embedding: Annotated[list[float], BigQueryType("ARRAY<FLOAT64>")]
+```
+
+You can also pass `column_overrides` when constructing the schema:
+
+```python
+schema = await bigquery.TableSchema.from_class(
+    ProductRow,
+    primary_key=["id"],
+    column_overrides={
+        "id": bigquery.BigQueryType("NUMERIC"),
+    },
+)
+```
+
+## Example
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class ProductRow:
+    id: str
+    name: str
+    price: float
+    metadata: dict[str, object]
+
+async def declare_products(rows: list[ProductRow]) -> None:
+    table = await bigquery.mount_table_target(
+        BIGQUERY,
+        table_name="product_index",
+        table_schema=await bigquery.TableSchema.from_class(
+            ProductRow,
+            primary_key=["id"],
+        ),
+        project="my-project",
+        dataset="analytics",
+    )
+
+    for row in rows:
+        table.declare_row(row=row)
+```
+
+See `examples/bigquery_target` for a runnable project.
+
+## Identifier handling
+
+Dataset, table, and column names must be simple BigQuery identifiers containing letters, numbers, and underscores, and must not start with a number. The connector quotes identifiers when generating SQL.

--- a/docs/src/content/docs/connectors/index.mdx
+++ b/docs/src/content/docs/connectors/index.mdx
@@ -38,6 +38,7 @@ Connectors that export data out of a flow. They're grouped by the kind of store,
 | [Apache Doris](/docs/connectors/doris/)  |    | Analytical database, HNSW/IVF vector + inverted full-text indexes |
 | [SQLite](/docs/connectors/sqlite/)       |    | Embedded database, optional vector search via `sqlite-vec` |
 | [Snowflake](/docs/connectors/snowflake/) |    | Cloud data warehouse — managed DDL, MERGE upserts, incremental deletes |
+| [BigQuery](/docs/connectors/bigquery/)   |    | Cloud data warehouse with managed DDL, MERGE upserts, incremental deletes |
 
 ### Vector databases
 

--- a/docs/src/data/docs-sidebar.ts
+++ b/docs/src/data/docs-sidebar.ts
@@ -63,6 +63,7 @@ export const sidebar: SidebarItem[] = [
     items: [
       { type: 'doc', slug: 'connectors', label: 'Overview' },
       { type: 'doc', slug: 'connectors/amazon_s3', label: 'Amazon S3' },
+      { type: 'doc', slug: 'connectors/bigquery', label: 'BigQuery' },
       { type: 'doc', slug: 'connectors/doris', label: 'Apache Doris' },
       { type: 'doc', slug: 'connectors/falkordb', label: 'FalkorDB' },
       { type: 'doc', slug: 'connectors/google_drive', label: 'Google Drive' },

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -702,6 +702,7 @@ export const EXAMPLE_CATALOG_GROUPS: ExampleCatalogGroup[] = [
     blurb: 'Bring your own transform or wire pipelines to streaming systems like Kafka.',
     entries: [
       { dir: 'files_transform', docs: 'files-transform', title: 'Files Transform', description: 'Watch a directory of Markdown files and convert each to HTML with markdown-it-py, writing .html outputs incrementally.' },
+      { dir: 'bigquery_target', title: 'BigQuery Target', description: 'Write order records to BigQuery with managed table creation, MERGE upserts, and cleanup.', run: RUN_MAIN },
       { dir: 'kafka_to_lancedb', docs: 'kafka-to-lancedb', title: 'Kafka → LanceDB', description: 'Consume JSON messages from a Kafka topic and dispatch them to two LanceDB tables by message shape.', run: 'cocoindex update -L main.py' },
       { dir: 'snowflake_target', title: 'Snowflake Target', description: 'Write order records to Snowflake with managed table creation, MERGE upserts, and cleanup.', run: RUN_MAIN },
     ],

--- a/examples/bigquery_target/.env.example
+++ b/examples/bigquery_target/.env.example
@@ -1,0 +1,9 @@
+COCOINDEX_DB=./cocoindex.db
+
+BIGQUERY_PROJECT=
+BIGQUERY_DATASET=cocoindex_demo
+BIGQUERY_TABLE=cocoindex_orders
+BIGQUERY_LOCATION=US
+
+# Optional. Leave blank to use Application Default Credentials.
+GOOGLE_APPLICATION_CREDENTIALS=

--- a/examples/bigquery_target/.gitignore
+++ b/examples/bigquery_target/.gitignore
@@ -1,0 +1,3 @@
+.env
+cocoindex.db
+__pycache__/

--- a/examples/bigquery_target/README.md
+++ b/examples/bigquery_target/README.md
@@ -1,0 +1,122 @@
+# BigQuery Target Example
+
+This example shows how to use BigQuery as a CocoIndex target.
+
+BigQuery is the table store in this example. CocoIndex is responsible for the
+target state: it creates the dataset and table when needed, writes rows with
+BigQuery `MERGE`, and deletes rows that are no longer declared by the flow.
+
+The example keeps the source data in Python so the BigQuery target behavior is
+easy to see. It declares three order records, computes `order_total`, writes the
+rows to BigQuery, then reads the table back with the BigQuery Python client.
+
+## What this creates
+
+By default the flow writes to:
+
+| Object | Default value | Created by |
+|--------|---------------|------------|
+| Project | value of `BIGQUERY_PROJECT` | You, before running the example |
+| Dataset | `cocoindex_demo` | CocoIndex, if the service account has permission |
+| Table | `cocoindex_orders` | CocoIndex |
+
+The Google Cloud project must exist before the flow runs. The BigQuery
+connector creates the dataset and table.
+
+## How the flow works
+
+1. `coco_lifespan` reads `BIGQUERY_*` environment variables and provides a
+   BigQuery connection config to CocoIndex.
+2. `mount_table_target` declares the BigQuery table target and its primary key.
+3. `process_order` converts each source order into the row shape stored in
+   BigQuery.
+4. `cocoindex update main` reconciles the declared rows with the table.
+
+## Prerequisites
+
+Run commands from this directory:
+
+```sh
+cd examples/bigquery_target
+```
+
+1. Install dependencies from a source checkout:
+
+```sh
+pip install -e "../..[bigquery]" -e .
+```
+
+2. Copy the environment template:
+
+```sh
+cp .env.example .env
+```
+
+3. Fill in `.env`.
+
+| Variable | Required | How to choose it |
+|----------|----------|------------------|
+| `COCOINDEX_DB` | Yes | Local CocoIndex state database. The default `./cocoindex.db` is fine for the example. |
+| `BIGQUERY_PROJECT` | Yes | Google Cloud project that owns the target dataset and table. |
+| `BIGQUERY_DATASET` | Yes | Target dataset name. CocoIndex creates it when the credential has permission. |
+| `BIGQUERY_TABLE` | Yes | Target table name. The default is `cocoindex_orders`. |
+| `BIGQUERY_LOCATION` | No | BigQuery job location, for example `US` or `EU`. Use the same location as the dataset. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | No | Path to a service account JSON key. Leave blank to use Application Default Credentials. |
+
+4. Use a credential with the needed permissions.
+
+For a small demo, the credential needs:
+
+- permission to create or use the target dataset
+- permission to create the target table
+- permission to run BigQuery query jobs
+- permission to run `MERGE` and `DELETE` on the target table
+
+## Authentication used here
+
+This example supports two standard Google authentication paths:
+
+```python
+bigquery.ConnectionConfig(
+    project=os.environ.get("BIGQUERY_PROJECT"),
+    credentials_path=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or None,
+    location=os.environ.get("BIGQUERY_LOCATION") or None,
+)
+```
+
+If `GOOGLE_APPLICATION_CREDENTIALS` is blank, the Google client uses
+Application Default Credentials.
+
+## Run
+
+Build/update the target table:
+
+```sh
+cocoindex update main
+```
+
+Print the rows written to BigQuery:
+
+```sh
+python main.py
+```
+
+Expected output:
+
+```text
+('ORD-1001', 'Summit Labs', 'mechanical keyboard', 2, 259.0, 'paid', 'web')
+('ORD-1002', 'Beacon Retail', 'standing desk', 1, 399.0, 'paid', 'sales')
+('ORD-1003', 'Ridgeview Health', 'noise cancelling headphones', 3, 599.97, 'pending', 'partner')
+```
+
+## Try an incremental update
+
+Edit `SAMPLE_ORDERS` in `main.py`, then run:
+
+```sh
+cocoindex update main
+python main.py
+```
+
+Only the changed order rows are upserted. If you remove one of the sample
+orders, CocoIndex deletes the corresponding row from BigQuery on the next run.

--- a/examples/bigquery_target/main.py
+++ b/examples/bigquery_target/main.py
@@ -1,0 +1,194 @@
+"""Write a small set of order rows to BigQuery with a CocoIndex table target."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from dotenv import load_dotenv
+
+import cocoindex as coco
+from cocoindex.connectors import bigquery
+
+load_dotenv()
+
+BIGQUERY = coco.ContextKey[bigquery.ConnectionConfig]("bigquery_demo")
+
+PROJECT = os.environ.get("BIGQUERY_PROJECT") or None
+DATASET = os.environ.get("BIGQUERY_DATASET", "cocoindex_demo")
+TABLE_NAME = os.environ.get("BIGQUERY_TABLE", "cocoindex_orders")
+LOCATION = os.environ.get("BIGQUERY_LOCATION") or None
+CREDENTIALS_PATH = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or None
+
+
+@dataclass(frozen=True)
+class SourceOrder:
+    order_id: str
+    customer: str
+    product: str
+    quantity: int
+    unit_price: float
+    status: str
+    attributes: dict[str, object]
+
+
+@dataclass(frozen=True)
+class BigQueryOrder:
+    order_id: str
+    customer: str
+    product: str
+    quantity: int
+    unit_price: float
+    order_total: float
+    status: str
+    attributes: dict[str, object]
+
+
+SAMPLE_ORDERS = (
+    SourceOrder(
+        order_id="ORD-1001",
+        customer="Summit Labs",
+        product="mechanical keyboard",
+        quantity=2,
+        unit_price=129.50,
+        status="paid",
+        attributes={"channel": "web", "priority": "standard"},
+    ),
+    SourceOrder(
+        order_id="ORD-1002",
+        customer="Beacon Retail",
+        product="standing desk",
+        quantity=1,
+        unit_price=399.00,
+        status="paid",
+        attributes={"channel": "sales", "priority": "rush"},
+    ),
+    SourceOrder(
+        order_id="ORD-1003",
+        customer="Ridgeview Health",
+        product="noise cancelling headphones",
+        quantity=3,
+        unit_price=199.99,
+        status="pending",
+        attributes={"channel": "partner", "priority": "expedite"},
+    ),
+)
+
+
+@coco.lifespan
+def coco_lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+    builder.provide(
+        BIGQUERY,
+        bigquery.ConnectionConfig(
+            project=PROJECT,
+            credentials_path=CREDENTIALS_PATH,
+            location=LOCATION,
+        ),
+    )
+    yield
+
+
+@coco.fn(memo=True)
+async def process_order(
+    order: SourceOrder,
+    table: bigquery.TableTarget[BigQueryOrder],
+) -> None:
+    table.declare_row(
+        row=BigQueryOrder(
+            order_id=order.order_id,
+            customer=order.customer,
+            product=order.product,
+            quantity=order.quantity,
+            unit_price=order.unit_price,
+            order_total=round(order.quantity * order.unit_price, 2),
+            status=order.status,
+            attributes=order.attributes,
+        )
+    )
+
+
+@coco.fn
+async def app_main() -> None:
+    table = await bigquery.mount_table_target(
+        BIGQUERY,
+        table_name=TABLE_NAME,
+        table_schema=await bigquery.TableSchema.from_class(
+            BigQueryOrder,
+            primary_key=["order_id"],
+        ),
+        project=PROJECT,
+        dataset=DATASET,
+    )
+
+    await coco.mount_each(
+        process_order,
+        ((order.order_id, order) for order in SAMPLE_ORDERS),
+        table,
+    )
+
+
+app = coco.App(
+    coco.AppConfig(name="BigQueryTarget"),
+    app_main,
+)
+
+
+def _qualified_table_name() -> str:
+    project_prefix = f"{PROJECT}." if PROJECT else ""
+    return f"`{project_prefix}{DATASET}.{TABLE_NAME}`"
+
+
+def _bigquery_client() -> Any:
+    from google.cloud import bigquery as google_bigquery
+
+    credentials = None
+    if CREDENTIALS_PATH:
+        from google.oauth2 import service_account
+
+        credentials = service_account.Credentials.from_service_account_file(
+            CREDENTIALS_PATH
+        )
+    return google_bigquery.Client(
+        project=PROJECT,
+        credentials=credentials,
+        location=LOCATION,
+    )
+
+
+def print_rows() -> None:
+    client = _bigquery_client()
+    query_job = client.query(
+        f"""
+        SELECT
+            `order_id`,
+            `customer`,
+            `product`,
+            `quantity`,
+            `order_total`,
+            `status`,
+            JSON_VALUE(`attributes`, '$.channel') AS channel
+        FROM {_qualified_table_name()}
+        ORDER BY `order_id`
+        """
+    )
+    for row in query_job.result():
+        print(
+            (
+                row["order_id"],
+                row["customer"],
+                row["product"],
+                row["quantity"],
+                row["order_total"],
+                row["status"],
+                row["channel"],
+            )
+        )
+    close = getattr(client, "close", None)
+    if close is not None:
+        close()
+
+
+if __name__ == "__main__":
+    print_rows()

--- a/examples/bigquery_target/pyproject.toml
+++ b/examples/bigquery_target/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "bigquery-target"
+version = "0.1.0"
+description = "CocoIndex example: write managed target rows to BigQuery."
+requires-python = ">=3.11"
+dependencies = [
+    "cocoindex[bigquery]>=1.0.7",
+    "google-cloud-bigquery>=3.0.0",
+    "python-dotenv>=1.0.1",
+]
+
+[tool.setuptools]
+py-modules = ["main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ colpali = ["colpali-engine"]
 lancedb = ["lancedb>=0.34.0", "pyarrow>=23.0.0"]
 postgres = ["asyncpg>=0.31.0"]
 qdrant = ["qdrant-client>=1.6.0"]
+bigquery = ["google-cloud-bigquery>=3.0.0", "google-auth>=2.0.0"]
 snowflake = ["snowflake-connector-python>=3.0.0"]
 sqlite = ["sqlite-vec>=0.1.6"]
 surrealdb = ["surrealdb>=1.0.0"]
@@ -110,6 +111,7 @@ all = [
     "asyncpg>=0.31.0",
     "pgvector>=0.4.2",
     "qdrant-client>=1.6.0",
+    "google-cloud-bigquery>=3.0.0",
     "snowflake-connector-python>=3.0.0",
     "sqlite-vec>=0.1.6",
     "surrealdb>=1.0.0",
@@ -201,6 +203,8 @@ module = [
     "torch.*",
     "qdrant_client",
     "qdrant_client.*",
+    "google.cloud",
+    "google.cloud.*",
     "snowflake",
     "snowflake.*",
     "sqlite_vec",

--- a/python/cocoindex/connectors/bigquery/__init__.py
+++ b/python/cocoindex/connectors/bigquery/__init__.py
@@ -1,0 +1,4 @@
+from . import _target
+from ._target import *  # noqa: F403
+
+__all__ = _target.__all__

--- a/python/cocoindex/connectors/bigquery/_target.py
+++ b/python/cocoindex/connectors/bigquery/_target.py
@@ -1,0 +1,998 @@
+"""
+BigQuery target for CocoIndex.
+
+This module provides a two-level target state system for BigQuery:
+1. Table level: Creates/drops tables in BigQuery
+2. Row level: Upserts/deletes rows within tables
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import decimal
+import json
+import re
+import uuid
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Generic,
+    Iterator,
+    Literal,
+    NamedTuple,
+    Sequence,
+)
+
+import msgspec
+from typing_extensions import TypeVar
+
+import cocoindex as coco
+from cocoindex._internal.context_keys import ContextKey, ContextProvider
+from cocoindex._internal.datatype import (
+    AnyType,
+    MappingType,
+    RecordType,
+    SequenceType,
+    TypeChecker,
+    UnionType,
+    analyze_type_info,
+    is_record_type,
+)
+from cocoindex.connectorkits import statediff, target
+from cocoindex.connectorkits.fingerprint import fingerprint_object
+
+_RowKey = tuple[Any, ...]
+_ROW_KEY_CHECKER = TypeChecker(tuple[Any, ...])
+_RowValue = dict[str, Any]
+_RowFingerprint = bytes
+ValueEncoder = Callable[[Any], Any]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROJECT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+
+@dataclasses.dataclass(frozen=True)
+class ConnectionConfig:
+    """Connection information for the BigQuery Python client."""
+
+    project: str | None = None
+    credentials_path: str | None = None
+    location: str | None = None
+
+
+class BigQueryType(NamedTuple):
+    """
+    Annotation to specify a BigQuery column type.
+
+    Use with ``typing.Annotated`` to override the default type mapping.
+    """
+
+    bigquery_type: str
+    encoder: ValueEncoder | None = None
+    use_parse_json: bool = False
+
+
+class _TypeMapping(NamedTuple):
+    """Mapping from Python type to BigQuery type with optional encoder."""
+
+    bigquery_type: str
+    encoder: ValueEncoder | None = None
+    use_parse_json: bool = False
+
+
+class ColumnDef(NamedTuple):
+    """Definition of a BigQuery table column."""
+
+    type: str
+    nullable: bool = True
+    encoder: ValueEncoder | None = None
+    use_parse_json: bool = False
+
+
+class QueryParam(NamedTuple):
+    """A named BigQuery query parameter."""
+
+    name: str
+    type: str
+    value: Any
+
+
+RowT = TypeVar("RowT", default=dict[str, Any])
+
+
+@dataclasses.dataclass(slots=True)
+class TableSchema(Generic[RowT]):
+    """Schema definition for a BigQuery table."""
+
+    columns: dict[str, ColumnDef]
+    primary_key: list[str]
+    row_type: type[RowT] | None
+
+    def __init__(
+        self,
+        columns: dict[str, ColumnDef],
+        primary_key: list[str],
+        *,
+        row_type: type[RowT] | None = None,
+    ) -> None:
+        self.columns = columns
+        self.primary_key = primary_key
+        self.row_type = row_type
+
+        for pk in self.primary_key:
+            if pk not in self.columns:
+                raise ValueError(
+                    f"Primary key column '{pk}' not found in columns: {list(self.columns.keys())}"
+                )
+
+    @classmethod
+    async def from_class(
+        cls,
+        record_type: type[RowT],
+        primary_key: list[str],
+        *,
+        column_overrides: dict[str, BigQueryType] | None = None,
+    ) -> "TableSchema[RowT]":
+        """
+        Create a TableSchema from a record type.
+
+        Args:
+            record_type: A dataclass, NamedTuple, or Pydantic model.
+            primary_key: List of column names that form the primary key.
+            column_overrides: Optional per-column BigQueryType overrides.
+        """
+        if not is_record_type(record_type):
+            raise TypeError(
+                f"record_type must be a record type (dataclass, NamedTuple, Pydantic model), "
+                f"got {type(record_type)}"
+            )
+        columns = await cls._columns_from_record_type(record_type, column_overrides)
+        return cls(columns, primary_key, row_type=record_type)
+
+    @staticmethod
+    async def _columns_from_record_type(
+        record_type: type,
+        column_overrides: dict[str, BigQueryType] | None,
+    ) -> dict[str, ColumnDef]:
+        """Convert a record type to a dict of column name to ColumnDef."""
+        record_info = RecordType(record_type)
+        columns: dict[str, ColumnDef] = {}
+
+        for field in record_info.fields:
+            override = column_overrides.get(field.name) if column_overrides else None
+            type_info = analyze_type_info(field.type_hint)
+
+            all_annotations: list[Any] = []
+            if override is not None:
+                all_annotations.append(override)
+            all_annotations.extend(type_info.annotations)
+
+            bigquery_type_annotation = next(
+                (t for t in all_annotations if isinstance(t, BigQueryType)), None
+            )
+
+            if bigquery_type_annotation is not None:
+                type_mapping = _TypeMapping(
+                    bigquery_type=bigquery_type_annotation.bigquery_type,
+                    encoder=bigquery_type_annotation.encoder,
+                    use_parse_json=bigquery_type_annotation.use_parse_json,
+                )
+            else:
+                type_mapping = await _get_type_mapping(field.type_hint)
+
+            columns[field.name] = ColumnDef(
+                type=type_mapping.bigquery_type.strip(),
+                nullable=type_info.nullable,
+                encoder=type_mapping.encoder,
+                use_parse_json=type_mapping.use_parse_json,
+            )
+
+        return columns
+
+
+def _json_encoder(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+_LEAF_TYPE_MAPPINGS: dict[type, _TypeMapping] = {
+    bool: _TypeMapping("BOOL"),
+    int: _TypeMapping("INT64"),
+    float: _TypeMapping("FLOAT64"),
+    decimal.Decimal: _TypeMapping("NUMERIC"),
+    str: _TypeMapping("STRING"),
+    bytes: _TypeMapping("BYTES"),
+    uuid.UUID: _TypeMapping("STRING", str),
+    datetime.date: _TypeMapping("DATE"),
+    datetime.time: _TypeMapping("TIME"),
+    datetime.datetime: _TypeMapping("TIMESTAMP"),
+    datetime.timedelta: _TypeMapping("FLOAT64", lambda v: v.total_seconds()),
+}
+
+_JSON_MAPPING = _TypeMapping("JSON", _json_encoder, True)
+
+
+async def _get_type_mapping(python_type: Any) -> _TypeMapping:
+    """Get the BigQuery type mapping for a Python type."""
+    type_info = analyze_type_info(python_type)
+
+    for annotation in type_info.annotations:
+        if isinstance(annotation, BigQueryType):
+            return _TypeMapping(
+                annotation.bigquery_type,
+                annotation.encoder,
+                annotation.use_parse_json,
+            )
+
+    base_type = type_info.base_type
+    if base_type in _LEAF_TYPE_MAPPINGS:
+        return _LEAF_TYPE_MAPPINGS[base_type]
+
+    if isinstance(
+        type_info.variant, (SequenceType, MappingType, RecordType, UnionType, AnyType)
+    ):
+        return _JSON_MAPPING
+
+    return _JSON_MAPPING
+
+
+def _validate_identifier(name: str, kind: str = "identifier") -> None:
+    if not isinstance(name, str) or not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid BigQuery {kind}: {name!r}")
+
+
+def _validate_project_id(project: str) -> None:
+    if not isinstance(project, str) or not _PROJECT_RE.match(project):
+        raise ValueError(f"Invalid BigQuery project: {project!r}")
+
+
+def _quote_path(parts: Sequence[str]) -> str:
+    return f"`{'.'.join(parts)}`"
+
+
+def _qualified_table_name(project: str | None, dataset: str, table_name: str) -> str:
+    parts = []
+    if project is not None:
+        _validate_project_id(project)
+        parts.append(project)
+    _validate_identifier(dataset)
+    _validate_identifier(table_name)
+    parts.extend([dataset, table_name])
+    return _quote_path(parts)
+
+
+def _qualified_dataset_name(project: str | None, dataset: str) -> str:
+    parts = []
+    if project is not None:
+        _validate_project_id(project)
+        parts.append(project)
+    _validate_identifier(dataset)
+    parts.append(dataset)
+    return _quote_path(parts)
+
+
+def _source_select_sql(table_schema: TableSchema[Any]) -> str:
+    source_cols = []
+    for idx, (col_name, col) in enumerate(table_schema.columns.items()):
+        value_expr = f"PARSE_JSON(@p{idx})" if col.use_parse_json else f"@p{idx}"
+        source_cols.append(f"{value_expr} AS `{col_name}`")
+    return "SELECT " + ", ".join(source_cols)
+
+
+def _merge_sql(qualified_table_name: str, table_schema: TableSchema[Any]) -> str:
+    all_col_names = list(table_schema.columns.keys())
+    pk_cols = table_schema.primary_key
+    non_pk_cols = [c for c in all_col_names if c not in pk_cols]
+
+    on_clause = " AND ".join(f"target.`{c}` = source.`{c}`" for c in pk_cols)
+    insert_cols = ", ".join(f"`{c}`" for c in all_col_names)
+    insert_values = ", ".join(f"source.`{c}`" for c in all_col_names)
+
+    sql_parts = [
+        f"MERGE {qualified_table_name} AS target",
+        f"USING ({_source_select_sql(table_schema)}) AS source",
+        f"ON {on_clause}",
+    ]
+
+    if non_pk_cols:
+        update_list = ", ".join(f"`{c}` = source.`{c}`" for c in non_pk_cols)
+        sql_parts.append(f"WHEN MATCHED THEN UPDATE SET {update_list}")
+
+    sql_parts.append(
+        f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_values})"
+    )
+    return " ".join(sql_parts)
+
+
+def _delete_sql(
+    qualified_table_name: str, table_schema: TableSchema[Any], *, row_count: int
+) -> str:
+    pk_cols = table_schema.primary_key
+    if row_count <= 0:
+        raise ValueError("row_count must be positive")
+
+    if len(pk_cols) == 1:
+        markers = ", ".join(f"@p{i}" for i in range(row_count))
+        return f"DELETE FROM {qualified_table_name} WHERE `{pk_cols[0]}` IN ({markers})"
+
+    row_clauses = []
+    param_idx = 0
+    for _ in range(row_count):
+        and_parts = []
+        for pk in pk_cols:
+            and_parts.append(f"`{pk}` = @p{param_idx}")
+            param_idx += 1
+        row_clauses.append(f"({' AND '.join(and_parts)})")
+    return f"DELETE FROM {qualified_table_name} WHERE {' OR '.join(row_clauses)}"
+
+
+def _encode_value(col: ColumnDef, value: Any) -> Any:
+    if value is None:
+        return None
+    if col.use_parse_json:
+        if isinstance(value, str):
+            return value
+        return _json_encoder(value)
+    if col.encoder is not None:
+        return col.encoder(value)
+    return value
+
+
+def _encode_row(table_schema: TableSchema[Any], row: _RowValue) -> tuple[Any, ...]:
+    return tuple(
+        _encode_value(col, row.get(col_name))
+        for col_name, col in table_schema.columns.items()
+    )
+
+
+def _query_param_type(col: ColumnDef) -> str:
+    if col.use_parse_json:
+        return "STRING"
+
+    col_type = col.type.upper()
+    if col_type in {
+        "BOOL",
+        "BOOLEAN",
+        "INT64",
+        "INTEGER",
+        "FLOAT64",
+        "FLOAT",
+        "NUMERIC",
+        "BIGNUMERIC",
+        "STRING",
+        "BYTES",
+        "DATE",
+        "TIME",
+        "DATETIME",
+        "TIMESTAMP",
+    }:
+        return col_type
+    if col_type.startswith("ARRAY<") and col_type.endswith(">"):
+        return col_type
+    return "STRING"
+
+
+def _row_query_params(
+    table_schema: TableSchema[Any], values: Sequence[Any]
+) -> tuple[QueryParam, ...]:
+    return tuple(
+        QueryParam(f"p{i}", _query_param_type(col), values[i])
+        for i, col in enumerate(table_schema.columns.values())
+    )
+
+
+def _delete_query_params(
+    table_schema: TableSchema[Any], keys: Sequence[_RowKey]
+) -> tuple[QueryParam, ...]:
+    pk_columns = [table_schema.columns[pk] for pk in table_schema.primary_key]
+    params: list[QueryParam] = []
+    idx = 0
+    for key in keys:
+        for key_idx, value in enumerate(key):
+            col = pk_columns[key_idx]
+            params.append(QueryParam(f"p{idx}", _query_param_type(col), value))
+            idx += 1
+    return tuple(params)
+
+
+@contextmanager
+def _connect(config: ConnectionConfig) -> Iterator[Any]:
+    try:
+        from google.cloud import bigquery  # type: ignore[import-not-found]
+        from google.oauth2 import service_account  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "google-cloud-bigquery is required to use the BigQuery connector. "
+            "Please install cocoindex[bigquery]."
+        ) from e
+
+    credentials = None
+    if config.credentials_path:
+        credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
+            config.credentials_path
+        )
+
+    client = bigquery.Client(
+        project=config.project,
+        credentials=credentials,
+        location=config.location,
+    )
+    try:
+        yield client
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            close()
+
+
+def _bigquery_query_param(param: QueryParam) -> Any:
+    try:
+        from google.cloud import bigquery  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "google-cloud-bigquery is required to use the BigQuery connector. "
+            "Please install cocoindex[bigquery]."
+        ) from e
+
+    if param.type.startswith("ARRAY<") and param.type.endswith(">"):
+        inner_type = param.type[len("ARRAY<") : -1]
+        return bigquery.ArrayQueryParameter(param.name, inner_type, param.value)
+    return bigquery.ScalarQueryParameter(param.name, param.type, param.value)
+
+
+def _run_query(client: Any, sql: str, params: Sequence[QueryParam] = ()) -> Any:
+    try:
+        from google.cloud import bigquery  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "google-cloud-bigquery is required to use the BigQuery connector. "
+            "Please install cocoindex[bigquery]."
+        ) from e
+
+    job_config = None
+    if params:
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[_bigquery_query_param(param) for param in params]
+        )
+    return client.query(sql, job_config=job_config).result()
+
+
+class _RowAction(NamedTuple):
+    """Action to perform on a row."""
+
+    key: _RowKey
+    value: _RowValue | None
+
+
+class _RowHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
+    """Handler for row-level target states within a table."""
+
+    _db_key: str
+    _project: str | None
+    _dataset: str
+    _table_name: str
+    _table_schema: TableSchema[Any]
+    _sink: coco.TargetActionSink[_RowAction, None]
+
+    def __init__(
+        self,
+        db_key: str,
+        project: str | None,
+        dataset: str,
+        table_name: str,
+        table_schema: TableSchema[Any],
+    ) -> None:
+        self._db_key = db_key
+        self._project = project
+        self._dataset = dataset
+        self._table_name = table_name
+        self._table_schema = table_schema
+        self._sink = coco.TargetActionSink[_RowAction, None].from_fn(
+            self._apply_actions
+        )
+
+    def _apply_actions(
+        self, context_provider: ContextProvider, actions: Sequence[_RowAction]
+    ) -> None:
+        if not actions:
+            return
+
+        config = context_provider.get(self._db_key, ConnectionConfig)
+        qualified_name = _qualified_table_name(
+            self._project, self._dataset, self._table_name
+        )
+        upserts = [action for action in actions if action.value is not None]
+        deletes = [action for action in actions if action.value is None]
+
+        with _connect(config) as client:
+            if upserts:
+                merge_sql = _merge_sql(qualified_name, self._table_schema)
+                for action in upserts:
+                    assert action.value is not None
+                    values = _encode_row(self._table_schema, action.value)
+                    _run_query(
+                        client,
+                        merge_sql,
+                        _row_query_params(self._table_schema, values),
+                    )
+
+            if deletes:
+                delete_sql = _delete_sql(
+                    qualified_name,
+                    self._table_schema,
+                    row_count=len(deletes),
+                )
+                _run_query(
+                    client,
+                    delete_sql,
+                    _delete_query_params(
+                        self._table_schema, [action.key for action in deletes]
+                    ),
+                )
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _RowValue | coco.NonExistenceType,
+        prev_possible_records: Collection[_RowFingerprint],
+        prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[_RowAction, _RowFingerprint] | None:
+        key = _ROW_KEY_CHECKER.check(key)
+        if coco.is_non_existence(desired_state):
+            if not prev_possible_records and not prev_may_be_missing:
+                return None
+            return coco.TargetReconcileOutput(
+                action=_RowAction(key=key, value=None),
+                sink=self._sink,
+                tracking_record=coco.NON_EXISTENCE,
+            )
+
+        target_fp = fingerprint_object(desired_state)
+        if not prev_may_be_missing and all(
+            prev == target_fp for prev in prev_possible_records
+        ):
+            return None
+
+        return coco.TargetReconcileOutput(
+            action=_RowAction(key=key, value=desired_state),
+            sink=self._sink,
+            tracking_record=target_fp,
+        )
+
+
+class _TableKey(NamedTuple):
+    """Key identifying a BigQuery table."""
+
+    db_key: str
+    project: str | None
+    dataset: str
+    table_name: str
+
+
+_TABLE_KEY_CHECKER = TypeChecker(tuple[str, str | None, str, str])
+
+
+@dataclasses.dataclass
+class _TableSpec:
+    """Specification for a BigQuery table."""
+
+    table_schema: TableSchema[Any]
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM
+
+
+class _PkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
+    """Primary-key column signature used for table-level main tracking record."""
+
+    name: str
+    type: str
+
+
+class _NonPkColumnTrackingRecord(msgspec.Struct, frozen=True, array_like=True):
+    """Per-non-PK column tracking record used for incremental ALTER TABLE operations."""
+
+    type: str
+    nullable: bool
+
+
+_COL_SUBKEY_PREFIX: str = "col:"
+
+
+def _col_subkey(col_name: str) -> str:
+    return f"{_COL_SUBKEY_PREFIX}{col_name}"
+
+
+_TableSubTrackingRecord = _NonPkColumnTrackingRecord | None
+
+
+def _table_composite_tracking_record_from_spec(
+    spec: _TableSpec,
+) -> statediff.CompositeTrackingRecord[
+    tuple[_PkColumnTrackingRecord, ...], str, _TableSubTrackingRecord
+]:
+    schema = spec.table_schema
+    col_by_name = schema.columns
+    pk_sig = tuple(
+        _PkColumnTrackingRecord(name=pk, type=col_by_name[pk].type)
+        for pk in schema.primary_key
+    )
+    sub: dict[str, _TableSubTrackingRecord] = {
+        _col_subkey(col_name): _NonPkColumnTrackingRecord(
+            type=col_def.type, nullable=col_def.nullable
+        )
+        for col_name, col_def in schema.columns.items()
+        if col_name not in schema.primary_key
+    }
+    return statediff.CompositeTrackingRecord(main=pk_sig, sub=sub)
+
+
+_TableTrackingRecord = statediff.MutualTrackingRecord[
+    statediff.CompositeTrackingRecord[
+        tuple[_PkColumnTrackingRecord, ...], str, _TableSubTrackingRecord
+    ]
+]
+
+
+class _TableAction(NamedTuple):
+    """Action to perform on a table."""
+
+    key: _TableKey
+    spec: _TableSpec | coco.NonExistenceType
+    main_action: statediff.DiffAction | None
+    column_actions: dict[str, statediff.DiffAction]
+
+
+def _column_sql(col_name: str, col: ColumnDef, primary_key: set[str]) -> str:
+    nullable = "" if col.nullable and col_name not in primary_key else " NOT NULL"
+    return f"`{col_name}` {col.type}{nullable}"
+
+
+def _drop_table(client: Any, key: _TableKey) -> None:
+    qualified_name = _qualified_table_name(key.project, key.dataset, key.table_name)
+    _run_query(client, f"DROP TABLE IF EXISTS {qualified_name}")
+
+
+def _create_table(
+    client: Any,
+    key: _TableKey,
+    schema: TableSchema[Any],
+    *,
+    if_not_exists: bool,
+) -> None:
+    _run_query(
+        client,
+        f"CREATE SCHEMA IF NOT EXISTS {_qualified_dataset_name(key.project, key.dataset)}",
+    )
+
+    primary_key = set(schema.primary_key)
+    col_defs = [
+        _column_sql(col_name, col, primary_key)
+        for col_name, col in schema.columns.items()
+    ]
+    pk_cols = ", ".join(f"`{c}`" for c in schema.primary_key)
+    col_defs.append(f"PRIMARY KEY ({pk_cols}) NOT ENFORCED")
+
+    if_not_exists_sql = " IF NOT EXISTS" if if_not_exists else ""
+    qualified_name = _qualified_table_name(key.project, key.dataset, key.table_name)
+    columns_sql = ", ".join(col_defs)
+    _run_query(
+        client,
+        f"CREATE TABLE{if_not_exists_sql} {qualified_name} ({columns_sql})",
+    )
+
+
+def _apply_column_actions(
+    client: Any,
+    key: _TableKey,
+    schema: TableSchema[Any],
+    column_actions: dict[str, statediff.DiffAction],
+) -> None:
+    qualified_name = _qualified_table_name(key.project, key.dataset, key.table_name)
+    pk_cols = set(schema.primary_key)
+    non_pk_col_by_name = {n: c for n, c in schema.columns.items() if n not in pk_cols}
+
+    for sub_key, action in column_actions.items():
+        if not sub_key.startswith(_COL_SUBKEY_PREFIX):
+            raise ValueError(
+                f"Unexpected column subkey format: {sub_key!r}, expected to start with {_COL_SUBKEY_PREFIX!r}"
+            )
+        col_name = sub_key[len(_COL_SUBKEY_PREFIX) :]
+        if col_name in pk_cols:
+            continue
+
+        if action == "delete":
+            _run_query(
+                client,
+                f"ALTER TABLE {qualified_name} DROP COLUMN IF EXISTS `{col_name}`",
+            )
+            continue
+
+        desired_col = non_pk_col_by_name.get(col_name)
+        if desired_col is None:
+            continue
+
+        if action == "insert":
+            _run_query(
+                client,
+                f"ALTER TABLE {qualified_name} "
+                f"ADD COLUMN {_column_sql(col_name, desired_col, pk_cols)}",
+            )
+            continue
+
+        if action == "upsert":
+            _run_query(
+                client,
+                f"ALTER TABLE {qualified_name} "
+                f"ADD COLUMN IF NOT EXISTS {_column_sql(col_name, desired_col, pk_cols)}",
+            )
+            continue
+
+        if action == "replace":
+            _run_query(
+                client,
+                f"ALTER TABLE {qualified_name} DROP COLUMN IF EXISTS `{col_name}`",
+            )
+            _run_query(
+                client,
+                f"ALTER TABLE {qualified_name} "
+                f"ADD COLUMN {_column_sql(col_name, desired_col, pk_cols)}",
+            )
+
+
+class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHandler]):
+    """Handler for table-level target states."""
+
+    _sink: coco.TargetActionSink[_TableAction, _RowHandler]
+
+    def __init__(self) -> None:
+        self._sink = coco.TargetActionSink[_TableAction, _RowHandler].from_fn(
+            self._apply_actions
+        )
+
+    def _apply_actions(
+        self, context_provider: ContextProvider, actions: Collection[_TableAction]
+    ) -> list[coco.ChildTargetDef[_RowHandler] | None]:
+        actions_list = list(actions)
+        outputs: list[coco.ChildTargetDef[_RowHandler] | None] = [None] * len(
+            actions_list
+        )
+
+        by_key: dict[_TableKey, list[int]] = {}
+        for i, action in enumerate(actions_list):
+            by_key.setdefault(action.key, []).append(i)
+
+        for key, idxs in by_key.items():
+            config = context_provider.get(key.db_key, ConnectionConfig)
+            with _connect(config) as client:
+                for i in idxs:
+                    action = actions_list[i]
+                    assert action.key == key
+
+                    if action.main_action in ("replace", "delete"):
+                        _drop_table(client, key)
+
+                    if coco.is_non_existence(action.spec):
+                        outputs[i] = None
+                        continue
+
+                    spec = action.spec
+                    outputs[i] = coco.ChildTargetDef(
+                        handler=_RowHandler(
+                            db_key=key.db_key,
+                            project=key.project,
+                            dataset=key.dataset,
+                            table_name=key.table_name,
+                            table_schema=spec.table_schema,
+                        )
+                    )
+
+                    if action.main_action in ("insert", "upsert", "replace"):
+                        _create_table(
+                            client,
+                            key,
+                            spec.table_schema,
+                            if_not_exists=(action.main_action == "upsert"),
+                        )
+                        continue
+
+                    if action.column_actions:
+                        _apply_column_actions(
+                            client, key, spec.table_schema, action.column_actions
+                        )
+
+        return outputs
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: _TableSpec | coco.NonExistenceType,
+        prev_possible_records: Collection[_TableTrackingRecord],
+        prev_may_be_missing: bool,
+        /,
+    ) -> (
+        coco.TargetReconcileOutput[_TableAction, _TableTrackingRecord, _RowHandler]
+        | None
+    ):
+        key = _TableKey(*_TABLE_KEY_CHECKER.check(key))
+        tracking_record: _TableTrackingRecord | coco.NonExistenceType
+
+        if coco.is_non_existence(desired_state):
+            tracking_record = coco.NON_EXISTENCE
+        else:
+            tracking_record = statediff.MutualTrackingRecord(
+                tracking_record=_table_composite_tracking_record_from_spec(
+                    desired_state
+                ),
+                managed_by=desired_state.managed_by,
+            )
+
+        resolved = statediff.resolve_system_transition(
+            statediff.TrackingRecordTransition(
+                tracking_record,
+                prev_possible_records,
+                prev_may_be_missing,
+            )
+        )
+        main_action, column_transitions = statediff.diff_composite(resolved)
+
+        column_actions: dict[str, statediff.DiffAction] = {}
+        if main_action is None:
+            for sub_key, t in column_transitions.items():
+                action = statediff.diff(t)
+                if action is not None:
+                    column_actions[sub_key] = action
+
+        child_invalidation: Literal["destructive", "lossy"] | None = None
+        if main_action == "replace":
+            child_invalidation = "destructive"
+        elif main_action is None and any(
+            a != "insert" for a in column_actions.values()
+        ):
+            child_invalidation = "lossy"
+
+        return coco.TargetReconcileOutput(
+            action=_TableAction(
+                key=key,
+                spec=desired_state,
+                main_action=main_action,
+                column_actions=column_actions,
+            ),
+            sink=self._sink,
+            tracking_record=tracking_record,
+            child_invalidation=child_invalidation,
+        )
+
+
+_table_provider = coco.register_root_target_states_provider(
+    "cocoindex/bigquery/table", _TableHandler()
+)
+
+
+class TableTarget(
+    Generic[RowT, coco.MaybePendingS], coco.ResolvesTo["TableTarget[RowT]"]
+):
+    """A target for writing rows to a BigQuery table."""
+
+    _provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS]
+    _table_schema: TableSchema[RowT]
+
+    def __init__(
+        self,
+        provider: coco.TargetStateProvider[_RowValue, None, coco.MaybePendingS],
+        table_schema: TableSchema[RowT],
+    ) -> None:
+        self._provider = provider
+        self._table_schema = table_schema
+
+    def declare_row(self: "TableTarget[RowT]", *, row: RowT) -> None:
+        row_dict = self._row_to_dict(row)
+        pk_values = tuple(row_dict[pk] for pk in self._table_schema.primary_key)
+        coco.declare_target_state(self._provider.target_state(pk_values, row_dict))
+
+    def _row_to_dict(self, row: RowT) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for col_name in self._table_schema.columns:
+            if isinstance(row, dict):
+                value = row.get(col_name)
+            else:
+                value = getattr(row, col_name)
+            out[col_name] = value
+        return out
+
+    def __coco_memo_key__(self) -> str:
+        return self._provider.memo_key
+
+
+def table_target(
+    db: ContextKey[ConnectionConfig],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    dataset: str,
+    project: str | None = None,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> coco.TargetState[_RowHandler]:
+    """
+    Create a TargetState for a BigQuery table target.
+
+    Use with ``coco.mount_target()`` or the convenience wrappers below.
+    """
+    _validate_identifier(table_name, "table name")
+    _validate_identifier(dataset, "dataset name")
+    if project is not None:
+        _validate_project_id(project)
+    for col_name in table_schema.columns:
+        _validate_identifier(col_name, "column name")
+
+    key = _TableKey(
+        db_key=db.key,
+        project=project,
+        dataset=dataset,
+        table_name=table_name,
+    )
+    spec = _TableSpec(
+        table_schema=table_schema,
+        managed_by=managed_by,
+    )
+    return _table_provider.target_state(key, spec)
+
+
+def declare_table_target(
+    db: ContextKey[ConnectionConfig],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    dataset: str,
+    project: str | None = None,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT, coco.PendingS]:
+    """Declare a BigQuery table target and return a pending TableTarget."""
+    provider = coco.declare_target_state_with_child(
+        table_target(
+            db,
+            table_name,
+            table_schema,
+            dataset=dataset,
+            project=project,
+            managed_by=managed_by,
+        )
+    )
+    return TableTarget(provider, table_schema)
+
+
+async def mount_table_target(
+    db: ContextKey[ConnectionConfig],
+    table_name: str,
+    table_schema: TableSchema[RowT],
+    *,
+    dataset: str,
+    project: str | None = None,
+    managed_by: target.ManagedBy = target.ManagedBy.SYSTEM,
+) -> TableTarget[RowT]:
+    """Mount a BigQuery table target and return a ready-to-use TableTarget."""
+    provider = await coco.mount_target(
+        table_target(
+            db,
+            table_name,
+            table_schema,
+            dataset=dataset,
+            project=project,
+            managed_by=managed_by,
+        )
+    )
+    return TableTarget(provider, table_schema)
+
+
+__all__ = [
+    "BigQueryType",
+    "ColumnDef",
+    "ConnectionConfig",
+    "TableSchema",
+    "TableTarget",
+    "ValueEncoder",
+    "declare_table_target",
+    "mount_table_target",
+    "table_target",
+]

--- a/python/tests/connectors/test_bigquery_target.py
+++ b/python/tests/connectors/test_bigquery_target.py
@@ -1,0 +1,448 @@
+"""Tests for BigQuery target connector."""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import decimal
+import os
+import uuid
+from typing import Annotated, Any, cast
+
+import pytest
+
+import cocoindex as coco
+from cocoindex.connectorkits import target
+from cocoindex.connectors import bigquery
+from cocoindex.connectors.bigquery import _target
+
+BIGQUERY_DB = coco.ContextKey[bigquery.ConnectionConfig]("bigquery_test_db")
+
+
+@dataclasses.dataclass
+class SimpleRow:
+    id: int
+    text: str
+
+
+@dataclasses.dataclass
+class TypedRow:
+    id: int
+    flag: bool
+    amount: decimal.Decimal
+    created_on: datetime.date
+    created_at: datetime.datetime
+    elapsed: datetime.timedelta
+    external_id: uuid.UUID
+    payload: dict[str, object]
+    tags: list[str]
+
+
+@dataclasses.dataclass
+class OverrideRow:
+    id: Annotated[int, bigquery.BigQueryType("NUMERIC")]
+    vector: Annotated[list[float], bigquery.BigQueryType("ARRAY<FLOAT64>")]
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[_target.QueryParam, ...]]] = []
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+class FakeConnectionContext:
+    def __init__(self, client: FakeClient) -> None:
+        self.client = client
+
+    def __enter__(self) -> FakeClient:
+        return self.client
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> None:
+        self.client.close()
+
+
+class FakeContextProvider:
+    def __init__(self, config: bigquery.ConnectionConfig) -> None:
+        self.config = config
+
+    def get(self, key: str, typ: type[Any]) -> Any:
+        assert key == BIGQUERY_DB.key
+        assert typ is bigquery.ConnectionConfig
+        return self.config
+
+
+def _connection_config() -> bigquery.ConnectionConfig:
+    return bigquery.ConnectionConfig(project="test_project", location="US")
+
+
+class FakeTargetStateProvider:
+    memo_key = "fake-bigquery-table"
+
+    def __init__(self) -> None:
+        self.key: tuple[Any, ...] | None = None
+        self.value: dict[str, Any] | None = None
+
+    def target_state(self, key: tuple[Any, ...], value: dict[str, Any]) -> object:
+        self.key = key
+        self.value = value
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_table_target_rejects_invalid_table_identifier() -> None:
+    schema = await bigquery.TableSchema.from_class(SimpleRow, primary_key=["id"])
+
+    with pytest.raises(ValueError, match="Invalid BigQuery table name"):
+        bigquery.table_target(
+            BIGQUERY_DB,
+            table_name="bad-table",
+            table_schema=schema,
+            dataset="analytics",
+        )
+
+
+@pytest.mark.asyncio
+async def test_table_target_rejects_invalid_column_identifier() -> None:
+    schema = bigquery.TableSchema(
+        columns={"bad-column": bigquery.ColumnDef(type="STRING")},
+        primary_key=["bad-column"],
+    )
+
+    with pytest.raises(ValueError, match="Invalid BigQuery column name"):
+        bigquery.table_target(
+            BIGQUERY_DB,
+            table_name="events",
+            table_schema=schema,
+            dataset="analytics",
+        )
+
+
+@pytest.mark.asyncio
+async def test_table_schema_maps_python_types_to_bigquery_types() -> None:
+    schema = await bigquery.TableSchema.from_class(TypedRow, primary_key=["id"])
+
+    assert schema.columns["id"].type == "INT64"
+    assert schema.columns["flag"].type == "BOOL"
+    assert schema.columns["amount"].type == "NUMERIC"
+    assert schema.columns["created_on"].type == "DATE"
+    assert schema.columns["created_at"].type == "TIMESTAMP"
+    assert schema.columns["elapsed"].type == "FLOAT64"
+    assert schema.columns["external_id"].type == "STRING"
+    assert schema.columns["payload"].type == "JSON"
+    assert schema.columns["payload"].use_parse_json is True
+    assert schema.columns["tags"].type == "JSON"
+    assert schema.columns["tags"].use_parse_json is True
+
+
+@pytest.mark.asyncio
+async def test_bigquery_type_override_is_used() -> None:
+    schema = await bigquery.TableSchema.from_class(OverrideRow, primary_key=["id"])
+
+    assert schema.columns["id"].type == "NUMERIC"
+    assert schema.columns["vector"].type == "ARRAY<FLOAT64>"
+    assert schema.columns["vector"].use_parse_json is False
+
+
+def test_qualified_table_name_quotes_each_part() -> None:
+    assert (
+        _target._qualified_table_name("demo-project", "analytics", "events")
+        == "`demo-project.analytics.events`"
+    )
+    assert (
+        _target._qualified_table_name(None, "analytics", "events")
+        == "`analytics.events`"
+    )
+
+
+def test_merge_sql_uses_merge_and_parse_json_for_json_columns() -> None:
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "payload": bigquery.ColumnDef(
+                type="JSON", nullable=True, use_parse_json=True
+            ),
+        },
+        primary_key=["id"],
+    )
+
+    sql = _target._merge_sql("`demo-project.analytics.events`", schema)
+
+    assert "MERGE `demo-project.analytics.events` AS target" in sql
+    assert "SELECT @p0 AS `id`, PARSE_JSON(@p1) AS `payload`" in sql
+    assert "ON target.`id` = source.`id`" in sql
+    assert "WHEN MATCHED THEN UPDATE SET `payload` = source.`payload`" in sql
+    assert (
+        "WHEN NOT MATCHED THEN INSERT (`id`, `payload`) VALUES "
+        "(source.`id`, source.`payload`)"
+    ) in sql
+
+
+def test_merge_sql_without_non_primary_key_columns_does_nothing_on_match() -> None:
+    schema = bigquery.TableSchema(
+        columns={"id": bigquery.ColumnDef(type="INT64", nullable=False)},
+        primary_key=["id"],
+    )
+
+    sql = _target._merge_sql("`events`", schema)
+
+    assert "WHEN MATCHED THEN UPDATE" not in sql
+    assert "WHEN NOT MATCHED THEN INSERT" in sql
+
+
+def test_delete_sql_supports_single_and_composite_primary_keys() -> None:
+    single = bigquery.TableSchema(
+        columns={"id": bigquery.ColumnDef(type="INT64", nullable=False)},
+        primary_key=["id"],
+    )
+    composite = bigquery.TableSchema(
+        columns={
+            "tenant": bigquery.ColumnDef(type="STRING", nullable=False),
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+        },
+        primary_key=["tenant", "id"],
+    )
+
+    assert (
+        _target._delete_sql("`events`", single, row_count=3)
+        == "DELETE FROM `events` WHERE `id` IN (@p0, @p1, @p2)"
+    )
+    assert (
+        _target._delete_sql("`events`", composite, row_count=2)
+        == "DELETE FROM `events` WHERE (`tenant` = @p0 AND `id` = @p1) "
+        "OR (`tenant` = @p2 AND `id` = @p3)"
+    )
+
+
+def test_encode_row_serializes_json_deterministically() -> None:
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "payload": bigquery.ColumnDef(type="JSON", use_parse_json=True),
+        },
+        primary_key=["id"],
+    )
+
+    assert _target._encode_row(schema, {"id": 1, "payload": {"b": 2, "a": [1]}}) == (
+        1,
+        '{"a":[1],"b":2}',
+    )
+
+
+def test_table_target_tracks_raw_rows_and_encodes_on_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "elapsed": bigquery.ColumnDef(
+                type="FLOAT64", encoder=lambda v: v.total_seconds()
+            ),
+        },
+        primary_key=["id"],
+    )
+    provider = FakeTargetStateProvider()
+    declared: list[object] = []
+    monkeypatch.setattr(coco, "declare_target_state", declared.append)
+
+    bigquery.TableTarget(cast(Any, provider), schema).declare_row(
+        row={"id": 1, "elapsed": datetime.timedelta(seconds=90)}
+    )
+
+    assert provider.key == (1,)
+    assert provider.value == {"id": 1, "elapsed": datetime.timedelta(seconds=90)}
+    assert len(declared) == 1
+    assert _target._encode_row(schema, provider.value) == (1, 90.0)
+
+
+def test_row_handler_executes_merge_and_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "payload": bigquery.ColumnDef(type="JSON", use_parse_json=True),
+        },
+        primary_key=["id"],
+    )
+    client = FakeClient()
+    monkeypatch.setattr(
+        _target, "_connect", lambda config: FakeConnectionContext(client)
+    )
+    monkeypatch.setattr(
+        _target,
+        "_run_query",
+        lambda client, sql, params=(): client.calls.append((sql, tuple(params))),
+    )
+
+    handler = _target._RowHandler(
+        db_key=BIGQUERY_DB.key,
+        project="demo-project",
+        dataset="analytics",
+        table_name="events",
+        table_schema=schema,
+    )
+
+    handler._apply_actions(
+        cast(Any, FakeContextProvider(_connection_config())),
+        [
+            _target._RowAction(key=(1,), value={"id": 1, "payload": {"b": 2}}),
+            _target._RowAction(key=(2,), value=None),
+        ],
+    )
+
+    assert len(client.calls) == 2
+    assert client.calls[0][0].startswith("MERGE `demo-project.analytics.events`")
+    assert client.calls[0][1] == (
+        _target.QueryParam("p0", "INT64", 1),
+        _target.QueryParam("p1", "STRING", '{"b":2}'),
+    )
+    assert client.calls[1] == (
+        "DELETE FROM `demo-project.analytics.events` WHERE `id` IN (@p0)",
+        (_target.QueryParam("p0", "INT64", 2),),
+    )
+    assert client.close_count == 1
+
+
+def test_table_handler_creates_dataset_and_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "payload": bigquery.ColumnDef(type="JSON", use_parse_json=True),
+        },
+        primary_key=["id"],
+    )
+    client = FakeClient()
+    monkeypatch.setattr(
+        _target, "_connect", lambda config: FakeConnectionContext(client)
+    )
+    monkeypatch.setattr(
+        _target,
+        "_run_query",
+        lambda client, sql, params=(): client.calls.append((sql, tuple(params))),
+    )
+
+    action = _target._TableAction(
+        key=_target._TableKey(
+            db_key=BIGQUERY_DB.key,
+            project="demo-project",
+            dataset="analytics",
+            table_name="events",
+        ),
+        spec=_target._TableSpec(
+            table_schema=schema,
+            managed_by=target.ManagedBy.SYSTEM,
+        ),
+        main_action="insert",
+        column_actions={},
+    )
+
+    children = _target._TableHandler()._apply_actions(
+        cast(Any, FakeContextProvider(_connection_config())), [action]
+    )
+
+    assert len(children) == 1
+    assert children[0] is not None
+    assert client.calls == [
+        ("CREATE SCHEMA IF NOT EXISTS `demo-project.analytics`", ()),
+        (
+            "CREATE TABLE `demo-project.analytics.events` "
+            "(`id` INT64 NOT NULL, `payload` JSON, "
+            "PRIMARY KEY (`id`) NOT ENFORCED)",
+            (),
+        ),
+    ]
+    assert client.close_count == 1
+
+
+REQUIRED_BIGQUERY_ENV = [
+    "BIGQUERY_PROJECT",
+    "BIGQUERY_DATASET",
+]
+
+
+def _bigquery_env_available() -> bool:
+    return all(os.environ.get(name) for name in REQUIRED_BIGQUERY_ENV)
+
+
+@pytest.mark.skipif(
+    not _bigquery_env_available(), reason="BigQuery credentials are not configured"
+)
+def test_live_bigquery_upsert_and_delete() -> None:
+    pytest.importorskip("google.cloud.bigquery")
+    table_name = f"cocoindex_test_{uuid.uuid4().hex}"
+    config = bigquery.ConnectionConfig(
+        project=os.environ["BIGQUERY_PROJECT"],
+        location=os.environ.get("BIGQUERY_LOCATION"),
+    )
+    dataset = os.environ["BIGQUERY_DATASET"]
+    schema = bigquery.TableSchema(
+        columns={
+            "id": bigquery.ColumnDef(type="INT64", nullable=False),
+            "payload": bigquery.ColumnDef(type="JSON", use_parse_json=True),
+        },
+        primary_key=["id"],
+    )
+    ctx = cast(Any, FakeContextProvider(config))
+    table_key = _target._TableKey(
+        db_key=BIGQUERY_DB.key,
+        project=os.environ["BIGQUERY_PROJECT"],
+        dataset=dataset,
+        table_name=table_name,
+    )
+
+    try:
+        _target._TableHandler()._apply_actions(
+            ctx,
+            [
+                _target._TableAction(
+                    key=table_key,
+                    spec=_target._TableSpec(schema, target.ManagedBy.SYSTEM),
+                    main_action="insert",
+                    column_actions={},
+                )
+            ],
+        )
+        _target._RowHandler(
+            db_key=BIGQUERY_DB.key,
+            project=os.environ["BIGQUERY_PROJECT"],
+            dataset=dataset,
+            table_name=table_name,
+            table_schema=schema,
+        )._apply_actions(
+            ctx,
+            [
+                _target._RowAction(key=(1,), value={"id": 1, "payload": {"v": "one"}}),
+                _target._RowAction(key=(2,), value={"id": 2, "payload": {"v": "two"}}),
+                _target._RowAction(
+                    key=(1,), value={"id": 1, "payload": {"v": "one-updated"}}
+                ),
+                _target._RowAction(key=(2,), value=None),
+            ],
+        )
+
+        with _target._connect(config) as client:
+            rows = list(
+                _target._run_query(
+                    client,
+                    f"SELECT `id`, JSON_VALUE(`payload`, '$.v') AS v FROM "
+                    f"{_target._qualified_table_name(os.environ['BIGQUERY_PROJECT'], dataset, table_name)}",
+                )
+            )
+            assert len(rows) == 1
+            assert int(rows[0]["id"]) == 1
+            assert rows[0]["v"] == "one-updated"
+    finally:
+        with _target._connect(config) as client:
+            _target._run_query(
+                client,
+                f"DROP TABLE IF EXISTS "
+                f"{_target._qualified_table_name(os.environ['BIGQUERY_PROJECT'], dataset, table_name)}",
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -582,6 +582,7 @@ all = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
+    { name = "google-cloud-bigquery" },
     { name = "httplib2" },
     { name = "instructor" },
     { name = "lancedb" },
@@ -602,6 +603,10 @@ all = [
 ]
 amazon-s3 = [
     { name = "aiobotocore" },
+]
+bigquery = [
+    { name = "google-auth" },
+    { name = "google-cloud-bigquery" },
 ]
 colpali = [
     { name = "colpali-engine" },
@@ -762,9 +767,12 @@ requires-dist = [
     { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "google-api-python-client", marker = "extra == 'google-drive'", specifier = ">=2.0.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "google-auth", marker = "extra == 'bigquery'", specifier = ">=2.0.0" },
     { name = "google-auth", marker = "extra == 'google-drive'", specifier = ">=2.0.0" },
     { name = "google-auth-httplib2", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "google-auth-httplib2", marker = "extra == 'google-drive'", specifier = ">=0.2.0" },
+    { name = "google-cloud-bigquery", marker = "extra == 'all'", specifier = ">=3.0.0" },
+    { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.0.0" },
     { name = "httplib2", marker = "extra == 'all'", specifier = ">=0.22.0" },
     { name = "httplib2", marker = "extra == 'google-drive'", specifier = ">=0.22.0" },
     { name = "instructor", marker = "extra == 'all'", specifier = ">=1.0" },
@@ -807,7 +815,7 @@ requires-dist = [
     { name = "zvec", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "zvec", marker = "extra == 'zvec'", specifier = ">=0.5.0" },
 ]
-provides-extras = ["all", "amazon-s3", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "snowflake", "sqlite", "surrealdb", "turbopuffer", "valkey", "zvec"]
+provides-extras = ["all", "amazon-s3", "bigquery", "colpali", "doris", "entity-resolution", "entity-resolution-llm", "falkordb", "google-drive", "iggy", "kafka", "lancedb", "litellm", "neo4j", "oci", "postgres", "qdrant", "sentence-transformers", "snowflake", "sqlite", "surrealdb", "turbopuffer", "valkey", "zvec"]
 
 [package.metadata.requires-dev]
 build-test = [
@@ -1255,6 +1263,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/b6/85c4d21067220b9a78cfb81f516f9725ea6befc1544ec9bd2c1acd97c324/google_api_core-2.29.0-py3-none-any.whl", hash = "sha256:d30bc60980daa36e314b5d5a3e5958b0200cb44ca8fa1be2b614e932b75a3ea9", size = 173906, upload-time = "2026-01-08T22:21:36.093Z" },
 ]
 
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
 [[package]]
 name = "google-api-python-client"
 version = "2.188.0"
@@ -1285,6 +1299,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
 ]
 
+[package.optional-dependencies]
+pyopenssl = [
+    { name = "pyopenssl" },
+]
+
 [[package]]
 name = "google-auth-httplib2"
 version = "0.3.0"
@@ -1296,6 +1315,79 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134, upload-time = "2025-12-15T22:13:51.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529, upload-time = "2025-12-15T22:13:51.048Z" },
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth", extra = ["pyopenssl"] },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/a2/be1cffbb1a9894ecf394ab0096b113ae9e4f73686595d906a9f3082b07c2/google_cloud_bigquery-3.42.1.tar.gz", hash = "sha256:3c6878f424fc2b21f0bb414ca7262abd008465575a7b7c44c552105278a18914", size = 515411, upload-time = "2026-06-22T23:21:05.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/1e/8b098aeb69ef87de5195d076ce6d82002c3ebf1920373d386ca7b6e63cfa/google_cloud_bigquery-3.42.1-py3-none-any.whl", hash = "sha256:159143c1b7248858f35549c09efea5d031c2883145623419ea7c505a50c0899a", size = 263814, upload-time = "2026-06-22T23:18:42.313Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
 ]
 
 [[package]]
@@ -1359,6 +1451,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/45/122df922d05655f63930cf42c9e3f72ba20aadb26c100ee105cad4ce4257/grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc", size = 7592214, upload-time = "2025-10-21T16:22:33.831Z" },
     { url = "https://files.pythonhosted.org/packages/4a/6e/0b899b7f6b66e5af39e377055fb4a6675c9ee28431df5708139df2e93233/grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e", size = 4062961, upload-time = "2025-10-21T16:22:36.468Z" },
     { url = "https://files.pythonhosted.org/packages/19/41/0b430b01a2eb38ee887f88c1f07644a1df8e289353b78e82b37ef988fb64/grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e", size = 4834462, upload-time = "2025-10-21T16:22:39.772Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.76.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/46/e9f19d5be65e8423f886813a2a9d0056ba94757b0c5007aa59aed1a961fa/grpcio_status-1.76.0.tar.gz", hash = "sha256:25fcbfec74c15d1a1cb5da3fab8ee9672852dc16a5a9eeb5baf7d7a9952943cd", size = 13679, upload-time = "2025-10-21T16:28:52.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/cc/27ba60ad5a5f2067963e6a858743500df408eb5855e98be778eaef8c9b02/grpcio_status-1.76.0-py3-none-any.whl", hash = "sha256:380568794055a8efbbd8871162df92012e0228a5f6dffaf57f2a00c534103b18", size = 14425, upload-time = "2025-10-21T16:28:40.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a BigQuery target connector with managed table creation, MERGE upserts, deletes, and schema diff handling.
- Add Python type to BigQuery type mapping, custom BigQueryType overrides, and Application Default Credentials or service account authentication.
- Add connector docs, a runnable BigQuery target example, and focused tests.

## Test plan

- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra bigquery pytest python/tests/connectors/test_bigquery_target.py python/tests/connectors/test_snowflake_target.py
- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra bigquery mypy python/cocoindex/connectors/bigquery python/tests/connectors/test_bigquery_target.py examples/bigquery_target/main.py
- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff format --check python/cocoindex/connectors/bigquery python/tests/connectors/test_bigquery_target.py examples/bigquery_target/main.py
- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check python/cocoindex/connectors/bigquery python/tests/connectors/test_bigquery_target.py examples/bigquery_target/main.py
- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache uv lock --check
- env -u CONDA_PREFIX UV_CACHE_DIR=/private/tmp/uv-cache BIGQUERY_PROJECT=rdms-data-warehouse BIGQUERY_DATASET=cocoindex_demo BIGQUERY_LOCATION=US uv run --extra bigquery pytest python/tests/connectors/test_bigquery_target.py -k live_bigquery -s -rs --timeout=120

Fixes #2249
