### PR TITLE
docs: serve example diagrams as SVG across all walkthroughs

### DIFF
--- a/docs/src/content/example-posts/amazon-s3-embedding.md
+++ b/docs/src/content/example-posts/amazon-s3-embedding.md
@@ -16,7 +16,7 @@ If you haven't read the base example yet, start there — it walks through the c
 
 ## Flow overview
 
-![CocoIndex Amazon S3 embedding flow: list Markdown objects from a bucket, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/amazon-s3-embedding/flow-v1.png)
+![CocoIndex Amazon S3 embedding flow: list Markdown objects from a bucket, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/amazon-s3-embedding/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/audio-to-text.md
+++ b/docs/src/content/example-posts/audio-to-text.md
@@ -16,7 +16,7 @@ The whole thing is ordinary `async` Python and your own types. The heavy lifting
 
 ## Flow overview
 
-![CocoIndex audio-to-text flow: read audio files from a local directory, transcribe each with LiteLLM, and store one transcript row per file in Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/flow-v1.png)
+![CocoIndex audio-to-text flow: read audio files from a local directory, transcribe each with LiteLLM, and store one transcript row per file in Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -91,7 +91,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process a file
 
-![One processing component per file: each audio file is transcribed with LiteLLM, producing one AudioTranscription row written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/stage-file-process.png)
+![One processing component per file: each audio file is transcribed with LiteLLM, producing one AudioTranscription row written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/audio-to-text/stage-file-process.svg)
 
 `process_file` runs once per file. It reads the audio, [transcribes it](https://cocoindex.io/docs/ops/litellm/), and declares a single target row — no chunking, one row per file.
 

--- a/docs/src/content/example-posts/csv-to-kafka.md
+++ b/docs/src/content/example-posts/csv-to-kafka.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python, and the Kafka topic is just a [ta
 
 ## Flow overview
 
-![CocoIndex CSV → Kafka flow: watch a folder of CSV files, run one process_csv component per file that turns each row into a JSON message, and declare it as a Kafka topic target state](https://cocoindex.io/blobs/docs-v1/img/examples/csv-to-kafka/flow-v1.png)
+![CocoIndex CSV → Kafka flow: watch a folder of CSV files, run one process_csv component per file that turns each row into a JSON message, and declare it as a Kafka topic target state](https://cocoindex.io/blobs/docs-v1/img/examples/csv-to-kafka/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -90,7 +90,7 @@ The SASL block is what a managed broker (StreamNative or similar) wants. For a l
 
 ## Process a file
 
-![One process_csv component per CSV file, fanned out with mount_each: each file's rows become (key, value) target states on the Kafka topic](https://cocoindex.io/blobs/docs-v1/img/examples/csv-to-kafka/stage-process-csv.png)
+![One process_csv component per CSV file, fanned out with mount_each: each file's rows become (key, value) target states on the Kafka topic](https://cocoindex.io/blobs/docs-v1/img/examples/csv-to-kafka/stage-process-csv.svg)
 
 `process_csv` runs once per file. It reads the text, parses rows with `csv.DictReader` (the header row becomes the keys), and declares each row as a target state — key from the first column, value the JSON-encoded row:
 

--- a/docs/src/content/example-posts/docs-to-knowledge-graph.md
+++ b/docs/src/content/example-posts/docs-to-knowledge-graph.md
@@ -48,7 +48,7 @@ A knowledge graph over living docs is exactly the kind of pipeline that's easy t
 
 ## Pipeline overview
 
-![CocoIndex flow: Markdown docs walked from the filesystem, per-doc LLM extraction declaring Document nodes and carrying triples forward, then a single graph-building pass declaring Entity nodes and edges into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/flow-v1.png)
+![CocoIndex flow: Markdown docs walked from the filesystem, per-doc LLM extraction declaring Document nodes and carrying triples forward, then a single graph-building pass declaring Entity nodes and edges into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/flow-v1.svg)
 
 The pipeline runs in two phases:
 
@@ -157,7 +157,7 @@ async def extract_relationships(content: str) -> list[Triple]:
 
 ## Phase 1: per-file extraction
 
-![Phase 1 — one processing component per doc: each file goes through memoized LLM extraction, declares its Document node into Neo4j, and returns DocTriples for phase 2](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/stage-phase1.png)
+![Phase 1 — one processing component per doc: each file goes through memoized LLM extraction, declares its Document node into Neo4j, and returns DocTriples for phase 2](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/stage-phase1.svg)
 
 `process_file` runs once per document: extract the summary, declare the `Document` node, extract the triples, and return them for phase 2.
 
@@ -199,7 +199,7 @@ Why a component per file? Ownership. The component at `("file", path_key)` owns 
 
 ## Phase 2: build the concept graph
 
-![Phase 2 — a single build_graph component: all docs' triples are deduplicated into Entity nodes and RELATIONSHIP / MENTION edges, declared into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/stage-phase2.png)
+![Phase 2 — a single build_graph component: all docs' triples are deduplicated into Entity nodes and RELATIONSHIP / MENTION edges, declared into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/docs-to-knowledge-graph/stage-phase2.svg)
 
 A single component takes every file's triples and declares the cross-document parts of the graph: deduplicated `Entity` nodes and the two edge types.
 

--- a/docs/src/content/example-posts/entire-session-search.md
+++ b/docs/src/content/example-posts/entire-session-search.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex Entire session search flow: walk a folder of checkpoints, route each file by name through process_file, embed transcripts, prompts, and context summaries, and store the vectors in Postgres with pgvector alongside a metadata table](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/flow-v1.png)
+![CocoIndex Entire session search flow: walk a folder of checkpoints, route each file by name through process_file, embed transcripts, prompts, and context summaries, and store the vectors in Postgres with pgvector alongside a metadata table](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -96,7 +96,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process a file
 
-![One processing component per checkpoint file: process_file routes by filename, embeds transcript, prompt, and context text into the embeddings table, and writes one metadata row](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/stage-file-process.png)
+![One processing component per checkpoint file: process_file routes by filename, embeds transcript, prompt, and context text into the embeddings table, and writes one metadata row](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/stage-file-process.svg)
 
 `process_file` runs once per checkpoint file and routes on its name. The checkpoint id and session index come straight from the file's path, and a fresh `IdGenerator` numbers the rows this file produces.
 
@@ -202,7 +202,7 @@ We use [`SentenceTransformerEmbedder`](https://cocoindex.io/docs/ops/sentence_tr
 
 ## Define the main function
 
-![mount_each fans out one process_file component per checkpoint file, from the Entire filesystem source to the two Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/stage-main-function.png)
+![mount_each fans out one process_file component per checkpoint file, from the Entire filesystem source to the two Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/entire-session-search/stage-main-function.svg)
 
 `app_main` wires the source to the targets. It mounts both Postgres tables, walks the checkpoint directory for the four file types, and mounts one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per file.
 

--- a/docs/src/content/example-posts/face-recognition.md
+++ b/docs/src/content/example-posts/face-recognition.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex face recognition flow: walk a folder of images, detect every face, embed each into a 128-d vector, and index one Qdrant point per face](https://cocoindex.io/blobs/docs-v1/img/examples/face-recognition/flow-v1.png)
+![CocoIndex face recognition flow: walk a folder of images, detect every face, embed each into a 128-d vector, and index one Qdrant point per face](https://cocoindex.io/blobs/docs-v1/img/examples/face-recognition/flow-v1.svg)
 
 Unlike a one-embedding-per-image index, an image here fans out to **many** faces — so the shape is *image → N faces → N points*:
 
@@ -85,7 +85,7 @@ async def process_file(file: FileLike, target: qdrant.CollectionTarget) -> None:
     await coco.map(process_face, faces, str(file.file_path.path), target)
 ```
 
-![One process_file component per image, fanned out with mount_each: each image is detected, every face embedded, and one Qdrant point declared per face](https://cocoindex.io/blobs/docs-v1/img/examples/face-recognition/stage-file-process.png)
+![One process_file component per image, fanned out with mount_each: each image is detected, every face embedded, and one Qdrant point declared per face](https://cocoindex.io/blobs/docs-v1/img/examples/face-recognition/stage-file-process.svg)
 
 [`@coco.fn(memo=True)`](https://cocoindex.io/docs/programming_guide/function/) makes it [incremental](https://cocoindex.io/docs/advanced_topics/memoization_keys/): an unchanged photo is never re-detected. Each image is its own [processing component](https://cocoindex.io/docs/programming_guide/processing_component/), so deleting a photo removes all its faces from Qdrant automatically. [`coco.map`](https://cocoindex.io/docs/programming_guide/app/) fans out one `process_face` per detected face — the multi-face equivalent of chunking a document.
 

--- a/docs/src/content/example-posts/files-transform.md
+++ b/docs/src/content/example-posts/files-transform.md
@@ -16,7 +16,7 @@ The transform is your own ordinary `async` function. The heavy lifting — [incr
 
 ## Flow overview
 
-![CocoIndex files transform flow: watch a directory of Markdown, render each file to HTML with markdown-it-py, and write the .html outputs to a local folder](https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/flow-v1.png)
+![CocoIndex files transform flow: watch a directory of Markdown, render each file to HTML with markdown-it-py, and write the .html outputs to a local folder](https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -28,7 +28,7 @@ You [declare the transformation logic](https://cocoindex.io/docs/programming_gui
 
 ## Process a file
 
-![One processing component per file: each Markdown file is rendered to HTML and written as a file target on the local filesystem](https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/stage-file-process.png)
+![One processing component per file: each Markdown file is rendered to HTML and written as a file target on the local filesystem](https://cocoindex.io/blobs/docs-v1/img/examples/files-transform/stage-file-process.svg)
 
 `process_file` runs once per file. It reads the Markdown, renders it to HTML, derives an output name from the source path, and declares the output file as a target state.
 

--- a/docs/src/content/example-posts/google-drive-embedding.md
+++ b/docs/src/content/example-posts/google-drive-embedding.md
@@ -16,7 +16,7 @@ The chunk-and-embed half is explained in full in the [base walkthrough](https://
 
 ## Flow overview
 
-![CocoIndex Google Drive embedding flow: read files from a Drive folder, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/google-drive-embedding/flow-v1.png)
+![CocoIndex Google Drive embedding flow: read files from a Drive folder, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/google-drive-embedding/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/hackernews-trending-topics.md
+++ b/docs/src/content/example-posts/hackernews-trending-topics.md
@@ -16,7 +16,7 @@ The data source here isn't a folder of files — it's a public HTTP API. We fetc
 
 ## Flow overview
 
-![Flow](https://cocoindex.io/blobs/docs-v1/img/examples/hackernews-trending-topics/flow-v1.png)
+![Flow](https://cocoindex.io/blobs/docs-v1/img/examples/hackernews-trending-topics/flow-v1.svg)
 
 1. Fetch a list of recent thread IDs from the Algolia HackerNews API
 2. For each thread, fetch the story and all of its comments
@@ -190,7 +190,7 @@ These are ordinary `async def` functions — no special CocoIndex decorators. An
 
 Each thread is processed by its own component. `process_thread` fetches the thread, extracts topics for the story and every comment, and declares the resulting rows.
 
-![Process thread](https://cocoindex.io/blobs/docs-v1/img/examples/hackernews-trending-topics/stage-file-process.png)
+![Process thread](https://cocoindex.io/blobs/docs-v1/img/examples/hackernews-trending-topics/stage-file-process.svg)
 
 ```python title="main.py"
 @coco.fn

--- a/docs/src/content/example-posts/image-search-colpali.md
+++ b/docs/src/content/example-posts/image-search-colpali.md
@@ -16,7 +16,7 @@ The store does the heavy lifting on the query side. We give [Qdrant](https://qdr
 
 ## Flow overview
 
-![CocoIndex ColPali image search indexing flow: walk a folder of images, embed each into a multi-vector bag of patch vectors with ColPali, and declare a point into a Qdrant MaxSim multivector collection](https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/flow-v1.png)
+![CocoIndex ColPali image search indexing flow: walk a folder of images, embed each into a multi-vector bag of patch vectors with ColPali, and declare a point into a Qdrant MaxSim multivector collection](https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/flow-v1.svg)
 
 The indexing path is short — there's no text to chunk, just one multi-vector embedding per image:
 
@@ -94,7 +94,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process an image
 
-![One process_file component per image, fanned out with mount_each: each image is ColPali-embedded into a bag of patch vectors and declared as a Qdrant multivector point](https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/stage-file-process.png)
+![One process_file component per image, fanned out with mount_each: each image is ColPali-embedded into a bag of patch vectors and declared as a Qdrant multivector point](https://cocoindex.io/blobs/docs-v1/img/examples/image-search-colpali/stage-file-process.svg)
 
 `process_file` runs once per image: read the bytes, embed with ColPali into a multi-vector, and declare a Qdrant point keyed by a stable id derived from the path, with the filename in the payload. The only difference from the CLIP version is the shape of `embedding` — a list of patch vectors rather than one vector.
 

--- a/docs/src/content/example-posts/image-search.md
+++ b/docs/src/content/example-posts/image-search.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex image search indexing flow: walk a folder of images, embed each with the CLIP image encoder, and declare a point into a Qdrant collection](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/flow-v1.png)
+![CocoIndex image search indexing flow: walk a folder of images, embed each with the CLIP image encoder, and declare a point into a Qdrant collection](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/flow-v1.svg)
 
 The indexing path is short — there's no text to chunk, just one embedding per image:
 
@@ -91,7 +91,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process an image
 
-![One process_file component per image, fanned out with mount_each: each image is CLIP-embedded and declared as a Qdrant point](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/stage-file-process.png)
+![One process_file component per image, fanned out with mount_each: each image is CLIP-embedded and declared as a Qdrant point](https://cocoindex.io/blobs/docs-v1/img/examples/image-search/stage-file-process.svg)
 
 `process_file` runs once per image: read the bytes, embed with CLIP, and declare a Qdrant point keyed by a stable id derived from the path, with the filename in the payload.
 

--- a/docs/src/content/example-posts/kafka-to-lancedb.md
+++ b/docs/src/content/example-posts/kafka-to-lancedb.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python. Kafka is just a [source](https://
 
 ## Flow overview
 
-![CocoIndex Kafka → LanceDB flow: subscribe a topic as a keyed map, run one process_message component per message that parses the JSON and dispatches by shape, and declare each row on the products or employees LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/kafka-to-lancedb/flow-v1.png)
+![CocoIndex Kafka → LanceDB flow: subscribe a topic as a keyed map, run one process_message component per message that parses the JSON and dispatches by shape, and declare each row on the products or employees LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/kafka-to-lancedb/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -86,7 +86,7 @@ The dataclass *is* the schema. When we mount the table below, [`TableSchema.from
 
 ## Process a message
 
-![One process_message component per Kafka message, fanned out with mount_each: each message is parsed and dispatched by shape to the products or employees LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/kafka-to-lancedb/stage-file-process.png)
+![One process_message component per Kafka message, fanned out with mount_each: each message is parsed and dispatched by shape to the products or employees LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/kafka-to-lancedb/stage-file-process.svg)
 
 `process_message` runs once per message. It decodes the value, parses the JSON, and dispatches on shape — declaring a typed row on whichever table matches:
 

--- a/docs/src/content/example-posts/manuals-llm-extraction.md
+++ b/docs/src/content/example-posts/manuals-llm-extraction.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy PDF 
 
 ## Flow overview
 
-![CocoIndex flow: walk a folder of PDF manuals, convert each to Markdown with docling, LLM-extract a typed ModuleInfo, and store a row per manual in Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/manuals-llm-extraction/flow-v1.png)
+![CocoIndex flow: walk a folder of PDF manuals, convert each to Markdown with docling, LLM-extract a typed ModuleInfo, and store a row per manual in Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/manuals-llm-extraction/flow-v1.svg)
 
 Per manual, two transforms and a row:
 

--- a/docs/src/content/example-posts/multi-format-indexing.md
+++ b/docs/src/content/example-posts/multi-format-indexing.md
@@ -20,7 +20,7 @@ A normal embedding squashes a whole page into one vector — fine for a paragrap
 
 ## Flow overview
 
-![CocoIndex flow: walk a folder of PDFs and images, render each PDF to per-page images, embed every page with ColPali, and store one multi-vector Qdrant point per page](https://cocoindex.io/blobs/docs-v1/img/examples/multi-format-indexing/flow-v1.png)
+![CocoIndex flow: walk a folder of PDFs and images, render each PDF to per-page images, embed every page with ColPali, and store one multi-vector Qdrant point per page](https://cocoindex.io/blobs/docs-v1/img/examples/multi-format-indexing/flow-v1.svg)
 
 A file fans out to **pages**, so the shape is *file → N pages → N points*:
 

--- a/docs/src/content/example-posts/oci-object-storage-embedding.md
+++ b/docs/src/content/example-posts/oci-object-storage-embedding.md
@@ -14,7 +14,7 @@ This is the [Semantic Search 101](https://cocoindex.io/docs/examples/text-embedd
 
 ## Flow overview
 
-![CocoIndex OCI Object Storage flow: list Markdown objects from a bucket, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/oci-object-storage-embedding/flow-v1.png)
+![CocoIndex OCI Object Storage flow: list Markdown objects from a bucket, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/oci-object-storage-embedding/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/paper-metadata.md
+++ b/docs/src/content/example-posts/paper-metadata.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex paper metadata flow: walk a folder of PDFs, read the first page, LLM-extract title/authors/abstract into a typed model, embed the title and abstract chunks, and store metadata, authors, and embeddings in three Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/flow-v1.png)
+![CocoIndex paper metadata flow: walk a folder of PDFs, read the first page, LLM-extract title/authors/abstract into a typed model, embed the title and abstract chunks, and store metadata, authors, and embeddings in three Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -157,7 +157,7 @@ Only the first page is read, and the prompt is capped at `markdown[:4000]` chara
 
 ## Process a file
 
-![One processing component per PDF: read the first page, LLM-extract metadata, embed the title and abstract chunks, and declare rows into three Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/stage-file-process.png)
+![One processing component per PDF: read the first page, LLM-extract metadata, embed the title and abstract chunks, and declare rows into three Postgres tables](https://cocoindex.io/blobs/docs-v1/img/examples/paper-metadata/stage-file-process.svg)
 
 `process_file` runs once per PDF and ties the steps together. It extracts the metadata, then declares the rows: one metadata row, one author-index row per author, and one embedding row for the title plus one for each abstract chunk.
 

--- a/docs/src/content/example-posts/patient-intake-baml.md
+++ b/docs/src/content/example-posts/patient-intake-baml.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python. You write a [BAML schema](https:/
 
 ## Flow overview
 
-![CocoIndex patient intake extraction flow: walk a folder of PDF intake forms, run one BAML Gemini-vision extraction per form into a typed Patient model, dump it to JSON, and write one JSON file per form to a local directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/flow-v1.png)
+![CocoIndex patient intake extraction flow: walk a folder of PDF intake forms, run one BAML Gemini-vision extraction per form into a typed Patient model, dump it to JSON, and write one JSON file per form to a local directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -100,7 +100,7 @@ The return type is `Patient` — the actual Pydantic class BAML generated, not a
 
 ## Process a file
 
-![One processing component per intake form: read the PDF, extract a typed Patient with BAML, serialize to JSON, and declare a JSON file into the output directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/stage-file-process.png)
+![One processing component per intake form: read the PDF, extract a typed Patient with BAML, serialize to JSON, and declare a JSON file into the output directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-baml/stage-file-process.svg)
 
 `process_patient_form` runs once per PDF. It reads the file, runs the BAML extraction, dumps the typed `Patient` to JSON, and declares one output file named after the source form.
 

--- a/docs/src/content/example-posts/patient-intake-dspy.md
+++ b/docs/src/content/example-posts/patient-intake-dspy.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex patient intake flow: walk a folder of PDF intake forms, render each page to an image, extract a typed Patient with a DSPy ChainOfThought vision module on Gemini, and write one JSON file per form to a local directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/flow-v1.png)
+![CocoIndex patient intake flow: walk a folder of PDF intake forms, render each page to an image, extract a typed Patient with a DSPy ChainOfThought vision module on Gemini, and write one JSON file per form to a local directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -138,7 +138,7 @@ def extract_patient(pdf_content: bytes) -> Patient:
 
 ## Process a file
 
-![One processing component per PDF: render to images, extract a Patient with DSPy, and declare a JSON file into the output directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/stage-file-process.png)
+![One processing component per PDF: render to images, extract a Patient with DSPy, and declare a JSON file into the output directory](https://cocoindex.io/blobs/docs-v1/img/examples/patient-intake-dspy/stage-file-process.svg)
 
 `process_patient_form` runs once per PDF. It reads the file's bytes, extracts the `Patient`, serializes it to pretty-printed JSON, and declares one output file named after the source form.
 

--- a/docs/src/content/example-posts/pdf-embedding.md
+++ b/docs/src/content/example-posts/pdf-embedding.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex PDF embedding flow: walk a folder of PDFs, convert each to Markdown with docling on a GPU runner, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/flow-v1.png)
+![CocoIndex PDF embedding flow: walk a folder of PDFs, convert each to Markdown with docling on a GPU runner, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -103,7 +103,7 @@ Two things make this hold up at scale:
 
 ## Process a file
 
-![One processing component per PDF: convert to Markdown, chunk, embed each chunk, and declare PdfEmbedding rows into Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/stage-file-process.png)
+![One processing component per PDF: convert to Markdown, chunk, embed each chunk, and declare PdfEmbedding rows into Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/stage-file-process.svg)
 
 `process_file` runs once per PDF. It converts the PDF to Markdown, [splits the text](https://cocoindex.io/docs/ops/text/) into overlapping chunks, and maps each chunk to `process_chunk`.
 
@@ -151,7 +151,7 @@ We use [`SentenceTransformerEmbedder`](https://cocoindex.io/docs/ops/sentence_tr
 
 ## Define the main function
 
-![mount_each fans out one processing component per PDF, from the filesystem source to the Postgres target](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/stage-main-function.png)
+![mount_each fans out one processing component per PDF, from the filesystem source to the Postgres target](https://cocoindex.io/blobs/docs-v1/img/examples/pdf-embedding/stage-main-function.svg)
 
 `app_main` wires the source to the target. It mounts the Postgres table, walks the source directory for PDFs, and mounts one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per file.
 

--- a/docs/src/content/example-posts/postgres-source.md
+++ b/docs/src/content/example-posts/postgres-source.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex Postgres source flow: read product rows from a Postgres table, derive fields and embed each row, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/flow-v1.png)
+![CocoIndex Postgres source flow: read product rows from a Postgres table, derive fields and embed each row, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -101,7 +101,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process a row
 
-![One processing component per row: each source row is derived and embedded, producing an OutputProduct row written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/stage-file-process.png)
+![One processing component per row: each source row is derived and embedded, producing an OutputProduct row written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/postgres-source/stage-file-process.svg)
 
 `process_product` runs once per source row. It builds a `full_description` from the category, name, and body, computes `total_value`, embeds the description, and declares the target row.
 

--- a/docs/src/content/example-posts/product-recommendation.md
+++ b/docs/src/content/example-posts/product-recommendation.md
@@ -27,7 +27,7 @@ The recommendation falls out of the graph: products whose *complementary* taxono
 
 ## Pipeline overview
 
-![CocoIndex flow: per-product LLM taxonomy extraction declaring Product nodes, then a single graph pass declaring the shared Taxonomy nodes and the two relationship types into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/product-recommendation/flow-v1.png)
+![CocoIndex flow: per-product LLM taxonomy extraction declaring Product nodes, then a single graph pass declaring the shared Taxonomy nodes and the two relationship types into Neo4j](https://cocoindex.io/blobs/docs-v1/img/examples/product-recommendation/flow-v1.svg)
 
 The taxonomy labels are shared across products, so — like the [docs knowledge graph](https://cocoindex.io/docs/examples/docs-to-knowledge-graph/) — the pipeline runs in two phases:
 

--- a/docs/src/content/example-posts/sec-edgar-analytics.md
+++ b/docs/src/content/example-posts/sec-edgar-analytics.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python. Embedding runs on a [GPU runner](
 
 ## Flow overview
 
-![CocoIndex flow: walk text filings and JSON facts, scrub PII, chunk, embed, tag topics, and load one row per chunk into Apache Doris with a vector index and a full-text index](https://cocoindex.io/blobs/docs-v1/img/examples/sec-edgar-analytics/flow-v1.png)
+![CocoIndex flow: walk text filings and JSON facts, scrub PII, chunk, embed, tag topics, and load one row per chunk into Apache Doris with a vector index and a full-text index](https://cocoindex.io/blobs/docs-v1/img/examples/sec-edgar-analytics/flow-v1.svg)
 
 Two source formats fan into one chunk table:
 

--- a/docs/src/content/example-posts/slides-to-speech.md
+++ b/docs/src/content/example-posts/slides-to-speech.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python. The vision and TTS steps run on a
 
 ## Flow overview
 
-![CocoIndex flow: render each slide to an image, a vision LLM writes speaker notes, Pocket TTS narrates them, the notes are embedded, and everything is stored per-slide in LanceDB](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/flow-v1.png)
+![CocoIndex flow: render each slide to an image, a vision LLM writes speaker notes, Pocket TTS narrates them, the notes are embedded, and everything is stored per-slide in LanceDB](https://cocoindex.io/blobs/docs-v1/img/examples/slides-to-speech/flow-v1.svg)
 
 A deck fans out to **slides**, and each slide produces text, audio, and a vector:
 

--- a/docs/src/content/example-posts/text-embedding-lancedb.md
+++ b/docs/src/content/example-posts/text-embedding-lancedb.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex text embedding flow with LanceDB: read Markdown, split into chunks, embed each chunk, and store the vectors in an embedded LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-lancedb/flow-v1.png)
+![CocoIndex text embedding flow with LanceDB: read Markdown, split into chunks, embed each chunk, and store the vectors in an embedded LanceDB table](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-lancedb/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/text-embedding-qdrant.md
+++ b/docs/src/content/example-posts/text-embedding-qdrant.md
@@ -16,7 +16,7 @@ If you want the full chunk-and-embed walkthrough, read the [base example](https:
 
 ## Flow overview
 
-![CocoIndex text embedding flow with Qdrant: read Markdown, split into chunks, embed each chunk, and upsert the vectors into a Qdrant collection](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-qdrant/flow-v1.png)
+![CocoIndex text embedding flow with Qdrant: read Markdown, split into chunks, embed each chunk, and upsert the vectors into a Qdrant collection](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-qdrant/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/text-embedding-turbopuffer.md
+++ b/docs/src/content/example-posts/text-embedding-turbopuffer.md
@@ -16,7 +16,7 @@ Everything else stays the same: ordinary `async` Python and your own types, with
 
 ## Flow overview
 
-![CocoIndex flow: read Markdown, split into chunks, embed each chunk, and upsert the vectors into a Turbopuffer namespace](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-turbopuffer/flow-v1.png)
+![CocoIndex flow: read Markdown, split into chunks, embed each chunk, and upsert the vectors into a Turbopuffer namespace](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding-turbopuffer/flow-v1.svg)
 
 From a high level, these are the steps:
 

--- a/docs/src/content/example-posts/text-embedding.md
+++ b/docs/src/content/example-posts/text-embedding.md
@@ -16,7 +16,7 @@ The whole pipeline is ordinary `async` Python and your own types. The heavy lift
 
 ## Flow overview
 
-![CocoIndex text embedding flow: read Markdown, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/flow-v1.png)
+![CocoIndex text embedding flow: read Markdown, split into chunks, embed each chunk, and store the vectors in Postgres with pgvector](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/flow-v1.svg)
 
 From a high level, these are the steps:
 
@@ -97,7 +97,7 @@ async def coco_lifespan(builder: coco.EnvironmentBuilder) -> AsyncIterator[None]
 
 ## Process a file
 
-![One processing component per file: each file is chunked and embedded, producing DocEmbedding rows written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-file-process.png)
+![One processing component per file: each file is chunked and embedded, producing DocEmbedding rows written to Postgres](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-file-process.svg)
 
 `process_file` runs once per file. It reads the file, [splits the text](https://cocoindex.io/docs/ops/text/) into overlapping chunks, and maps each chunk to `process_chunk`.
 
@@ -147,7 +147,7 @@ We use [`SentenceTransformerEmbedder`](https://cocoindex.io/docs/ops/sentence_tr
 
 ## Define the main function
 
-![mount_each fans out one processing component per file, from the Markdown source to the Postgres target](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-main-function.png)
+![mount_each fans out one processing component per file, from the Markdown source to the Postgres target](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-main-function.svg)
 
 `app_main` wires the source to the target. It mounts the Postgres table (with a [vector index](https://cocoindex.io/docs/common_resources/vector_schema/)), walks the source directory, and mounts one [processing component](https://cocoindex.io/docs/programming_guide/processing_component/) per file.
 
@@ -176,7 +176,7 @@ async def app_main(sourcedir: pathlib.Path) -> None:
 
 ## Create the App
 
-![A CocoIndex App binds the source, the transform, and the target state into one runnable unit](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-create-app.png)
+![A CocoIndex App binds the source, the transform, and the target state into one runnable unit](https://cocoindex.io/blobs/docs-v1/img/examples/text-embedding/stage-create-app.svg)
 
 Bind `app_main` into a `coco.App` and point it at the folder of Markdown files.
 


### PR DESCRIPTION
Generated flow + stage diagrams on 27 example pages now link the vector `.svg` published in the blobs repo instead of the PNG rasters — 48 link swaps, no other content changes. Follows the meeting-notes conversion (#2331). Covers (og:image) and screenshots stay raster.

Depends on cocoindex-io/blobs#11 — merge that first so the `.svg` URLs resolve.

Remaining raster diagrams (separate follow-up, no generator sources exist in blobs): `index-codebase` and `podcast-to-knowledge-graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)