### PR TITLE
fix(memoization): canonicalize Fingerprint keys deterministically

### DIFF
--- a/python/cocoindex/_internal/memo_fingerprint.py
+++ b/python/cocoindex/_internal/memo_fingerprint.py
@@ -256,7 +256,7 @@ def _stable_sort_key(v: Fingerprintable) -> tuple[typing.Any, ...]:
         return (3, struct.pack("!d", v))
     if isinstance(v, str):
         return (4, v)
-    if isinstance(v, (bytes, bytearray, memoryview)):
+    if isinstance(v, (bytes, bytearray, memoryview, core.Fingerprint)):
         return (5, bytes(v))
     if isinstance(v, typing.Sequence):
         return (6, tuple(_stable_sort_key(e) for e in v))

--- a/python/tests/internal/test_memo_fingerprint.py
+++ b/python/tests/internal/test_memo_fingerprint.py
@@ -757,3 +757,26 @@ def test_apply_memo_key_transforms_varkw() -> None:
 
     assert result_args == (1,)
     assert result_kwargs == {"count": 2}
+
+
+def test_fingerprint_dict_and_set_with_fingerprint_keys_order_independent() -> None:
+    from cocoindex._internal import core
+    from cocoindex._internal.memo_fingerprint import memo_fingerprint
+
+    fp1 = core.fingerprint_simple_object("alpha")
+    fp2 = core.fingerprint_simple_object("beta")
+
+    # Dict order independence with Fingerprint keys
+    d1 = {fp1: "val1", fp2: "val2"}
+    d2 = {fp2: "val2", fp1: "val1"}
+    assert memo_fingerprint(d1) == memo_fingerprint(d2)
+
+    # Set order independence with Fingerprint elements
+    s1 = {fp1, fp2}
+    s2 = {fp2, fp1}
+    assert memo_fingerprint(s1) == memo_fingerprint(s2)
+
+    # Nested container order independence with Fingerprint keys
+    nested1 = {"items": [{fp1: 1, fp2: 2}]}
+    nested2 = {"items": [{fp2: 2, fp1: 1}]}
+    assert memo_fingerprint(nested1) == memo_fingerprint(nested2)


### PR DESCRIPTION
## Summary

Teaches `_stable_sort_key()` in `memo_fingerprint.py` to explicitly handle `core.Fingerprint` values by sorting them using their 16-byte representation.

---

## Problem

When canonicalizing dictionaries or sets for memoization fingerprints (`_canonicalize`), key-value pairs and set elements are sorted using `_stable_sort_key(v)` to ensure order-independence across process runs and insertion orders.

Previously, `_stable_sort_key()` lacked explicit handling for `core.Fingerprint` objects. Because `core.Fingerprint` is a PyO3 extension type and not a standard Python sequence/primitive, it fell through to the generic fallback sort key `(99,)`.

Consequently:
1. All `Fingerprint` keys evaluated to identical sort keys `(99,)`.
2. `items.sort()` performed a stable sort that preserved initial insertion order.
3. Two dictionaries or sets containing identical `{Fingerprint: Value}` pairs constructed in different orders produced different 16-byte memoization fingerprints.

---

## Solution

Updated `_stable_sort_key()` in `python/cocoindex/_internal/memo_fingerprint.py` to include `core.Fingerprint` in the byte-like type branch:

```python
if isinstance(v, (bytes, bytearray, memoryview, core.Fingerprint)):
    return (5, bytes(v))
```

- **Deterministic Sort**: `core.Fingerprint` implements `__bytes__` in PyO3 (`pub fn __bytes__`), so `bytes(v)` yields its 16-byte raw digest.
- **Python-Only & Minimal**: Python's `list.sort()` compares the returned tuples `(5, bytes(...))` using Python's native `bytes` comparison. No PyO3 Rust API modifications are needed.
- **Zero Collision Risk**: In Rust (`rust/py/src/memo_fingerprint.rs`), `write_py_memo_key` serializes `PyBytes` with type tag `"b"` and `PyFingerprint` with type tag `"fp"`, ensuring distinct type tags in the final hash calculation.

---

## Testing & Verification

Added regression test `test_fingerprint_dict_and_set_with_fingerprint_keys_order_independent` in `python/tests/internal/test_memo_fingerprint.py` covering:
- Dictionary order-independence with `Fingerprint` keys
- Set order-independence with `Fingerprint` elements
- Nested container order-independence with `Fingerprint` keys

### Checks Passed:
- `uv run pytest python/tests/internal/test_memo_fingerprint.py` (38 passed)
- `uv run ruff check` (All checks passed)
- `uv run ruff format --check` (Formatted)
- `uv run mypy` (No issues found in source files)
