### PR TITLE
fix: commit dbi-opening read txns to keep LMDB handles valid across processes

### DIFF
--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -861,3 +861,42 @@ class TestShowTree:
         assert file1_indent > files_indent, (
             "file1.txt should be indented as child of files"
         )
+
+
+# =============================================================================
+# Test: Show command reading directly from a database (--db/--app-name)
+# =============================================================================
+
+
+class TestShowFromDatabase:
+    """Tests for show --db/--app-name: opening a database from a fresh process
+    without loading the app module.
+
+    Regression tests: these flows used to fail with EINVAL (os error 22)
+    because the sub-database handle was opened in a read txn that was dropped
+    without commit, which leaves the handle invalid in any process other than
+    the one that created the sub-database.
+    """
+
+    def test_show_db_long_lists_details(self) -> None:
+        """show --db/--app-name -l should render details without the module."""
+        run_cli("update", "./flat_target_app.py")
+
+        result = run_cli(
+            "show", "--db", "./cocoindex.db", "--app-name", "FlatPreviewApp", "-l"
+        )
+
+        assert "Stable paths:" in result.stdout
+        assert "- path:" in result.stdout
+        assert "states:1:Existing" in result.stdout
+
+    def test_show_db_tree_displays_components(self) -> None:
+        """show --db/--app-name --tree should render the tree without the module."""
+        run_cli("update", "./flat_target_app.py")
+
+        result = run_cli(
+            "show", "--db", "./cocoindex.db", "--app-name", "FlatPreviewApp", "--tree"
+        )
+
+        assert "Stable paths" in result.stdout
+        assert "[component]" in result.stdout

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -394,6 +394,11 @@ impl Storage {
         let _guard = self.inner.coord.read().await;
         let rtxn = self.inner.db_env.read_txn()?;
         let db: Option<Database> = self.inner.db_env.open_database(&rtxn, Some(app_name))?;
+        // The dbi handle opened in a read txn only becomes usable by other
+        // transactions after this txn commits; dropping (aborting) it instead
+        // leaves the handle invalid and later reads fail with EINVAL when the
+        // sub-database was created by another process.
+        rtxn.commit()?;
         let env = self.inner.db_env.clone();
         let storage = self.clone();
         Ok(db.map(|db| AppStore::new(db, env, storage.clone())))
@@ -408,9 +413,14 @@ impl Storage {
         let db = {
             let _guard = self.inner.coord.read().await;
             let rtxn = self.inner.db_env.read_txn()?;
-            self.inner
+            let db = self
+                .inner
                 .db_env
-                .open_database::<heed::types::Bytes, heed::types::Bytes>(&rtxn, Some(app_name))?
+                .open_database::<heed::types::Bytes, heed::types::Bytes>(&rtxn, Some(app_name))?;
+            // See `open_app_store_by_name`: commit so the dbi handle stays
+            // valid for the write txn below.
+            rtxn.commit()?;
+            db
         };
         let Some(db) = db else {
             return Ok(());


### PR DESCRIPTION
## What broke — try it

Every by-name database inspection — `cocoindex show --db <path> --app-name <name>`, in any variant (plain, `-l`, `--tree`) — fails on `main` whenever the app database was created by another process. Since inspecting a database *without loading the app module* is the entire point of `show --db`, the flow is broken in all real usage.

To see it, from `examples/files_transform/` (any app works; this one is dependency-free):

```bash
git checkout main && uv run maturin develop
cd examples/files_transform

# Process A writes the database:
COCOINDEX_DB=./cocoindex.db uv run --project ../.. cocoindex update main

# Process B reads it by name — and fails:
COCOINDEX_DB=./cocoindex.db uv run --project ../.. cocoindex show --db ./cocoindex.db --app-name FilesTransform -l
```
```
RuntimeError: Invalid argument (os error 22)
```

Meanwhile the module-loading flow works fine on the same broken build — this masking is what hid the bug:

```bash
COCOINDEX_DB=./cocoindex.db uv run --project ../.. cocoindex show main -l   # works
```

On this branch, the same command against the **same database** succeeds (the on-disk format is untouched; only the reader changed):

```bash
cd ../.. && git checkout fix/lmdb-dbi-handle-commit && uv run maturin develop
cd examples/files_transform
COCOINDEX_DB=./cocoindex.db uv run --project ../.. cocoindex show --db ./cocoindex.db --app-name FilesTransform -l
```
```
Stable paths:
  /
    type:component version:1 processor:app_main
    ...
  /@process_file
    type:component version:1 processor:_MountEachLiveComponent.process
    ...
```

Cleanup: `rm -rf cocoindex.db output`

## Why

LMDB requires the transaction that opened a named sub-database handle (dbi) to **commit** before the handle becomes valid in other transactions. heed's `RoTxn::commit` docs call out this exact failure:

> It's mandatory in a multi-process setup to call `RoTxn::commit` upon read-only database opening. After the transaction opening, the database is dropped. The next transaction might return `Io(Os { code: 22, ... })` known as `EINVAL`.

`Storage::open_app_store_by_name` (and `drop_app`, same pattern) opened the handle inside a read txn and let it drop — and dropping a read txn *aborts* it, so the handle was never published to the environment's shared handle table. Every later transaction using that `AppStore` got EINVAL.

The masking above also follows from this: whenever the same process had already created the sub-database via `create_app_store` (a committed write txn — which happens on every module-loading flow), the handle was already shared and `open_app_store_by_name` silently worked. Only the "fresh process opens a DB some other process wrote" case broke.

## How

Commit the dbi-opening read txns in `Storage::open_app_store_by_name` and `drop_app`.

## Test coverage

No in-process test can catch this: any test that creates the DB itself publishes the handle through the committed write txn, and LMDB forbids opening the same environment twice within one process, so a second "process" can't be simulated in a Rust unit test. Regression coverage is therefore subprocess e2e tests (`TestShowFromDatabase`) driving the pre-existing `show --db -l` and `show --db --tree` flows through the CLI, where `update` and `show` naturally run as separate processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
