### PR TITLE
docs: upgrade @cocoindex/brand to v0.4.41

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.33",
+        "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.41",
         "@docsearch/css": "^4.6.2",
         "@docsearch/js": "^4.6.2",
         "astro": "^6.1.8",
@@ -247,8 +247,8 @@
       }
     },
     "node_modules/@cocoindex/brand": {
-      "version": "0.4.33",
-      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#756814bd3a71686e0f0639deb5d9d3783a0c6d5f",
+      "version": "0.4.41",
+      "resolved": "git+ssh://git@github.com/cocoindex-io/cocoindex-brand.git#03f1a728ce374399c87085aa693d3f411484222b",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.33",
+    "@cocoindex/brand": "github:cocoindex-io/cocoindex-brand#v0.4.41",
     "@docsearch/css": "^4.6.2",
     "@docsearch/js": "^4.6.2",
     "astro": "^6.1.8",


### PR DESCRIPTION
Pin bump v0.4.33 → v0.4.41 + lockfile re-resolve (explicit install, resolves to 03f1a72). Two files only.

Eight releases of contrast/consistency/component fixes land on the docs surface — semantic state inks for sidebar/TOC/copy-page states, tracking + radius/z token ladders, MobileSheet focus trap, copy-button aria-live + failure feedback, shared `.cta-end`/`.sec-lead`/`.hl-mark` primitives. Release notes: https://github.com/cocoindex-io/cocoindex-brand/releases/tag/v0.4.41 (and v0.4.40 / PR [cocoindex-brand#8](https://github.com/cocoindex-io/cocoindex-brand/pull/8)).

Local docs build: 98 pages green, agent-artifact check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)