### PR TITLE
docs: resolve connections at action time in custom target connector guide

### DIFF
--- a/dev/agent-skills/target-connector/SKILL.md
+++ b/dev/agent-skills/target-connector/SKILL.md
@@ -153,6 +153,8 @@ pool = context_provider.get(key.db_key, asyncpg.Pool)
 
 This decouples target identity from transient connection details — changing a password, switching replicas, or rotating credentials won't invalidate tracked states.
 
+**Resolve connections at action time, never at declare time.** Target states outlive the code that declared them: when a declaration disappears or an app is dropped, CocoIndex generates delete actions in a run where the mount/declare code never executes — only the persisted key and the current environment's `ContextProvider` are available then. Don't capture a live connection at declare time; resolve in the sink, then pass the typed connection down to child handlers directly (store `_pool: asyncpg.Pool`, not the key string).
+
 **Reference:** See `_TableKey` in `python/cocoindex/connectors/postgres/_target.py` and `python/cocoindex/connectors/surrealdb/_target.py`.
 
 ### Idempotent Actions

--- a/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
+++ b/docs/src/content/docs/advanced_topics/custom_target_connector.mdx
@@ -592,6 +592,8 @@ pool = context_provider.get(key.db_key, asyncpg.Pool)
 
 This way, changing a password, switching replicas, or rotating credentials won't invalidate tracked states or break reconciliation.
 
+**Resolve connections at action time, never at declare time.** Target states outlive the code that declared them: when a declaration disappears or an app is dropped, CocoIndex generates delete actions in a run where your mount/declare code never executes. At that point the only inputs available are the persisted target state key and the current environment — which is why the sink receives a `ContextProvider` and why the key must carry `ContextKey.key`. Don't capture a live connection when the target is declared; a connection captured at declare time won't exist for cleanup, and resolving in the sink keeps create, update, and delete on one code path. Once resolved in the root sink, pass the typed connection down to child handlers directly (e.g., store `_pool: asyncpg.Pool`, not the key string).
+
 See `_TableKey` in [`cocoindex/connectors/postgres/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/postgres/_target.py) and [`cocoindex/connectors/surrealdb/_target.py`](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/connectors/surrealdb/_target.py) for reference implementations.
 
 ### Idempotent actions


### PR DESCRIPTION
## Summary
- Document why target connectors must resolve `ContextKey` → live connection at action time (in the sink, via `ContextProvider`) rather than at declare time: target states outlive the code that declared them, and delete actions run in processes where the mount/declare code never executes.
- Added to the "Use `ContextKey` for external resource identity" best practice in `docs/advanced_topics/custom_target_connector.mdx`, plus a condensed version in the `dev/agent-skills/target-connector` playbook (the `.claude/skills/` and `.agents/skills/` entries are symlinks and pick this up automatically).

## Test plan
Prose-only doc change; CI docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
