### PR TITLE
bench(state_store): add LMDB state-store latency benchmark

### DIFF
--- a/benchmarks/state_store/README.md
+++ b/benchmarks/state_store/README.md
@@ -1,0 +1,78 @@
+# State-store latency benchmark
+
+A focused benchmark that isolates the state-store cost of three core
+operations as the component count grows:
+
+| Phase | What the CLI does | What gets measured |
+| ----- | ----------------- | ------------------ |
+| `cold` | first `cocoindex update` against a fresh state | path bookkeeping + memo writes for all `N` components |
+| `warm` | a second `cocoindex update` against the populated state | memo lookups (all cache hits) for all `N` components |
+| `drop` | `cocoindex drop -f` against the populated state | drop cascade + tombstone GC + final clear |
+
+The pipeline ([main.py](main.py)) is a single `app_main` that
+`mount_each`'s `N` child components, each running a memoized function that
+declares `M` target states against a no-op fake target. The engine still
+runs the full pre_commit / commit lifecycle and writes the per-target
+tracking records, but the user-facing sink does nothing — so the only work
+measured is cocoindex's own state-store traffic, isolated from any external
+IO. With `M = 0` (the default) no target states are declared at all, leaving
+just component-path bookkeeping, memo read/write, and tombstone GC on drop.
+
+`N` and `M` are read from the `BENCH_N` / `BENCH_M` env vars. The runner
+sweeps across multiple values, pointing `COCOINDEX_DB` at a fresh temp
+directory per cell, so each `(N, M)` cell starts from a truly cold state.
+
+## Running
+
+```sh
+# Default: N ∈ {100, 1000, 10000}, M = 0
+./run.sh
+
+# Just one N
+./run.sh --n 100
+
+# Also exercise the target-state write path (M states per component)
+./run.sh --n 1000 --m 0,10
+
+# JSON output (for piping into something)
+./run.sh --format json
+```
+
+## Requirements
+
+- `cocoindex` importable by the current `python3` (e.g. built from this repo
+  via `uv run maturin develop`); the runner invokes the CLI as
+  `python -m cocoindex.cli` subprocesses.
+
+Alternatively, run through the benchmark's own uv project from the repo root
+(builds the editable install automatically):
+
+```sh
+uv run --project benchmarks/state_store python benchmarks/state_store/runner.py --n 100
+```
+
+## How to read the output
+
+```
+       N     M      cold      warm      drop
+---------------------------------------------
+     100     0     0.500     0.300     0.250
+    1000     0     0.700     0.350     0.300
+   10000     0     2.100     0.900     0.500
+```
+
+(Illustrative numbers; run the benchmark for the real ones.) If state-store
+round-trip cost dominates, times should grow roughly linearly with `N` for
+`cold` and `warm`; `drop` additionally exercises the cascade, which is
+serialized through the single-writer transaction batcher.
+
+## Files
+
+```
+benchmarks/state_store/
+├─ README.md       ← you are here
+├─ run.sh          ← thin wrapper → python3 runner.py
+├─ runner.py       ← orchestrator: cell loop + table/JSON output
+├─ main.py         ← the benchmarked pipeline (N memoized children × M no-op target states)
+└─ pyproject.toml  ← uv project pinning the local cocoindex editable install
+```

