### PR TITLE
feat: render tracked target-state paths readably in cocoindex show

### DIFF
--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -161,6 +161,7 @@ cocoindex show [OPTIONS] [APP_TARGET] [STABLE_PATH]
 | `-l, --long` | Display detailed information in multi-line format. |
 | `-r, --recursive` | Show all children recursively (requires stable_path). |
 | `-p, --parents` | Show all parent paths (requires stable_path). |
+| `--fingerprints` | Show target-state paths as raw fingerprints (as stored) instead of readable keys. |
 | `--help` | Show this message and exit. |
 
 ---

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -217,6 +217,7 @@ class ProviderGeneration:
 
 class TargetStateInfoItemSummary:
     target_state_path: str
+    fingerprint_path: str
     key: StableKey
     states: list[TargetStateVersion]
     provider_schema_version: int

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -627,6 +627,13 @@ def ls(app_target: str | None, db: str | None) -> None:
     default=False,
     help="Show all parent paths (requires stable_path).",
 )
+@click.option(
+    "--fingerprints",
+    "fingerprints",
+    is_flag=True,
+    default=False,
+    help="Show target-state paths as raw fingerprints (as stored) instead of readable keys.",
+)
 def show(
     app_target: str | None,
     db: str | None,
@@ -636,6 +643,7 @@ def show(
     stable_path: str | None,
     recursive: bool,
     parents: bool,
+    fingerprints: bool,
 ) -> None:
     """
     Show the app's stable paths.
@@ -665,6 +673,7 @@ def show(
                 stable_path=stable_path,
                 recursive=recursive,
                 parents=parents,
+                fingerprints=fingerprints,
             )
         )
     elif db and app_name:
@@ -677,6 +686,7 @@ def show(
                 stable_path=stable_path,
                 recursive=recursive,
                 parents=parents,
+                fingerprints=fingerprints,
             )
         )
     elif db or app_name:
@@ -718,6 +728,7 @@ async def _show_from_app(
     stable_path: str | None = None,
     recursive: bool = False,
     parents: bool = False,
+    fingerprints: bool = False,
 ) -> None:
     try:
         if stable_path is not None:
@@ -730,7 +741,7 @@ async def _show_from_app(
                 recursive=recursive,
                 include_parents=parents,
             )
-            _print_details(details)
+            _print_details(details, fingerprints)
         elif long_format:
             # Stream paths, fetch detail one-by-one (no buffering)
             click.echo("Stable paths:")
@@ -739,7 +750,7 @@ async def _show_from_app(
                 path_obj = StablePath(item.path)
                 detail = await get_stable_path_detail(app, path_obj)
                 if detail:
-                    _print_one_detail(detail)
+                    _print_one_detail(detail, fingerprints)
                 count += 1
             if count == 0:
                 click.echo("  (none)")
@@ -762,6 +773,7 @@ async def _show_from_database(
     stable_path: str | None = None,
     recursive: bool = False,
     parents: bool = False,
+    fingerprints: bool = False,
 ) -> None:
     db_path_obj = pathlib.Path(db_path)
     if not db_path_obj.exists():
@@ -784,7 +796,7 @@ async def _show_from_database(
             recursive=recursive,
             include_parents=parents,
         )
-        _print_details(details)
+        _print_details(details, fingerprints)
     elif long_format:
         click.echo("Stable paths:")
         count = 0
@@ -792,7 +804,7 @@ async def _show_from_database(
             path_obj = StablePath(item.path)
             detail = await get_stable_path_detail_by_name(env, app_name, path_obj)
             if detail:
-                _print_one_detail(detail)
+                _print_one_detail(detail, fingerprints)
             count += 1
         if count == 0:
             click.echo("  (none)")
@@ -807,7 +819,9 @@ async def _show_from_database(
             click.echo(f"  {StablePath(item.path)}")
 
 
-def _print_details(details: list[_core.StablePathDetail]) -> None:
+def _print_details(
+    details: list[_core.StablePathDetail], fingerprints: bool = False
+) -> None:
     """Print a list of StablePathDetail in multi-line format."""
     if not details:
         click.echo("Stable paths:")
@@ -816,10 +830,12 @@ def _print_details(details: list[_core.StablePathDetail]) -> None:
 
     click.echo("Stable paths:")
     for detail in details:
-        _print_one_detail(detail)
+        _print_one_detail(detail, fingerprints)
 
 
-def _print_one_detail(detail: _core.StablePathDetail) -> None:
+def _print_one_detail(
+    detail: _core.StablePathDetail, fingerprints: bool = False
+) -> None:
     """Print a single StablePathDetail in multi-line format."""
     path = StablePath(detail.path)
     node_type = (
@@ -846,7 +862,12 @@ def _print_one_detail(detail: _core.StablePathDetail) -> None:
                 else "None"
             )
             states = ", ".join(f"{s.version}:{s.state}" for s in item_summary.states)
-            click.echo(f"      - path:{item_summary.target_state_path}")
+            path_str = (
+                item_summary.fingerprint_path
+                if fingerprints
+                else item_summary.target_state_path
+            )
+            click.echo(f"      - path:{path_str}")
             click.echo(
                 f"        states:{states or '-'}"
                 f" schema_version:{item_summary.provider_schema_version}"

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -846,9 +846,7 @@ def _print_one_detail(detail: _core.StablePathDetail) -> None:
                 else "None"
             )
             states = ", ".join(f"{s.version}:{s.state}" for s in item_summary.states)
-            click.echo(
-                f"      - path:{item_summary.target_state_path} key:{item_summary.key!r}"
-            )
+            click.echo(f"      - path:{item_summary.target_state_path}")
             click.echo(
                 f"        states:{states or '-'}"
                 f" schema_version:{item_summary.provider_schema_version}"

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -888,6 +888,9 @@ class TestShowFromDatabase:
 
         assert "Stable paths:" in result.stdout
         assert "- path:" in result.stdout
+        # The leaf key "x" is resolved from tracking info even without the
+        # app module loaded; the root provider segment stays a fingerprint.
+        assert '/"x"' in result.stdout
         assert "states:1:Existing" in result.stdout
 
     def test_show_db_tree_displays_components(self) -> None:

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -931,3 +931,21 @@ class TestShowLong:
         assert '/"x"' in path_line
         assert "@test_cli/flat_preview" in path_line
         assert "#" not in path_line
+
+    def test_show_long_fingerprints_flag_shows_raw_paths(self) -> None:
+        """show -l --fingerprints should render raw fingerprint paths."""
+        run_cli("update", "./flat_target_app.py")
+
+        result = run_cli("show", "./flat_target_app.py", "-l", "--fingerprints")
+
+        path_line = next(
+            (
+                line
+                for line in result.stdout.split("\n")
+                if line.strip().startswith("- path:")
+            ),
+            None,
+        )
+        assert path_line is not None
+        assert "/#" in path_line
+        assert "@test_cli/flat_preview" not in path_line

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -903,3 +903,32 @@ class TestShowFromDatabase:
 
         assert "Stable paths" in result.stdout
         assert "[component]" in result.stdout
+
+
+class TestShowLong:
+    """Tests for target-state rendering in show -l."""
+
+    def test_show_long_renders_readable_target_state_path(self) -> None:
+        """show -l should render target state paths with readable keys."""
+        run_cli("update", "./flat_target_app.py")
+
+        result = run_cli("show", "./flat_target_app.py", "-l")
+
+        path_line = next(
+            (
+                line
+                for line in result.stdout.split("\n")
+                if line.strip().startswith("- path:")
+            ),
+            None,
+        )
+        assert path_line is not None, (
+            f"Should have a target state path line:\n{result.stdout}"
+        )
+        # The leaf key "x" is resolved from tracking info; the root provider
+        # segment is resolved from the live provider registry (the app module
+        # is loaded), so no fingerprint remains.
+        assert '/"x"' in path_line
+        assert "@test_cli/flat_preview" in path_line
+        assert "#" not in path_line
+        assert "key:'x'" in path_line

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -931,4 +931,3 @@ class TestShowLong:
         assert '/"x"' in path_line
         assert "@test_cli/flat_preview" in path_line
         assert "#" not in path_line
-        assert "key:'x'" in path_line

--- a/rust/core/src/engine/target_state.rs
+++ b/rust/core/src/engine/target_state.rs
@@ -276,6 +276,10 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
         self.register_all_attachment_providers(registry)
     }
 
+    pub fn stable_key(&self) -> &StableKey {
+        &self.inner.stable_key
+    }
+
     pub fn stable_key_chain(&self) -> Vec<StableKey> {
         let mut chain = vec![self.inner.stable_key.clone()];
         let mut current = self;

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -106,9 +106,15 @@ struct TargetKeyResolver {
 }
 
 impl TargetKeyResolver {
-    fn new() -> Self {
+    /// `provider_keys` seeds the cache with the original keys of live
+    /// registered providers (see [`provider_key_seed`]); root provider
+    /// segments are resolvable only through this seed.
+    fn new(provider_keys: std::collections::HashMap<TargetStatePath, StableKey>) -> Self {
         Self {
-            cache: std::collections::HashMap::new(),
+            cache: provider_keys
+                .into_iter()
+                .map(|(path, key)| (path, Some(key)))
+                .collect(),
         }
     }
 
@@ -197,6 +203,26 @@ impl TargetKeyResolver {
         }
         Ok(rendered)
     }
+}
+
+/// Collect the original keys of all target-state providers registered in the
+/// live environment: root providers and their attachments, registered by name
+/// at module import time and never persisted, so this registry is the only
+/// source that can render their path segments readably. Two classes of
+/// provider-only segments remain unresolvable and keep the fingerprint
+/// fallback: providers whose modules aren't imported in this process (e.g.
+/// inspecting a database without loading the app), and attachments of nested
+/// providers, which live in build-local registries that are discarded when
+/// the run finishes.
+fn provider_key_seed<Prof: EngineProfile>(
+    env: &Environment<Prof>,
+) -> std::collections::HashMap<TargetStatePath, StableKey> {
+    let registry = env.target_states_providers().lock().unwrap();
+    registry
+        .providers
+        .iter()
+        .map(|(path, provider)| (path.clone(), provider.stable_key().clone()))
+        .collect()
 }
 
 fn summarize_target_state_items(
@@ -335,11 +361,12 @@ fn read_detail_in_txn(
 
 async fn get_stable_path_detail_from_store(
     store: &AppStore,
+    provider_keys: std::collections::HashMap<TargetStatePath, StableKey>,
     path: &StablePath,
 ) -> Result<Option<StablePathDetail>> {
     let db = store.db();
     let txn = store.read_txn().await?;
-    let mut resolver = TargetKeyResolver::new();
+    let mut resolver = TargetKeyResolver::new(provider_keys);
     Ok(Some(read_detail_in_txn(&db, &*txn, &mut resolver, path)?))
 }
 
@@ -348,7 +375,8 @@ pub async fn get_stable_path_detail<Prof: EngineProfile>(
     app: &App<Prof>,
     path: &StablePath,
 ) -> Result<Option<StablePathDetail>> {
-    get_stable_path_detail_from_store(app.app_ctx().app_store(), path).await
+    let seed = provider_key_seed(app.app_ctx().env());
+    get_stable_path_detail_from_store(app.app_ctx().app_store(), seed, path).await
 }
 
 pub async fn get_stable_path_detail_by_name<Prof: EngineProfile>(
@@ -360,7 +388,7 @@ pub async fn get_stable_path_detail_by_name<Prof: EngineProfile>(
         Some(store) => store,
         None => return Ok(None),
     };
-    get_stable_path_detail_from_store(&store, path).await
+    get_stable_path_detail_from_store(&store, provider_key_seed(env), path).await
 }
 
 /// List direct children of a path. With `recursive=true`, walks the full subtree.
@@ -418,6 +446,7 @@ fn list_parents_in_txn(
 /// Query details for a path with optional children/parents, all in a single read txn.
 async fn query_details_from_store(
     store: &AppStore,
+    provider_keys: std::collections::HashMap<TargetStatePath, StableKey>,
     path: &StablePath,
     include_children: bool,
     recursive: bool,
@@ -425,7 +454,7 @@ async fn query_details_from_store(
 ) -> Result<Vec<StablePathDetail>> {
     let db = store.db();
     let txn = store.read_txn().await?;
-    let mut resolver = TargetKeyResolver::new();
+    let mut resolver = TargetKeyResolver::new(provider_keys);
 
     let mut results = Vec::new();
 
@@ -458,6 +487,7 @@ pub async fn query_stable_path_details<Prof: EngineProfile>(
 ) -> Result<Vec<StablePathDetail>> {
     query_details_from_store(
         app.app_ctx().app_store(),
+        provider_key_seed(app.app_ctx().env()),
         path,
         include_children,
         recursive,
@@ -479,7 +509,15 @@ pub async fn query_stable_path_details_by_name<Prof: EngineProfile>(
         Some(store) => store,
         None => return Ok(Vec::new()),
     };
-    query_details_from_store(&store, path, include_children, recursive, include_parents).await
+    query_details_from_store(
+        &store,
+        provider_key_seed(env),
+        path,
+        include_children,
+        recursive,
+        include_parents,
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -487,7 +525,63 @@ mod tests {
     use super::*;
     use crate::state_store::test_support::make_test_store;
     use cocoindex_utils::fingerprint::Fingerprint;
+    use std::borrow::Cow;
     use std::sync::Arc;
+
+    fn comp_path(name: &str) -> StablePath {
+        StablePath(Arc::from(vec![StableKey::Str(Arc::from(name))]))
+    }
+
+    fn with_pid(path: &TargetStatePath, provider_id: Option<u64>) -> TargetStatePathWithProviderId {
+        TargetStatePathWithProviderId {
+            target_state_path: path.clone(),
+            provider_id,
+        }
+    }
+
+    fn tracking_bytes(items: Vec<(TargetStatePathWithProviderId, StableKey)>) -> Vec<u8> {
+        let mut info = db_schema::StablePathEntryTrackingInfo::new(Cow::Borrowed("test"));
+        for (path_with_pid, key) in items {
+            info.target_state_items.insert(
+                path_with_pid,
+                db_schema::TargetStateInfoItem {
+                    key: Cow::Owned(storekey::encode_vec(&key).unwrap()),
+                    states: Vec::new(),
+                    provider_schema_version: 0,
+                    provider_generation: None,
+                },
+            );
+        }
+        rmp_serde::to_vec_named(&info).unwrap()
+    }
+
+    async fn commit_writes(
+        store: &AppStore,
+        tracking: Vec<(StablePath, Vec<u8>)>,
+        owners: Vec<(TargetStatePath, StablePath)>,
+    ) {
+        let store2 = store.clone();
+        store
+            .storage
+            .run_txn(move |wtxn| {
+                let store = store2.clone();
+                let tracking = tracking.clone();
+                let owners = owners.clone();
+                Box::pin(async move {
+                    for (path, bytes) in &tracking {
+                        store.write_tracking_info_raw(wtxn, path, bytes).await?;
+                    }
+                    for (ts_path, owner) in &owners {
+                        store
+                            .upsert_target_state_owner(wtxn, ts_path, owner)
+                            .await?;
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+    }
 
     #[tokio::test]
     async fn render_path_falls_back_to_fingerprints() {
@@ -497,11 +591,95 @@ mod tests {
 
         let db = store.db();
         let txn = store.read_txn().await.unwrap();
-        let mut resolver = TargetKeyResolver::new();
+        let mut resolver = TargetKeyResolver::new(Default::default());
         let rendered = resolver.render_path(&db, &txn, &path, None).unwrap();
 
         // Nothing is resolvable in an empty store: both segments stay fingerprints.
         assert_eq!(rendered, path.to_string());
         assert_eq!(rendered.matches("/#").count(), 2);
+    }
+
+    #[tokio::test]
+    async fn resolves_root_segment_from_provider_seed() {
+        let (store, _dir) = make_test_store().await;
+        let root_path = TargetStatePath::new(Fingerprint::from(&"my_root").unwrap(), None);
+        let key = StableKey::Str(Arc::from("file.md"));
+        let path = root_path.concat(&key);
+        let comp = comp_path("comp");
+        commit_writes(
+            &store,
+            vec![(
+                comp.clone(),
+                tracking_bytes(vec![(with_pid(&path, None), key.clone())]),
+            )],
+            vec![(path.clone(), comp)],
+        )
+        .await;
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+        // Seed the root provider's key, as provider_key_seed does from the
+        // live registry (root providers are never persisted).
+        let seed = std::collections::HashMap::from([(
+            root_path.clone(),
+            StableKey::Symbol(Arc::from("my_root")),
+        )]);
+        let mut resolver = TargetKeyResolver::new(seed);
+        let rendered = resolver.render_path(&db, &txn, &path, None).unwrap();
+        assert_eq!(rendered, "/@my_root/\"file.md\"");
+    }
+
+    #[tokio::test]
+    async fn resolves_readable_paths_in_detail() {
+        let (store, _dir) = make_test_store().await;
+
+        // comp_c declares a "table" target state under an (unresolvable) root
+        // provider; the table creates a provider under which comp_d declares
+        // a row keyed by the integer 13.
+        let root_path = TargetStatePath::new(Fingerprint::from(&"root_target").unwrap(), None);
+        let table_key = StableKey::Str(Arc::from("table"));
+        let table_path = root_path.concat(&table_key);
+        let row_key = StableKey::Int(13);
+        let row_path = table_path.concat(&row_key);
+
+        let comp_c = comp_path("comp_c");
+        let comp_d = comp_path("comp_d");
+
+        commit_writes(
+            &store,
+            vec![
+                (
+                    comp_c.clone(),
+                    tracking_bytes(vec![(with_pid(&table_path, None), table_key.clone())]),
+                ),
+                (
+                    comp_d.clone(),
+                    tracking_bytes(vec![(with_pid(&row_path, Some(0)), row_key.clone())]),
+                ),
+            ],
+            vec![
+                (table_path.clone(), comp_c.clone()),
+                (row_path.clone(), comp_d.clone()),
+            ],
+        )
+        .await;
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+
+        let root_seg = root_path.to_string();
+        let mut resolver = TargetKeyResolver::new(Default::default());
+        let rendered = resolver.render_path(&db, &txn, &row_path, None).unwrap();
+        assert_eq!(rendered, format!("{root_seg}/\"table\"/13"));
+
+        // Detail summary renders readable paths (with provider_id suffix).
+        let mut resolver = TargetKeyResolver::new(Default::default());
+        let detail = read_detail_in_txn(&db, &txn, &mut resolver, &comp_d).unwrap();
+        assert_eq!(detail.target_state_items.len(), 1);
+        assert_eq!(
+            detail.target_state_items[0].target_state_path,
+            format!("{root_seg}/\"table\"/13[provider_id=0]")
+        );
+        assert_eq!(detail.target_state_items[0].key, row_key);
     }
 }

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -7,6 +7,7 @@ use crate::engine::environment::Environment;
 use crate::engine::{app::App, profile::EngineProfile};
 use crate::state::db_schema::{self, ChildExistenceInfo, DbEntryKey, StablePathEntryKey};
 use crate::state::stable_path::{StableKey, StablePath, StablePathRef};
+use crate::state::target_state_path::{TargetStatePath, TargetStatePathWithProviderId};
 use crate::state_store::AppStore;
 use cocoindex_utils::deser::from_msgpack_slice;
 use futures::stream::{Stream, StreamExt};
@@ -96,12 +97,117 @@ fn decode_target_state_key(key_bytes: &[u8]) -> StableKey {
     }
 }
 
+/// Resolves fingerprinted target state path segments back to their original
+/// `StableKey`s via the inverted owner index + the owner's tracking info.
+/// Caches per path prefix, including misses, so items sharing ancestors are
+/// resolved once per read txn.
+struct TargetKeyResolver {
+    cache: std::collections::HashMap<TargetStatePath, Option<StableKey>>,
+}
+
+impl TargetKeyResolver {
+    fn new() -> Self {
+        Self {
+            cache: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Resolve the original `StableKey` for the last segment of `prefix`.
+    /// Returns `None` when the prefix has no owner entry or tracking item:
+    /// provider-only path segments (root providers, provider attachments) are
+    /// never declared as target states so they have neither, and a crashed or
+    /// in-flight run can leave either record missing.
+    fn resolve_segment(
+        &mut self,
+        db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+        txn: &heed::RoTxn<'_, heed::WithoutTls>,
+        prefix: &TargetStatePath,
+    ) -> Result<Option<StableKey>> {
+        if let Some(cached) = self.cache.get(prefix) {
+            return Ok(cached.clone());
+        }
+        let resolved = Self::resolve_segment_uncached(db, txn, prefix)?;
+        self.cache.insert(prefix.clone(), resolved.clone());
+        Ok(resolved)
+    }
+
+    fn resolve_segment_uncached(
+        db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+        txn: &heed::RoTxn<'_, heed::WithoutTls>,
+        prefix: &TargetStatePath,
+    ) -> Result<Option<StableKey>> {
+        let owner_key = DbEntryKey::TargetState(prefix.clone()).encode()?;
+        let owner_bytes = match db.get(txn, owner_key.as_slice())? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        let owner: db_schema::TargetStateOwnerInfo = from_msgpack_slice(owner_bytes)?;
+        let tracking_key =
+            DbEntryKey::StablePath(owner.component_path, StablePathEntryKey::TrackingInfo)
+                .encode()?;
+        let tracking_bytes = match db.get(txn, tracking_key.as_slice())? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        let info: db_schema::StablePathEntryTrackingInfo = from_msgpack_slice(tracking_bytes)?;
+        // Items are ordered by (target_state_path, provider_id) with `None < Some`,
+        // so the first item at or after (prefix, None) has the matching path, if any.
+        let start = TargetStatePathWithProviderId {
+            target_state_path: prefix.clone(),
+            provider_id: None,
+        };
+        Ok(info
+            .target_state_items
+            .range(start..)
+            .next()
+            .filter(|(path_with_pid, _)| path_with_pid.target_state_path == *prefix)
+            .map(|(_, item)| decode_target_state_key(item.key.as_ref())))
+    }
+
+    /// Render a readable path like `/@target/"file.md"/[13]`, falling back to
+    /// the `#hex` fingerprint for any segment that cannot be resolved.
+    /// `leaf_key` supplies the already-decoded key for the last segment.
+    fn render_path(
+        &mut self,
+        db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+        txn: &heed::RoTxn<'_, heed::WithoutTls>,
+        path: &TargetStatePath,
+        leaf_key: Option<&StableKey>,
+    ) -> Result<String> {
+        let num_segments = path.as_slice().len();
+        let mut rendered = String::new();
+        for i in 0..num_segments {
+            let key = if i + 1 == num_segments {
+                match leaf_key {
+                    Some(key) => {
+                        // Seed the cache: a provider item's full path is an
+                        // ancestor prefix of its child items' paths.
+                        self.cache.insert(path.clone(), Some(key.clone()));
+                        Some(key.clone())
+                    }
+                    None => self.resolve_segment(db, txn, path)?,
+                }
+            } else {
+                self.resolve_segment(db, txn, &path.prefix(i + 1))?
+            };
+            match key {
+                Some(key) => rendered.push_str(&format!("/{key}")),
+                None => rendered.push_str(&format!("/{}", path.as_slice()[i])),
+            }
+        }
+        Ok(rendered)
+    }
+}
+
 fn summarize_target_state_items(
+    db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+    txn: &heed::RoTxn<'_, heed::WithoutTls>,
+    resolver: &mut TargetKeyResolver,
     target_state_items: &std::collections::BTreeMap<
-        crate::state::target_state_path::TargetStatePathWithProviderId,
+        TargetStatePathWithProviderId,
         db_schema::TargetStateInfoItem,
     >,
-) -> Vec<TargetStateInfoItemSummary> {
+) -> Result<Vec<TargetStateInfoItemSummary>> {
     target_state_items
         .iter()
         .map(|(path_with_pid, item)| {
@@ -128,13 +234,19 @@ fn summarize_target_state_items(
                         provider_schema_version: generation.provider_schema_version,
                     });
 
-            TargetStateInfoItemSummary {
-                target_state_path: path_with_pid.to_string(),
+            let mut target_state_path =
+                resolver.render_path(db, txn, &path_with_pid.target_state_path, Some(&key))?;
+            if let Some(id) = path_with_pid.provider_id {
+                target_state_path.push_str(&format!("[provider_id={id}]"));
+            }
+
+            Ok(TargetStateInfoItemSummary {
+                target_state_path,
                 key,
                 states,
                 provider_schema_version: item.provider_schema_version,
                 provider_generation,
-            }
+            })
         })
         .collect()
 }
@@ -183,6 +295,7 @@ fn lookup_node_type(
 fn read_detail_in_txn(
     db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
     txn: &heed::RoTxn<'_, heed::WithoutTls>,
+    resolver: &mut TargetKeyResolver,
     path: &StablePath,
 ) -> Result<StablePathDetail> {
     // Get TrackingInfo (version, processor_name, target_state_items)
@@ -196,7 +309,7 @@ fn read_detail_in_txn(
                 info.version,
                 info.processor_name.to_string(),
                 info.target_state_items.len(),
-                summarize_target_state_items(&info.target_state_items),
+                summarize_target_state_items(db, txn, resolver, &info.target_state_items)?,
             )
         } else {
             (0, String::new(), 0, Vec::new())
@@ -226,7 +339,8 @@ async fn get_stable_path_detail_from_store(
 ) -> Result<Option<StablePathDetail>> {
     let db = store.db();
     let txn = store.read_txn().await?;
-    Ok(Some(read_detail_in_txn(&db, &*txn, path)?))
+    let mut resolver = TargetKeyResolver::new();
+    Ok(Some(read_detail_in_txn(&db, &*txn, &mut resolver, path)?))
 }
 
 /// Get detailed information about a single stable path from LMDB
@@ -253,6 +367,7 @@ pub async fn get_stable_path_detail_by_name<Prof: EngineProfile>(
 fn list_children_in_txn(
     db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
     txn: &heed::RoTxn<'_, heed::WithoutTls>,
+    resolver: &mut TargetKeyResolver,
     path: &StablePath,
     recursive: bool,
 ) -> Result<Vec<StablePathDetail>> {
@@ -275,7 +390,7 @@ fn list_children_in_txn(
                 queue.push_back(child_path.clone());
             }
 
-            results.push(read_detail_in_txn(db, txn, &child_path)?);
+            results.push(read_detail_in_txn(db, txn, resolver, &child_path)?);
         }
     }
     Ok(results)
@@ -285,13 +400,14 @@ fn list_children_in_txn(
 fn list_parents_in_txn(
     db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
     txn: &heed::RoTxn<'_, heed::WithoutTls>,
+    resolver: &mut TargetKeyResolver,
     path: &StablePath,
 ) -> Result<Vec<StablePathDetail>> {
     let mut results = Vec::new();
     let mut current: StablePathRef<'_> = path.as_ref();
     while let Some((parent_ref, _key)) = current.split_parent() {
         let parent_path: StablePath = parent_ref.into();
-        results.push(read_detail_in_txn(db, txn, &parent_path)?);
+        results.push(read_detail_in_txn(db, txn, resolver, &parent_path)?);
         current = parent_ref;
     }
     // Reverse so parents appear root-first
@@ -309,17 +425,24 @@ async fn query_details_from_store(
 ) -> Result<Vec<StablePathDetail>> {
     let db = store.db();
     let txn = store.read_txn().await?;
+    let mut resolver = TargetKeyResolver::new();
 
     let mut results = Vec::new();
 
     if include_parents {
-        results.extend(list_parents_in_txn(&db, &*txn, path)?);
+        results.extend(list_parents_in_txn(&db, &*txn, &mut resolver, path)?);
     }
 
-    results.push(read_detail_in_txn(&db, &*txn, path)?);
+    results.push(read_detail_in_txn(&db, &*txn, &mut resolver, path)?);
 
     if include_children {
-        results.extend(list_children_in_txn(&db, &*txn, path, recursive)?);
+        results.extend(list_children_in_txn(
+            &db,
+            &*txn,
+            &mut resolver,
+            path,
+            recursive,
+        )?);
     }
 
     Ok(results)
@@ -357,4 +480,28 @@ pub async fn query_stable_path_details_by_name<Prof: EngineProfile>(
         None => return Ok(Vec::new()),
     };
     query_details_from_store(&store, path, include_children, recursive, include_parents).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_store::test_support::make_test_store;
+    use cocoindex_utils::fingerprint::Fingerprint;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn render_path_falls_back_to_fingerprints() {
+        let (store, _dir) = make_test_store().await;
+        let path = TargetStatePath::new(Fingerprint::from(&"root_target").unwrap(), None)
+            .concat(&StableKey::Str(Arc::from("file.md")));
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+        let mut resolver = TargetKeyResolver::new();
+        let rendered = resolver.render_path(&db, &txn, &path, None).unwrap();
+
+        // Nothing is resolvable in an empty store: both segments stay fingerprints.
+        assert_eq!(rendered, path.to_string());
+        assert_eq!(rendered.matches("/#").count(), 2);
+    }
 }

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -77,7 +77,10 @@ pub struct ProviderGeneration {
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct TargetStateInfoItemSummary {
+    /// Readable rendering, e.g. `/@target/"file.md"/[13][provider_id=0]`.
     pub target_state_path: String,
+    /// Raw fingerprint rendering as stored, e.g. `/#96..../#48....[provider_id=0]`.
+    pub fingerprint_path: String,
     pub key: StableKey,
     pub states: Vec<TargetStateVersion>,
     pub provider_schema_version: u64,
@@ -268,6 +271,7 @@ fn summarize_target_state_items(
 
             Ok(TargetStateInfoItemSummary {
                 target_state_path,
+                fingerprint_path: path_with_pid.to_string(),
                 key,
                 states,
                 provider_schema_version: item.provider_schema_version,
@@ -679,6 +683,10 @@ mod tests {
         assert_eq!(
             detail.target_state_items[0].target_state_path,
             format!("{root_seg}/\"table\"/13[provider_id=0]")
+        );
+        assert_eq!(
+            detail.target_state_items[0].fingerprint_path,
+            format!("{row_path}[provider_id=0]")
         );
         assert_eq!(detail.target_state_items[0].key, row_key);
     }

--- a/rust/core/src/state/target_state_path.rs
+++ b/rust/core/src/state/target_state_path.rs
@@ -66,6 +66,10 @@ impl TargetStatePath {
         &self.0[..self.0.len() - 1]
     }
 
+    pub fn prefix(&self, len: usize) -> Self {
+        Self(Arc::from(&self.0[..len]))
+    }
+
     pub fn as_slice(&self) -> &[utils::fingerprint::Fingerprint] {
         &self.0
     }

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -969,32 +969,10 @@ mod tests {
     use super::AppStore;
     use crate::state::db_schema::StateKind;
     use crate::state::stable_path::{StableKey, StablePath};
+    use crate::state_store::test_support::make_test_store;
     use crate::state_store::txn::WriteTxn;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use tempfile::TempDir;
-
-    /// Open a fresh in-process LMDB environment and return an `AppStore`
-    /// backed by it. The caller must keep `TempDir` alive for the duration
-    /// of the test; dropping it removes the directory.
-    async fn make_test_store() -> (AppStore, TempDir) {
-        let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("mdb");
-        std::fs::create_dir_all(&db_path).unwrap();
-        let env = unsafe {
-            heed::EnvOpenOptions::new()
-                .read_txn_without_tls()
-                .max_dbs(4)
-                .map_size(1 << 22) // 4 MiB
-                .open(&db_path)
-        }
-        .unwrap();
-        let mut wtxn = env.write_txn().unwrap();
-        let db = env.create_database(&mut wtxn, Some("test_app")).unwrap();
-        wtxn.commit().unwrap();
-        let storage = crate::state_store::Storage::from_env(env.clone());
-        (AppStore::new(db, env, storage), dir)
-    }
 
     fn comp_path(name: &str) -> StablePath {
         StablePath(Arc::from(vec![StableKey::Str(Arc::from(name))]))

--- a/rust/core/src/state_store/mod.rs
+++ b/rust/core/src/state_store/mod.rs
@@ -11,6 +11,8 @@
 mod app_store;
 mod storage;
 mod submit_session;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod txn;
 
 pub use app_store::AppStore;

--- a/rust/core/src/state_store/test_support.rs
+++ b/rust/core/src/state_store/test_support.rs
@@ -1,0 +1,26 @@
+//! Shared test-only helpers for constructing in-process stores.
+
+use super::AppStore;
+use tempfile::TempDir;
+
+/// Open a fresh in-process LMDB environment and return an `AppStore`
+/// backed by it. The caller must keep `TempDir` alive for the duration
+/// of the test; dropping it removes the directory.
+pub(crate) async fn make_test_store() -> (AppStore, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("mdb");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let env = unsafe {
+        heed::EnvOpenOptions::new()
+            .read_txn_without_tls()
+            .max_dbs(4)
+            .map_size(1 << 22) // 4 MiB
+            .open(&db_path)
+    }
+    .unwrap();
+    let mut wtxn = env.write_txn().unwrap();
+    let db = env.create_database(&mut wtxn, Some("test_app")).unwrap();
+    wtxn.commit().unwrap();
+    let storage = super::Storage::from_env(env.clone());
+    (AppStore::new(db, env, storage), dir)
+}

--- a/rust/py/src/inspect.rs
+++ b/rust/py/src/inspect.rs
@@ -187,6 +187,8 @@ pub struct PyProviderGeneration {
 pub struct PyTargetStateInfoItemSummary {
     #[pyo3(get)]
     pub target_state_path: String,
+    #[pyo3(get)]
+    pub fingerprint_path: String,
     pub key: StableKey,
     #[pyo3(get)]
     pub states: Vec<PyTargetStateVersion>,
@@ -240,6 +242,7 @@ fn convert_detail(
             .map(|item| -> PyResult<PyTargetStateInfoItemSummary> {
                 Ok(PyTargetStateInfoItemSummary {
                     target_state_path: item.target_state_path,
+                    fingerprint_path: item.fingerprint_path,
                     key: item.key,
                     states: item
                         .states


### PR DESCRIPTION
First half of #2296: `cocoindex show` renders tracked target-state paths readably instead of as opaque fingerprints.

## Before / after

`examples/files_transform`, `cocoindex update main` then `cocoindex show main -l`, same database on both sides:

**Before:**
```
  /@process_file/"bizarre_animals.md"
    type:component version:1 processor:process_file
    has_memoization:true target_state_count:1
    Target states:
      - path:/#9142763800ab4da61971eddf69b897de/#8c5e6914737a99848bcdefd959e71a3c key:(None, 'output_html/data__bizarre_animals.md.html')
        states:1:Existing schema_version:0 generation:None
```

**After:**
```
  /@process_file/"bizarre_animals.md"
    type:component version:1 processor:process_file
    has_memoization:true target_state_count:1
    Target states:
      - path:/@cocoindex/localfs/[null,"output_html/data__bizarre_animals.md.html"]
        states:1:Existing schema_version:0 generation:None
```

**After, with `--fingerprints`** — toggles back to the stored form (readable is the default):
```
  /@process_file/"bizarre_animals.md"
    type:component version:1 processor:process_file
    has_memoization:true target_state_count:1
    Target states:
      - path:/#9142763800ab4da61971eddf69b897de/#8c5e6914737a99848bcdefd959e71a3c
        states:1:Existing schema_version:0 generation:None
```

## How it works

Fingerprints are one-way hashes, but the original `StableKey`s are recoverable from records the engine already persists: for each path prefix, resolve the owning component via the inverted owner index, then storekey-decode the pre-fingerprint `key` from that component's tracking item (cached per read txn). Root providers and their attachments are never declared as target states, so they resolve from the live provider registry instead. Anything unresolvable falls back to `#hex` — never an error.

## Decisions

1. **Reconstruct at display time, not persist readable names.** No schema change, works retroactively on existing databases. Persisting is more robust (no joins, survives crash windows) but needs a migration — deferred to #2300; the approaches compose.
2. **Readable replaces the existing `target_state_path` string; raw stays available** via the new `fingerprint_path` field and the `--fingerprints` flag, since fingerprints remain the join key against the physical DB.
3. **Roots from the live registry.** Covers `show <app>` fully; `--db` runs without importing the app's modules, so roots keep the `#hex` fallback there — also closed by #2300.
4. **Dropped the `key:` display field** — the leaf of the readable path *is* the key now (the old field used Python repr: `(13,)` vs `[13]`). The API attribute remains.

## Follow-up

#2300: persist segment names for provider-only segments (`--db` roots; attachments of nested providers, which live in discarded build-local registries).

## Tests

Rust: fallback, nested-chain reconstruction (`root → "table" → 13`, incl. `[provider_id=N]`), registry-seed roots. E2E: `show -l` fully readable from a loaded app; `--fingerprints` raw form; `show --db -l` leaf-readable with root fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
