### PR TITLE
test(core): assert target-owner index contents in deletion e2e tests

### DIFF
--- a/python/tests/common/__init__.py
+++ b/python/tests/common/__init__.py
@@ -1,2 +1,3 @@
 from .environment import *
+from .inspect_utils import *
 from . import target_states

--- a/python/tests/common/inspect_utils.py
+++ b/python/tests/common/inspect_utils.py
@@ -1,0 +1,39 @@
+"""Helpers for asserting on engine-internal state in end-to-end tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import cocoindex as coco
+import cocoindex.inspect as coco_inspect
+
+__all__ = [
+    "list_target_state_owners",
+    "list_target_state_owners_sync",
+]
+
+
+async def list_target_state_owners(
+    app: coco.App[Any, Any],
+) -> dict[str, coco.StablePath]:
+    """Map each tracked target-state path (readable form) to its owner component path.
+
+    Also asserts the inverted owner index is consistent: every row must resolve
+    against its owner component's tracking info. A dangling row is a leak —
+    left behind by a component deletion or an interrupted cleanup.
+    """
+    owners: dict[str, coco.StablePath] = {}
+    async for entry in coco_inspect.iter_target_states(app):
+        assert not entry.dangling, (
+            f"dangling target-state owner row {entry.readable_path} "
+            f"owned by {entry.owner_component_path}"
+        )
+        owners[entry.readable_path] = coco.StablePath(entry.owner_component_path)
+    return owners
+
+
+def list_target_state_owners_sync(
+    app: coco.App[Any, Any],
+) -> dict[str, coco.StablePath]:
+    return asyncio.run(list_target_state_owners(app))

--- a/python/tests/core/test_app_drop.py
+++ b/python/tests/core/test_app_drop.py
@@ -47,6 +47,11 @@ def test_drop_blocking() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+    }
 
     # Drop the app
     app.drop_blocking()
@@ -54,6 +59,7 @@ def test_drop_blocking() -> None:
     # Verify target states were reverted and database is cleared
     assert DictsTarget.store.data == {}
     assert coco_inspect.list_stable_paths_sync(app) == []
+    assert common.list_target_state_owners_sync(app) == {}
 
 
 @pytest.mark.asyncio
@@ -91,6 +97,7 @@ async def test_drop_reverts_target_states() -> None:
 
     # Verify database is cleared
     assert await coco_inspect.list_stable_paths(app) == []
+    assert await common.list_target_state_owners(app) == {}
 
 
 @pytest.mark.asyncio
@@ -111,6 +118,8 @@ async def test_drop_clears_database() -> None:
     # Verify app has state
     paths_before = await coco_inspect.list_stable_paths(app)
     assert len(paths_before) > 0
+    owners_before = await common.list_target_state_owners(app)
+    assert len(owners_before) > 0
 
     # Drop the app
     await app.drop()
@@ -118,6 +127,7 @@ async def test_drop_clears_database() -> None:
     # Verify database is cleared
     paths_after = await coco_inspect.list_stable_paths(app)
     assert paths_after == []
+    assert await common.list_target_state_owners(app) == {}
 
 
 @pytest.mark.asyncio
@@ -149,6 +159,10 @@ async def test_drop_allows_rerun() -> None:
     assert DictsTarget.store.data == {
         "D2": {"b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True)},
     }
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "dict" / "D2",
+        '/@test_target_state/dicts/"D2"/"b"': coco.ROOT_PATH,
+    }
 
 
 @pytest.mark.asyncio
@@ -167,6 +181,7 @@ async def test_drop_empty_app() -> None:
 
     # Verify no paths exist
     assert await coco_inspect.list_stable_paths(app) == []
+    assert await common.list_target_state_owners(app) == {}
 
 
 # ============================================================================
@@ -216,6 +231,7 @@ def test_drop_with_live_component_in_registry() -> None:
     # Verify state is fully cleaned up after drop.
     assert DictsTarget.store.data == {}
     assert coco_inspect.list_stable_paths_sync(app) == []
+    assert common.list_target_state_owners_sync(app) == {}
 
 
 def test_drop_failure_preserves_tracking_for_retry() -> None:
@@ -250,6 +266,10 @@ def test_drop_failure_preserves_tracking_for_retry() -> None:
     assert paths_before_failed_drop, (
         "tracking records should exist after the initial update"
     )
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+    }
 
     # First drop attempt with a failing sink. Whether or not it raises,
     # the tracking record for the failed delete MUST survive.
@@ -269,8 +289,16 @@ def test_drop_failure_preserves_tracking_for_retry() -> None:
         "tracking records must survive a failed drop so retry can find them; "
         f"got empty list — target state would leak"
     )
+    # The owner row for the failed delete must survive alongside the tracking
+    # record. Only the container's sink failed (`sink_exception` is on the
+    # parent store); the leaf entry's delete succeeded, so its owner row is
+    # legitimately gone.
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+    }
 
     # Healthy retry cleans up properly.
     app.drop_blocking()
     assert DictsTarget.store.data == {}
     assert coco_inspect.list_stable_paths_sync(app) == []
+    assert common.list_target_state_owners_sync(app) == {}

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -112,6 +112,12 @@ def test_dicts_data_together_delete_dict() -> None:
         coco.ROOT_PATH / "dict" / "D1",
         coco.ROOT_PATH / "dict" / "D2",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "dict" / "D2",
+    }
 
     del _source_data["D1"]
     _source_data["D2"]["c"] = 3
@@ -137,6 +143,12 @@ def test_dicts_data_together_delete_dict() -> None:
         coco.ROOT_PATH / "dict" / "D2",
         coco.ROOT_PATH / "dict" / "D3",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "dict" / "D2",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "dict" / "D3",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH,
+    }
 
     # Re-insert after deletion
     _source_data["D1"] = {"a": 3, "c": 4}
@@ -162,39 +174,15 @@ def test_dicts_data_together_delete_dict() -> None:
         coco.ROOT_PATH / "dict" / "D2",
         coco.ROOT_PATH / "dict" / "D3",
     ]
-
-
-@pytest.mark.asyncio
-async def test_delete_dict_clears_target_owner_index() -> None:
-    """Deleting a component drops its rows from the inverted owner index.
-
-    The `__track` row goes away with the component, so any `__target` owner
-    row it left behind is dangling and never reclaimed.
-    """
-    DictsTarget.store.clear()
-    _source_data.clear()
-
-    app = coco.App(
-        coco.AppConfig(
-            name="test_delete_dict_clears_target_owner_index", environment=coco_env
-        ),
-        _declare_dicts_data_together,
-    )
-
-    _source_data["D1"] = {"a": 1, "b": 2}
-    _source_data["D2"] = {"c": 3}
-    await app.update()
-
-    owners_before = [entry async for entry in coco_inspect.iter_target_states(app)]
-    assert any("D1" in entry.readable_path for entry in owners_before), owners_before
-    assert not any(entry.dangling for entry in owners_before)
-
-    del _source_data["D1"]
-    await app.update()
-
-    owners_after = [entry async for entry in coco_inspect.iter_target_states(app)]
-    assert not any("D1" in entry.readable_path for entry in owners_after), owners_after
-    assert not any(entry.dangling for entry in owners_after)
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "dict" / "D2",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "dict" / "D3",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH,
+    }
 
 
 def test_dicts_data_together_delete_entry() -> None:
@@ -228,6 +216,10 @@ def test_dicts_data_together_delete_entry() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
     assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+    }
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -247,6 +239,12 @@ def test_dicts_data_together_delete_entry() -> None:
         coco.ROOT_PATH / "dict",
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH,
+    }
 
 
 ##################################################################################
@@ -347,6 +345,12 @@ def test_dicts_in_sub_components_delete_dict() -> None:
         coco.ROOT_PATH / "D2",
         coco.ROOT_PATH / "D2" / "setup",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "D1" / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "D2" / "setup",
+    }
 
     del _source_data["D1"]
     _source_data["D2"]["c"] = 3
@@ -373,6 +377,12 @@ def test_dicts_in_sub_components_delete_dict() -> None:
         coco.ROOT_PATH / "D3",
         coco.ROOT_PATH / "D3" / "setup",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "D2" / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "D3" / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / "D3",
+    }
 
     # Re-insert after deletion
     _source_data["D1"] = {"a": 3, "c": 4}
@@ -400,6 +410,15 @@ def test_dicts_in_sub_components_delete_dict() -> None:
         coco.ROOT_PATH / "D3",
         coco.ROOT_PATH / "D3" / "setup",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "D1" / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "D2" / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "D3" / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / "D3",
+    }
 
 
 def test_dicts_in_sub_components_delete_entry() -> None:
@@ -433,6 +452,10 @@ def test_dicts_in_sub_components_delete_entry() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
     assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "D1" / "setup",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+    }
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -452,6 +475,12 @@ def test_dicts_in_sub_components_delete_entry() -> None:
         coco.ROOT_PATH / "D1",
         coco.ROOT_PATH / "D1" / "setup",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "D1" / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH / "D1",
+    }
 
 
 ##################################################################################
@@ -560,6 +589,12 @@ async def test_dicts_containers_together_delete_dict() -> None:
         coco.ROOT_PATH / "D2",
         coco.ROOT_PATH / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "setup",
+    }
 
     del _source_data["D1"]
     _source_data["D2"]["c"] = 3
@@ -585,6 +620,12 @@ async def test_dicts_containers_together_delete_dict() -> None:
         coco.ROOT_PATH / "D3",
         coco.ROOT_PATH / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / "D3",
+    }
 
     # Re-insert after deletion
     _source_data["D1"] = {"a": 3, "c": 4}
@@ -610,6 +651,15 @@ async def test_dicts_containers_together_delete_dict() -> None:
         coco.ROOT_PATH / "D3",
         coco.ROOT_PATH / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / "D3",
+    }
 
 
 @pytest.mark.asyncio
@@ -645,6 +695,10 @@ async def test_dicts_containers_together_delete_entry() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": AtMost(1)}
     assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "delete": 1}
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+    }
 
     # Re-insert after deletion
     _source_data["D1"]["a"] = 3
@@ -664,6 +718,12 @@ async def test_dicts_containers_together_delete_entry() -> None:
         coco.ROOT_PATH / "D1",
         coco.ROOT_PATH / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH / "D1",
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH / "D1",
+    }
 
 
 ##################################################################################
@@ -699,6 +759,10 @@ def test_proceed_with_failed_creation() -> None:
         coco.ROOT_PATH / "dict",
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+    }
 
 
 ##################################################################################
@@ -796,11 +860,15 @@ def test_cleanup_partially_built_components() -> None:
         coco.ROOT_PATH / "D1",
         coco.ROOT_PATH / "D1" / "setup",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "D1" / "setup",
+    }
 
     del _source_data["D1"]
     app.update_blocking()
     assert DictsTarget.store.data == {}
     assert coco_inspect.list_stable_paths_sync(app) == [coco.ROOT_PATH]
+    assert common.list_target_state_owners_sync(app) == {}
 
 
 ##################################################################################
@@ -826,6 +894,9 @@ def test_retry_from_gc_failed_components() -> None:
         coco.ROOT_PATH / "dict",
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+    }
 
     # Inject an exception for GC
     del _source_data["D1"]
@@ -839,6 +910,11 @@ def test_retry_from_gc_failed_components() -> None:
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    # The owner row must survive the failed GC along with the tracking record,
+    # so the retry can still find and clean up the target state.
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+    }
 
     # After retry, it should proceed with GC
     app.update_blocking()
@@ -846,6 +922,7 @@ def test_retry_from_gc_failed_components() -> None:
     assert coco_inspect.list_stable_paths_sync(app) == [
         coco.ROOT_PATH,
     ]
+    assert common.list_target_state_owners_sync(app) == {}
 
 
 def test_restore_from_gc_failed_components() -> None:
@@ -867,6 +944,9 @@ def test_restore_from_gc_failed_components() -> None:
         coco.ROOT_PATH / "dict",
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+    }
 
     # Inject an exception for GC
     del _source_data["D1"]
@@ -880,6 +960,9 @@ def test_restore_from_gc_failed_components() -> None:
         coco.ROOT_PATH,
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+    }
 
     # The entry reappears, and the previous failed GC shouldn't affect it
     _source_data["D1"] = {"a": 1}
@@ -892,6 +975,10 @@ def test_restore_from_gc_failed_components() -> None:
         coco.ROOT_PATH / "dict",
         coco.ROOT_PATH / "dict" / "D1",
     ]
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / "dict" / "D1",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+    }
 
 
 ##################################################################################
@@ -996,6 +1083,12 @@ async def test_mount_each_delete() -> None:
         coco.ROOT_PATH / _me / "D3",
         coco.ROOT_PATH / _me / "D3" / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / _me / "D2" / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / _me / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / _me / "D3" / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / _me / "D3",
+    }
 
     # Re-insert after deletion
     _source_data["D1"] = {"a": 3, "c": 4}
@@ -1023,6 +1116,15 @@ async def test_mount_each_delete() -> None:
         coco.ROOT_PATH / _me / "D3",
         coco.ROOT_PATH / _me / "D3" / "setup",
     ]
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/dicts/"D1"': coco.ROOT_PATH / _me / "D1" / "setup",
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH / _me / "D1",
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH / _me / "D1",
+        '/@test_target_state/dicts/"D2"': coco.ROOT_PATH / _me / "D2" / "setup",
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH / _me / "D2",
+        '/@test_target_state/dicts/"D3"': coco.ROOT_PATH / _me / "D3" / "setup",
+        '/@test_target_state/dicts/"D3"/"a"': coco.ROOT_PATH / _me / "D3",
+    }
 
 
 ##################################################################################
@@ -1218,6 +1320,16 @@ def test_mount_target_delete() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "insert": 2}
     assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(2), "upsert": 3}
+    _mt = coco.ROOT_PATH / "dict" / coco.Symbol("cocoindex/mount_target")
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': _mt
+        / (coco.Symbol("test_target_state/dicts"), "D1"),
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D2"': _mt
+        / (coco.Symbol("test_target_state/dicts"), "D2"),
+        '/@test_target_state/dicts/"D2"/"c"': coco.ROOT_PATH,
+    }
 
     # Delete D2, modify D1
     del _mount_target_source_data["D2"]
@@ -1232,6 +1344,13 @@ def test_mount_target_delete() -> None:
     }
     assert DictsTarget.store.metrics.collect() == {"sink": AtMost(2), "delete": 1}
     assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': _mt
+        / (coco.Symbol("test_target_state/dicts"), "D1"),
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"c"': coco.ROOT_PATH,
+    }
 
 
 ##################################################################################
@@ -1300,6 +1419,13 @@ def test_directory_to_component_transition() -> None:
             "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
         },
     }
+    _mt = coco.ROOT_PATH / "transition_test" / coco.Symbol("cocoindex/mount_target")
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': _mt
+        / (coco.Symbol("test_target_state/dicts"), "D1"),
+        '/@test_target_state/dicts/"D1"/"a"': coco.ROOT_PATH,
+        '/@test_target_state/dicts/"D1"/"b"': coco.ROOT_PATH,
+    }
 
     # Transition from Directory target to Component mount
     _transition_to_component_mode = True
@@ -1307,6 +1433,7 @@ def test_directory_to_component_transition() -> None:
 
     # The old children should be deleted from the target state
     assert DictsTarget.store.data == {}
+    assert common.list_target_state_owners_sync(app) == {}
 
     # Verify stable paths reflect the component is still there, but children are gone
     paths = coco_inspect.list_stable_paths_sync(app)

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -40,6 +40,9 @@ def test_ownership_transfer_basic() -> None:
     _source_data["C1"] = {"x": 1}
     app.update_blocking()
     assert GlobalDictTarget.store.data["x"].data == 1
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C1",
+    }
     GlobalDictTarget.store.metrics.collect()
 
     # Run 2: Ownership transfers from C1 to C2
@@ -47,6 +50,9 @@ def test_ownership_transfer_basic() -> None:
     _source_data["C2"] = {"x": 2}
     app.update_blocking()
     assert GlobalDictTarget.store.data["x"].data == 2
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
 
 
 def test_ownership_transfer_same_value() -> None:
@@ -71,6 +77,9 @@ def test_ownership_transfer_same_value() -> None:
     app.update_blocking()
     # Final state must still be 1, regardless of whether preempt or delete+insert happened.
     assert GlobalDictTarget.store.data["x"].data == 1
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
 
 
 def test_ownership_transfer_then_delete() -> None:
@@ -102,6 +111,7 @@ def test_ownership_transfer_then_delete() -> None:
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
     assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
+    assert common.list_target_state_owners_sync(app) == {}
 
 
 def test_ownership_transfer_ordering_independence() -> None:
@@ -127,6 +137,9 @@ def test_ownership_transfer_ordering_independence() -> None:
     # The target state must exist (this is the bug fix)
     assert "x" in GlobalDictTarget.store.data
     assert GlobalDictTarget.store.data["x"].data == 2
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
 
 
 def test_ownership_transfer_multiple_keys() -> None:
@@ -155,6 +168,10 @@ def test_ownership_transfer_multiple_keys() -> None:
     # prev_may_be_missing) are nondeterministic due to concurrent processing order.
     assert GlobalDictTarget.store.data["a"].data == 3
     assert GlobalDictTarget.store.data["b"].data == 2
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"a"': coco.ROOT_PATH / "C2",
+        '/@test_target_state/global_dict/"b"': coco.ROOT_PATH / "C1",
+    }
 
 
 def test_ownership_transfer_chain() -> None:
@@ -171,18 +188,27 @@ def test_ownership_transfer_chain() -> None:
     _source_data["C1"] = {"x": 1}
     app.update_blocking()
     assert GlobalDictTarget.store.data["x"].data == 1
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C1",
+    }
 
     # Run 2: C1 gone, C2 takes over
     _source_data.clear()
     _source_data["C2"] = {"x": 2}
     app.update_blocking()
     assert GlobalDictTarget.store.data["x"].data == 2
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
 
     # Run 3: C2 gone, C3 takes over
     _source_data.clear()
     _source_data["C3"] = {"x": 3}
     app.update_blocking()
     assert GlobalDictTarget.store.data["x"].data == 3
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C3",
+    }
 
 
 @coco.fn
@@ -227,6 +253,9 @@ def test_ownership_transfer_preempt_strict() -> None:
     }
     # Should be 1 upsert (update), NOT a delete + insert
     assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
 
     # Run 3: Same value transfer — no action needed
     _source_data.clear()
@@ -236,6 +265,9 @@ def test_ownership_transfer_preempt_strict() -> None:
         "x": DictDataWithPrev(data=2, prev=[1], prev_may_be_missing=False),
     }
     assert GlobalDictTarget.store.metrics.collect() == {}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C3",
+    }
 
 
 def test_component_delete_cleans_inverted_tracking() -> None:
@@ -253,12 +285,17 @@ def test_component_delete_cleans_inverted_tracking() -> None:
     # Run 1: C1 owns "x"
     _source_data["C1"] = {"x": 1}
     app.update_blocking()
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C1",
+    }
     GlobalDictTarget.store.metrics.collect()
 
-    # Run 2: C1 is gone entirely
+    # Run 2: C1 is gone entirely — its owner row must go with it, not linger
+    # as a dangling entry pointing at a component with no tracking info.
     _source_data.clear()
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
+    assert common.list_target_state_owners_sync(app) == {}
     GlobalDictTarget.store.metrics.collect()
 
     # Run 3: C2 declares "x" fresh (no previous owner)
@@ -266,4 +303,7 @@ def test_component_delete_cleans_inverted_tracking() -> None:
     app.update_blocking()
     assert GlobalDictTarget.store.data == {
         "x": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+    }
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
     }


### PR DESCRIPTION
## What

Revises the component-deletion e2e tests to also assert the contents of the inverted `__target` owner index, not just stable paths.

- New shared helper `tests/common/inspect_utils.py`: `list_target_state_owners(app)` / `list_target_state_owners_sync(app)` returns `{readable target-state path → owner component path}` from `coco_inspect.iter_target_states`, and internally asserts no entry is dangling (a dangling row is exactly the leak class fixed in #2318).
- `test_component_target_states.py`: exact owner-map assertions at each phase (before deletion / after deletion / after re-insert) of the deletion tests across all three mounting styles, plus `test_mount_each_delete`, `test_mount_target_delete`, partial-build cleanup, both GC-failure tests (owner rows must survive a failed GC alongside the tracking record, then clear on retry), the directory-to-component transition, and failed-creation recovery.
- `test_app_drop.py`: all drop tests assert the owner index is empty after drop; the failed-drop test asserts exactly which row survives for retry (only the container's — `sink_exception` is on the parent store, so the leaf entry's delete succeeds and its row is legitimately gone).
- `test_ownership_transfer.py`: every test asserts who owns each key after each run; `test_component_delete_cleans_inverted_tracking` now asserts the index empties when the owning component disappears — the exact #2318 scenario.
- Removes the bespoke `test_delete_dict_clears_target_owner_index` added by #2318: its scenario is now a strict subset of the strengthened `test_dicts_data_together_delete_dict`. The Rust preempt-guard test from that PR keeps its unique coverage.

## Why

The deletion e2e tests asserted only `list_stable_paths` (the `__track` keyspace), so leaked `__target` owner rows were invisible to the entire suite — the leak fixed in #2318 was only caught by the single bespoke test that PR added. Owner-index consistency is now checked systematically wherever component deletion, GC, drop, or ownership transfer is exercised.

## Verification

- With the #2318 engine fix temporarily reverted and rebuilt, **10 of the revised tests fail** (previously: zero). With the fix restored, all pass.
- `prek run --all-files` fully green (cargo test, mypy, full pytest, ruff-format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
