### PR TITLE
feat: persist readable names for provider-only target-state path segments

### DIFF
--- a/dev/run_cargo_test.sh
+++ b/dev/run_cargo_test.sh
@@ -77,4 +77,4 @@ fi
 
 # Plain `cargo test` never compiles bench targets; compile-check (not run)
 # them here to keep them from bit-rotting.
-cargo check -p cocoindex --benches
+cargo check -p cocoindex --features bench-support --benches

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -888,9 +888,10 @@ class TestShowFromDatabase:
 
         assert "Stable paths:" in result.stdout
         assert "- path:" in result.stdout
-        # The leaf key "x" is resolved from tracking info even without the
-        # app module loaded; the root provider segment stays a fingerprint.
-        assert '/"x"' in result.stdout
+        # All segments resolve without the app module loaded: the leaf key
+        # from tracking info, the root provider from the segment-name entries
+        # persisted at update time.
+        assert '@test_cli/flat_preview/"x"' in result.stdout
         assert "states:1:Existing" in result.stdout
 
     def test_show_db_tree_displays_components(self) -> None:
@@ -990,8 +991,11 @@ class TestShowTargetStates:
             "--target-states",
         )
 
-        assert '/"x"' in result.stdout
+        # Fully readable without the app module: the root provider segment
+        # resolves from the persisted segment-name entries.
+        assert '@test_cli/flat_preview/"x"' in result.stdout
         assert "owner:/" in result.stdout
+        assert "/#" not in result.stdout
 
     def test_show_target_states_tree(self) -> None:
         """show --target-states --tree should nest entries under their parents."""

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -36,6 +36,11 @@ async-trait = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 
+[features]
+# Extra store hooks for the state-store read benchmarks (see the SDK crate's
+# `state_store_read` bench). Never enabled by production dependents.
+bench-support = []
+
 [dev-dependencies]
 serde_json = { workspace = true }
 axum = { workspace = true }

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -792,13 +792,12 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
     // backed provider contribute no entries here (and no existence-check
     // reads at apply time). Deduped by fingerprint; the apply step skips
     // already-persisted entries.
-    let segment_names: Vec<(Fingerprint, StableKey)> = {
+    let segment_names: HashMap<Fingerprint, StableKey> = {
         let guard = declared_target_states.lock().await;
-        let mut seen: HashSet<Fingerprint> = HashSet::new();
-        let mut names = Vec::new();
+        let mut names = HashMap::new();
         for decl in guard.values() {
             decl.provider
-                .collect_provider_only_segment_names(&mut seen, &mut names);
+                .collect_provider_only_segment_names(&mut names);
         }
         names
     };

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -781,6 +781,29 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
     if pending_retry {
         return Ok(PreCommitOutcome::PendingRetry);
     }
+
+    // Readable names for the provider segments (root → … → immediate
+    // provider) of every declared target-state path. Provider-only segments
+    // (root providers, attachments) have no owner-index/tracking record, so
+    // these write-once name entries are the only persisted source inspection
+    // can resolve them from (see `DbEntryKey::TargetSegmentName`). Deduped
+    // here by fingerprint; the apply step skips already-persisted entries.
+    let segment_names: Vec<(Fingerprint, StableKey)> = {
+        let guard = declared_target_states.lock().await;
+        let mut seen: HashSet<Fingerprint> = HashSet::new();
+        let mut names = Vec::new();
+        for decl in guard.values() {
+            let provider_path = decl.provider.target_state_path().as_slice();
+            for (fp, key) in std::iter::zip(provider_path.iter(), decl.provider.stable_key_chain())
+            {
+                if seen.insert(*fp) {
+                    names.push((*fp, key));
+                }
+            }
+        }
+        names
+    };
+
     let mut modified_old_owners: HashSet<StablePath> = HashSet::new();
     let previously_exists = tracking_info.is_some();
     if let Some(tracking_info) = &mut tracking_info {
@@ -1174,6 +1197,7 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
             self_path: stable_path.clone(),
             new_tracking_info: new_tracking_info_bytes,
             preempted_owner_updates,
+            segment_names,
         },
     })
 }

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -782,24 +782,23 @@ async fn pre_commit<'tracking, Prof: EngineProfile>(
         return Ok(PreCommitOutcome::PendingRetry);
     }
 