--- a/benchmarks/state_store/main.py
+++ b/benchmarks/state_store/main.py
@@ -1,0 +1,89 @@
+"""
+State-store benchmark pipeline.
+
+Mounts N child components. Each runs a memoized function that declares M
+target states against a no-op fake target — the engine still writes the
+per-target tracking records into the state store (and runs the full
+pre_commit / commit lifecycle), but the user-facing sink does nothing,
+so we isolate cocoindex-side cost.
+
+`M = 0` reproduces the original "component-path bookkeeping + memo only"
+shape (no target-state traffic).
+
+Environment knobs:
+    BENCH_N — number of mounted child components (default 100).
+    BENCH_M — number of target states declared per component (default 0).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Collection
+
+import cocoindex as coco
+
+
+_N: int = int(os.environ.get("BENCH_N", "100"))
+_M: int = int(os.environ.get("BENCH_M", "0"))
+
+
+class _NoopTargetHandler:
+    """Target handler that drives the per-state tracking record through
+    pre_commit + commit but does nothing user-visible. `desired_state` is
+    `None` for upsert and `NonExistence` for delete; the sink is a no-op so
+    we measure cocoindex's own per-target write path without external IO."""
+
+    def __init__(self) -> None:
+        self._sink: coco.TargetActionSink[tuple[coco.StableKey, bool], None] = (
+            coco.TargetActionSink.from_fn(self._apply)
+        )
+
+    @staticmethod
+    def _apply(
+        _ctx: coco.ContextProvider,
+        _actions: Collection[tuple[coco.StableKey, bool]],
+        /,
+    ) -> None:
+        return None
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: None | coco.NonExistenceType,
+        _prev_records: Collection[None],
+        _prev_may_be_missing: bool,
+        /,
+    ) -> coco.TargetReconcileOutput[tuple[coco.StableKey, bool], None] | None:
+        is_delete = coco.is_non_existence(desired_state)
+        tracking_record: None | coco.NonExistenceType = (
+            coco.NON_EXISTENCE if is_delete else None
+        )
+        return coco.TargetReconcileOutput(
+            action=(key, is_delete),
+            sink=self._sink,
+            tracking_record=tracking_record,
+        )
+
+
+_noop_provider = coco.register_root_target_states_provider(
+    "cocoindex/bench/noop", _NoopTargetHandler()
+)
+
+
+@coco.fn(memo=True)
+async def noop_component(idx: int) -> None:
+    """Memoized component: declares _M no-op target states. Memo lets warm
+    runs short-circuit recomputation; declared target states still flow
+    through pre_commit / commit so the target-state write path is
+    exercised."""
+    for j in range(_M):
+        coco.declare_target_state(_noop_provider.target_state(f"{idx}-{j}", None))
+
+
+@coco.fn
+async def app_main() -> None:
+    items = [(str(i), i) for i in range(_N)]
+    await coco.mount_each(noop_component, items)
+
+
+app = coco.App("StateStoreBench", app_main)

--- a/benchmarks/state_store/pyproject.toml
+++ b/benchmarks/state_store/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "state_store_bench"
+version = "0.1.0"
+description = "Latency benchmark for the cocoindex state store (LMDB)"
+requires-python = ">=3.11"
+dependencies = [
+    "cocoindex",
+]
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+cocoindex = {path = "../../", editable = true}

--- a/benchmarks/state_store/run.sh
+++ b/benchmarks/state_store/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$DIR/runner.py" "$@"

