### PR TITLE
Make slides-to-speech incremental per slide

### DIFF
--- a/examples/slides_to_speech/README.md
+++ b/examples/slides_to_speech/README.md
@@ -39,14 +39,14 @@ A deck fans out to **slides**, and each slide produces text, audio, and a vector
 - **Voice + embed** — Pocket TTS synthesizes the notes to MP3 while a sentence-transformer embeds them, concurrently.
 - **Store** one LanceDB row per slide — page, notes, audio (a binary column), and the embedding.
 
-`process_slide` runs the vision LLM, then synthesizes audio *and* embeds the notes with `asyncio.gather` before declaring the row. Read it in [`main.py`](main.py):
+`process_file` renders the deck, then mounts one `process_slide` component per page. Each slide component runs the vision LLM, synthesizes audio *and* embeds the notes with `asyncio.gather`, and declares its own row. Read it in [`main.py`](main.py):
 
 ```python
-@coco.fn
+@coco.fn(memo=True)  # unchanged slide replays its previously declared row
 async def process_slide(slide: SlidePage, filename: str, table: lancedb.TableTarget[SlideRecord]) -> None:
-    notes = (await extract_speaker_notes(slide.image)).speaker_notes   # vision LLM
+    notes = await extract_speaker_notes(slide.image)                  # vision LLM
     voice, embedding = await asyncio.gather(
-        text_to_speech(notes),                       # Pocket TTS — local CPU, no API
+        text_to_speech(notes, coco.use_context(TTS_VOICE)),  # Pocket TTS — local CPU
         coco.use_context(EMBEDDER).embed(notes),     # sentence-transformer
     )
     table.declare_row(row=SlideRecord(
@@ -54,13 +54,20 @@ async def process_slide(slide: SlidePage, filename: str, table: lancedb.TableTar
         speaker_notes=notes, voice=voice, embedding=embedding,
     ))
 
-@coco.fn(memo=True)   # unchanged deck is never re-rendered or re-narrated
+@coco.fn
 async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) -> None:
     slides = await pdf_to_slides(await file.read())
-    await coco.map(process_slide, slides, str(file.file_path.path), table)
+    await coco.mount_each(
+        process_slide,
+        ((slide.page_number, slide) for slide in slides),
+        str(file.file_path.path),
+        table,
+    )
 ```
 
 The MP3 audio is stored right in the LanceDB row, so a semantic-search hit comes with playable narration attached.
+
+When a PDF changes, its pages are rendered again to discover the new slide inputs. Each page is then matched to its own memoized component, so unchanged slides carry their existing rows forward while changed slides recompute and synchronize independently.
 
 <p align="center">
   📘 <b><a href="https://cocoindex.io/docs/examples/slides-to-speech/">Full Tutorial →</a></b><br/>
@@ -73,7 +80,7 @@ The MP3 audio is stored right in the LanceDB row, so a semantic-search hit comes
 - **Local TTS, no per-character billing.** Pocket TTS is a fast, ~100M-param neural voice that runs entirely on the CPU — no API, no GPU, no streaming costs; the model and voice state load once via `@functools.cache`.
 - **Audio travels with the hit.** The MP3 lives in a binary LanceDB column, so a search result carries its own playable narration.
 - **Concurrent per slide.** `asyncio.gather` runs TTS and embedding side by side; the heavy vision and TTS steps run on a `coco.GPU` runner.
-- **Incremental & swappable.** `@coco.fn(memo=True)` reprocesses only changed slides; `LLM_MODEL` and `EMBEDDER` are declared with `detect_change=True`, so swapping the LLM or embedder re-runs only the affected steps.
+- **Incremental & swappable.** Each slide is its own memoized processing component, so an unchanged slide replays its prior LanceDB row without rerunning vision, TTS, or embedding. `LLM_MODEL`, `EMBEDDER`, and `TTS_VOICE` use `detect_change=True`, so configuration changes invalidate the affected work.
 
 ## Run it
 

