### PR TITLE
feat(py): RetryWithSmallerBatch — split failed batches, retry halves

### DIFF
--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -310,6 +310,23 @@ embeddings = await asyncio.gather(
 
 The `max_batch_size` parameter limits how many inputs can be processed in a single batch.
 
+#### Retrying a failed batch as smaller batches
+
+Some batch failures depend on the batch's composition rather than any single input — e.g. a provider's per-request token or payload limit, or one input the provider rejects. No fixed `max_batch_size` can rule these out. When the function body hits such a failure, raise `coco.RetryWithSmallerBatch` from it: CocoIndex halves the batch and retries each half, recursing down to single items. At size 1, the wrapped original error is raised as that item's own failure — so one bad input fails only its own caller, while the rest of the batch still succeeds. There is no need to check the batch size before raising: at size 1 the engine simply unwraps the signal and raises the original error.
+
+```python
+@coco.fn(batching=True, max_batch_size=64)
+async def embed(texts: list[str]) -> list[list[float]]:
+    try:
+        return await provider.embed(texts)
+    except ProviderError as e:
+        if is_transient(e) or is_auth_error(e):
+            raise  # retrying smaller can't help these
+        raise coco.RetryWithSmallerBatch() from e
+```
+
+Raising it is safe for *any* deterministic batch failure, even when you can't tell whether the batch size was the cause: if the error was actually global (it would fail at any size), the recursion terminates at single items and every caller receives the underlying error, at the bounded cost of extra attempts. Only propagate directly for errors where splitting provably can't help — global errors like invalid credentials, and transient errors (rate limits, network blips) that haven't yet been retried at the same size. Once same-size retries are exhausted, splitting is a reasonable last resort: a smaller request may pass where the large one timed out.
+
 :::tip[When to use batching]
 
 Batching is beneficial when:

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -43,6 +43,7 @@ from .component_ctx import (
 
 
 from .stable_path import StableKey
+from .batching import RetryWithSmallerBatch
 from .function import (
     AnyCallable,
     AsyncCallable,
@@ -907,6 +908,8 @@ __all__ = [
     "timeout",
     "check_cancellation",
     "DeadlineExceededError",
+    # .batching
+    "RetryWithSmallerBatch",
     # .context_keys
     "ContextKey",
     "ContextProvider",

--- a/python/cocoindex/_internal/batching.py
+++ b/python/cocoindex/_internal/batching.py
@@ -1,0 +1,183 @@
+"""Batch splitting: retry a failed batch as smaller batches.
+
+``RetryWithSmallerBatch`` is the control-flow signal a batched function body
+(``@coco.fn(batching=True)``) raises to tell the engine that the batch failed
+in a way that may depend on the batch's composition — e.g. a provider's
+per-request token/payload limit, or a single input the provider rejects. The
+engine reacts by halving the batch and re-running each half, recursing down
+to single items; at size 1 the wrapped original error becomes that item's own
+failure. Sub-batches that succeed along the way keep their results, so one
+bad input fails only its own caller instead of the whole batch.
+
+The signal is always consumed by the engine — it never propagates to callers.
+Raising it is safe for *any* deterministic batch failure: if the error was
+actually global (would fail at any size), the recursion terminates at single
+items and every caller receives the underlying error, at the bounded cost of
+extra attempts (at most ``2n - 1`` for a batch of ``n``). Transient errors
+(rate limits, network blips) should first be retried at the same batch size;
+once that retry budget is exhausted, splitting is a reasonable last resort —
+a smaller request may pass where the large one timed out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pickle
+from typing import Any, Awaitable, Callable, Coroutine
+
+__all__ = ["RetryWithSmallerBatch"]
+
+
+class RetryWithSmallerBatch(Exception):
+    """Raise from a batched function body to retry the work as smaller batches.
+
+    Use ``raise RetryWithSmallerBatch() from err`` inside the ``except`` block
+    handling the batch-level error ``err``. Safe to raise at any batch size —
+    no need to special-case single-item batches: when the recursion bottoms
+    out at one item, the engine unwraps the signal and raises ``err`` as that
+    item's failure.
+    """
+
+    # Set only when the signal is restored from a pickle round-trip (e.g.
+    # crossing a subprocess-runner boundary). Plain exception pickling drops
+    # ``__cause__`` — and ``concurrent.futures`` then overwrites it with its
+    # remote-traceback marker on the parent side — so the cause travels in
+    # regular state instead, where nothing touches it.
+    _restored_cause: BaseException | None = None
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        cause = self.__cause__ or self.__context__ or self._restored_cause
+        if cause is not None:
+            try:
+                pickle.dumps(cause)
+            except Exception:
+                # An unpicklable cause would fail the whole transit; dropping
+                # it degrades to the pre-pickling behavior (signal without
+                # cause) instead.
+                cause = None
+        return (_restore_signal, (self.args, cause))
+
+
+def _restore_signal(
+    args: tuple[Any, ...], cause: BaseException | None
+) -> RetryWithSmallerBatch:
+    exc = RetryWithSmallerBatch(*args)
+    exc._restored_cause = cause
+    return exc
+
+
+class BatchItemFailure:
+    """Sentinel in a batch output list marking that single item's failure.
+
+    Produced by the split drivers below when a sub-batch fails after a split;
+    unwrapped (re-raised) on the caller side by ``AsyncFunction._execute``.
+    Items of one failed sub-batch share one exception object — same behavior
+    as multiple awaiters of a single ``asyncio.Future``.
+    """
+
+    __slots__ = ("error",)
+
+    error: BaseException
+
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+
+def split_cause(e: RetryWithSmallerBatch) -> BaseException:
+    """The per-item error a leaf-level ``RetryWithSmallerBatch`` stands for.
+
+    ``_restored_cause`` is checked first: after a subprocess round-trip it
+    holds the true cause, while ``__cause__`` holds the executor's
+    remote-traceback marker (see ``RetryWithSmallerBatch.__reduce__``).
+    """
+    return e._restored_cause or e.__cause__ or e.__context__ or e
+
+
+def wrap_batch_fn_async(
+    fn: Callable[[list[Any]], Awaitable[list[Any]]],
+) -> Callable[[list[Any]], Coroutine[Any, Any, list[Any]]]:
+    """Add ``RetryWithSmallerBatch`` split-and-retry around an async batch fn."""
+
+    async def run_with_split(inputs: list[Any]) -> list[Any]:
+        return await _run_split_async(fn, inputs, is_root=True)
+
+    return run_with_split
+
+
+def wrap_batch_fn_sync(
+    fn: Callable[[list[Any]], list[Any]],
+) -> Callable[[list[Any]], list[Any]]:
+    """Add ``RetryWithSmallerBatch`` split-and-retry around a sync batch fn."""
+
+    def run_with_split(inputs: list[Any]) -> list[Any]:
+        return _run_split_sync(fn, inputs, is_root=True)
+
+    return run_with_split
+
+
+# Both drivers share this structure (see `_run_split_async` for comments):
+# the split/raise happens *outside* the `except` blocks so the consumed
+# `RetryWithSmallerBatch` signal doesn't get chained into the `__context__`
+# of errors surfaced to callers.
+
+
+async def _run_split_async(
+    fn: Callable[[list[Any]], Awaitable[list[Any]]],
+    inputs: list[Any],
+    is_root: bool,
+) -> list[Any]:
+    root_leaf_error: BaseException | None = None
+    try:
+        return await fn(inputs)
+    except RetryWithSmallerBatch as e:
+        if len(inputs) > 1:
+            pass  # split below
+        elif is_root:
+            root_leaf_error = split_cause(e)
+        else:
+            return [BatchItemFailure(split_cause(e))]
+    except Exception as e:
+        if is_root:
+            # No split happened; propagate as a whole-batch failure — the
+            # engine fans it out to every caller with proper per-caller
+            # error replication.
+            raise
+        # Deterministic failure of a sub-batch after a split (e.g. the body
+        # re-raised the original error for a single bad item): confine it to
+        # this sub-batch's items so sibling sub-batches keep their results.
+        return [BatchItemFailure(e) for _ in inputs]
+    if root_leaf_error is not None:
+        raise root_leaf_error
+    mid = len(inputs) // 2
+    first, second = await asyncio.gather(
+        _run_split_async(fn, inputs[:mid], is_root=False),
+        _run_split_async(fn, inputs[mid:], is_root=False),
+    )
+    return [*first, *second]
+
+
+def _run_split_sync(
+    fn: Callable[[list[Any]], list[Any]],
+    inputs: list[Any],
+    is_root: bool,
+) -> list[Any]:
+    root_leaf_error: BaseException | None = None
+    try:
+        return fn(inputs)
+    except RetryWithSmallerBatch as e:
+        if len(inputs) > 1:
+            pass  # split below
+        elif is_root:
+            root_leaf_error = split_cause(e)
+        else:
+            return [BatchItemFailure(split_cause(e))]
+    except Exception as e:
+        if is_root:
+            raise
+        return [BatchItemFailure(e) for _ in inputs]
+    if root_leaf_error is not None:
+        raise root_leaf_error
+    mid = len(inputs) // 2
+    first = _run_split_sync(fn, inputs[:mid], is_root=False)
+    second = _run_split_sync(fn, inputs[mid:], is_root=False)
+    return [*first, *second]

--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -34,6 +34,11 @@ from typing import (
 from cocoindex._internal.environment import Environment, get_event_loop_or_default
 
 from . import core
+from .batching import (
+    BatchItemFailure,
+    wrap_batch_fn_async,
+    wrap_batch_fn_sync,
+)
 from .component_ctx import (
     _context_var,
     _enter_component_context,
@@ -1480,9 +1485,15 @@ class AsyncFunction(Function[P, R_co]):
         try:
             result = await batcher.run(input_val)
             _deadline_checkpoint()
-            return result
         finally:
             self._release_batcher(batcher_key)
+        # After a RetryWithSmallerBatch split, a failed sub-batch delivers its
+        # error as a per-item sentinel through the output list (the batcher
+        # itself only supports whole-batch errors). Unwrap it here so only the
+        # affected callers see the failure.
+        if isinstance(result, BatchItemFailure):
+            raise result.error
+        return result
 
     async def _execute_orig_async_fn(self, *args: Any, **kwargs: Any) -> Any:
         assert self._orig_async_fn is not None
@@ -1643,6 +1654,14 @@ class AsyncFunction(Function[P, R_co]):
         options = core.BatchingOptions(
             max_batch_size=self._max_batch_size if self._batching else 1
         )
+        # Honor RetryWithSmallerBatch raised by the batch body: split the
+        # batch and retry the halves. Only meaningful in batching mode
+        # (runner-only batches always have exactly one item).
+        if self._batching:
+            if inspect.iscoroutinefunction(batch_runner_fn):
+                batch_runner_fn = wrap_batch_fn_async(batch_runner_fn)
+            else:
+                batch_runner_fn = wrap_batch_fn_sync(batch_runner_fn)  # type: ignore[arg-type]
         if inspect.iscoroutinefunction(batch_runner_fn):
             return core.Batcher.new_async(queue, options, batch_runner_fn, async_ctx)
         else:

--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -93,6 +93,22 @@ _RETRYABLE_LITELLM_EXCEPTION_CLASSES = _litellm_exception_classes(
     "Timeout",
 )
 
+# Errors about who we are or what we asked for (credentials, permissions,
+# unknown model, exhausted budget) — batch composition can't affect them, so
+# splitting the batch can't help.
+_GLOBAL_LITELLM_EXCEPTION_CLASSES = _litellm_exception_classes(
+    "AuthenticationError",
+    "PermissionDeniedError",
+    "NotFoundError",
+    "BudgetExceededError",
+)
+
+
+def _is_global_litellm_error(error: BaseException) -> bool:
+    return isinstance(
+        error, _GLOBAL_LITELLM_EXCEPTION_CLASSES
+    ) or _message_indicates_non_retryable_credentials_error(str(error))
+
 
 def _http_status_code(error: BaseException) -> int | None:
     for attr in ("status_code", "exception_status_code"):
@@ -250,7 +266,22 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         extra: dict[str, _Any] = {}
         if input_type is not None:
             extra["input_type"] = input_type
-        response = await self._aembedding_with_retry(texts, **extra)
+        try:
+            response = await self._aembedding_with_retry(texts, **extra)
+        except Exception as e:
+            # Anything reaching here is either global (credentials/model —
+            # splitting can't help) or has already exhausted its same-size
+            # retry budget above. For the latter, ask the engine to halve the
+            # batch and retry: smaller requests may pass where the big one
+            # couldn't (a provider's token/payload cap, one rejected input,
+            # or a timeout on an oversized payload). If the error is actually
+            # global after all, splitting still terminates: every item fails
+            # with it at size 1, at the cost of the sub-batches' retries.
+            # (No batch-size check needed — at size 1 the engine unwraps the
+            # signal and raises the original error.)
+            if not _is_global_litellm_error(e):
+                raise coco.RetryWithSmallerBatch() from e
+            raise
         return [
             _np.array(item["embedding"], dtype=_np.float32) for item in response.data
         ]

--- a/python/cocoindex/ops/sentence_transformers.py
+++ b/python/cocoindex/ops/sentence_transformers.py
@@ -22,6 +22,34 @@ if _typing.TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
 
 
+def _is_oom_error(error: BaseException) -> bool:
+    """Whether ``error`` is an accelerator/host out-of-memory failure.
+
+    Matches by message rather than type so it covers ``torch.OutOfMemoryError``
+    ("CUDA out of memory..."), MPS ("MPS backend out of memory..."), and older
+    torch versions that raise plain ``RuntimeError`` — without importing torch.
+    """
+    return isinstance(error, MemoryError) or "out of memory" in str(error).lower()
+
+
+def _empty_accelerator_cache() -> None:
+    """Best-effort release of cached accelerator memory after an OOM.
+
+    Without this, allocator fragmentation often makes the retried halves OOM
+    as well. Never raises — failure to release just means the retry is less
+    likely to succeed.
+    """
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        elif torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
 class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
     """Wrapper for SentenceTransformer models that implements VectorSchemaProvider.
 
@@ -114,13 +142,26 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
             calls — mixing explicit values with defaults creates separate batchers.
         """
         model = self._get_model()
-        embeddings: _NDArray[_np.float32] = model.encode(
-            texts,
-            prompt_name=prompt_name,
-            convert_to_numpy=True,
-            normalize_embeddings=normalize_embeddings,
-            show_progress_bar=False,
-        )  # type: ignore[assignment]
+        try:
+            embeddings: _NDArray[_np.float32] = model.encode(
+                texts,
+                prompt_name=prompt_name,
+                convert_to_numpy=True,
+                normalize_embeddings=normalize_embeddings,
+                show_progress_bar=False,
+            )  # type: ignore[assignment]
+        except Exception as e:
+            # Out-of-memory scales with batch size × padded sequence length,
+            # so smaller batches may fit where this one didn't: ask the
+            # engine to halve and retry. Unlike remote providers, local
+            # failures are transparent — OOM is the one composition-dependent
+            # class, so everything else (config/model errors) propagates
+            # as-is. A single item that doesn't fit fails on its own: at
+            # size 1 the engine unwraps the signal and raises the OOM error.
+            if _is_oom_error(e):
+                _empty_accelerator_cache()
+                raise coco.RetryWithSmallerBatch() from e
+            raise
         return list(embeddings)
 
     @coco.fn(memo=True, version=1, logic_tracking="self")

--- a/python/tests/core/test_function_batching.py
+++ b/python/tests/core/test_function_batching.py
@@ -1057,6 +1057,171 @@ async def test_batching_method_clears_idle_batchers_per_instance() -> None:
     assert async_fn._batchers == {}  # type: ignore[attr-defined]
 
 
+# ============================================================================
+# RetryWithSmallerBatch: the engine splits the batch and retries the halves
+# ============================================================================
+
+
+class _BatchLimitError(Exception):
+    """Stands in for a provider-side 'batch too large' rejection."""
+
+
+@pytest.mark.asyncio
+async def test_retry_with_smaller_batch_splits_until_success() -> None:
+    """A batch rejected as too large is halved until every item succeeds."""
+    batch_sizes: list[int] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @coco.fn.as_async(batching=True)
+    async def limited(inputs: list[int]) -> list[int]:
+        batch_sizes.append(len(inputs))
+        if len(batch_sizes) == 1:
+            started.set()
+            await release.wait()
+        if len(inputs) > 2:
+            raise coco.RetryWithSmallerBatch() from _BatchLimitError("too big")
+        return [x * 2 for x in inputs]
+
+    # First call runs inline and blocks, so the next four queue into one batch.
+    task0 = asyncio.create_task(limited(0))
+    await started.wait()
+    tasks = [asyncio.create_task(limited(v)) for v in [1, 2, 3, 4]]
+    await asyncio.sleep(0.05)  # let them enqueue behind the inline call
+    release.set()
+
+    results = await asyncio.gather(task0, *tasks)
+    assert results == [0, 2, 4, 6, 8]
+
+    # Inline [0], then the rejected batch of 4, then its two halves.
+    assert batch_sizes[:2] == [1, 4]
+    assert sorted(batch_sizes[2:]) == [2, 2]
+
+
+@pytest.mark.asyncio
+async def test_retry_with_smaller_batch_isolates_poison_item() -> None:
+    """One bad input fails only its own caller; the rest of the batch succeeds."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    @coco.fn.as_async(batching=True)
+    async def embed(inputs: list[int]) -> list[int]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            started.set()
+            await release.wait()
+        if any(x < 0 for x in inputs):
+            if len(inputs) == 1:
+                raise ValueError(f"bad input {inputs[0]}")
+            raise coco.RetryWithSmallerBatch() from _BatchLimitError("rejected")
+        return [x * 2 for x in inputs]
+
+    task0 = asyncio.create_task(embed(1))
+    await started.wait()
+    tasks = [asyncio.create_task(embed(v)) for v in [2, 3, -7, 4]]
+    await asyncio.sleep(0.05)
+    release.set()
+
+    results = await asyncio.gather(task0, *tasks, return_exceptions=True)
+    assert results[:3] == [2, 4, 6]
+    assert isinstance(results[3], ValueError)
+    assert str(results[3]) == "bad input -7"
+    assert results[4] == 8
+
+
+@pytest.mark.asyncio
+async def test_retry_with_smaller_batch_single_item_raises_cause() -> None:
+    """At batch size 1 the wrapped original error surfaces, not the signal."""
+
+    @coco.fn.as_async(batching=True)
+    async def always_split(inputs: list[int]) -> list[int]:
+        raise coco.RetryWithSmallerBatch() from ValueError("real error")
+
+    with pytest.raises(ValueError, match="real error"):
+        await always_split(1)
+
+
+@pytest.mark.asyncio
+async def test_retry_with_smaller_batch_single_item_without_cause() -> None:
+    """Signal raised bare (no cause) at size 1 propagates as itself."""
+
+    @coco.fn.as_async(batching=True)
+    async def always_split(inputs: list[int]) -> list[int]:
+        raise coco.RetryWithSmallerBatch()
+
+    with pytest.raises(coco.RetryWithSmallerBatch):
+        await always_split(1)
+
+
+def test_retry_with_smaller_batch_sync_driver() -> None:
+    """The sync split driver: same halving semantics, sequential halves."""
+    from cocoindex._internal.batching import BatchItemFailure, wrap_batch_fn_sync
+
+    batch_sizes: list[int] = []
+
+    def body(inputs: list[int]) -> list[int]:
+        batch_sizes.append(len(inputs))
+        if len(inputs) > 1:
+            raise coco.RetryWithSmallerBatch() from _BatchLimitError("too big")
+        if inputs[0] < 0:
+            raise ValueError(f"bad input {inputs[0]}")
+        return [x * 2 for x in inputs]
+
+    run = wrap_batch_fn_sync(body)
+    outputs = run([1, 2, -3, 4])
+
+    assert outputs[0] == 2
+    assert outputs[1] == 4
+    assert isinstance(outputs[2], BatchItemFailure)
+    assert isinstance(outputs[2].error, ValueError)
+    assert outputs[3] == 8
+    # 4 -> (2, 2) -> four singles.
+    assert sorted(batch_sizes) == [1, 1, 1, 1, 2, 2, 4]
+
+
+def test_retry_with_smaller_batch_pickle_preserves_cause() -> None:
+    """The signal carries its cause through pickling (subprocess runners drop
+    ``__cause__`` and concurrent.futures then overwrites it with a
+    remote-traceback marker — the restored cause must win over that)."""
+    import pickle
+
+    from cocoindex._internal.batching import split_cause
+
+    try:
+        raise coco.RetryWithSmallerBatch() from ValueError("original failure")
+    except coco.RetryWithSmallerBatch as e:
+        signal = e
+
+    restored = pickle.loads(pickle.dumps(signal))
+    # Simulate concurrent.futures clobbering __cause__ on the parent side.
+    restored.__cause__ = RuntimeError("remote traceback marker")
+
+    cause = split_cause(restored)
+    assert isinstance(cause, ValueError)
+    assert str(cause) == "original failure"
+
+
+@coco.fn.as_async(batching=True, runner=coco.GPU)
+def _rwsb_subprocess_fn(inputs: list[int]) -> list[int]:
+    """Raises the split signal unconditionally — including at batch size 1."""
+    raise coco.RetryWithSmallerBatch() from ValueError("original failure")
+
+
+@pytest.mark.asyncio
+async def test_gpu_runner_subprocess_retry_with_smaller_batch(
+    monkeypatch: pytest.MonkeyPatch, _reset_gpu_runner: None
+) -> None:
+    """The signal raised at size 1 inside a real subprocess unwraps to the
+    original error on the caller side — no batch-size check in the body."""
+    monkeypatch.setenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", "1")
+    coco.GPU._use_subprocess = None
+
+    with pytest.raises(ValueError, match="original failure"):
+        await _rwsb_subprocess_fn(5)
+
+
 # Note: With always-async design, functions with batching/runner are always async.
 # The underlying implementation can be sync - it gets wrapped appropriately.
 # Both in-process and subprocess execution work for sync underlying functions.

--- a/python/tests/ops/test_embedder_refactor.py
+++ b/python/tests/ops/test_embedder_refactor.py
@@ -8,6 +8,9 @@ single ``NDArray[np.float32]`` rather than a ``list[NDArray]``.
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, call, patch
 
 import numpy as np
@@ -15,6 +18,9 @@ import pytest
 
 pytest.importorskip("litellm", reason="litellm not installed")
 
+from litellm.exceptions import AuthenticationError  # noqa: E402
+
+import cocoindex as coco  # noqa: E402
 from cocoindex.ops.litellm import LiteLLMEmbedder  # noqa: E402
 
 # Note on the sleep patch target below: retry sleeps now happen inside
@@ -139,6 +145,119 @@ async def test_litellm_embedder_does_not_retry_non_transient_embedding_errors() 
 
     mocked_embedding.assert_awaited_once()
     sleep.assert_not_called()
+
+
+# ============================================================================
+# RetryWithSmallerBatch: over-limit batches are split, global errors are not
+# ============================================================================
+
+
+def _fake_embedding_response(texts: list[str]) -> Any:
+    # Embedding derived from the text so tests can verify item alignment.
+    return SimpleNamespace(data=[{"embedding": [float(len(t))]} for t in texts])
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_splits_oversized_batch() -> None:
+    """A provider batch-size rejection splits the batch; every text succeeds
+    with its own embedding (results stay aligned through the split)."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_inputs: list[list[str]] = []
+
+    async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        call_inputs.append(list(input))
+        if len(call_inputs) == 1:
+            started.set()
+            await release.wait()
+        if len(input) > 2:
+            raise _FakeHTTPError(400, "TOO_MANY_TOKENS_IN_BATCH")
+        return _fake_embedding_response(input)
+
+    embedder = LiteLLMEmbedder("fake-model")
+    with patch("cocoindex.ops.litellm.litellm.aembedding", new=fake_aembedding):
+        # First call runs inline and blocks, so the next four coalesce into
+        # one batch of 4 — which the fake provider rejects.
+        task0 = asyncio.create_task(embedder.embed("a"))
+        await started.wait()
+        texts = ["bb", "ccc", "dddd", "eeeee"]
+        tasks = [asyncio.create_task(embedder.embed(t)) for t in texts]
+        await asyncio.sleep(0.05)  # let them enqueue behind the inline call
+        release.set()
+        results = await asyncio.gather(task0, *tasks)
+
+    for text, vec in zip(["a", *texts], results):
+        assert vec.tolist() == [float(len(text))]
+    # Inline [1], rejected [4], then the two halves of 2.
+    assert [len(c) for c in call_inputs[:2]] == [1, 4]
+    assert sorted(len(c) for c in call_inputs[2:]) == [2, 2]
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_raises_retry_with_smaller_batch_on_400() -> None:
+    """A non-retryable, non-global error on a multi-text batch becomes the
+    RetryWithSmallerBatch signal (with the original error as its cause)."""
+    embedder = LiteLLMEmbedder("fake-model")
+    provider_error = _FakeHTTPError(400, "batch exceeds maximum context length")
+    with patch(
+        "cocoindex.ops.litellm.litellm.aembedding",
+        new=AsyncMock(side_effect=provider_error),
+    ):
+        with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+            await embedder._embed._execute_orig_async_fn(["a", "b"])
+    assert exc_info.value.__cause__ is provider_error
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_single_text_error_surfaces_original() -> None:
+    """With one text there is nothing to split — the caller sees the original
+    provider error (the engine unwraps the size-1 signal)."""
+    embedder = LiteLLMEmbedder("fake-model")
+    with patch(
+        "cocoindex.ops.litellm.litellm.aembedding",
+        new=AsyncMock(side_effect=_FakeHTTPError(400, "input too large")),
+    ):
+        with pytest.raises(_FakeHTTPError):
+            await embedder.embed("only")
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_splits_after_transient_retries_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient error that survives the same-size retry budget is still
+    splittable — a smaller request may pass where the large one timed out."""
+    # Near-zero retry budget: the retry wrapper exhausts its deadline almost
+    # immediately (DeadlineExceededError, a TimeoutError subclass).
+    monkeypatch.setattr("cocoindex.ops.litellm._EMBEDDING_RETRY_TIMEOUT_SECONDS", 0.05)
+    embedder = LiteLLMEmbedder("fake-model")
+    with patch(
+        "cocoindex.ops.litellm.litellm.aembedding",
+        new=AsyncMock(side_effect=_FakeHTTPError(429)),
+    ):
+        with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+            await embedder._embed._execute_orig_async_fn(["a", "b"])
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_does_not_split_global_errors() -> None:
+    """Credential / auth errors can't be fixed by splitting — they propagate
+    as-is even for multi-text batches."""
+    embedder = LiteLLMEmbedder("fake-model")
+    auth_error = AuthenticationError(
+        message="access denied", llm_provider="openai", model="fake-model"
+    )
+    for error in (
+        _FakeHTTPError(401, "Invalid API key provided"),
+        auth_error,
+    ):
+        with patch(
+            "cocoindex.ops.litellm.litellm.aembedding",
+            new=AsyncMock(side_effect=error),
+        ):
+            with pytest.raises(type(error)):
+                await embedder._embed._execute_orig_async_fn(["a", "b"])
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/test_sentence_transformer_embedder.py
+++ b/python/tests/ops/test_sentence_transformer_embedder.py
@@ -1,0 +1,114 @@
+"""Tests for SentenceTransformerEmbedder's OOM split-and-retry behavior.
+
+The real sentence-transformers package is not needed: ``_get_model`` is
+stubbed with a fake model, so these tests exercise the op's error
+classification and the batching engine's RetryWithSmallerBatch path
+(including the GPU runner) without loading any model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+import cocoindex as coco
+from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
+
+_OOM_MESSAGE = "CUDA out of memory. Tried to allocate 20.00 GiB"
+
+
+class _FakeModel:
+    """Fake SentenceTransformer: OOMs on batches larger than ``oom_above``.
+
+    Embeddings are derived from the text length so tests can verify that
+    results stay aligned to their inputs through a split.
+    """
+
+    def __init__(self, oom_above: int = 2) -> None:
+        self.oom_above = oom_above
+        self.encode_sizes: list[int] = []
+        self.first_call_started = threading.Event()
+        self.release_first_call = threading.Event()
+        self._lock = threading.Lock()
+
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        with self._lock:
+            first = not self.encode_sizes
+            self.encode_sizes.append(len(texts))
+        if first:
+            self.first_call_started.set()
+            assert self.release_first_call.wait(timeout=5)
+        if len(texts) > self.oom_above:
+            raise RuntimeError(_OOM_MESSAGE)
+        return np.array([[float(len(t))] for t in texts], dtype=np.float32)
+
+
+def _make_embedder(model: Any) -> SentenceTransformerEmbedder:
+    embedder = SentenceTransformerEmbedder("fake-model")
+    embedder._get_model = lambda: model  # type: ignore[method-assign]
+    return embedder
+
+
+@pytest.mark.asyncio
+async def test_sentence_transformer_splits_oom_batch() -> None:
+    """An OOM on a large batch splits it; every text succeeds with its own
+    embedding, end to end through the batcher and the GPU runner."""
+    fake = _FakeModel(oom_above=2)
+    embedder = _make_embedder(fake)
+
+    # First call runs inline and blocks inside encode (on a GPU runner
+    # thread), so the next four coalesce into one batch of 4 — which OOMs.
+    task0 = asyncio.create_task(embedder.embed("a"))
+    assert await asyncio.to_thread(fake.first_call_started.wait, 5)
+    texts = ["bb", "ccc", "dddd", "eeeee"]
+    tasks = [asyncio.create_task(embedder.embed(t)) for t in texts]
+    await asyncio.sleep(0.05)  # let them enqueue behind the inline call
+    fake.release_first_call.set()
+    results = await asyncio.gather(task0, *tasks)
+
+    for text, vec in zip(["a", *texts], results):
+        assert vec.tolist() == [float(len(text))]
+    # Inline [1], the OOMing batch of 4, then its two halves.
+    assert fake.encode_sizes == [1, 4, 2, 2]
+
+
+class _AlwaysFailModel:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        raise self.error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [RuntimeError(_OOM_MESSAGE), MemoryError("host allocation failed")],
+    ids=["cuda", "host"],
+)
+def test_sentence_transformer_oom_on_multi_text_raises_signal(
+    error: BaseException,
+) -> None:
+    embedder = _make_embedder(_AlwaysFailModel(error))
+    with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+        embedder._embed._execute_orig_sync_fn(["a", "b", "c"])
+    assert exc_info.value.__cause__ is error
+
+
+@pytest.mark.asyncio
+async def test_sentence_transformer_oom_on_single_text_surfaces_original() -> None:
+    """A single text that doesn't fit is its own failure — the caller sees the
+    OOM error (the engine unwraps the size-1 signal)."""
+    embedder = _make_embedder(_AlwaysFailModel(RuntimeError(_OOM_MESSAGE)))
+    with pytest.raises(RuntimeError, match="out of memory"):
+        await embedder.embed("only")
+
+
+def test_sentence_transformer_non_oom_error_propagates() -> None:
+    """Config/model errors aren't composition-dependent — no split."""
+    embedder = _make_embedder(_AlwaysFailModel(KeyError("unknown prompt_name")))
+    with pytest.raises(KeyError):
+        embedder._embed._execute_orig_sync_fn(["a", "b"])


### PR DESCRIPTION
## Summary
- Add `coco.RetryWithSmallerBatch`: a batched function body (`@coco.fn(batching=True)`) raises it to have the engine halve the batch and retry the halves, recursing to single items — recovering from batch failures that depend on the batch's composition (provider token/payload caps, one rejected input, GPU OOM), which no fixed `max_batch_size` can rule out. Failed sub-batches deliver errors per item, so one poison input fails only its own caller instead of the whole batch. Safe to raise at any batch size (at size 1 the engine unwraps and raises the original error), and the signal carries its cause through pickling so this holds across subprocess-runner boundaries. Pure-Python: the split wrapper sits around the batch body; no Rust changes.
- `LiteLLMEmbedder`: raise the signal for any deterministic non-global error (not credentials/permissions/model/budget), including transient errors that exhausted their same-size retry budget. Fixes `TOO_MANY_TOKENS_IN_BATCH`-style aborts (e.g. voyage-code-3's 120k-token batch cap with `max_batch_size=64`, where count-based batching can deterministically exceed the provider's token cap).
- `SentenceTransformerEmbedder`: OOM-only trigger (local failures are transparent — OOM is the composition-dependent class), with best-effort accelerator cache release before the retry.

## Test plan
CI. New coverage: engine split/isolation/unwrap semantics (async + sync drivers), split-signal pickling fidelity incl. a real subprocess-runner round trip, litellm classification (split vs global vs single-text) and an end-to-end oversized-batch split with per-text result alignment, sentence-transformers OOM split end-to-end through the GPU runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