-    // Readable names for the provider segments (root → … → immediate
-    // provider) of every declared target-state path. Provider-only segments
-    // (root providers, attachments) have no owner-index/tracking record, so
-    // these write-once name entries are the only persisted source inspection
-    // can resolve them from (see `DbEntryKey::TargetSegmentName`). Deduped
-    // here by fingerprint; the apply step skips already-persisted entries.
+    // Readable names for the provider-only segments (root providers,
+    // attachments) reachable from every declared target-state path. Such
+    // segments have no owner-index/tracking record, so these write-once name
+    // entries are the only persisted source inspection can resolve them from
+    // (see `DbEntryKey::TargetSegmentName`). Each chain walk stops at the
+    // first target-state-backed ancestor — its declaring component covers
+    // itself and everything above — so N sibling declarations under the same
+    // backed provider contribute no entries here (and no existence-check
+    // reads at apply time). Deduped by fingerprint; the apply step skips
+    // already-persisted entries.
     let segment_names: Vec<(Fingerprint, StableKey)> = {
         let guard = declared_target_states.lock().await;
         let mut seen: HashSet<Fingerprint> = HashSet::new();
         let mut names = Vec::new();
         for decl in guard.values() {
-            let provider_path = decl.provider.target_state_path().as_slice();
-            for (fp, key) in std::iter::zip(provider_path.iter(), decl.provider.stable_key_chain())
-            {
-                if seen.insert(*fp) {
-                    names.push((*fp, key));
-                }
-            }
+            decl.provider
+                .collect_provider_only_segment_names(&mut seen, &mut names);
         }
         names
     };

--- a/rust/core/src/engine/target_state.rs
+++ b/rust/core/src/engine/target_state.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     hash::{Hash, Hasher},
 };
 
@@ -301,14 +301,13 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
     /// for this provider and its ancestors, stopping at the first ancestor
     /// backed by a declared target state: that segment resolves via its
     /// declaring component's owner-index/tracking records, and that
-    /// component's own pre-commit covers the segments above it. `seen`
-    /// dedups across calls; a seen fingerprint is skipped but the walk
+    /// component's own pre-commit covers the segments above it. `out` dedups
+    /// across calls; an already-present fingerprint is skipped but the walk
     /// continues, since providers at different depths can share a segment
     /// (e.g. the same attachment type on two tables).