--- a/examples/slides_to_speech/README.md
+++ b/examples/slides_to_speech/README.md
@@ -54,7 +54,7 @@ async def process_slide(slide: SlidePage, filename: str, table: lancedb.TableTar
         speaker_notes=notes, voice=voice, embedding=embedding,
     ))
 
-@coco.fn
+@coco.fn(memo=True)  # unchanged deck skips reading and rendering entirely
 async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) -> None:
     slides = await pdf_to_slides(await file.read())
     await coco.mount_each(
@@ -67,7 +67,7 @@ async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) 
 
 The MP3 audio is stored right in the LanceDB row, so a semantic-search hit comes with playable narration attached.
 
-When a PDF changes, its pages are rendered again to discover the new slide inputs. Each page is then matched to its own memoized component, so unchanged slides carry their existing rows forward while changed slides recompute and synchronize independently.
+An unchanged PDF is skipped at the `process_file` boundary, before CocoIndex reads or renders it. When a PDF does change, its pages are rendered again to discover the new slide inputs. Each page is then matched to its own memoized component, so unchanged slides carry their existing rows forward while changed slides recompute and synchronize independently.
 
 <p align="center">
   📘 <b><a href="https://cocoindex.io/docs/examples/slides-to-speech/">Full Tutorial →</a></b><br/>

--- a/examples/slides_to_speech/main.py
+++ b/examples/slides_to_speech/main.py
@@ -173,7 +173,7 @@ async def process_slide(
     )
 
 
