### PR TITLE
feat(code_ast): memoized tree-trust hazard scan on CodeSource

### DIFF
--- a/rust/code_ast/src/hazards.rs
+++ b/rust/code_ast/src/hazards.rs
@@ -1,0 +1,77 @@
+//! Tree-trust hazards: a pre-pass over a parsed AST detecting trees whose top
+//! structure cannot be trusted (shallow parse errors) and pathologically deep
+//! subtrees that recursive walks must treat as opaque.
+//!
+//! Accessed through [`CodeSource::tree_hazards`](crate::CodeSource::tree_hazards),
+//! which memoizes the scan alongside the parse.
+
+use crate::positions::TextRange;
+
+/// Max AST depth for recursive consumers. Walks that recurse with tree depth
+/// (structural chunking, frame extraction) would overflow worker-thread stacks
+/// on pathological nesting (parser stress tests with thousands of nested
+/// braces) — subtrees past this depth are reported as opaque spans instead.
+const MAX_TREE_DEPTH: usize = 500;
+
+/// A sizeable ERROR/MISSING node near the top of the tree means error recovery has
+/// reshaped the file's structural skeleton (truncated classes, members leaking as
+/// siblings) — structure derived from it would misstate the file.
+/// Deep or zero-width errors are local hiccups consumers tolerate. Calibrated
+/// on llvm/spark corpora: damaged files show >=17B errors at depth <= 3; healthy
+/// files (even with thousands of deep error bytes) max out at 1B shallow.
+const SHALLOW_ERROR_MAX_DEPTH: usize = 3;
+const SHALLOW_ERROR_MIN_BYTES: usize = 8;
+
+/// Pre-pass result: file-level unfitness plus local depth hazards.
+pub struct TreeHazards {
+    /// A shallow parse error: error recovery reshaped the tree's skeleton, so
+    /// no structure derived from the tree is trustworthy.
+    pub parse_error: bool,
+    /// Shallowest subtrees crossing the depth limit, in source order. Recursive
+    /// walks must treat them as opaque: never classified or descended into.
+    pub deep_spans: Vec<TextRange>,
+}
+
+/// One iterative pre-pass: detects the file-level parse-error hazard and collects
+/// local deep-subtree hazards (never descends past the depth limit).
+pub(crate) fn scan_tree_hazards(root: tree_sitter::Node) -> TreeHazards {
+    let mut hazards = TreeHazards {
+        parse_error: root.is_error(),
+        deep_spans: Vec::new(),
+    };
+    if hazards.parse_error {
+        return hazards;
+    }
+    let mut cursor = root.walk();
+    let mut depth = 0usize;
+    loop {
+        let node = cursor.node();
+        if depth <= SHALLOW_ERROR_MAX_DEPTH
+            && (node.is_error() || node.is_missing())
+            && node.end_byte() - node.start_byte() >= SHALLOW_ERROR_MIN_BYTES
+        {
+            hazards.parse_error = true;
+            hazards.deep_spans.clear();
+            return hazards;
+        }
+        let block_descent = depth >= MAX_TREE_DEPTH;
+        if block_descent && node.child_count() > 0 {
+            hazards
+                .deep_spans
+                .push(TextRange::new(node.start_byte(), node.end_byte()));
+        }
+        if !block_descent && cursor.goto_first_child() {
+            depth += 1;
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return hazards;
+            }
+            depth -= 1;
+        }
+    }
+}

--- a/rust/code_ast/src/lib.rs
+++ b/rust/code_ast/src/lib.rs
@@ -10,6 +10,7 @@
 //! - byte→position machinery ([`positions`]): [`LineIndex`], [`OutputPosition`],
 //!   [`TextRange`].
 
+mod hazards;
 pub mod positions;
 pub mod prog_langs;
 mod source;
@@ -18,5 +19,6 @@ mod source;
 /// dependency (grammars are pinned to one version workspace-wide here).
 pub use tree_sitter;
 
+pub use hazards::TreeHazards;
 pub use positions::{LineIndex, OutputPosition, TextRange};
 pub use source::{CodeSource, ParseOutcome};

--- a/rust/code_ast/src/source.rs
+++ b/rust/code_ast/src/source.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::sync::OnceLock;
 
+use crate::hazards::{TreeHazards, scan_tree_hazards};
 use crate::positions::LineIndex;
 use crate::prog_langs::{self, ProgrammingLanguageInfo, TreeSitterLanguageInfo};
 
@@ -55,6 +56,7 @@ pub struct CodeSource<'a> {
     /// Lazy parse; inner `None` = the parser returned no tree (memoized).
     tree: OnceLock<Option<tree_sitter::Tree>>,
     line_index: OnceLock<LineIndex>,
+    hazards: OnceLock<TreeHazards>,
 }
 
 impl<'a> CodeSource<'a> {
@@ -97,6 +99,7 @@ impl<'a> CodeSource<'a> {
             info,
             tree: OnceLock::new(),
             line_index: OnceLock::new(),
+            hazards: OnceLock::new(),
         }
     }
 
@@ -145,6 +148,21 @@ impl<'a> CodeSource<'a> {
     /// Get-or-build the byte→(char offset, line, column) index, memoized.
     pub fn line_index(&self) -> &LineIndex {
         self.line_index.get_or_init(|| LineIndex::build(&self.text))
+    }
+
+    /// Get-or-scan the tree-trust hazards of the parsed AST, memoized: a
+    /// shallow parse error (error recovery reshaped the tree's top structure —
+    /// consumers deriving structure from it should degrade) and pathologically
+    /// deep subtrees (recursive walks must treat them as opaque). `None` when
+    /// there is no tree to scan.
+    pub fn tree_hazards(&self) -> Option<&TreeHazards> {
+        let ParseOutcome::Parsed(tree) = self.tree() else {
+            return None;
+        };
+        Some(
+            self.hazards
+                .get_or_init(|| scan_tree_hazards(tree.root_node())),
+        )
     }
 }
 
@@ -200,6 +218,19 @@ mod tests {
         assert!(std::ptr::eq(src.info().unwrap(), info));
         assert_eq!(src.requested_language(), Some("rust"));
         assert!(matches!(src.tree(), ParseOutcome::Parsed(_)));
+    }
+
+    #[test]
+    fn tree_hazards_memoized_and_gated_on_parse() {
+        let src = CodeSource::with_language("def f():\n    return 1\n", "python");
+        let first = src.tree_hazards().expect("parsed") as *const TreeHazards;
+        let second = src.tree_hazards().expect("parsed") as *const TreeHazards;
+        assert_eq!(first, second);
+        assert!(!src.tree_hazards().unwrap().parse_error);
+        assert!(src.tree_hazards().unwrap().deep_spans.is_empty());
+
+        let no_grammar = CodeSource::new("plain text");
+        assert!(no_grammar.tree_hazards().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `CodeSource::tree_hazards()`: a lazily computed, memoized pre-pass over the parsed AST detecting shallow parse errors (error recovery reshaped the tree's top structure — structure-deriving consumers should degrade) and pathologically deep subtrees (recursive walks must treat them as opaque spans).
- Memoized alongside the parse and line index (`OnceLock`), so any number of consumers scan a source at most once; `None` when there is no tree to scan.
- Groundwork for structure-deriving consumers of the shared parse — context frames for code-match rendering, and structural chunking (which already uses this in the Plus edition). The scan lives next to the grammar pins whose node shapes it interprets.

## Test plan
- CI; new unit test covers memoization (same `&TreeHazards` across calls) and the no-tree gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
