### PR TITLE
docs: recommend npx skills CLI for installing the agent skill

### DIFF
--- a/docs/src/content/docs/getting_started/ai_coding_agents.mdx
+++ b/docs/src/content/docs/getting_started/ai_coding_agents.mdx
@@ -19,72 +19,29 @@ CocoIndex v1 is a fundamental redesign from v0. Without context, an LLM trained 
 - **Connectors** — PostgreSQL, SQLite, LanceDB, Qdrant, SurrealDB, Apache Doris, LocalFS, S3, Kafka, Google Drive.
 - **Best practices** — memoization, stable component paths, vector schema with `Annotated[NDArray, KEY]`.
 
-## Use with agent clients
+## Install the skill
 
-| Client / workflow | Recommended setup |
-| --- | --- |
-| **Codex / Agent Skills-compatible clients** | Use `.agents/skills/cocoindex` for repo-local discovery. In this CocoIndex repo, checked-in `.agents/skills` symlinks expose the public skill and contributor playbooks automatically. |
-| **Claude Code** | Use `.claude/skills/cocoindex` in a project, or `~/.claude/skills/cocoindex` globally. |
-| **Cursor** | Copy `skills/cocoindex/SKILL.md` into `.cursor/rules/cocoindex.md`. |
-| **Generic AGENTS.md / CLAUDE.md** | Link to, import, or summarize `skills/cocoindex/SKILL.md` from your top-level agent instructions. |
-| **Context7** | This repo's `context7.json` already indexes `skills/cocoindex`; custom stacks can index the same folder. |
-| **Custom RAG / agent stack** | Index the `skills/cocoindex/` directory, including `references/`, as regular documentation. |
-
-Agent Skills-compatible clients load a skill directory that contains `SKILL.md`.
-If `.agents/skills/cocoindex` is checked into your project, no extra install step is
-needed for clients that scan that path.
-
-Project-local install for Codex or other Agent Skills-compatible clients:
+The recommended way to install is the [`skills` CLI](https://skills.sh) — one command, works with Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, and other Agent Skills-compatible clients:
 
 ```sh
-mkdir -p .agents/skills
-git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-cp -r /tmp/cocoindex-skill/skills/cocoindex .agents/skills/
+npx skills add cocoindex-io/cocoindex
 ```
 
-## Use with Claude Code
+Run it in your project root. It installs the skill into `.agents/skills/cocoindex` (the universal convention that Codex, Cursor, and other clients scan) and symlinks it into `.claude/skills/cocoindex` for Claude Code. It also writes a `skills-lock.json` that pins the installed skill by content hash, so you can track exactly which version you have and when it was updated.
 
-Claude Code auto-loads skills from `.claude/skills/` in the current project, or from `~/.claude/skills/` globally.
-
-Project-local install (recommended for repos that build with CocoIndex):
+To update to the latest version later:
 
 ```sh
-mkdir -p .claude/skills
-git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-cp -r /tmp/cocoindex-skill/skills/cocoindex .claude/skills/
+npx skills update cocoindex
 ```
 
-Global install:
+To install globally (user-level, available in every project) instead of project-local:
 
 ```sh
-mkdir -p ~/.claude/skills
-git clone --depth=1 https://github.com/cocoindex-io/cocoindex.git /tmp/cocoindex-skill
-cp -r /tmp/cocoindex-skill/skills/cocoindex ~/.claude/skills/
+npx skills add -g cocoindex-io/cocoindex
 ```
 
-Once installed, Claude Code picks up the skill automatically when you ask it to build or modify a CocoIndex pipeline.
-
-## Use with other agents
-
-The skill is plain Markdown — `SKILL.md` plus a few reference files. Any agent that accepts file-based context will work:
-
-- **Cursor** — copy `skills/cocoindex/SKILL.md` into `.cursor/rules/cocoindex.md`.
-- **Generic AGENTS.md / CLAUDE.md** — concatenate or `@import` `SKILL.md` from your top-level agent instructions file.
-- **Context7** — use this repo's `context7.json` shape as a reference; it indexes `skills/cocoindex` alongside docs and examples.
-- **Custom RAG / agent stack** — index the `skills/cocoindex/` directory like any other documentation source.
-
-## What's inside
-
-```
-skills/cocoindex/
-├── SKILL.md                       # main entry — concepts, APIs, patterns
-└── references/
-    ├── api_reference.md           # quick API reference
-    ├── connectors.md              # full connector reference
-    ├── patterns.md                # detailed pipeline patterns
-    ├── setup_project.md           # project setup
-    └── setup_database.md          # database setup
-```
+Once installed, your agent picks up the skill automatically when you ask it to build or modify a CocoIndex pipeline.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Replace the manual `git clone` + `cp` skill-install instructions with the [`skills` CLI](https://skills.sh): `npx skills add cocoindex-io/cocoindex` installs for Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, and other Agent Skills-compatible clients in one command, and pins the installed version via `skills-lock.json`; `npx skills update cocoindex` updates it.
- Drop content that duplicated what the CLI now handles or would go stale: the per-client setup table, Context7/RAG notes, and the hardcoded skill file tree (the intro's GitHub link to `skills/cocoindex/` remains the single source of truth).

Verified end-to-end in a scratch directory: `npx skills add cocoindex-io/cocoindex` discovers the skill under `skills/cocoindex/`, installs into `.agents/skills/cocoindex`, symlinks `.claude/skills/cocoindex`, and writes `skills-lock.json`.

## Test plan
CI (docs-only change; command flow manually verified as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
