### PR TITLE
feat(py): deprecated compat shims for the removed CodeAst surface

### DIFF
--- a/python/cocoindex/ops/code.py
+++ b/python/cocoindex/ops/code.py
@@ -17,6 +17,8 @@ __all__ = [
     "match_code",
 ]
 
+import typing as _typing
+import warnings as _warnings
 from dataclasses import dataclass as _dataclass
 
 from cocoindex._internal import core as _core
@@ -71,6 +73,17 @@ class CodeSource:
     def language(self) -> str | None:
         """The language as given at construction (may be an alias/extension)."""
         return self._src.language
+
+    @property
+    def source(self) -> str:
+        """Deprecated alias of :attr:`text` (the name the removed ``CodeAst``
+        class used); use ``.text``."""
+        _warnings.warn(
+            "CodeSource.source is deprecated; use CodeSource.text",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._src.text
 
     def __repr__(self) -> str:
         return f"CodeSource(language={self.language!r}, text_len={len(self.text)})"
@@ -176,6 +189,18 @@ class FileMatch:
     """The matches found (always at least one — ``match_file`` returns ``None``
     when there are none)."""
 
+    @property
+    def ast(self) -> CodeSource:
+        """Deprecated alias of :attr:`source` (the field's name when it held the
+        removed ``CodeAst`` class); use ``.source``."""
+        _warnings.warn(
+            "FileMatch.ast is deprecated; use FileMatch.source "
+            "(and .text for the file content)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.source
+
 
 def match_code(
     pattern: str, source: "str | CodeSource", language: str | None = None
@@ -238,3 +263,23 @@ def _convert_chunk(raw: "_core.Chunk", text: str) -> _chunk.Chunk:
             column=raw.end_column,
         ),
     )
+
+
+def __getattr__(name: str) -> _typing.Any:
+    # Deprecated alias for the removed ``CodeAst`` class, so annotations and
+    # ``isinstance`` checks in older callers keep working. ``CodeSource`` is
+    # the single handle now; note its constructor is lazy and tolerant where
+    # ``CodeAst``'s was eager and raising, and the old ``.matches`` / ``.split``
+    # / ``.index_terms`` methods live on the consumers instead
+    # (``CodePattern.match_source`` / ``match_code``, ``RecursiveSplitter.split``,
+    # ``index_terms``).
+    if name == "CodeAst":
+        _warnings.warn(
+            "CodeAst is deprecated and now aliases CodeSource; use CodeSource "
+            "with CodePattern.match_source / match_code, RecursiveSplitter.split, "
+            "and index_terms",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return CodeSource
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/tests/ops/test_code.py
+++ b/python/tests/ops/test_code.py
@@ -199,3 +199,28 @@ def test_index_terms_str_and_code_source() -> None:
         index_terms(CodeSource(src_text, language="nonsense-lang"))
     with pytest.raises(ValueError, match="language"):
         index_terms(src, language="python")  # CodeSource carries its own
+
+
+def test_deprecated_codeast_compat_shims(tmp_path: Path) -> None:
+    """The removed CodeAst surface that released downstreams (e.g.
+    cocoindex-code's grep) still touch keeps working for one deprecation
+    cycle: ``FileMatch.ast``, ``CodeSource.source``, and the ``CodeAst``
+    module alias."""
+    cp = CodePattern(r"def \NAME(\(A*\)):", language="python")
+    hit = tmp_path / "hit.py"
+    hit.write_text(_PY_SRC, newline="")
+    fm = cp.match_file(str(hit))
+    assert fm is not None
+    with pytest.deprecated_call():
+        assert fm.ast is fm.source
+    with pytest.deprecated_call():
+        assert fm.source.source == _PY_SRC  # the exact downstream expression shape
+
+    from cocoindex.ops import code as code_module
+
+    with pytest.deprecated_call():
+        deprecated_cls = code_module.CodeAst
+    assert deprecated_cls is CodeSource
+    assert isinstance(CodeSource(_PY_SRC, language="python"), deprecated_cls)
+    with pytest.raises(AttributeError):
+        _ = code_module.NoSuchName


### PR DESCRIPTION
Released downstreams still touch the \`CodeAst\` surface removed in #2254 — \`cocoindex-code\`'s grep reads \`fm.ast.source\`, and its published wheels pin \`cocoindex>=1.0.13,<1.1.0\`, so they will meet the new API within the pin range. Keep the load-bearing pieces working for one deprecation cycle, each emitting a \`DeprecationWarning\` naming the replacement:

- \`FileMatch.ast\` → \`FileMatch.source\`
- \`CodeSource.source\` → \`CodeSource.text\`
- \`CodeAst\` → \`CodeSource\` (module \`__getattr__\` alias, so imports/annotations/\`isinstance\` keep working). The old methods are deliberately **not** resurrected — nothing downstream uses them, and the warning points at \`CodePattern.match_source\` / \`match_code\`, \`RecursiveSplitter.split\`, and \`index_terms\`.

Tested: shim behaviors + warnings (incl. the exact downstream expression shape), unknown-attribute still raises \`AttributeError\`; pytest/mypy/ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)