### PR TITLE
fix(tests): prevent Windows test environment database path leakage

### DIFF
--- a/python/tests/common/environment.py
+++ b/python/tests/common/environment.py
@@ -14,18 +14,20 @@ def get_env_db_path(name: str) -> pathlib.Path:
     return _tmp_db_path_base / name
 
 
-_PATH_PREFIX = str(pathlib.Path(__file__).parent.parent) + "/"
-
-
 def create_test_env(
     test_file_path: str,
     suffix: str | None = None,
     *,
     exception_handler: cocoindex.ExceptionHandler | None = None,
 ) -> cocoindex.Environment:
-    base_name = (
-        test_file_path.removeprefix(_PATH_PREFIX).removesuffix(".py").replace("/", "__")
-    )
+    tests_dir = pathlib.Path(__file__).parent.parent.resolve()
+    test_path = pathlib.Path(test_file_path).resolve()
+    try:
+        rel_path = test_path.relative_to(tests_dir)
+        base_name = str(rel_path.with_suffix("")).replace("\\", "__").replace("/", "__")
+    except ValueError:
+        base_name = test_path.name.removesuffix(".py")
+
     if suffix is not None:
         base_name = f"{base_name}__{suffix}"
     settings = cocoindex.Settings.from_env(db_path=get_env_db_path(base_name))


### PR DESCRIPTION
## Summary

Fixes a Windows-specific bug in the test environment where LMDB databases could be created inside the repository instead of the temporary test directory.

## Root Cause

`create_test_env()` built database names using string manipulation:

- `_PATH_PREFIX` contained forward slashes
- Windows test paths contained backslashes
- `removeprefix()` therefore became a no-op

The resulting path still contained an absolute Windows path (e.g. `C:\Users\...`).

When joined with the temporary directory using `pathlib.Path`, the absolute path discarded the temporary directory entirely, causing LMDB databases to be written into the repository instead of isolated temporary locations.

This leaked state across test runs and caused stale tracking information to persist between tests.

## Fix

- Replace fragile string-based path handling with `pathlib.Path.relative_to()`
- Generate database names from the relative test path
- Normalize path separators into `__`
- Remove the now-unused `_PATH_PREFIX` module-level constant (dead code)
- Ensure every test environment always uses an isolated temporary database

## Result

- Prevents persistent LMDB state leakage on Windows
- Restores proper test isolation
- Eliminates failures caused by stale database state
- 512 tests pass, 0 failures (verified on Windows)
