### PR TITLE
fix(core): clear inverted target-owner index on component deletion

### DIFF
--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -164,6 +164,39 @@ def test_dicts_data_together_delete_dict() -> None:
     ]
 
 
+@pytest.mark.asyncio
+async def test_delete_dict_clears_target_owner_index() -> None:
+    """Deleting a component drops its rows from the inverted owner index.
+
+    The `__track` row goes away with the component, so any `__target` owner
+    row it left behind is dangling and never reclaimed.
+    """
+    DictsTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_delete_dict_clears_target_owner_index", environment=coco_env
+        ),
+        _declare_dicts_data_together,
+    )
+
+    _source_data["D1"] = {"a": 1, "b": 2}
+    _source_data["D2"] = {"c": 3}
+    await app.update()
+
+    owners_before = [entry async for entry in coco_inspect.iter_target_states(app)]
+    assert any("D1" in entry.readable_path for entry in owners_before), owners_before
+    assert not any(entry.dangling for entry in owners_before)
+
+    del _source_data["D1"]
+    await app.update()
+
+    owners_after = [entry async for entry in coco_inspect.iter_target_states(app)]
+    assert not any("D1" in entry.readable_path for entry in owners_after), owners_after
+    assert not any(entry.dangling for entry in owners_after)
+
+
 def test_dicts_data_together_delete_entry() -> None:
     DictsTarget.store.clear()
     _source_data.clear()

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -458,14 +458,37 @@ impl<Prof: EngineProfile> Committer<Prof> {
 
     /// Engine-side reconcile that produces the `(new_tracking_info,
     /// target_owners_to_delete)` portion of [`CommitPlan`]. Delete
-    /// mode short-circuits to `(None, vec![])`, signalling the
-    /// session to delete the `__track` row.
+    /// mode short-circuits to `(None, owned_target_paths)`, signalling
+    /// the session to delete the `__track` row and every `__target`
+    /// owner row this component still holds.
     async fn build_commit_writes(
         &self,
         curr_version: Option<u64>,
     ) -> Result<(Option<Vec<u8>>, Vec<TargetStatePath>)> {
         if self.component_ctx.mode() == ComponentProcessingMode::Delete {
-            return Ok((None, Vec::new()));
+            // Whole-component deletion also drops the inverted `__target`
+            // owner index for every path this component still owns. Without
+            // this the `__track` row is removed but the owner rows leak,
+            // growing LMDB unboundedly for permanently-abandoned paths.
+            let owners_to_delete = match self
+                .app_store
+                .read_tracking_info(&self.component_path)
+                .await?
+            {
+                Some(bytes) => {
+                    let tracking_info: db_schema::StablePathEntryTrackingInfo<'_> =
+                        from_msgpack_slice(&bytes)?;
+                    tracking_info
+                        .target_state_items
+                        .keys()
+                        .map(|path_with_pid| path_with_pid.target_state_path.clone())
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect()
+                }
+                None => Vec::new(),
+            };
+            return Ok((None, owners_to_delete));
         }
         let curr_version = curr_version
             .ok_or_else(|| internal_error!("curr_version is required for Build mode"))?;

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -498,9 +498,19 @@ impl AppStore {
                             .await?;
                     }
                     for target_path in &plan.target_owners_to_delete {
-                        app_store
-                            .delete_target_state_owner(wtxn, target_path)
-                            .await?;
+                        // Only drop the owner row if it still points at us. A
+                        // component that preempted this path between our last
+                        // run and this delete has already upserted itself as
+                        // owner; deleting unconditionally would orphan it.
+                        let still_ours = app_store
+                            .read_target_state_owner_in_txn(wtxn, target_path)
+                            .await?
+                            .is_some_and(|info| info.component_path == component_path);
+                        if still_ours {
+                            app_store
+                                .delete_target_state_owner(wtxn, target_path)
+                                .await?;
+                        }
                     }
                     if plan.fn_memo_clear_all_first {
                         app_store.delete_all_fn_memos(wtxn, &component_path).await?;

--- a/rust/core/tests/target_owner_cleanup.rs
+++ b/rust/core/tests/target_owner_cleanup.rs
@@ -1,0 +1,119 @@
+//! Integration test for the inverted `__target` owner-index guard: a
+//! component's delete must not drop an owner row another component has
+//! since claimed. Uses only the public `cocoindex_core` API so the test
+//! lives outside production sources.
+
+use std::sync::Arc;
+
+use cocoindex_core::state::stable_path::{StableKey, StablePath};
+use cocoindex_core::state::target_state_path::TargetStatePath;
+use cocoindex_core::state_store::{
+    AppStore, CommitPlan, ExistenceReconciler, Storage, StorageSettings,
+};
+use cocoindex_utils::fingerprint::Fingerprint;
+use tempfile::TempDir;
+
+async fn make_test_store() -> (Storage, AppStore, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("mdb");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let settings = StorageSettings {
+        db_path,
+        lmdb_max_dbs: 4,
+        lmdb_map_size: 1 << 24, // 16 MiB
+    };
+    let storage = Storage::new(&settings).await.unwrap();
+    let store = storage.create_app_store("test_app").await.unwrap();
+    (storage, store, dir)
+}
+
+fn comp_path(name: &str) -> StablePath {
+    StablePath(Arc::from(vec![StableKey::Str(Arc::from(name))]))
+}
+
+fn target_path(name: &str) -> TargetStatePath {
+    TargetStatePath::new(Fingerprint::from(name).unwrap(), None)
+}
+
+async fn upsert_owner(
+    storage: &Storage,
+    store: &AppStore,
+    path: &TargetStatePath,
+    owner: &StablePath,
+) {
+    let store = store.clone();
+    let path = path.clone();
+    let owner = owner.clone();
+    storage
+        .run_txn(move |wtxn| {
+            let store = store.clone();
+            let path = path.clone();
+            let owner = owner.clone();
+            Box::pin(async move { store.upsert_target_state_owner(wtxn, &path, &owner).await })
+        })
+        .await
+        .unwrap();
+}
+
+async fn read_owner(
+    storage: &Storage,
+    store: &AppStore,
+    path: &TargetStatePath,
+) -> Option<StablePath> {
+    let store = store.clone();
+    let path = path.clone();
+    storage
+        .run_txn(move |wtxn| {
+            let store = store.clone();
+            let path = path.clone();
+            Box::pin(async move {
+                Ok(store
+                    .read_target_state_owner_in_txn(wtxn, &path)
+                    .await?
+                    .map(|info| info.component_path))
+            })
+        })
+        .await
+        .unwrap()
+}
+
+async fn commit_owner_deletes(
+    store: &AppStore,
+    component_path: &StablePath,
+    deletes: Vec<TargetStatePath>,
+) {
+    let plan = CommitPlan {
+        new_tracking_info: None,
+        target_owners_to_upsert: Vec::new(),
+        target_owners_to_delete: deletes,
+        fn_memo_clear_all_first: false,
+        fn_memo_writes: Vec::new(),
+        fn_memo_deletes: Vec::new(),
+        user_state_clear_all_first: false,
+        user_state_writes: Vec::new(),
+        user_state_deletes: Vec::new(),
+        user_state_clear_live: false,
+        child_path_set: None,
+    };
+    let reconciler: ExistenceReconciler = Box::new(|_wtxn| Box::pin(async { Ok(()) }));
+    store
+        .commit(component_path, plan, reconciler)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn delete_preserves_owner_row_preempted_by_other_component() {
+    let (storage, store, _dir) = make_test_store().await;
+    let old_owner = comp_path("comp");
+    let new_owner = comp_path("comp_new");
+    let tsp = target_path("mystore/D1");
+
+    // A different component has since claimed the path.
+    upsert_owner(&storage, &store, &tsp, &new_owner).await;
+
+    // The old owner's delete must not orphan the new owner.
+    commit_owner_deletes(&store, &old_owner, vec![tsp.clone()]).await;
+
+    assert_eq!(read_owner(&storage, &store, &tsp).await, Some(new_owner));
+}


### PR DESCRIPTION
## Summary

Whole-component deletion removed the component's `__track` row but left every `__target` owner row it held behind. Those rows point at a component whose tracking info no longer exists, so `iter_target_states` reports them as `dangling` and nothing ever reclaims them.

`build_commit_writes` short-circuited Delete mode to `(None, vec![])`:

```rust
if self.component_ctx.mode() == ComponentProcessingMode::Delete {
    return Ok((None, Vec::new()));   // <- no owner rows collected
}
```

`target_owners_to_delete` is the only mechanism that removes rows from the inverted index, and it was always empty on delete. There is no sweep or GC elsewhere that collects them (the Phase 5 GC handles child components via tombstones, not the owner index), so the leak is permanent for paths that are never re-declared.

## Root cause / execution trace

1. A component owning target-state paths is orphaned (source key removed) or dropped.
2. `Committer::commit` calls `build_commit_writes`, which returns `(None, vec![])` for `Delete`.
3. `AppStore::commit` sees `new_tracking_info == None` and deletes the `__track` row, then iterates an empty `target_owners_to_delete`.
4. The `__target` rows survive, now pointing at a component with no tracking info — precisely the state `TargetStateEntry::dangling` documents as "left behind by ... an interrupted cleanup".

## Fix

Delete mode now reads the component's own tracking info and collects the target-state paths it still owns (deduped across provider ids), so the owner rows are dropped in the same commit txn as the `__track` row.

The delete in `AppStore::commit` is guarded on the row still pointing at the deleting component. A component that preempted the path between our last run and this delete has already upserted itself as owner via `precommit_claim_targets`; deleting unconditionally would orphan that live claim. This ordering is reachable because the owner index is claimed during precommit while the delete plan is built from a component-scoped read.

## Behavior

| | before | after |
|---|---|---|
| `__target` row after component delete | retained, `dangling: true` | removed |
| path preempted by another component | n/a (never deleted) | preserved for the new owner |

Reclaiming a leaked path was already safe (`old_tracking_cache` misses → `prev_item = None` → `prev_may_be_missing = true`, the conservative branch), so this is an orphaned-state/unbounded-growth fix rather than a data-corruption one. It also removes spurious `[dangling]` entries from `cocoindex show --target-states`.

## Test plan

- [x] New e2e test `test_delete_dict_clears_target_owner_index` in `python/tests/core/test_component_target_states.py`, reusing the existing `_declare_dicts_data_together` fixture: deletes one dict component while the app lives on, asserts its owner rows are gone and none are `dangling`. **Fails before the fix** (`assert not any(entry.dangling ...)` → `assert not True`), passes after.
- [x] New `rust/core/tests/target_owner_cleanup.rs` covers the preemption guard — asserts a delete does not drop a row another component has claimed. Fails without the guard.
- [x] `cargo test -p cocoindex_core` — 84 passed, 0 failed
- [x] `uv run pytest python/tests/core/` — 520 passed, 1 skipped
- [x] `uv run pytest python/tests/cli/ python/tests/internal/` — 97 passed
- [x] `uv run mypy` — clean (278 files); `cargo fmt --check` clean; `ruff format/check` clean on touched files