--- a/benchmarks/state_store/runner.py
+++ b/benchmarks/state_store/runner.py
@@ -1,0 +1,157 @@
+"""
+State-store benchmark runner.
+
+For each (N, M) cell, runs three phases via the cocoindex CLI against a
+fresh LMDB state store in a temp directory:
+
+    cold   — fresh state, first `cocoindex update` (creates app + memo entries)
+    warm   — second `cocoindex update` against the populated state (all memo hits)
+    drop   — `cocoindex drop -f` on the populated state (cascade + clear)
+
+Times are wall-clock from subprocess.run, matching what the user observes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+BENCH_DIR = Path(__file__).resolve().parent
+MAIN_PY = BENCH_DIR / "main.py"
+
+DEFAULT_NS = (100, 1_000, 10_000)
+
+
+@dataclass
+class CellResult:
+    n: int
+    m: int
+    cold_s: float
+    warm_s: float
+    drop_s: float
+
+
+def _run(cmd: list[str], env: dict[str, str], cwd: Path) -> float:
+    """Run a subprocess to completion and return its wall-clock seconds."""
+    t = time.perf_counter()
+    proc = subprocess.run(cmd, env=env, cwd=cwd, capture_output=True, text=True)
+    elapsed = time.perf_counter() - t
+    if proc.returncode != 0:
+        print(f"  ! {' '.join(cmd)} failed (rc={proc.returncode})", file=sys.stderr)
+        if proc.stdout:
+            print(proc.stdout, file=sys.stderr)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        raise RuntimeError(f"{cmd[0]} failed")
+    return elapsed
+
+
+_COCOINDEX_CMD = [sys.executable, "-m", "cocoindex.cli"]
+
+
+def _cell(n: int, m: int) -> CellResult:
+    update_cmd = [*_COCOINDEX_CMD, "update", str(MAIN_PY)]
+    drop_cmd = [*_COCOINDEX_CMD, "drop", "-f", str(MAIN_PY)]
+    with tempfile.TemporaryDirectory(prefix="coco-bench-lmdb-") as tmp:
+        env = {
+            **os.environ,
+            "COCOINDEX_DB": str(Path(tmp) / "db"),
+            "BENCH_N": str(n),
+            "BENCH_M": str(m),
+        }
+        cold = _run(update_cmd, env, BENCH_DIR)
+        warm = _run(update_cmd, env, BENCH_DIR)
+        drop = _run(drop_cmd, env, BENCH_DIR)
+    return CellResult(n=n, m=m, cold_s=cold, warm_s=warm, drop_s=drop)
+
+
+def _print_table(results: list[CellResult]) -> None:
+    hdr = f"{'N':>8}  {'M':>4}  {'cold':>8}  {'warm':>8}  {'drop':>8}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in sorted(results, key=lambda r: (r.n, r.m)):
+        print(
+            f"{r.n:>8}  {r.m:>4}  {r.cold_s:>8.3f}  {r.warm_s:>8.3f}  {r.drop_s:>8.3f}"
+        )
+    print()
+    print("All numbers in seconds. Lower is better.")
+
+
+def _print_json(results: list[CellResult]) -> None:
+    print(
+        json.dumps(
+            [
+                {
+                    "n": r.n,
+                    "m": r.m,
+                    "cold_s": r.cold_s,
+                    "warm_s": r.warm_s,
+                    "drop_s": r.drop_s,
+                }
+                for r in results
+            ],
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--n",
+        default=",".join(str(n) for n in DEFAULT_NS),
+        help=f"Comma-separated list of component counts. Default: {','.join(str(n) for n in DEFAULT_NS)}",
+    )
+    parser.add_argument(
+        "--m",
+        default="0",
+        help=(
+            "Comma-separated list of per-component target-state counts. "
+            "Default: 0 (no target states). Each non-zero M exercises the "
+            "target-state write path on every component."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+    )
+    args = parser.parse_args()
+
+    ns = [int(s) for s in args.n.split(",") if s.strip()]
+    ms = [int(s) for s in args.m.split(",") if s.strip()]
+
+    results: list[CellResult] = []
+    for n in ns:
+        for m in ms:
+            label = f"N={n}/M={m}"
+            print(f"running {label} …", flush=True)
+            try:
+                r = _cell(n, m)
+            except Exception as exc:
+                print(f"  ! {label} failed: {exc}", file=sys.stderr)
+                continue
+            print(
+                f"  cold {r.cold_s:.3f}s   warm {r.warm_s:.3f}s   drop {r.drop_s:.3f}s",
+                flush=True,
+            )
+            results.append(r)
+
+    print()
+    if args.format == "json":
+        _print_json(results)
+    else:
+        _print_table(results)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `benchmarks/state_store/`: a focused latency benchmark for the state store, measuring cold / warm / drop wall-clock via the `cocoindex` CLI across `N` mounted components × `M` no-op target states per component, with a fresh LMDB store per cell.
- Backported from cocoindex-plus, with the Pg backend pruned (and the now-dead backend dimension removed from the runner/output).

## Test plan
- `uv run python benchmarks/state_store/runner.py --n 20,50 --m 0,3` runs all cells end-to-end; `--format json` verified.
- `uv run mypy` (strict covers `benchmarks/`), `ruff format --check`, `ruff check` all pass; full pre-commit hook suite passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