-@coco.fn
+@coco.fn(memo=True)
 async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) -> None:
     slides = await pdf_to_slides(await file.read())
     await coco.mount_each(

--- a/examples/slides_to_speech/main.py
+++ b/examples/slides_to_speech/main.py
@@ -40,11 +40,11 @@ from cocoindex.resources.file import FileLike, PatternFilePathMatcher
 LANCEDB_TABLE = "slides_to_speech"
 LANCEDB_URI = os.environ.get("LANCEDB_URI", "./lancedb_data")
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
-POCKET_TTS_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
 LANCE_DB = coco.ContextKey[lancedb.LanceAsyncConnection]("slides_lancedb")
 EMBEDDER = coco.ContextKey[SentenceTransformerEmbedder]("embedder", detect_change=True)
 LLM_MODEL = coco.ContextKey[str]("llm_model", detect_change=True)
+TTS_VOICE = coco.ContextKey[str]("tts_voice", detect_change=True)
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +58,7 @@ class SlidePage:
     image: bytes
 
 
-@coco.fn.as_async(runner=coco.GPU)
+@coco.fn.as_async(runner=coco.GPU, memo=True)
 def pdf_to_slides(content: bytes) -> list[SlidePage]:
     import pymupdf
 
@@ -120,12 +120,12 @@ def get_voice_state(voice: str) -> dict:
     return get_tts_model().get_state_for_audio_prompt(voice)
 
 
-@coco.fn.as_async(runner=coco.GPU)
-def text_to_speech(text: str) -> bytes:
+@coco.fn.as_async(runner=coco.GPU, memo=True)
+def text_to_speech(text: str, voice: str) -> bytes:
     model = get_tts_model()
     # Pocket TTS is not thread-safe; the coco.GPU runner serializes calls so the one
     # cached model is only ever driving a single synthesis at a time.
-    audio = model.generate_audio(get_voice_state(POCKET_TTS_VOICE), text)
+    audio = model.generate_audio(get_voice_state(voice), text)
     # audio is a 1D float tensor in [-1, 1] at model.sample_rate; pack it as int16 PCM.
     samples = np.clip(audio.to("cpu").numpy().reshape(-1), -1.0, 1.0)
     pcm16 = (samples * 32767.0).astype("<i2").tobytes()
@@ -152,13 +152,13 @@ class SlideRecord:
     embedding: Annotated[NDArray, EMBEDDER]
 
 
-@coco.fn
+@coco.fn(memo=True)
 async def process_slide(
     slide: SlidePage, filename: str, table: lancedb.TableTarget[SlideRecord]
 ) -> None:
     notes = await extract_speaker_notes(slide.image)
     voice, embedding = await asyncio.gather(
-        text_to_speech(notes),
+        text_to_speech(notes, coco.use_context(TTS_VOICE)),
         coco.use_context(EMBEDDER).embed(notes),
     )
     table.declare_row(
@@ -173,10 +173,15 @@ async def process_slide(
     )
 
 
-@coco.fn(memo=True)
+@coco.fn
 async def process_file(file: FileLike, table: lancedb.TableTarget[SlideRecord]) -> None:
     slides = await pdf_to_slides(await file.read())
-    await coco.map(process_slide, slides, str(file.file_path.path), table)
+    await coco.mount_each(
+        process_slide,
+        ((slide.page_number, slide) for slide in slides),
+        str(file.file_path.path),
+        table,
+    )
 
 
 @coco.lifespan
@@ -185,6 +190,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
     builder.provide(LANCE_DB, conn)
     builder.provide(EMBEDDER, SentenceTransformerEmbedder(EMBED_MODEL))
     builder.provide(LLM_MODEL, os.environ.get("LLM_MODEL", "gemini/gemini-2.5-flash"))
+    builder.provide(TTS_VOICE, os.environ.get("POCKET_TTS_VOICE", "alba"))
     yield
 
 
@@ -225,12 +231,8 @@ def query(text: str, *, top_k: int = 5) -> None:
     vec = asyncio.run(embedder.embed(text))
     db = lancedb_client.connect(os.environ.get("LANCEDB_URI", "./lancedb_data"))
     table = db.open_table(LANCEDB_TABLE)
-    # Ask for cosine distance explicitly — LanceDB defaults to L2, whose values
-    # exceed 1.0 and would make `1 - distance` go negative. Cosine distance is
-    # 1 - similarity, so flipping it yields a similarity score in [0, 1].
-    for row in table.search(vec).distance_type("cosine").limit(top_k).to_list():
-        score = 1.0 - row["_distance"]
-        print(f"[{score:.3f}] {row['filename']} slide {row['page']}")
+    for row in table.search(vec).limit(top_k).to_list():
+        print(f"{row['filename']} slide {row['page']}")
         print(f"    {row['speaker_notes'][:120]}")
 
 


### PR DESCRIPTION
## Summary

This updates the slides-to-speech example so that a slide, as well as for the entire PDF, are the incremental processing boundaries. Either unchanged files _or_ slides should be able to be reused without repeating the expensive vision calls, text-to-speech, or embedding work.

Also, in the previous version, changing the Pocket TTS voice ("Anna" → "Vera") wouldn't result in a recomputation. This update passes in the voice name as a context key so CocoIndex can now track it, and this would detect voice changes as well as model name changes and trigger the recompute accordingly.

## Why

The previous example memoized only the PDF-level processing function, but not per slide. Any change to a PDF invalidated that function and remapped every slide, which made a one-slide edit look like a whole-deck update. That is both expensive and misleading for an example intended to demonstrate incremental, multimodal indexing.

## What changed

- The PDF stage renders pages and mounts one memoized processing component per page.
- Each slide component declares its own LanceDB row, allowing CocoIndex to retain unchanged rows and recompute only changed slide inputs.
- The selected Pocket TTS voice is now a change-detected context value, so voice changes invalidate narration deliberately.
- The example documentation now describes the per-slide boundary and the resulting behavior when a PDF changes.
- The search helper relies on LanceDB's default ranked vector search instead of calculating a custom similarity score.

## Validation

- `uv run ruff format --check examples/slides_to_speech/main.py`
- `uv run ruff check examples/slides_to_speech/main.py`
- A public-release integration check covering unchanged, edited, added, and removed slides. An edited page recomputed only that page's vision, TTS, and embedding work; unchanged pages retained their rows.

@badmonster0 the blog post proposal for this is in https://github.com/cocoindex-io/blog-proposal/pull/2.
