### PR TITLE
fix: trailing blank line in surrealdb example note

### DIFF
--- a/examples/meeting_notes_graph_surrealdb/notes/team-sync.md
+++ b/examples/meeting_notes_graph_surrealdb/notes/team-sync.md
@@ -22,4 +22,3 @@ Action items:
 
 - Alice C. to review the Q3 roadmap draft.
 - David Kim to schedule the onboarding design review.
-


### PR DESCRIPTION
Fixes the `Fast Check` failure on `main` introduced by #2329: `end-of-file-fixer` flagged a double newline at the end of `examples/meeting_notes_graph_surrealdb/notes/team-sync.md`. Normalized to a single trailing newline; `prek` hooks now pass on all files from that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)