### PR TITLE
ci: add gitleaks secret-scanning pre-commit hook + allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Gitleaks config for the pre-commit hook (and ad-hoc `gitleaks git` scans).
+
+[extend]
+# Keep all default detection rules; entries below only add allowlisting.
+useDefault = true
+
+[allowlist]
+description = "Known non-secrets"
+paths = [
+  # Throwaway RS256 test-only key for JWT-signing unit tests — same rationale
+  # as the detect-private-key exclude in .pre-commit-config.yaml.
+  '''rust/sdk/cocoindex/src/gdrive\.rs''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
         exclude_types: [python]  # Covered by Ruff W291.
         exclude: ".*(data.*|licenses.*|_static.*|\\.ya?ml|\\.jpe?g|\\.png|\\.svg|\\.webp)$"
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        # Scans the staged diff for hardcoded secrets before each commit.
+
   - repo: local
     hooks:
       - id: cargo-fmt


### PR DESCRIPTION
## Summary
- Add the `gitleaks` pre-commit hook (pinned v8.30.1): scans the staged diff for hardcoded secrets before each commit — commit-time defense in depth ahead of GitHub's push-time secret scanning (already enabled on this repo).
- Add `.gitleaks.toml`: keeps all default detection rules; allowlists the documented throwaway RS256 test key in `rust/sdk/cocoindex/src/gdrive.rs` (mirrors the existing `detect-private-key` exclude).
- Same hook already merged in the sibling repos; this closes the remaining corrective action from an internal incident review.

## Test plan
CI — prek runs on the changed files; the gitleaks hook installs and executes on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
