### PR TITLE
Slides to Speech: local CPU TTS (Pocket TTS) + DSPy vision

### DIFF
--- a/docs/src/content/example-posts/slides-to-speech.md
+++ b/docs/src/content/example-posts/slides-to-speech.md
@@ -1,71 +1,68 @@
 ---
 title: Slides to Narrated Search
-description: 'Turn slide decks into a narrated, searchable index with CocoIndex V1 — a vision LLM writes speaker notes for each slide, Piper synthesizes them to audio locally, and the notes are embedded into LanceDB for semantic search.'
+description: 'Turn slide decks into a narrated, searchable index with CocoIndex V1 — a vision LLM writes speaker notes for each slide, Pocket TTS synthesizes them to audio locally on the CPU, and the notes are embedded into LanceDB for semantic search.'
 slug: slides-to-speech
 image: https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.png
 tags: [multimodal, text-to-speech]
 ---
 
-![Turn slide decks into narrated, searchable audio with a vision LLM and Piper TTS](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.png)
+![Turn slide decks into narrated, searchable audio with a vision LLM and Pocket TTS](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.png)
 
-A slide deck is a great outline and a terrible thing to *listen to* or *search*. In this tutorial we'll build a [CocoIndex](https://github.com/cocoindex-io/cocoindex) pipeline that fixes both: for each slide, a vision LLM writes natural speaker notes, [Piper](https://github.com/OHF-Voice/piper1-gpl) synthesizes them to audio locally, and the notes are embedded into [LanceDB](https://lancedb.com/) so you can search the deck by meaning and play back the narration for any hit.
+A slide deck is a great outline and a terrible thing to *listen to* or *search*. In this tutorial we'll build a [CocoIndex](https://github.com/cocoindex-io/cocoindex) pipeline that fixes both: for each slide, a vision LLM writes natural speaker notes, [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) synthesizes them to audio locally on the CPU, and the notes are embedded into [LanceDB](https://lancedb.com/) so you can search the deck by meaning and play back the narration for any hit.
 
