### PR TITLE
perf(inspect): stream stable-path details with one shared resolver

### DIFF
--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -234,6 +234,16 @@ class StablePathDetail:
     has_memoization: bool
     target_state_items: list[TargetStateInfoItemSummary]
 
+class StablePathDetailAsyncIterator:
+    """Async iterator of StablePathDetail; use with async for."""
+
+    def __aiter__(self) -> StablePathDetailAsyncIterator: ...
+    def __anext__(self) -> Awaitable[StablePathDetail]: ...
+
+def iter_stable_path_details(app: App) -> StablePathDetailAsyncIterator: ...
+def iter_stable_path_details_by_name(
+    env: Environment, app_name: str
+) -> StablePathDetailAsyncIterator: ...
 def get_stable_path_detail(app: App, path: StablePath) -> StablePathDetail | None: ...
 def get_stable_path_detail_by_name(
     env: Any, app_name: str, path: StablePath

--- a/python/cocoindex/_internal/inspect_api.py
+++ b/python/cocoindex/_internal/inspect_api.py
@@ -57,6 +57,30 @@ def list_stable_paths_info_sync(
     return asyncio.run(_iter_stable_paths_collected(app))
 
 
+async def iter_stable_path_details(
+    app: App[Any, Any],
+) -> AsyncIterator[core.StablePathDetail]:
+    """
+    Async iterator of details for every stable path.
+
+    Runs the whole iteration in one read transaction with one shared
+    path-key resolver, so provider prefixes shared across paths are
+    resolved once — unlike calling :func:`get_stable_path_detail` per path.
+    """
+    core_app = await app._get_core()
+    async for detail in core.iter_stable_path_details(core_app):
+        yield detail
+
+
+async def iter_stable_path_details_by_name(
+    env: Environment,
+    app_name: str,
+) -> AsyncIterator[core.StablePathDetail]:
+    """Like :func:`iter_stable_path_details`, but takes an environment and an app name."""
+    async for detail in core.iter_stable_path_details_by_name(env._core_env, app_name):
+        yield detail
+
+
 async def get_stable_path_detail(
     app: App[Any, Any],
     path: StablePath,
@@ -139,6 +163,8 @@ __all__ = [
     "list_stable_paths_sync",
     "get_stable_path_detail",
     "get_stable_path_detail_by_name",
+    "iter_stable_path_details",
+    "iter_stable_path_details_by_name",
     "query_stable_path_details",
     "query_stable_path_details_by_name",
     "iter_target_states",

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -25,8 +25,8 @@ from cocoindex._internal.setting import get_default_db_path
 from cocoindex.inspect import (
     iter_stable_paths,
     iter_stable_paths_by_name,
-    get_stable_path_detail,
-    get_stable_path_detail_by_name,
+    iter_stable_path_details,
+    iter_stable_path_details_by_name,
     iter_target_states,
     iter_target_states_by_name,
     query_stable_path_details,
@@ -771,14 +771,12 @@ async def _show_from_app(
             )
             _print_details(details, fingerprints)
         elif long_format:
-            # Stream paths, fetch detail one-by-one (no buffering)
+            # Stream details in one read txn with one shared resolver
+            # (no buffering, no per-path txn/resolver).
             click.echo("Stable paths:")
             count = 0
-            async for item in iter_stable_paths(app):
-                path_obj = StablePath(item.path)
-                detail = await get_stable_path_detail(app, path_obj)
-                if detail:
-                    _print_one_detail(detail, fingerprints)
+            async for detail in iter_stable_path_details(app):
+                _print_one_detail(detail, fingerprints)
                 count += 1
             if count == 0:
                 click.echo("  (none)")
@@ -828,11 +826,8 @@ async def _show_from_database(
     elif long_format:
         click.echo("Stable paths:")
         count = 0
-        async for item in iter_stable_paths_by_name(env, app_name):
-            path_obj = StablePath(item.path)
-            detail = await get_stable_path_detail_by_name(env, app_name, path_obj)
-            if detail:
-                _print_one_detail(detail, fingerprints)
+        async for detail in iter_stable_path_details_by_name(env, app_name):
+            _print_one_detail(detail, fingerprints)
             count += 1
         if count == 0:
             click.echo("  (none)")

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -8,7 +8,7 @@ use crate::engine::{app::App, profile::EngineProfile};
 use crate::state::db_schema::{self, ChildExistenceInfo, DbEntryKey, StablePathEntryKey};
 use crate::state::stable_path::{StableKey, StablePath, StablePathRef};
 use crate::state::target_state_path::{TargetStatePath, TargetStatePathWithProviderId};
-use crate::state_store::AppStore;
+use crate::state_store::{AppStore, Storage};
 use cocoindex_utils::deser::from_msgpack_slice;
 use cocoindex_utils::fingerprint::Fingerprint;
 use futures::stream::{Stream, StreamExt};
@@ -386,6 +386,21 @@ fn read_detail_in_txn(
     resolver: &mut TargetKeyResolver,
     path: &StablePath,
 ) -> Result<StablePathDetail> {
+    let node_type = lookup_node_type(db, txn, path)?;
+    read_detail_in_txn_at(db, txn, resolver, path, node_type)
+}
+
+/// Like [`read_detail_in_txn`], for callers that already know the node
+/// type (e.g. the stable-path walk, which reads the parent's
+/// child-existence entry as part of enumeration) — skips the duplicate
+/// lookup.
+fn read_detail_in_txn_at(
+    db: &heed::Database<heed::types::Bytes, heed::types::Bytes>,
+    txn: &heed::RoTxn<'_, heed::WithoutTls>,
+    resolver: &mut TargetKeyResolver,
+    path: &StablePath,
+    node_type: db_schema::StablePathNodeType,
+) -> Result<StablePathDetail> {
     // Get TrackingInfo (version, processor_name, target_state_items)
     let tracking_key =
         DbEntryKey::StablePath(path.clone(), StablePathEntryKey::TrackingInfo).encode()?;
@@ -407,8 +422,6 @@ fn read_detail_in_txn(
     let mem_key =
         DbEntryKey::StablePath(path.clone(), StablePathEntryKey::ComponentMemoization).encode()?;
     let has_memoization = db.get(txn, mem_key.as_slice())?.is_some();
-
-    let node_type = lookup_node_type(db, txn, path)?;
 
     Ok(StablePathDetail {
         path: path.clone(),
@@ -454,6 +467,53 @@ pub async fn get_stable_path_detail_by_name<Prof: EngineProfile>(
         None => return Ok(None),
     };
     get_stable_path_detail_from_store(&store, provider_key_seed(env), path).await
+}
+
+/// Stream `StablePathDetail` for every stable path, in one read txn with
+/// ONE shared resolver — provider prefixes and owner tracking blobs are
+/// resolved once for the whole iteration instead of once per path (the
+/// per-call shape of [`get_stable_path_detail_from_store`]). Iteration
+/// runs on a dedicated thread (read txns/cursors are !Send); items are
+/// sent over a channel.
+pub async fn spawn_stable_path_detail_iter(
+    store: AppStore,
+    provider_keys: std::collections::HashMap<TargetStatePath, StableKey>,
+) -> impl Stream<Item = Result<StablePathDetail>> + Send + 'static {
+    let storage = store.storage.clone();
+    let rx = storage
+        .spawn_read_txn_receiver(store, move |db, txn, tx| {
+            let mut resolver = TargetKeyResolver::new(provider_keys);
+            Storage::for_each_stable_path_in_txn(db, txn, |path, node_type| {
+                let detail = read_detail_in_txn_at(db, txn, &mut resolver, &path, node_type)?;
+                Ok(tx.blocking_send(Ok(detail)).is_ok())
+            })
+        })
+        .await;
+    ReceiverStream::new(rx)
+}
+
+/// Stream details for all stable paths from a live App (see
+/// [`spawn_stable_path_detail_iter`]).
+pub async fn iter_stable_path_details<Prof: EngineProfile>(
+    app: &App<Prof>,
+) -> impl Stream<Item = Result<StablePathDetail>> + Send + 'static + use<Prof> {
+    let seed = provider_key_seed(app.app_ctx().env());
+    spawn_stable_path_detail_iter(app.app_ctx().app_store().clone(), seed).await
+}
+
+/// Like [`iter_stable_path_details`], but takes an environment and an app
+/// name. Returns an empty stream if the app's database doesn't exist.
+pub async fn iter_stable_path_details_by_name<Prof: EngineProfile>(
+    env: &Environment<Prof>,
+    app_name: &str,
+) -> Result<Pin<Box<dyn Stream<Item = Result<StablePathDetail>> + Send + 'static>>> {
+    let store = match env.storage().open_app_store_by_name(app_name).await? {
+        Some(store) => store,
+        None => return Ok(Box::pin(futures::stream::empty())),
+    };
+    Ok(Box::pin(
+        spawn_stable_path_detail_iter(store, provider_key_seed(env)).await,
+    ))
 }
 
 /// List direct children of a path. With `recursive=true`, walks the full subtree.
@@ -868,6 +928,74 @@ mod tests {
         let mut resolver = TargetKeyResolver::new(seed);
         let rendered = resolver.render_path(&db, &txn, &path, None).unwrap();
         assert_eq!(rendered, "/@my_root/\"file.md\"");
+    }
+
+    /// The streaming detail iterator (one txn, one shared resolver) yields
+    /// the same details as the per-path query shape, for every stable path.
+    #[tokio::test]
+    async fn streamed_details_match_per_path_queries() {
+        let (store, _dir) = make_test_store().await;
+        let root_path = TargetStatePath::new(Fingerprint::from(&"root_target").unwrap(), None);
+        let table_key = StableKey::Str(Arc::from("table"));
+        let table_path = root_path.concat(&table_key);
+        let row_key = StableKey::Int(13);
+        let row_path = table_path.concat(&row_key);
+        let comp_c = comp_path("comp_c");
+        let comp_d = comp_path("comp_d");
+        commit_writes(
+            &store,
+            vec![
+                (
+                    comp_c.clone(),
+                    tracking_bytes(vec![(with_pid(&table_path, None), table_key.clone())]),
+                ),
+                (
+                    comp_d.clone(),
+                    tracking_bytes(vec![(with_pid(&row_path, Some(0)), row_key.clone())]),
+                ),
+            ],
+            vec![
+                (table_path.clone(), comp_c.clone()),
+                (row_path.clone(), comp_d.clone()),
+            ],
+        )
+        .await;
+
+        let streamed: Vec<StablePathDetail> =
+            spawn_stable_path_detail_iter(store.clone(), Default::default())
+                .await
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect::<Result<_>>()
+                .unwrap();
+        assert_eq!(streamed.len(), 2);
+        assert_eq!(
+            streamed.iter().map(|d| d.path.clone()).collect::<Vec<_>>(),
+            vec![comp_c, comp_d]
+        );
+
+        for detail in &streamed {
+            let single =
+                get_stable_path_detail_from_store(&store, Default::default(), &detail.path)
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(single.node_type, detail.node_type);
+            assert_eq!(single.processor_name, detail.processor_name);
+            assert_eq!(
+                single
+                    .target_state_items
+                    .iter()
+                    .map(|item| item.target_state_path.clone())
+                    .collect::<Vec<_>>(),
+                detail
+                    .target_state_items
+                    .iter()
+                    .map(|item| item.target_state_path.clone())
+                    .collect::<Vec<_>>()
+            );
+        }
     }
 
     /// Provider-only segments (root provider, attachment) resolve from

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -481,56 +481,72 @@ impl Storage {
         app_store: AppStore,
     ) -> tokio::sync::mpsc::Receiver<Result<(StablePath, StablePathNodeType)>> {
         self.spawn_read_txn_receiver(app_store, |db, txn, tx| {
-            let encoded_key_prefix =
-                DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
-
-            let mut last_prefix: Option<Vec<u8>> = None;
-            for entry in db.prefix_iter(txn, &encoded_key_prefix)? {
-                let (raw_key, _) = entry?;
-                if let Some(last_prefix) = &last_prefix
-                    && raw_key.starts_with(last_prefix)
-                {
-                    continue;
-                }
-                let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
-                let path = match key {
-                    DbEntryKey::StablePath(path, _) => path,
-                    other => {
-                        return Err(internal_error!("Expected StablePath, got {other:?}"));
-                    }
-                };
-                last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
-
-                let node_type = if path.as_ref().is_empty() {
-                    StablePathNodeType::Component
-                } else {
-                    let path_ref: StablePathRef<'_> = path.as_ref();
-                    if let Some((parent_ref, key)) = path_ref.split_parent() {
-                        let parent_owned: StablePath = parent_ref.into();
-                        let info = {
-                            let key_encoded = DbEntryKey::StablePath(
-                                parent_owned,
-                                StablePathEntryKey::ChildExistence(key.clone()),
-                            )
-                            .encode()?;
-                            db.get(txn, &key_encoded)?
-                                .map(from_msgpack_slice::<ChildExistenceInfo>)
-                                .transpose()?
-                        };
-                        info.map(|i| i.node_type)
-                            .unwrap_or(StablePathNodeType::Directory)
-                    } else {
-                        StablePathNodeType::Component
-                    }
-                };
-
-                if tx.blocking_send(Ok((path, node_type))).is_err() {
-                    break;
-                }
-            }
-            Ok(())
+            Self::for_each_stable_path_in_txn(db, txn, |path, node_type| {
+                Ok(tx.blocking_send(Ok((path, node_type))).is_ok())
+            })
         })
         .await
+    }
+
+    /// Walk every stable path in `db` within an open read txn, calling
+    /// `emit(path, node_type)` per path in stored order. `emit` returns
+    /// `false` to stop early (e.g. when a channel receiver is gone).
+    /// Shared by the stable-path streaming above and the detail streaming
+    /// in `inspect::db_inspect`, which folds per-path reads into the same
+    /// txn.
+    pub(crate) fn for_each_stable_path_in_txn(
+        db: &Database,
+        txn: &heed::RoTxn<'_, heed::WithoutTls>,
+        mut emit: impl FnMut(StablePath, StablePathNodeType) -> Result<bool>,
+    ) -> Result<()> {
+        let encoded_key_prefix =
+            DbEntryKey::StablePathPrefixPrefix(StablePathPrefix::default()).encode()?;
+
+        let mut last_prefix: Option<Vec<u8>> = None;
+        for entry in db.prefix_iter(txn, &encoded_key_prefix)? {
+            let (raw_key, _) = entry?;
+            if let Some(last_prefix) = &last_prefix
+                && raw_key.starts_with(last_prefix)
+            {
+                continue;
+            }
+            let key: DbEntryKey = DbEntryKey::decode(raw_key)?;
+            let path = match key {
+                DbEntryKey::StablePath(path, _) => path,
+                other => {
+                    return Err(internal_error!("Expected StablePath, got {other:?}"));
+                }
+            };
+            last_prefix = Some(DbEntryKey::StablePathPrefix(path.as_ref()).encode()?);
+
+            let node_type = if path.as_ref().is_empty() {
+                StablePathNodeType::Component
+            } else {
+                let path_ref: StablePathRef<'_> = path.as_ref();
+                if let Some((parent_ref, key)) = path_ref.split_parent() {
+                    let parent_owned: StablePath = parent_ref.into();
+                    let info = {
+                        let key_encoded = DbEntryKey::StablePath(
+                            parent_owned,
+                            StablePathEntryKey::ChildExistence(key.clone()),
+                        )
+                        .encode()?;
+                        db.get(txn, &key_encoded)?
+                            .map(from_msgpack_slice::<ChildExistenceInfo>)
+                            .transpose()?
+                    };
+                    info.map(|i| i.node_type)
+                        .unwrap_or(StablePathNodeType::Directory)
+                } else {
+                    StablePathNodeType::Component
+                }
+            };
+
+            if !emit(path, node_type)? {
+                break;
+            }
+        }
+        Ok(())
     }
 
     /// Resolves the app store by name, then spawns the stable-path iteration

--- a/rust/py/src/inspect.rs
+++ b/rust/py/src/inspect.rs
@@ -288,6 +288,84 @@ pub fn get_stable_path_detail_by_name(
     detail.map(|d| convert_detail(py, d)).transpose()
 }
 
+/// Python async iterator that yields `StablePathDetail` items one-by-one
+/// (same shape as [`PyStablePathInfoAsyncIterator`]).
+#[pyclass(name = "StablePathDetailAsyncIterator")]
+pub struct PyStablePathDetailAsyncIterator {
+    stream: Arc<
+        tokio::sync::Mutex<
+            Pin<Box<dyn Stream<Item = Result<db_inspect::StablePathDetail>> + Send>>,
+        >,
+    >,
+}
+
+#[pymethods]
+impl PyStablePathDetailAsyncIterator {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        use futures::StreamExt;
+
+        let stream = Arc::clone(&self.stream);
+        future_into_py(py, async move {
+            let mut guard = stream.lock().await;
+            match StreamExt::next(&mut *guard).await {
+                None => Err(PyStopAsyncIteration::new_err(())),
+                Some(result) => {
+                    let detail = result.into_py_result()?;
+                    Python::attach(|py| {
+                        let converted = convert_detail(py, detail)?;
+                        Py::new(py, converted).map(|p| p.into_any())
+                    })
+                    .map_err(|e| e.into())
+                }
+            }
+        })
+    }
+}
+
+fn wrap_detail_stream_as_async_iterator<'py>(
+    stream: impl Stream<Item = Result<db_inspect::StablePathDetail>> + Send + 'static,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let stream: Pin<Box<dyn Stream<Item = Result<db_inspect::StablePathDetail>> + Send>> =
+        Box::pin(stream);
+    let iterator = PyStablePathDetailAsyncIterator {
+        stream: Arc::new(tokio::sync::Mutex::new(stream)),
+    };
+    Ok(Py::new(py, iterator)?.into_any().into_bound(py))
+}
+
+#[pyfunction]
+pub fn iter_stable_path_details<'py>(app: &PyApp, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    let app_clone = app.0.clone();
+    let stream = py.detach(|| {
+        get_runtime()
+            .block_on(async move { db_inspect::iter_stable_path_details(&app_clone).await })
+    });
+    wrap_detail_stream_as_async_iterator(stream, py)
+}
+
+#[pyfunction]
+pub fn iter_stable_path_details_by_name<'py>(
+    env: &PyEnvironment,
+    app_name: &str,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let env_clone = env.0.clone();
+    let app_name = app_name.to_string();
+    let stream = py
+        .detach(|| {
+            get_runtime().block_on(async move {
+                db_inspect::iter_stable_path_details_by_name(&env_clone, &app_name).await
+            })
+        })
+        .into_py_result()?;
+    wrap_detail_stream_as_async_iterator(stream, py)
+}
+
 #[pyclass(name = "TargetStateEntry", skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyTargetStateEntry {

--- a/rust/py/src/lib.rs
+++ b/rust/py/src/lib.rs
@@ -82,6 +82,11 @@ fn core_module(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()>
 
     m.add_function(wrap_pyfunction!(inspect::iter_stable_paths, m)?)?;
     m.add_function(wrap_pyfunction!(inspect::iter_stable_paths_by_name, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect::iter_stable_path_details, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        inspect::iter_stable_path_details_by_name,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(inspect::list_app_names, m)?)?;
     m.add_function(wrap_pyfunction!(inspect::get_stable_path_detail, m)?)?;
     m.add_function(wrap_pyfunction!(

--- a/rust/sdk/cocoindex/benches/state_store_read.rs
+++ b/rust/sdk/cocoindex/benches/state_store_read.rs
@@ -19,7 +19,9 @@
 //!    txn-scoped batching / streaming-detail fix.
 //! 2. `list_target_states` — full listing in one txn with one shared
 //!    resolver: the "how much is on the table" reference for (1).
-//! 3. `resolver_prefix_sharing` — same total states, varying provider
+//! 3. `detail_all_paths` — full-store detail queries, per-path shape vs
+//!    the streaming iterator sharing one txn + resolver across paths.
+//! 4. `resolver_prefix_sharing` — same total states, varying provider
 //!    fanout and persisted-name availability: the axes #2300 moves.
 
 use std::collections::HashMap;
@@ -33,7 +35,7 @@ use futures::StreamExt;
 use tempfile::TempDir;
 
 use cocoindex_core::inspect::db_inspect::{
-    get_stable_path_detail_from_store, spawn_target_state_iter,
+    get_stable_path_detail_from_store, spawn_stable_path_detail_iter, spawn_target_state_iter,
 };
 use cocoindex_core::state::stable_path::StablePath;
 use cocoindex_core::state_store::{AppStore, Storage, StorageSettings};
@@ -262,6 +264,7 @@ const DETAIL_SAMPLE: usize = 100;
 struct SeededStore {
     store: AppStore,
     detail_paths: Vec<StablePath>,
+    component_paths: Vec<StablePath>,
     num_target_states: usize,
     _dir: TempDir,
 }
@@ -306,6 +309,7 @@ fn seed(rt: &tokio::runtime::Runtime, shape: SyntheticStoreShape) -> SeededStore
         SeededStore {
             store,
             detail_paths,
+            component_paths: paths.component_paths,
             num_target_states: paths.num_target_states,
             _dir: dir,
         }
@@ -390,6 +394,46 @@ fn bench_list_target_states(c: &mut Criterion) {
     group.finish();
 }
 
+/// Full-store detail queries: the per-path shape (fresh txn + resolver
+/// per call, what `show -l` used to do) vs the streaming iterator (one
+/// txn, one shared resolver — PR #2301's review r3609040686).
+fn bench_detail_all_paths(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("detail_all_paths");
+    group.sampling_mode(SamplingMode::Flat);
+    for (label, num_components, states_per_component) in SCALES {
+        let seeded = seed(&rt, scale_shape(num_components, states_per_component));
+        group.throughput(Throughput::Elements(seeded.component_paths.len() as u64));
+        group.bench_function(BenchmarkId::new("per_path", label), |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut total_items = 0;
+                for path in &seeded.component_paths {
+                    let detail =
+                        get_stable_path_detail_from_store(&seeded.store, HashMap::new(), path)
+                            .await
+                            .unwrap()
+                            .unwrap();
+                    total_items += detail.target_state_items.len();
+                }
+                black_box(total_items)
+            });
+        });
+        group.bench_function(BenchmarkId::new("stream", label), |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut stream = std::pin::pin!(
+                    spawn_stable_path_detail_iter(seeded.store.clone(), HashMap::new()).await
+                );
+                let mut total_items = 0;
+                while let Some(detail) = stream.next().await {
+                    total_items += detail.unwrap().target_state_items.len();
+                }
+                black_box(total_items)
+            });
+        });
+    }
+    group.finish();
+}
+
 fn bench_resolver_prefix_sharing(c: &mut Criterion) {
     let rt = runtime();
     let mut group = c.benchmark_group("resolver_prefix_sharing");
@@ -435,6 +479,6 @@ fn benchmark_config() -> Criterion {
 criterion_group! {
     name = benches;
     config = benchmark_config();
-    targets = bench_detail_per_path, bench_list_target_states, bench_resolver_prefix_sharing
+    targets = bench_detail_per_path, bench_list_target_states, bench_detail_all_paths, bench_resolver_prefix_sharing
 }
 criterion_main!(benches);


### PR DESCRIPTION
Addresses https://github.com/cocoindex-io/cocoindex/pull/2301#discussion_r3609040686.

The review asked for the `TargetKeyResolver` to be shared across multiple `StablePath` resolves, since provider paths have high reuse. The `show -l` flow was worse than per-path resolvers: it streamed the path list, then opened a **fresh read txn + fresh resolver per path** (and the `--db` flow also re-opened the app store per call), so shared provider prefixes were re-resolved on every path.

This PR adds a streaming detail iterator that folds the stable-path walk and the per-path detail reads into **one read txn with one shared resolver**, and switches both `show -l` flows to it:

- `db_inspect::spawn_stable_path_detail_iter` (+ `iter_stable_path_details[_by_name]` wrappers) reuses the extracted stable-path walk, and passes the walk's node-type straight into detail building instead of looking it up a second time per path.
- Wired through the PyO3 bindings and `cocoindex show -l` / `show --db -l`. Output is unchanged (a test pins that streamed details match the per-path query results).

## Perf impact

New `detail_all_paths` bench group (in this PR) queries details for **all** components both ways:

```
$ cargo bench -p cocoindex --features bench-support --bench state_store_read -- '^detail_all_paths/'
detail_all_paths/per_path/1k
                        time:   [5.5928 ms 5.6050 ms 5.6174 ms]
                        thrpt:  [17.802 Kelem/s 17.841 Kelem/s 17.880 Kelem/s]
detail_all_paths/stream/1k
                        time:   [2.6245 ms 2.6314 ms 2.6391 ms]
                        thrpt:  [37.891 Kelem/s 38.002 Kelem/s 38.102 Kelem/s]
detail_all_paths/per_path/10k
                        time:   [58.252 ms 58.371 ms 58.521 ms]
                        thrpt:  [17.088 Kelem/s 17.132 Kelem/s 17.167 Kelem/s]
detail_all_paths/stream/10k
                        time:   [26.142 ms 26.468 ms 26.836 ms]
                        thrpt:  [37.264 Kelem/s 37.781 Kelem/s 38.253 Kelem/s]
detail_all_paths/per_path/100k
                        time:   [293.02 ms 293.35 ms 293.72 ms]
                        thrpt:  [3.4046 Kelem/s 3.4089 Kelem/s 3.4127 Kelem/s]
detail_all_paths/stream/100k
                        time:   [243.36 ms 246.09 ms 249.03 ms]
                        thrpt:  [4.0157 Kelem/s 4.0636 Kelem/s 4.1092 Kelem/s]
```

**2.1× faster at 1k target states, 2.2× at 10k** — the gain is largest exactly where the review predicted: many paths sharing provider prefixes. At 100k the fixture packs 100 items per component, so per-item summarize work dominates and ancestor resolution already amortizes within each single call, leaving 1.2×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

