### PR TITLE
fix(py): LiveMap watch double-delivered arm/scan-seam changes

### DIFF
--- a/python/cocoindex/resources/live_map.py
+++ b/python/cocoindex/resources/live_map.py
@@ -92,6 +92,9 @@ class _Change(_NamedTuple):
     key: _Any
     value: _Any
     deleted: bool
+    # Orders emissions relative to `_scan` snapshots: the watch loop skips changes
+    # already reflected in the snapshot it delivered (see `watch`).
+    seq: int
 
 
 # ============================================================================
@@ -172,12 +175,14 @@ async def _apply_entry_actions(
         if action.deleted:
             if action.key in live_map._entries:
                 del live_map._entries[action.key]
-                live_map._emit(_Change(action.key, None, True))
+                live_map._seq += 1
+                live_map._emit(_Change(action.key, None, True, live_map._seq))
         else:
             prev = live_map._entries.get(action.key, _MISSING)
             if prev is _MISSING or prev != action.value:
                 live_map._entries[action.key] = action.value
-                live_map._emit(_Change(action.key, action.value, False))
+                live_map._seq += 1
+                live_map._emit(_Change(action.key, action.value, False, live_map._seq))
 
 
 async def _apply_container_actions(
@@ -229,6 +234,8 @@ class LiveMap(_Generic[_K, _V]):
         "_entry_provider",
         "_watcher_queue",
         "__weakref__",
+        "_seq",
+        "_watch_scan_seq",
     )
 
     _uuid: _uuid.UUID
@@ -242,6 +249,11 @@ class LiveMap(_Generic[_K, _V]):
         self._uuid = _uuid.uuid4()
         self._entries = {}
         self._watcher_queue = None
+        # Monotonic emission counter (single event loop: applies are sequential, so a
+        # change with seq <= the seq recorded at snapshot time is already in that
+        # snapshot).
+        self._seq = 0
+        self._watch_scan_seq: int | None = None
 
     @classmethod
     async def create(cls) -> "LiveMap[_K, _V]":
@@ -261,7 +273,12 @@ class LiveMap(_Generic[_K, _V]):
 
     async def _scan(self) -> _AsyncIterator[tuple[_K, _V]]:
         # Snapshot synchronously so a sink firing between yields can't mutate mid-iteration.
-        for item in list(self._entries.items()):
+        snapshot = list(self._entries.items())
+        if self._watcher_queue is not None and self._watch_scan_seq is None:
+            # First scan after a watch armed its queue = the watcher's initial
+            # snapshot (`subscriber.update_all`): record how far it reached.
+            self._watch_scan_seq = self._seq
+        for item in snapshot:
             yield item
 
     async def watch(self, subscriber: "_coco.LiveMapSubscriber[_K, _V]") -> None:
@@ -269,14 +286,21 @@ class LiveMap(_Generic[_K, _V]):
         if self._watcher_queue is not None:
             raise RuntimeError("LiveMap supports a single active watch() at a time.")
         queue: _asyncio.Queue[_Change] = _asyncio.Queue()
-        self._watcher_queue = (
-            queue  # arm before the scan so concurrent changes aren't lost
-        )
+        # Arm before the scan so changes concurrent with it aren't lost. The mirror
+        # image of that choice is a change landing between arming and the snapshot:
+        # it gets queued AND included in the snapshot. The seq gate below drops such
+        # already-delivered changes at drain time (they'd otherwise re-notify the
+        # consumer with an equal value, defeating the `==` gate).
+        self._watcher_queue = queue
+        self._watch_scan_seq = None
         try:
             await subscriber.update_all()
             await subscriber.mark_ready()
+            snapshot_seq = self._watch_scan_seq
             while True:
                 change = await queue.get()
+                if snapshot_seq is not None and change.seq <= snapshot_seq:
+                    continue  # already reflected in the initial snapshot
                 if change.deleted:
                     handle = await subscriber.delete(change.key)
                 else:
@@ -284,6 +308,7 @@ class LiveMap(_Generic[_K, _V]):
                 await handle.ready()
         finally:
             self._watcher_queue = None
+            self._watch_scan_seq = None
 
     def _emit(self, change: _Change) -> None:
         queue = self._watcher_queue

--- a/python/tests/resources/test_live_map.py
+++ b/python/tests/resources/test_live_map.py
@@ -419,3 +419,73 @@ async def test_live_delete_via_ownership() -> None:
         assert "b" not in GlobalDictTarget.store.data
 
     await _run_live(name, body)
+
+
+# ============================================================================
+# Arm/scan seam (regression for a CI flake: duplicate delivery)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_watch_change_in_arm_scan_seam_delivered_once() -> None:
+    """A change landing between watch() arming its queue and the initial snapshot
+    used to be delivered twice: once inside the snapshot, once from the queue
+    (defeating the `==` gate and re-running consumers with an equal value)."""
+    from cocoindex.resources.live_map import _EntryAction, _apply_entry_actions
+
+    lm: LiveMap[str, str] = LiveMap()
+    scan_gate = asyncio.Event()
+    settled = asyncio.Event()
+
+    class _Handle:
+        async def ready(self) -> None:
+            pass
+
+    class _SeamSub:
+        def __init__(self) -> None:
+            self.snapshot: dict[str, str] = {}
+            self.updates: list[tuple[str, Any]] = []
+
+        async def update_all(self) -> None:
+            await scan_gate.wait()  # hold the seam open
+            async for k, v in lm:
+                self.snapshot[k] = v
+
+        async def mark_ready(self) -> None:
+            settled.set()
+
+        async def update(self, key: str, value: Any) -> _Handle:
+            self.updates.append((key, value))
+            return _Handle()
+
+        async def delete(self, key: str) -> _Handle:
+            self.updates.append((key, None))
+            return _Handle()
+
+    sub = _SeamSub()
+    task = asyncio.create_task(lm.watch(sub))  # type: ignore[arg-type]
+    await asyncio.sleep(0)  # queue armed; update_all blocked at the gate
+
+    # The change lands in the seam: queued (queue is armed) AND visible to the
+    # upcoming snapshot (it mutates _entries first).
+    await _apply_entry_actions(None, [_EntryAction(lm, "a", "1", False)])  # type: ignore[arg-type]
+
+    scan_gate.set()
+    await asyncio.wait_for(settled.wait(), timeout=5)
+    await asyncio.sleep(0.05)  # let the drain loop process the queued change
+
+    assert sub.snapshot == {"a": "1"}
+    assert sub.updates == []  # seam change must NOT be re-delivered
+
+    # A genuinely new change (post-snapshot) is still delivered exactly once.
+    await _apply_entry_actions(None, [_EntryAction(lm, "a", "2", False)])  # type: ignore[arg-type]
+    deadline = asyncio.get_event_loop().time() + 5
+    while sub.updates != [("a", "2")] and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+    assert sub.updates == [("a", "2")]
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Summary
- `LiveMap.watch()` arms its change queue before the initial snapshot (so concurrent changes aren't lost), but a change landing between arming and the snapshot was delivered twice — once inside the snapshot, once from the queue — re-notifying consumers with an `==`-equal value and defeating the sink's equality gate. This was the root cause of intermittent `test_live_update_value` CI failures (timing-dependent: same commit passed on some matrix cells, failed on loaded ones).
- Fix keeps the early arming and adds a sequence gate: emissions carry a monotonic seq, the initial scan records how far its snapshot reached, and the drain loop skips queued changes already reflected in it. Applies are sequential on the single event loop, so the comparison is exact.
- New deterministic regression test holds the seam open with a gated fake subscriber; it fails on the previous implementation.

## Test plan
CI. `test_live_map.py`: 13/13 (incl. the new seam test) × 10 consecutive local runs; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