-The whole pipeline is ordinary `async` Python. The vision and TTS steps run on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/), and the Rust engine handles [incremental processing](https://cocoindex.io/docs/programming_guide/core_concepts/) — add a deck and only its slides get processed.
+The whole pipeline is ordinary `async` Python. The vision and TTS steps run on a [`coco.GPU` runner](https://cocoindex.io/docs/programming_guide/function/) that offloads each blocking call off the event loop and serializes it — Pocket TTS is CPU-only, so no GPU is required — and the Rust engine handles [incremental processing](https://cocoindex.io/docs/programming_guide/core_concepts/) — add a deck and only its slides get processed.
 
 [→ View on GitHub](https://github.com/cocoindex-io/cocoindex/tree/main/examples/slides_to_speech)
 
 ## Flow overview
 
-![CocoIndex flow: render each slide to an image, a vision LLM writes speaker notes, Piper TTS narrates them, the notes are embedded, and everything is stored per-slide in LanceDB](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/flow-v1.png)
+![CocoIndex flow: render each slide to an image, a vision LLM writes speaker notes, Pocket TTS narrates them, the notes are embedded, and everything is stored per-slide in LanceDB](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/flow-v1.png)
 
 A deck fans out to **slides**, and each slide produces text, audio, and a vector:
 
 1. Render each slide of the PDF to an image (pymupdf).
 2. A vision LLM writes speaker notes for the slide.
-3. Piper synthesizes the notes to MP3 audio; a sentence-transformer embeds the notes.
+3. Pocket TTS synthesizes the notes to MP3 audio; a sentence-transformer embeds the notes.
 4. Store one LanceDB row per slide — page, notes, audio, and embedding.
 
 ## Speaker notes from a slide image
 
-The vision LLM reads the rendered slide and writes presenter narration. Extraction is [instructor](https://github.com/instructor-ai/instructor) over [LiteLLM](https://docs.litellm.ai/), so the image goes in as a data URL and a typed `SlideTranscript` comes back:
+The vision LLM reads the rendered slide and writes presenter narration. Extraction uses [DSPy](https://dspy.ai/): a typed signature declares the slide image going in and the narration coming out, and `dspy.Predict` handles the call — no hand-written prompt or JSON parsing:
 
 ```python title="main.py"
-class SlideTranscript(pydantic.BaseModel):
-    speaker_notes: str = pydantic.Field(
-        description="Natural spoken narration for this slide, as a presenter would say it."
-    )
+class SlideNotes(dspy.Signature):
+    """Write natural spoken narration for a slide, as a presenter would say it aloud."""
+
+    slide: dspy.Image = dspy.InputField(desc="the rendered slide image")
+    speaker_notes: str = dspy.OutputField(desc="a few sentences — no markdown or bullet symbols")
+
+
+_speaker_notes = dspy.Predict(SlideNotes)
 
 
 @coco.fn(memo=True)
-async def extract_speaker_notes(image: bytes) -> SlideTranscript:
-    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
+async def extract_speaker_notes(image: bytes) -> str:
     data_url = "data:image/png;base64," + base64.b64encode(image).decode()
-    result = await client.chat.completions.create(
-        model=coco.use_context(LLM_MODEL),          # e.g. gemini/gemini-2.5-flash
-        response_model=SlideTranscript,
-        messages=[{"role": "user", "content": [
-            {"type": "text", "text": "Write speaker notes for this slide."},
-            {"type": "image_url", "image_url": {"url": data_url}},
-        ]}],
-    )
-    return SlideTranscript.model_validate(result.model_dump())
+    with dspy.context(lm=_get_lm(coco.use_context(LLM_MODEL))):   # e.g. gemini/gemini-3.5-flash
+        result = await _speaker_notes.acall(slide=dspy.Image(url=data_url))
+    return result.speaker_notes
 ```
 
-> **A note on the port.** The v0 example pulled slides from Google Drive and used BAML for the vision call; this v1 port reads slides from a local folder and uses instructor + LiteLLM (any vision model — Gemini, GPT-4o, …). Point the source at a [Google Drive folder](https://cocoindex.io/docs/connectors/google_drive/) to reproduce the original.
+> **A note on the port.** The v0 example pulled slides from Google Drive and used BAML for the vision call; this v1 port reads slides from a local folder and uses DSPy (any vision model — Gemini, GPT-4o, …). Point the source at a [Google Drive folder](https://cocoindex.io/docs/connectors/google_drive/) to reproduce the original.
 
-## Narrate locally with Piper
+## Narrate locally with Pocket TTS
 
-Piper is a fast, fully local neural TTS — no API, no per-character billing. The voice model loads once and synthesizes the notes to MP3:
+[Pocket TTS](https://github.com/kyutai-labs/pocket-tts) is a fast, ~100M-parameter neural TTS that runs entirely on the CPU — no API, no GPU, no per-character billing. The model and voice state load once (via `@functools.cache`) and synthesize the notes to MP3. The model isn't thread-safe, so the `coco.GPU` runner serializes each call on a worker thread — off the event loop, one at a time:
 
 ```python title="main.py"
-@coco.fn.as_async(runner=coco.GPU)
+@coco.fn.as_async(runner=coco.GPU)                  # offloaded + serialized off the event loop
 def text_to_speech(text: str) -> bytes:
-    voice = get_piper_voice()                       # cached PiperVoice
-    chunks = list(voice.synthesize(text))
-    pcm = b"".join(c.audio_int16_bytes for c in chunks)
-    audio = AudioSegment(data=pcm, sample_width=chunks[0].sample_width,
-                         frame_rate=chunks[0].sample_rate, channels=chunks[0].sample_channels)
-    out = io.BytesIO(); audio.export(out, format="mp3", bitrate="64k")
+    model = get_tts_model()                          # cached TTSModel — loads once
+    audio = model.generate_audio(get_voice_state(POCKET_TTS_VOICE), text)  # 1D float PCM
+    samples = np.clip(audio.to("cpu").numpy().reshape(-1), -1.0, 1.0)
+    pcm16 = (samples * 32767.0).astype("<i2").tobytes()   # float -> int16 PCM
+    seg = AudioSegment(data=pcm16, sample_width=2, frame_rate=model.sample_rate, channels=1)
+    out = io.BytesIO(); seg.export(out, format="mp3", bitrate="64k")
     return out.getvalue()
 ```
 
@@ -92,13 +89,12 @@ The MP3 audio is stored right in the LanceDB row (a binary column), so a search 
 ## Run the pipeline
 
 ```sh
-python3 -m piper.download_voices en_US-lessac-medium   # ~60 MB local voice
-cp .env.example .env                                    # set GEMINI_API_KEY (or OPENAI_API_KEY)
-pip install -e .                                        # needs ffmpeg for MP3 export
-cocoindex update main
+cp .env.example .env      # set GEMINI_API_KEY (or OPENAI_API_KEY)
+pip install -e .          # needs ffmpeg for MP3 export
+cocoindex update main     # first run downloads the Pocket TTS + embedder weights (~100M params)
 ```
 
-Drop a slide-deck PDF into `slides/`. On a 3-slide sample deck, this produces three LanceDB rows, each with Gemini-written speaker notes and ~170–280 KB of Piper MP3 audio.
+Drop a slide-deck PDF into `slides/`. On a 3-slide sample deck, this produces three LanceDB rows, each with Gemini-written speaker notes and ~170–280 KB of Pocket TTS MP3 audio.
 
 ## Search the deck
 
@@ -114,7 +110,7 @@ On the sample deck, that query ranks the **Engineering Priorities** slide first 
 
 - **Add a deck** — only its slides are rendered, narrated, and embedded.
 - **Edit a deck** — slides reconcile against LanceDB; unchanged slides keep their notes and audio.
-- **Swap the voice or LLM** — change `PIPER_MODEL_NAME` or `LLM_MODEL`; the affected steps re-run, the rest is served from cache.
+- **Swap the LLM** — change `LLM_MODEL` and only the narration step re-runs; the rest is served from cache. (A new `POCKET_TTS_VOICE` takes effect on a fresh build.)
 
 ## Run it
 

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -535,7 +535,7 @@ export const examples: ExampleCard[] = [
     index: '31 / 32',
     category: 'image',
     thumbLabel: 'Slides · vision + TTS',
-    description: 'Render each slide, write speaker notes with a vision LLM, narrate them with Piper TTS locally, and embed the notes into LanceDB — search a deck by meaning and play back the narration.',
+    description: 'Render each slide, write speaker notes with a vision LLM, narrate them with Pocket TTS locally on the CPU, and embed the notes into LanceDB — search a deck by meaning and play back the narration.',
     tags: [
       { kind: 'src', label: 'Local FS' },
       { kind: 'ops', label: 'Vision LLM + TTS' },
@@ -676,7 +676,7 @@ export const EXAMPLE_CATALOG_GROUPS: ExampleCatalogGroup[] = [
       { dir: 'face_recognition', docs: 'face-recognition', title: 'Build Your Own Face Search', description: 'Detect faces in a folder of photos, embed each with face_recognition (dlib), and index them in Qdrant for face search; query demo.', run: RUN_MAIN },
       { dir: 'audio_to_text', docs: 'audio-to-text', title: 'Audio → Text', description: 'Transcribe local audio files with LiteLLM and store one row per file in Postgres, keyed by filename.', run: RUN_MAIN_PY },
       { dir: 'multi_format_indexing', docs: 'multi-format-indexing', title: 'Multi-format Visual Search (ColPali)', description: 'Index PDFs and images as page screenshots with the ColPali multi-vector model — no OCR, no chunking — into Qdrant with MaxSim; text query demo.', run: RUN_MAIN },
-      { dir: 'slides_to_speech', docs: 'slides-to-speech', title: 'Slides to Narrated Search', description: 'Render each slide, write speaker notes with a vision LLM, narrate them with Piper TTS locally, embed the notes into LanceDB; semantic search with playable audio.', run: RUN_MAIN },
+      { dir: 'slides_to_speech', docs: 'slides-to-speech', title: 'Slides to Narrated Search', description: 'Render each slide, write speaker notes with a vision LLM, narrate them with Pocket TTS locally on the CPU, embed the notes into LanceDB; semantic search with playable audio.', run: RUN_MAIN },
     ],
   },
   {

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -119,7 +119,7 @@ A walkthrough URL means there's a step-by-step guide at
 - `multi_format_indexing` — PDFs + images as page screenshots → ColPali → Qdrant; no OCR, no chunking. *(walkthrough: multi-format-indexing)*
 - `face_recognition` — detect faces (dlib) → 128-d embeddings → Qdrant face search. *(walkthrough: face-recognition)*
 - `audio_to_text` — transcribe audio with LiteLLM → Postgres.
-- `slides_to_speech` — slides → vision-LLM notes → Piper TTS narration → LanceDB semantic search. *(walkthrough: slides-to-speech)*
+- `slides_to_speech` — slides → vision-LLM notes → Pocket TTS narration → LanceDB semantic search. *(walkthrough: slides-to-speech)*
 
 ### Structured extraction (LLM / BAML / DSPy)
 - `multi_codebase_summarization` — LLM per-file summaries across many repos. *(walkthrough: multi-codebase-summarization)*

--- a/examples/slides_to_speech/.env.example
+++ b/examples/slides_to_speech/.env.example
@@ -1,5 +1,5 @@
 COCOINDEX_DB=./cocoindex.db
 LANCEDB_URI=./lancedb_data
 GEMINI_API_KEY=
-LLM_MODEL=gemini/gemini-2.5-flash
-PIPER_MODEL_NAME=en_US-lessac-medium
+LLM_MODEL=gemini/gemini-3.5-flash
+POCKET_TTS_VOICE=anna

--- a/examples/slides_to_speech/.gitignore
+++ b/examples/slides_to_speech/.gitignore
@@ -1,7 +1,10 @@
 .env
 cocoindex.db
+.mypy_cache
 .venv-test/
 __pycache__/
 lancedb_data/
-*.onnx
-*.onnx.json
+
+# Local
+scratch
+slides_to_speech.egg-info

--- a/examples/slides_to_speech/README.md
+++ b/examples/slides_to_speech/README.md
@@ -1,13 +1,13 @@
 <p align="center">
-  <a href="https://cocoindex.io/docs/examples/slides-to-speech/" title="Turn slide decks into a narrated, searchable index with CocoIndex — vision LLM speaker notes, local Piper TTS, and LanceDB, in plain async Python">
-    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.svg" alt="Turn slide decks into narrated, searchable audio with CocoIndex — a vision LLM writes speaker notes for each slide, Piper synthesizes them to MP3 locally, and the notes are embedded into LanceDB for semantic search with playable narration attached" width="100%" draggable="false"/>
+  <a href="https://cocoindex.io/docs/examples/slides-to-speech/" title="Turn slide decks into a narrated, searchable index with CocoIndex — vision LLM speaker notes, local Pocket TTS, and LanceDB, in plain async Python">
+    <img src="https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/cover.svg" alt="Turn slide decks into narrated, searchable audio with CocoIndex — a vision LLM writes speaker notes for each slide, Pocket TTS synthesizes them to MP3 locally on the CPU, and the notes are embedded into LanceDB for semantic search with playable narration attached" width="100%" draggable="false"/>
   </a>
 </p>
 
 <h1 align="center">Turn a slide deck into <em>narrated</em>, searchable audio.</h1>
 
 <p align="center">
-  <b>A vision LLM writes speaker notes for each slide, Piper synthesizes them to audio <em>locally</em>, and the notes are embedded into LanceDB — so you search the deck by meaning and play back the narration for any hit.</b><br/>
+  <b>A vision LLM writes speaker notes for each slide, Pocket TTS synthesizes them to audio <em>locally on the CPU</em>, and the notes are embedded into LanceDB — so you search the deck by meaning and play back the narration for any hit.</b><br/>
   A deck is a great outline and a terrible thing to listen to or search; this fixes both — in plain async Python.
 </p>
 
@@ -28,15 +28,15 @@
 
 <br/>
 
-A slide deck is a great outline and a terrible thing to *listen to* or *search*. This pipeline fixes both: for each slide, a vision LLM writes natural speaker notes, [Piper](https://github.com/OHF-Voice/piper1-gpl) synthesizes them to audio locally, and the notes are embedded into [LanceDB](https://lancedb.com/) so you can search the deck by meaning and play back the narration for any hit. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — the vision and TTS steps run on a [GPU runner](https://cocoindex.io/docs/programming_guide/function/), and the Rust engine handles incremental processing, so adding a deck processes only its slides.
+A slide deck is a great outline and a terrible thing to *listen to* or *search*. This pipeline fixes both: for each slide, a vision LLM writes natural speaker notes, [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) synthesizes them to audio locally on the CPU, and the notes are embedded into [LanceDB](https://lancedb.com/) so you can search the deck by meaning and play back the narration for any hit. You declare the transformation in native Python and your own types — `target_state = transformation(source_state)` — the vision and TTS steps run on a [`coco.GPU` runner](https://cocoindex.io/docs/programming_guide/function/) that serializes them off the event loop, and the Rust engine handles incremental processing, so adding a deck processes only its slides.
 
 ## How it works
 
 A deck fans out to **slides**, and each slide produces text, audio, and a vector:
 
 - **Render** each slide of the PDF to an image (pymupdf).
-- **Narrate** — a vision LLM (instructor over LiteLLM) writes natural speaker notes for the slide image.
-- **Voice + embed** — Piper synthesizes the notes to MP3 while a sentence-transformer embeds them, concurrently.
+- **Narrate** — a vision LLM (via DSPy) writes natural speaker notes for the slide image.
+- **Voice + embed** — Pocket TTS synthesizes the notes to MP3 while a sentence-transformer embeds them, concurrently.
 - **Store** one LanceDB row per slide — page, notes, audio (a binary column), and the embedding.
 
 `process_slide` runs the vision LLM, then synthesizes audio *and* embeds the notes with `asyncio.gather` before declaring the row. Read it in [`main.py`](main.py):
@@ -46,7 +46,7 @@ A deck fans out to **slides**, and each slide produces text, audio, and a vector
 async def process_slide(slide: SlidePage, filename: str, table: lancedb.TableTarget[SlideRecord]) -> None:
     notes = (await extract_speaker_notes(slide.image)).speaker_notes   # vision LLM
     voice, embedding = await asyncio.gather(
-        text_to_speech(notes),                       # Piper TTS — local, no API
+        text_to_speech(notes),                       # Pocket TTS — local CPU, no API
         coco.use_context(EMBEDDER).embed(notes),     # sentence-transformer
     )
     table.declare_row(row=SlideRecord(
@@ -64,43 +64,37 @@ The MP3 audio is stored right in the LanceDB row, so a semantic-search hit comes
 
 <p align="center">
   📘 <b><a href="https://cocoindex.io/docs/examples/slides-to-speech/">Full Tutorial →</a></b><br/>
-  Step-by-step walkthrough with the vision-LLM speaker notes, local Piper TTS, the per-slide LanceDB row, and searching the deck by meaning.
+  Step-by-step walkthrough with the vision-LLM speaker notes, local Pocket TTS, the per-slide LanceDB row, and searching the deck by meaning.
 </p>
 
 ## Why it's worth a star ⭐
 
-- **Three modalities, one row.** Each slide becomes text (LLM notes), audio (Piper MP3), and a vector (sentence-transformer) — declared as a single LanceDB `SlideRecord`.
-- **Local TTS, no per-character billing.** Piper is a fast, fully local neural voice — no API, no streaming costs; the voice model loads once via `@functools.cache`.
+- **Three modalities, one row.** Each slide becomes text (LLM notes), audio (Pocket TTS MP3), and a vector (sentence-transformer) — declared as a single LanceDB `SlideRecord`.
+- **Local TTS, no per-character billing.** Pocket TTS is a fast, ~100M-param neural voice that runs entirely on the CPU — no API, no GPU, no streaming costs; the model and voice state load once via `@functools.cache`.
 - **Audio travels with the hit.** The MP3 lives in a binary LanceDB column, so a search result carries its own playable narration.
 - **Concurrent per slide.** `asyncio.gather` runs TTS and embedding side by side; the heavy vision and TTS steps run on a `coco.GPU` runner.
-- **Incremental & swappable.** `@coco.fn(memo=True)` reprocesses only changed slides; `LLM_MODEL` and `EMBEDDER` are declared with `detect_change=True`, so swapping the model or voice re-runs only the affected steps.
+- **Incremental & swappable.** `@coco.fn(memo=True)` reprocesses only changed slides; `LLM_MODEL` and `EMBEDDER` are declared with `detect_change=True`, so swapping the LLM or embedder re-runs only the affected steps.
 
 ## Run it
 
-> Needs **LLM credentials** for the vision model (default `gemini/gemini-2.5-flash` → `GEMINI_API_KEY`), a local **Piper** voice, and **ffmpeg** for MP3 export.
+> Needs **LLM credentials** for the vision model (default `gemini/gemini-2.5-flash` → `GEMINI_API_KEY`) and **ffmpeg** for MP3 export. **Pocket TTS** runs locally on the CPU — its weights download automatically on first run, no GPU or API key required.
 
-**1. Download a Piper voice** (~60 MB, local):
-
-```sh
-python3 -m piper.download_voices en_US-lessac-medium
-```
-
-**2. Configure & install:**
+**1. Configure & install:**
 
 ```sh
 cp .env.example .env     # set GEMINI_API_KEY (or swap LLM_MODEL, e.g. OpenAI)
 pip install -e .
 ```
 
-**3. Build the index** — drop a slide-deck PDF into `slides/`, then:
+**2. Build the index** — drop a slide-deck PDF into `slides/`, then:
 
 ```sh
 cocoindex update main        # or: cocoindex update -L main   (keep watching the folder)
 ```
 
-On a 3-slide sample deck this produces three LanceDB rows, each with vision-LLM speaker notes and ~170–280 KB of Piper MP3 audio.
+The first run downloads the Pocket TTS weights (~100M params) from Hugging Face and caches them. On a 3-slide sample deck this produces three LanceDB rows, each with vision-LLM speaker notes and ~170–280 KB of MP3 narration. Pick a different voice with `POCKET_TTS_VOICE` (e.g. `alba`, `charles`, `vera`).
 
-**4. Search the deck** — embed a query the same way and search LanceDB:
+**3. Search the deck** — embed a query the same way and search LanceDB:
 
 ```sh
 python main.py "reducing latency and reliability"

--- a/examples/slides_to_speech/main.py
+++ b/examples/slides_to_speech/main.py
@@ -3,8 +3,8 @@ Slides to Speech (v1) — CocoIndex pipeline example.
 
 Turn a slide deck (PDF) into a narrated, searchable index. For each slide:
 render it to an image, use a vision LLM to write speaker notes, synthesize
-those notes to audio with Piper (local TTS), embed the notes for semantic
-search, and store everything in LanceDB.
+those notes to audio with Pocket TTS (Kyutai's local, CPU-only TTS), embed the
+notes for semantic search, and store everything in LanceDB.
 
 Index (use `-L` for live mode, omit for one-shot catch-up):
     cocoindex update main
@@ -26,11 +26,10 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Annotated
 
-import instructor
-import litellm
-import pydantic
+import dspy
+import numpy as np
 from numpy.typing import NDArray
-from piper import PiperVoice
+from pocket_tts import TTSModel
 from pydub import AudioSegment
 
 import cocoindex as coco
@@ -38,12 +37,10 @@ from cocoindex.connectors import localfs, lancedb
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
 from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 
-litellm.drop_params = True
-
 LANCEDB_TABLE = "slides_to_speech"
 LANCEDB_URI = os.environ.get("LANCEDB_URI", "./lancedb_data")
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
-PIPER_MODEL = os.environ.get("PIPER_MODEL_NAME", "en_US-lessac-medium")
+POCKET_TTS_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
 LANCE_DB = coco.ContextKey[lancedb.LanceAsyncConnection]("slides_lancedb")
 EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_change=True)
@@ -75,60 +72,68 @@ def pdf_to_slides(content: bytes) -> list[SlidePage]:
 
 
 # ---------------------------------------------------------------------------
-# Vision LLM: slide image -> speaker notes
+# Vision LLM: slide image -> speaker notes (DSPy)
 # ---------------------------------------------------------------------------
 
 
-class SlideTranscript(pydantic.BaseModel):
-    speaker_notes: str = pydantic.Field(
-        description="Natural spoken narration for this slide, as a presenter would "
-        "say it aloud — a few sentences, no markdown or bullet symbols."
+class SlideNotes(dspy.Signature):
+    """Write natural spoken narration for a slide, as a presenter would say it aloud."""
+
+    slide: dspy.Image = dspy.InputField(desc="the rendered slide image")
+    speaker_notes: str = dspy.OutputField(
+        desc="a few sentences of spoken narration — no markdown or bullet symbols"
     )
+
+
+_speaker_notes = dspy.Predict(SlideNotes)
+
+
+@functools.cache
+def _get_lm(model: str) -> dspy.LM:
+    # max_tokens leaves headroom for the model's hidden reasoning plus the answer.
+    return dspy.LM(model, max_tokens=8192)
 
 
 @coco.fn(memo=True)
-async def extract_speaker_notes(image: bytes) -> SlideTranscript:
-    client = instructor.from_litellm(litellm.acompletion, mode=instructor.Mode.JSON)
+async def extract_speaker_notes(image: bytes) -> str:
     data_url = "data:image/png;base64," + base64.b64encode(image).decode()
-    result = await client.chat.completions.create(
-        model=coco.use_context(LLM_MODEL),
-        response_model=SlideTranscript,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Write speaker notes for this slide."},
-                    {"type": "image_url", "image_url": {"url": data_url}},
-                ],
-            }
-        ],
-    )
-    return SlideTranscript.model_validate(result.model_dump())
+    with dspy.context(lm=_get_lm(coco.use_context(LLM_MODEL))):
+        result = await _speaker_notes.acall(slide=dspy.Image(url=data_url))
+    return result.speaker_notes
 
 
 # ---------------------------------------------------------------------------
-# Piper TTS: text -> mp3 bytes
+# Pocket TTS: text -> mp3 bytes (local, CPU-only)
 # ---------------------------------------------------------------------------
 
 
 @functools.cache
-def get_piper_voice() -> PiperVoice:
-    return PiperVoice.load(f"{PIPER_MODEL}.onnx")
+def get_tts_model() -> TTSModel:
+    # ~100M-param model; weights download from Hugging Face on first use, then cache.
+    return TTSModel.load_model()
+
+
+@functools.cache
+def get_voice_state(voice: str) -> dict:
+    # A voice state is a reusable conditioning template. Loading it is slow, so we
+    # cache one per voice; generate_audio(copy_state=True) leaves it intact to reuse.
+    return get_tts_model().get_state_for_audio_prompt(voice)
 
 
 @coco.fn.as_async(runner=coco.GPU)
 def text_to_speech(text: str) -> bytes:
-    voice = get_piper_voice()
-    chunks = list(voice.synthesize(text))
-    pcm = b"".join(c.audio_int16_bytes for c in chunks)
-    audio = AudioSegment(
-        data=pcm,
-        sample_width=chunks[0].sample_width,
-        frame_rate=chunks[0].sample_rate,
-        channels=chunks[0].sample_channels,
+    model = get_tts_model()
+    # Pocket TTS is not thread-safe; the coco.GPU runner serializes calls so the one
+    # cached model is only ever driving a single synthesis at a time.
+    audio = model.generate_audio(get_voice_state(POCKET_TTS_VOICE), text)
+    # audio is a 1D float tensor in [-1, 1] at model.sample_rate; pack it as int16 PCM.
+    samples = np.clip(audio.to("cpu").numpy().reshape(-1), -1.0, 1.0)
+    pcm16 = (samples * 32767.0).astype("<i2").tobytes()
+    segment = AudioSegment(
+        data=pcm16, sample_width=2, frame_rate=model.sample_rate, channels=1
     )
     out = io.BytesIO()
-    audio.export(out, format="mp3", bitrate="64k")
+    segment.export(out, format="mp3", bitrate="64k")
     return out.getvalue()
 
 
@@ -151,8 +156,7 @@ class SlideRecord:
 async def process_slide(
     slide: SlidePage, filename: str, table: lancedb.TableTarget[SlideRecord]
 ) -> None:
-    transcript = await extract_speaker_notes(slide.image)
-    notes = transcript.speaker_notes
+    notes = await extract_speaker_notes(slide.image)
     voice, embedding = await asyncio.gather(
         text_to_speech(notes),
         coco.use_context(EMBEDDER).embed(notes),
@@ -221,8 +225,12 @@ def query(text: str, *, top_k: int = 5) -> None:
     vec = asyncio.run(embedder.embed(text))
     db = lancedb_client.connect(os.environ.get("LANCEDB_URI", "./lancedb_data"))
     table = db.open_table(LANCEDB_TABLE)
-    for row in table.search(vec).limit(top_k).to_list():
-        print(f"[{1.0 - row['_distance']:.3f}] {row['filename']} slide {row['page']}")
+    # Ask for cosine distance explicitly — LanceDB defaults to L2, whose values
+    # exceed 1.0 and would make `1 - distance` go negative. Cosine distance is
+    # 1 - similarity, so flipping it yields a similarity score in [0, 1].
+    for row in table.search(vec).distance_type("cosine").limit(top_k).to_list():
+        score = 1.0 - row["_distance"]
+        print(f"[{score:.3f}] {row['filename']} slide {row['page']}")
         print(f"    {row['speaker_notes'][:120]}")
 
 

--- a/examples/slides_to_speech/pyproject.toml
+++ b/examples/slides_to_speech/pyproject.toml
@@ -1,17 +1,17 @@
 [project]
 name = "slides-to-speech"
 version = "0.1.0"
-description = "CocoIndex example: turn slide decks into narrated, searchable indexes — vision LLM speaker notes, Piper TTS, and LanceDB."
+description = "CocoIndex example: turn slide decks into narrated, searchable indexes — vision LLM speaker notes, Pocket TTS, and LanceDB."
 requires-python = ">=3.11"
 dependencies = [
-    "cocoindex[lancedb,sentence_transformers]>=1.0.7",
-    "instructor>=1.0.0",
-    "litellm>=1.0.0",
-    "pydantic>=2.0.0",
+    "cocoindex[lancedb,sentence_transformers]>=1.0.16",
+    "lancedb>=0.34.0",    # queried directly in main.py; also pinned by the cocoindex[lancedb] extra
+    "dspy>=3.0.0",        # vision LLM structured extraction (brings litellm + pydantic transitively)
     "pymupdf>=1.24.0",
-    "piper-tts>=1.2.0",
+    "pocket-tts>=2.1.0",
     "pydub>=0.25.1",
-    "numpy<2.5",          # numpy 2.5 breaks NDArray vector-column resolution
+    "audioop-lts; python_version >= '3.13'",  # pydub needs stdlib audioop, removed in Python 3.13
+    "numpy>=2,<2.5",      # >=2 required by pocket-tts; <2.5 keeps NDArray vector-column resolution working
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Modernizes the slides-to-speech example end-to-end, with a cheaper CPU-based TTS model and a more idiomatic DSPy pipeline to make the program more composable/optimizable. Also updates to the latest versions of CocoIndex, LanceDB SDKs and uses `gemini-3.5-flash` as the reasoning model.

## What changed

- **TTS is now fully local on CPU** — swapped Piper (which leaned on a GPU runner) for Kyutai's Pocket TTS (~100M params, CPU-only, no API). The CPU synthesis runs one-at-a-time on a worker thread, so it never blocks the event loop, and the slides' vision-LLM calls still run concurrently
- **DSPy for the vision LLM** — replaced instructor + LiteLLM with a typed DSPy signature + `dspy.Predict`. DSPy can be better than instructor + LiteLLM for programs that have even a tiny chance of being reused, composed, evaluated, or optimized later — the call stays a declarative signature rather than hand-written prompt + JSON-parsing glue.
- **Model & voice** — vision model gemini-3.5-flash; narration uses the "anna" voice.
- **Dependencies** — tracks cocoindex 1.0.16 and its LanceDB 0.34.0 connector; adds an `audioop` backport so MP3 export works on Python 3.13+.
- **Query fix** — search now uses cosine distance, so printed relevance scores read a sensible 0–1 instead of going negative.
- **Docs** — refreshed the walkthrough and example catalog to match.

## Verified

Ran end-to-end: a 3-slide deck yields 3 LanceDB rows (notes + MP3 + embedding), and semantic search ranks the expected slide first with correct scores; audio is valid 24 kHz MP3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