-    pub fn collect_provider_only_segment_names(
+    pub(crate) fn collect_provider_only_segment_names(
         &self,
-        seen: &mut HashSet<utils::fingerprint::Fingerprint>,
-        out: &mut Vec<(utils::fingerprint::Fingerprint, StableKey)>,
+        out: &mut HashMap<utils::fingerprint::Fingerprint, StableKey>,
     ) {
         let mut current = self;
         loop {
@@ -321,9 +320,8 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
                 .as_slice()
                 .last()
                 .expect("target state path is never empty");
-            if seen.insert(fp) {
-                out.push((fp, current.inner.stable_key.clone()));
-            }
+            out.entry(fp)
+                .or_insert_with(|| current.inner.stable_key.clone());
             match &current.inner.parent_provider {
                 Some(parent) => current = parent,
                 None => return,

--- a/rust/core/src/engine/target_state.rs
+++ b/rust/core/src/engine/target_state.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use cocoindex_utils::batching::{BatchQueue, Batcher, BatchingOptions, Runner};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     hash::{Hash, Hasher},
 };
 
@@ -241,6 +241,12 @@ pub(crate) struct TargetStateProviderInner<Prof: EngineProfile> {
     parent_provider: Option<TargetStateProvider<Prof>>,
     stable_key: StableKey,
     target_state_path: TargetStatePath,
+    /// Whether this provider was created for a declared target state (child
+    /// providers from `register_lazy`), as opposed to provider-only segments
+    /// (root providers, attachments). Target-state-backed segments resolve
+    /// via the declaring component's owner-index/tracking records, so they
+    /// need no persisted segment-name entry.
+    backed_by_target_state: bool,
     handler: OnceLock<Prof::TargetHdl>,
     orphaned: OnceLock<()>,
     provider_generation: OnceLock<TargetStateProviderGeneration>,
@@ -291,6 +297,40 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
         chain
     }
 
+    /// Collect segment-name entries (lone segment fingerprint → stable key)
+    /// for this provider and its ancestors, stopping at the first ancestor
+    /// backed by a declared target state: that segment resolves via its
+    /// declaring component's owner-index/tracking records, and that
+    /// component's own pre-commit covers the segments above it. `seen`
+    /// dedups across calls; a seen fingerprint is skipped but the walk
+    /// continues, since providers at different depths can share a segment
+    /// (e.g. the same attachment type on two tables).
+    pub fn collect_provider_only_segment_names(
+        &self,
+        seen: &mut HashSet<utils::fingerprint::Fingerprint>,
+        out: &mut Vec<(utils::fingerprint::Fingerprint, StableKey)>,
+    ) {
+        let mut current = self;
+        loop {
+            if current.inner.backed_by_target_state {
+                return;
+            }
+            let fp = *current
+                .inner
+                .target_state_path
+                .as_slice()
+                .last()
+                .expect("target state path is never empty");
+            if seen.insert(fp) {
+                out.push((fp, current.inner.stable_key.clone()));
+            }
+            match &current.inner.parent_provider {
+                Some(parent) => current = parent,
+                None => return,
+            }
+        }
+    }
+
     pub fn is_orphaned(&self) -> bool {
         self.inner.orphaned.get().is_some()
     }
@@ -334,6 +374,7 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
                     parent_provider: Some(self.clone()),
                     stable_key: symbol_key,
                     target_state_path: target_state_path.clone(),
+                    backed_by_target_state: false,
                     handler: OnceLock::from(att_handler),
                     orphaned: OnceLock::new(),
                     provider_generation: OnceLock::from(provider_generation.clone()),
@@ -387,6 +428,7 @@ impl<Prof: EngineProfile> TargetStateProvider<Prof> {
                 parent_provider: Some(self.clone()),
                 stable_key: symbol_key,
                 target_state_path: target_state_path.clone(),
+                backed_by_target_state: false,
                 handler: OnceLock::from(att_handler),
                 orphaned: OnceLock::new(),
                 provider_generation: OnceLock::from(provider_generation),
@@ -451,6 +493,7 @@ impl<Prof: EngineProfile> TargetStateProviderRegistry<Prof> {
                 parent_provider: None,
                 stable_key: StableKey::Symbol(name.into()),
                 target_state_path: target_state_path.clone(),
+                backed_by_target_state: false,
                 handler: OnceLock::from(handler),
                 orphaned: OnceLock::new(),
                 provider_generation: OnceLock::new(),
@@ -473,6 +516,7 @@ impl<Prof: EngineProfile> TargetStateProviderRegistry<Prof> {
                 parent_provider: Some(parent_provider.clone()),
                 stable_key,
                 target_state_path: target_state_path.clone(),
+                backed_by_target_state: true,
                 handler: OnceLock::new(),
                 orphaned: OnceLock::new(),
                 provider_generation: OnceLock::new(),

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -10,6 +10,7 @@ use crate::state::stable_path::{StableKey, StablePath, StablePathRef};
 use crate::state::target_state_path::{TargetStatePath, TargetStatePathWithProviderId};
 use crate::state_store::AppStore;
 use cocoindex_utils::deser::from_msgpack_slice;
+use cocoindex_utils::fingerprint::Fingerprint;
 use futures::stream::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -97,7 +98,9 @@ fn decode_target_state_key(key_bytes: &[u8]) -> StableKey {
 }
 
 /// Resolves fingerprinted target state path segments back to their original
-/// `StableKey`s via the inverted owner index + the owner's tracking info.
+/// `StableKey`s via the inverted owner index + the owner's tracking info,
+/// falling back to the persisted segment-name entries
+/// ([`db_schema::DbEntryKey::TargetSegmentName`]) for provider-only segments.
 /// Caches per path prefix, including misses, so items sharing ancestors are
 /// resolved once per read txn.
 struct TargetKeyResolver {
@@ -105,12 +108,17 @@ struct TargetKeyResolver {
     /// Owner components whose tracking items have already been folded into
     /// `cache`, so each tracking blob is deserialized at most once per txn.
     loaded_owners: std::collections::HashSet<StablePath>,
+    /// Persisted segment-name entries, cached per lone segment fingerprint,
+    /// including misses. Kept separate from `cache` so
+    /// [`Self::resolve_segment`] stays a pure owner-index/tracking signal
+    /// (its miss is what flags an entry as dangling).
+    segment_names: std::collections::HashMap<Fingerprint, Option<StableKey>>,
 }
 
 impl TargetKeyResolver {
     /// `provider_keys` seeds the cache with the original keys of live
-    /// registered providers (see [`provider_key_seed`]); root provider
-    /// segments are resolvable only through this seed.
+    /// registered providers (see [`provider_key_seed`]); it covers provider
+    /// segments whose persisted name entries don't exist yet.
     fn new(provider_keys: std::collections::HashMap<TargetStatePath, StableKey>) -> Self {
         Self {
             cache: provider_keys
@@ -118,14 +126,18 @@ impl TargetKeyResolver {
                 .map(|(path, key)| (path, Some(key)))
                 .collect(),
             loaded_owners: std::collections::HashSet::new(),
+            segment_names: std::collections::HashMap::new(),
         }
     }
 
-    /// Resolve the original `StableKey` for the last segment of `prefix`.
-    /// Returns `None` when the prefix has no owner entry or tracking item:
-    /// provider-only path segments (root providers, provider attachments) are
-    /// never declared as target states so they have neither, and a crashed or
-    /// in-flight run can leave either record missing.
+    /// Resolve the original `StableKey` for the last segment of `prefix` via
+    /// the inverted owner index + the owner's tracking info. Returns `None`
+    /// when the prefix has no owner entry or tracking item: provider-only
+    /// path segments (root providers, provider attachments) are never
+    /// declared as target states so they have neither, and a crashed or
+    /// in-flight run can leave either record missing. A `None` from here is
+    /// the dangling signal; rendering additionally falls back to
+    /// [`Self::lookup_segment_name`].
     fn resolve_segment(
         &mut self,
         db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
@@ -176,6 +188,28 @@ impl TargetKeyResolver {
         Ok(())
     }
 
+    /// Look up the persisted readable name for a lone segment fingerprint
+    /// (see [`db_schema::DbEntryKey::TargetSegmentName`]). This is the only
+    /// persisted source for provider-only segments (root providers,
+    /// attachments), which have no owner-index/tracking record.
+    fn lookup_segment_name(
+        &mut self,
+        db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+        txn: &heed::RoTxn<'_, heed::WithoutTls>,
+        fp: Fingerprint,
+    ) -> Result<Option<StableKey>> {
+        if let Some(cached) = self.segment_names.get(&fp) {
+            return Ok(cached.clone());
+        }
+        let key = DbEntryKey::TargetSegmentName(fp).encode()?;
+        let resolved = db
+            .get(txn, key.as_slice())?
+            .map(from_msgpack_slice::<StableKey>)
+            .transpose()?;
+        self.segment_names.insert(fp, resolved.clone());
+        Ok(resolved)
+    }
+
     /// Render a readable path like `/@target/"file.md"/[13]`, falling back to
     /// the `#hex` fingerprint for any segment that cannot be resolved.
     /// `leaf_key` supplies the already-decoded key for the last segment.
@@ -193,7 +227,7 @@ impl TargetKeyResolver {
         let num_segments = path.as_slice().len();
         let mut rendered = Vec::with_capacity(num_segments);
         for i in 0..num_segments {
-            let key = if i + 1 == num_segments {
+            let mut key = if i + 1 == num_segments {
                 match leaf_key {
                     Some(key) => {
                         // Seed the cache: a provider item's full path is an
@@ -206,6 +240,9 @@ impl TargetKeyResolver {
             } else {
                 self.resolve_segment(db, txn, &path.prefix(i + 1))?
             };
+            if key.is_none() {
+                key = self.lookup_segment_name(db, txn, path.as_slice()[i])?;
+            }
             rendered.push(match key {
                 Some(key) => key.to_string(),
                 None => path.as_slice()[i].to_string(),
@@ -233,13 +270,11 @@ fn join_segments(segments: &[String]) -> String {
 
 /// Collect the original keys of all target-state providers registered in the
 /// live environment: root providers and their attachments, registered by name
-/// at module import time and never persisted, so this registry is the only
-/// source that can render their path segments readably. Two classes of
-/// provider-only segments remain unresolvable and keep the fingerprint
-/// fallback: providers whose modules aren't imported in this process (e.g.
-/// inspecting a database without loading the app), and attachments of nested
-/// providers, which live in build-local registries that are discarded when
-/// the run finishes.
+/// at module import time. Provider segments are also persisted as
+/// [`db_schema::DbEntryKey::TargetSegmentName`] entries at precommit time, so
+/// this seed only adds coverage for segments the database doesn't know yet:
+/// providers registered in this process whose target states were last
+/// committed before name persistence existed, or not committed at all.
 fn provider_key_seed<Prof: EngineProfile>(
     env: &Environment<Prof>,
 ) -> std::collections::HashMap<TargetStatePath, StableKey> {
@@ -717,6 +752,26 @@ mod tests {
             .unwrap();
     }
 
+    async fn commit_segment_names(store: &AppStore, names: Vec<(Fingerprint, StableKey)>) {
+        let store2 = store.clone();
+        store
+            .storage
+            .run_txn(move |wtxn| {
+                let store = store2.clone();
+                let names = names.clone();
+                Box::pin(async move {
+                    for (fp, key) in &names {
+                        store
+                            .write_target_segment_name_if_missing(wtxn, *fp, key)
+                            .await?;
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn lists_target_states_via_open_by_name() {
         use crate::state_store::{Storage, StorageSettings};
@@ -813,6 +868,94 @@ mod tests {
         let mut resolver = TargetKeyResolver::new(seed);
         let rendered = resolver.render_path(&db, &txn, &path, None).unwrap();
         assert_eq!(rendered, "/@my_root/\"file.md\"");
+    }
+
+    /// Provider-only segments (root provider, attachment) resolve from
+    /// persisted segment-name entries with no live registry seed — the
+    /// `--db`/`--app-name` inspection flow of issue #2300.
+    #[tokio::test]
+    async fn resolves_provider_segments_from_persisted_names() {
+        let (store, _dir) = make_test_store().await;
+        let root_fp = Fingerprint::from(&"my_root").unwrap();
+        let root_path = TargetStatePath::new(root_fp, None);
+        let table_key = StableKey::Str(Arc::from("table"));
+        let table_path = root_path.concat(&table_key);
+        let att_key = StableKey::Symbol(Arc::from("vector_index"));
+        let att_path = table_path.concat(&att_key);
+        let idx_key = StableKey::Str(Arc::from("idx"));
+        let idx_path = att_path.concat(&idx_key);
+
+        let comp_t = comp_path("comp_t");
+        let comp_i = comp_path("comp_i");
+        commit_writes(
+            &store,
+            vec![
+                (
+                    comp_t.clone(),
+                    tracking_bytes(vec![(with_pid(&table_path, None), table_key.clone())]),
+                ),
+                (
+                    comp_i.clone(),
+                    tracking_bytes(vec![(with_pid(&idx_path, Some(0)), idx_key.clone())]),
+                ),
+            ],
+            vec![(table_path.clone(), comp_t), (idx_path.clone(), comp_i)],
+        )
+        .await;
+        // Names the precommit apply step would persist for the declared
+        // states' provider chains: root, table, attachment.
+        commit_segment_names(
+            &store,
+            vec![
+                (root_fp, StableKey::Symbol(Arc::from("my_root"))),
+                (Fingerprint::from(&table_key).unwrap(), table_key.clone()),
+                (Fingerprint::from(&att_key).unwrap(), att_key.clone()),
+            ],
+        )
+        .await;
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+        let mut resolver = TargetKeyResolver::new(Default::default());
+        let rendered = resolver.render_path(&db, &txn, &idx_path, None).unwrap();
+        assert_eq!(rendered, "/@my_root/\"table\"/@vector_index/\"idx\"");
+    }
+
+    /// Segment-name entries are write-once, and rendering an entry from them
+    /// must not clear its dangling flag (which tracks owner-index/tracking
+    /// consistency, not renderability).
+    #[tokio::test]
+    async fn segment_names_are_write_once_and_do_not_mask_dangling() {
+        let (store, _dir) = make_test_store().await;
+        let root_fp = Fingerprint::from(&"root").unwrap();
+        let root_path = TargetStatePath::new(root_fp, None);
+        let key = StableKey::Str(Arc::from("gone"));
+        let dangling_path = root_path.concat(&key);
+        let comp = comp_path("comp");
+        // Owner entry without a tracking item → dangling.
+        commit_writes(&store, vec![], vec![(dangling_path.clone(), comp)]).await;
+        commit_segment_names(
+            &store,
+            vec![
+                (root_fp, StableKey::Symbol(Arc::from("root"))),
+                (Fingerprint::from(&key).unwrap(), key.clone()),
+            ],
+        )
+        .await;
+        // A second write under an already-persisted fingerprint is a no-op.
+        commit_segment_names(
+            &store,
+            vec![(root_fp, StableKey::Symbol(Arc::from("other")))],
+        )
+        .await;
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+        let mut resolver = TargetKeyResolver::new(Default::default());
+        let entries = collect_target_states(&db, &txn, &mut resolver);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].dangling);
+        assert_eq!(entries[0].readable_path, "/@root/\"gone\"");
     }
 
     #[tokio::test]

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -172,6 +172,10 @@ pub enum DbEntryKey<'a> {
     /// shared across paths.
     /// Value type: StableKey (msgpack)
     TargetSegmentName(Fingerprint),
+    /// Prefix covering all `TargetSegmentName` entries, for prefix scans.
+    /// Only used by the bench-support store hooks today.
+    #[cfg(feature = "bench-support")]
+    TargetSegmentNamePrefix,
 
     /// Value type: IdSequencerInfo
     IdSequencer(StableKey),
@@ -206,6 +210,10 @@ impl<'a> storekey::Encode for DbEntryKey<'a> {
             DbEntryKey::TargetSegmentName(fp) => {
                 e.write_u8(0x28)?;
                 fp.encode(e)?;
+            }
+            #[cfg(feature = "bench-support")]
+            DbEntryKey::TargetSegmentNamePrefix => {
+                e.write_u8(0x28)?;
             }
 
             DbEntryKey::IdSequencer(key) => {

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -163,6 +163,16 @@ pub enum DbEntryKey<'a> {
     TargetStatePrefix,
     TargetState(TargetStatePath),
 
+    /// Readable name for one target-state path segment, keyed by the lone
+    /// segment fingerprint (a pure function of the key, so one entry serves
+    /// every path sharing the segment). Written idempotently (write-once) at
+    /// precommit time for provider segments, so inspection can resolve
+    /// provider-only segments (root providers, attachments) that have no
+    /// owner-index/tracking record. Never cleaned up: entries are tiny and
+    /// shared across paths.
+    /// Value type: StableKey (msgpack)
+    TargetSegmentName(Fingerprint),
+
     /// Value type: IdSequencerInfo
     IdSequencer(StableKey),
 }
@@ -193,6 +203,11 @@ impl<'a> storekey::Encode for DbEntryKey<'a> {
                 path.encode(e)?;
             }
 
+            DbEntryKey::TargetSegmentName(fp) => {
+                e.write_u8(0x28)?;
+                fp.encode(e)?;
+            }
+
             DbEntryKey::IdSequencer(key) => {
                 e.write_u8(0x30)?;
                 key.encode(e)?;
@@ -215,6 +230,10 @@ impl<'a> storekey::Decode for DbEntryKey<'a> {
             0x20 => {
                 let path: TargetStatePath = storekey::Decode::decode(d)?;
                 DbEntryKey::TargetState(path)
+            }
+            0x28 => {
+                let fp: Fingerprint = storekey::Decode::decode(d)?;
+                DbEntryKey::TargetSegmentName(fp)
             }
             _ => return Err(storekey::DecodeError::InvalidFormat),
         };
@@ -662,6 +681,21 @@ mod tests {
             state_bytes.len() > prefix_bytes.len(),
             "UserState key bytes should be strictly longer than prefix bytes"
         );
+    }
+
+    /// `TargetSegmentName` roundtrips and never matches the `TargetState`
+    /// prefix scan (its `0x28` discriminant is not an extension of `0x20`).
+    #[test]
+    fn target_segment_name_roundtrip_and_isolation() {
+        let fp = utils::fingerprint::Fingerprint([0xCD; 16]);
+        let bytes = DbEntryKey::TargetSegmentName(fp).encode().expect("encode");
+        match DbEntryKey::decode(&bytes).expect("decode") {
+            DbEntryKey::TargetSegmentName(decoded) => assert_eq!(decoded, fp),
+            other => panic!("expected TargetSegmentName, got {other:?}"),
+        }
+
+        let target_state_prefix = DbEntryKey::TargetStatePrefix.encode().expect("encode");
+        assert!(!bytes.starts_with(&target_state_prefix));
     }
 
     /// Prefix for path A must not match entries under path B.

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -211,6 +211,10 @@ fn key_target_state_owner(path: &TargetStatePath) -> Result<Vec<u8>> {
     DbEntryKey::TargetState(path.clone()).encode()
 }
 
+fn key_target_segment_name(fp: Fingerprint) -> Result<Vec<u8>> {
+    DbEntryKey::TargetSegmentName(fp).encode()
+}
+
 fn key_id_sequencer(key: &StableKey) -> Result<Vec<u8>> {
     DbEntryKey::IdSequencer(key.clone()).encode()
 }
@@ -696,6 +700,25 @@ impl AppStore {
     ) -> Result<()> {
         let key = key_target_state_owner(path)?;
         self.db().delete(&mut **txn, &key)?;
+        Ok(())
+    }
+
+    /// Persist the readable name for one target-state path segment, keyed by
+    /// the lone segment fingerprint. Write-once: an existing entry is left
+    /// untouched (the fingerprint is a pure function of the key, so any
+    /// existing value is already correct).
+    pub async fn write_target_segment_name_if_missing(
+        &self,
+        txn: &mut WriteTxn<'_>,
+        fp: Fingerprint,
+        segment_key: &StableKey,
+    ) -> Result<()> {
+        let key = key_target_segment_name(fp)?;
+        if self.db().get(&**txn, &key)?.is_some() {
+            return Ok(());
+        }
+        let value = rmp_serde::to_vec_named(segment_key)?;
+        self.db().put(&mut **txn, &key, &value)?;
         Ok(())
     }
 }

--- a/rust/core/src/state_store/app_store.rs
+++ b/rust/core/src/state_store/app_store.rs
@@ -721,6 +721,23 @@ impl AppStore {
         self.db().put(&mut **txn, &key, &value)?;
         Ok(())
     }
+
+    /// Delete every persisted target-segment-name entry. Benchmark support
+    /// only: lets the read-path benches measure resolution against stores
+    /// written before segment names existed (the fallback-miss shape).
+    #[cfg(feature = "bench-support")]
+    pub async fn delete_all_target_segment_names(&self, txn: &mut WriteTxn<'_>) -> Result<()> {
+        let prefix = DbEntryKey::TargetSegmentNamePrefix.encode()?;
+        let db = self.db();
+        let mut iter = db.prefix_iter_mut(&mut **txn, &prefix)?;
+        while iter.next().transpose()?.is_some() {
+            // Safety: we drop the borrowed key/value before the next `next()`.
+            unsafe {
+                iter.del_current()?;
+            }
+        }
+        Ok(())
+    }
 }
 
 // --- ID sequencer --------------------------------------------------------

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -64,7 +64,7 @@
 //! ```
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
@@ -183,7 +183,7 @@ pub struct PrecommitWritePlan {
     /// target-state paths, keyed by lone segment fingerprint. Applied
     /// write-once (existing entries left untouched) so inspection can
     /// resolve provider-only segments without the app module loaded.
-    pub segment_names: Vec<(Fingerprint, StableKey)>,
+    pub segment_names: HashMap<Fingerprint, StableKey>,
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -179,6 +179,11 @@ pub struct PrecommitWritePlan {
     /// For each preempted other-owner: their new tracking-info bytes
     /// (with the preempted item removed by the engine).
     pub preempted_owner_updates: BTreeMap<StablePath, Vec<u8>>,
+    /// Readable names for the provider segments of the declared
+    /// target-state paths, keyed by lone segment fingerprint. Applied
+    /// write-once (existing entries left untouched) so inspection can
+    /// resolve provider-only segments without the app module loaded.
+    pub segment_names: Vec<(Fingerprint, StableKey)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -438,6 +443,11 @@ impl AppStore {
                             for (owner_path, bytes) in plan.preempted_owner_updates {
                                 app_store
                                     .write_tracking_info_raw(wtxn, &owner_path, &bytes)
+                                    .await?;
+                            }
+                            for (fp, segment_key) in &plan.segment_names {
+                                app_store
+                                    .write_target_segment_name_if_missing(wtxn, *fp, segment_key)
                                     .await?;
                             }
                             Ok(Some(output))

--- a/rust/sdk/cocoindex/Cargo.toml
+++ b/rust/sdk/cocoindex/Cargo.toml
@@ -59,6 +59,9 @@ neo4j = ["dep:serde_json", "dep:neo4rs"]
 falkordb = ["dep:serde_json", "dep:redis"]
 # Valkey/Redis (RediSearch) vector-search target. Reuses the `redis` crate.
 valkey = ["dep:redis", "dep:serde_json"]
+# Extra core store hooks for the `state_store_read` bench (its
+# `required-features`). Never enabled by production dependents.
+bench-support = ["cocoindex_core/bench-support"]
 
 [dependencies]
 cocoindex_macros = { path = "../cocoindex_macros" }
@@ -147,3 +150,5 @@ harness = false
 [[bench]]
 name = "state_store_read"
 harness = false
+# Run with: cargo bench -p cocoindex --features bench-support
+required-features = ["bench-support"]

--- a/rust/sdk/cocoindex/benches/state_store_read.rs
+++ b/rust/sdk/cocoindex/benches/state_store_read.rs
@@ -4,7 +4,7 @@
 //! Run with:
 //!
 //! ```bash
-//! cargo bench -p cocoindex --bench state_store_read
+//! cargo bench -p cocoindex --features bench-support --bench state_store_read
 //! ```
 //!
 //! All groups measure against a store seeded by a real end-to-end noop
@@ -20,7 +20,7 @@
 //! 2. `list_target_states` — full listing in one txn with one shared
 //!    resolver: the "how much is on the table" reference for (1).
 //! 3. `resolver_prefix_sharing` — same total states, varying provider
-//!    fanout: how much shared-prefix reuse the resolver sees.
+//!    fanout and persisted-name availability: the axes #2300 moves.
 
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -70,6 +70,11 @@ mod fixture {
         /// These segments are provider-only: never declared as target
         /// states themselves.
         pub extra_depth: usize,
+        /// Keep the `TargetSegmentName` entries the engine persists at
+        /// commit time (the data issue #2300 added). `false` deletes them
+        /// after seeding, reproducing a store written before segment
+        /// names existed (the fallback-miss shape).
+        pub with_names: bool,
     }
 
     /// A noop target handler for one node of the provider chain. Every
@@ -280,6 +285,16 @@ fn seed(rt: &tokio::runtime::Runtime, shape: SyntheticStoreShape) -> SeededStore
             .await
             .unwrap()
             .expect("seeded app store must exist");
+        if !shape.with_names {
+            let store2 = store.clone();
+            storage
+                .run_txn(move |wtxn| {
+                    let store = store2.clone();
+                    Box::pin(async move { store.delete_all_target_segment_names(wtxn).await })
+                })
+                .await
+                .unwrap();
+        }
         let step = (paths.component_paths.len() / DETAIL_SAMPLE).max(1);
         let detail_paths: Vec<StablePath> = paths
             .component_paths
@@ -315,6 +330,7 @@ fn scale_shape(num_components: usize, states_per_component: usize) -> SyntheticS
         states_per_component,
         fanout: 16,
         extra_depth: 1,
+        with_names: true,
     }
 }
 
@@ -379,26 +395,32 @@ fn bench_resolver_prefix_sharing(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolver_prefix_sharing");
     group.sampling_mode(SamplingMode::Flat);
     // Fixed ~10k states; deeper provider-only chains (attachment-like) so
-    // shared-prefix resolution actually participates.
+    // the persisted-name lookups actually participate in resolution.
     for fanout in [1usize, 100] {
-        let shape = SyntheticStoreShape {
-            num_components: 1_000,
-            states_per_component: 10,
-            fanout,
-            extra_depth: 2,
-        };
-        let seeded = seed(&rt, shape);
-        let cfg = format!("fanout{fanout}");
-        group.throughput(Throughput::Elements(seeded.num_target_states as u64));
-        group.bench_function(BenchmarkId::new("list", &cfg), |b| {
-            b.to_async(&rt)
-                .iter(|| async { black_box(drain_listing(&seeded).await) });
-        });
-        group.throughput(Throughput::Elements(seeded.detail_paths.len() as u64));
-        group.bench_function(BenchmarkId::new("detail", &cfg), |b| {
-            b.to_async(&rt)
-                .iter(|| async { black_box(query_detail_sample(&seeded).await) });
-        });
+        for with_names in [true, false] {
+            let shape = SyntheticStoreShape {
+                num_components: 1_000,
+                states_per_component: 10,
+                fanout,
+                extra_depth: 2,
+                with_names,
+            };
+            let seeded = seed(&rt, shape);
+            let cfg = format!(
+                "fanout{fanout}/names_{}",
+                if with_names { "on" } else { "off" }
+            );
+            group.throughput(Throughput::Elements(seeded.num_target_states as u64));
+            group.bench_function(BenchmarkId::new("list", &cfg), |b| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(drain_listing(&seeded).await) });
+            });
+            group.throughput(Throughput::Elements(seeded.detail_paths.len() as u64));
+            group.bench_function(BenchmarkId::new("detail", &cfg), |b| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(query_detail_sample(&seeded).await) });
+            });
+        }
     }
     group.finish();
 }


### PR DESCRIPTION
Closes #2300.

`cocoindex show` resolves fingerprinted target-state path segments from persisted records (owner index + tracking items) and, for live apps, the provider registry. Two classes of provider-only segments had no persisted mapping and always rendered as `#hex`: root providers when inspecting via `--db`/`--app-name` (registry empty without the module), and attachments of nested providers (build-local registry, discarded after the run).

This PR persists segment names in a new `TargetSegmentName` keyspace:

- **Keyed by lone segment fingerprint**, not full prefix path — a segment's fingerprint is a pure function of its key, so one entry serves every path sharing that segment and write-once semantics are safe.
- **Written at precommit time**: `pre_commit` collects each declared target state's provider-only segments into the precommit write plan, walking the provider chain only up to the nearest ancestor backed by a declared target state (per review — backed segments resolve via their declaring component's tracking records, and that component's own pre-commit covers the chain above them, so N sibling declarations under one provider contribute no entries and no apply-time existence checks). Preview mode and `PendingRetry` stay write-free; the apply step persists missing entries (get-before-put) inside the existing batched txn.
- **Read as a fallback**: the inspect resolver consults the names only after owner-index/tracking resolution misses, kept out of `resolve_segment` itself so the `dangling` diagnostic still reflects owner/tracking consistency (test pins this).
- **No cleanup**: entries are tiny and shared across paths, per the issue's considerations. The live-registry seed remains for databases written before this feature; upgraded DBs fill in as components rebuild.

Demo — app declaring `table → vector_index → index` (root provider `demo/table_store`), inspected from a fresh process without the module. Same commands on both sides, fresh DB each time:

**Before** (parent commit of this PR):

```
$ cocoindex update ./attachment_demo_app.py
$ cocoindex show --db ./cocoindex.db --app-name AttachmentDemo --target-states
Target states:
  /#6581a8809bdcec2ded1d60b6d5319465/"my_table"
    owner:/@declare_table
  /#6581a8809bdcec2ded1d60b6d5319465/"my_table"/"row1"
    owner:/
  /#6581a8809bdcec2ded1d60b6d5319465/"my_table"/#52fbd0f1fa2fe96eba65ffd4bff4199f/"idx"
    owner:/
```

**After** (this PR):

```
$ cocoindex update ./attachment_demo_app.py
$ cocoindex show --db ./cocoindex.db --app-name AttachmentDemo --target-states
Target states:
  /@demo/table_store/"my_table"
    owner:/@declare_table
  /@demo/table_store/"my_table"/"row1"
    owner:/
  /@demo/table_store/"my_table"/@vector_index/"idx"
    owner:/
```

The two `#hex` segments are exactly the issue's two classes: the root provider (unresolvable via `--db` because the registry is empty without the module) and the `vector_index` attachment (unresolvable even with the app loaded, because its registry is build-local).

## Perf impact

Measured with #2305's benches (criterion baseline saved at the #2305 tip, compared at this branch's tip; the fixture's end-to-end seeding run persists names automatically on this branch):

```
$ cargo bench -p cocoindex --features bench-support --bench state_store_read -- --baseline sdk2305 '^(detail_per_path|list_target_states)/'
detail_per_path/1k      time:   [5.5587 ms 5.5774 ms 5.5998 ms]
                 change: time:  [-10.703% -9.8453% -8.9369%] (p = 0.00 < 0.05)
                        Performance has improved.
detail_per_path/10k     time:   [5.8169 ms 5.8489 ms 5.8861 ms]
                 change: time:  [-12.006% -11.393% -10.733%] (p = 0.00 < 0.05)
                        Performance has improved.
detail_per_path/100k    time:   [29.268 ms 29.320 ms 29.372 ms]
                 change: time:  [-19.714% -19.025% -18.218%] (p = 0.00 < 0.05)
                        Performance has improved.
list_target_states/1k   time:   [3.9012 ms 3.9147 ms 3.9325 ms]
                 change: time:  [-16.248% -13.677% -10.759%] (p = 0.00 < 0.05)
                        Performance has improved.
list_target_states/10k  time:   [40.897 ms 41.068 ms 41.245 ms]
                 change: time:  [-4.2961% -3.1976% -2.1034%] (p = 0.00 < 0.05)
                        Performance has improved.
list_target_states/100k time:   [387.00 ms 390.42 ms 393.95 ms]
                 change: time:  [-9.9264% -8.8161% -7.7064%] (p = 0.00 < 0.05)
                        Performance has improved.
```

3–19% faster across the board: persisted names replace the `#hex` fingerprint rendering, which costs more than the extra name lookup. The fallback itself is free — with names deleted after seeding, this branch's resolver measures the same as the #2305 baseline (`resolver_prefix_sharing/detail/fanout1`: `names_off` 4.31 ms vs baseline 4.33 ms), while `names_on` drops it to 3.60 ms.

The second commit adds the `names on/off` axis so this stays measurable: the engine persists names during the fixture's E2E seeding run (names-on comes free), and a small `bench-support`-gated core hook prefix-deletes them afterwards for the names-off shape — a targeted deletion through the typed keyspace, not record simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

