### PR TITLE
fix(ops): bound SentenceTransformer MPS memory

### DIFF
--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -196,6 +196,25 @@ embedder = SentenceTransformerEmbedder("sentence-transformers/paraphrase-multili
 embedder = SentenceTransformerEmbedder("/path/to/local/model")
 ```
 
+### Memory management on Apple Silicon (MPS)
+
+PyTorch's MPS allocator on Apple Silicon uses unified system memory and can retain allocated Metal buffers longer than expected across embedding runs. To prevent host memory growth during indexing jobs, `SentenceTransformerEmbedder` executes MPS workloads (`device="mps"` or default `device=None` on macOS) inside a persistent worker process by default. The model stays loaded in memory between batches, while Metal allocations remain isolated from the main process.
+
+When allocator memory usage exceeds the low watermark ratio, CocoIndex automatically synchronizes the device and purges unused PyTorch and Python heap caches. If an out-of-memory (OOM) error occurs, the MPS cache is immediately flushed before splitting and retrying the batch.
+
+By default, worker processes configure conservative PyTorch allocator thresholds:
+
+- `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.4`
+- `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.5`
+
+Pre-existing environment variables are respected. If your workload requires custom memory thresholds, set these variables before initializing GPU operations.
+
+To run MPS workloads in the main process instead of a worker process, set:
+
+```bash
+export COCOINDEX_RUN_GPU_IN_SUBPROCESS=0
+```
+
 ### Normalization
 
 By default, embeddings are normalized to unit length (suitable for cosine similarity):

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -385,5 +385,7 @@ embeddings = await asyncio.gather(
 ```
 
 :::note
-By default, `coco.GPU` runs functions in-process, so no pickling is required. When using subprocess mode (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`), the function and all its arguments must be picklable since they are serialized for subprocess execution.
+By default, `coco.GPU` executes functions in-process without argument serialization. When subprocess mode is enabled (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`), function arguments and return values must be picklable.
+
+On Apple Silicon (macOS), `SentenceTransformerEmbedder` overrides this default to run MPS workloads in a persistent worker process, mitigating PyTorch Metal allocator memory growth. You can opt out by setting `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0`. Custom functions using `runner=coco.GPU` directly remain in-process by default.
 :::

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -15,6 +15,7 @@ import functools
 import os
 import pickle
 import subprocess
+import sys
 import threading
 import multiprocessing as mp
 import warnings
@@ -93,8 +94,21 @@ class Runner(ABC):
 # ============================================================================
 
 _WATCHDOG_INTERVAL_SECONDS = 10.0
+_MPS_LOW_WATERMARK_RATIO = "0.4"
+_MPS_HIGH_WATERMARK_RATIO = "0.5"
 _pool_lock = threading.Lock()
 _pool: ProcessPoolExecutor | None = None
+
+
+def _configure_mps_allocator_defaults() -> None:
+    """Configure conservative PyTorch MPS allocator defaults if not explicitly set.
+
+    PyTorch evaluates watermark variables when initializing the MPS allocator.
+    This function is idempotent and respects pre-existing user environment settings.
+    """
+
+    os.environ.setdefault("PYTORCH_MPS_LOW_WATERMARK_RATIO", _MPS_LOW_WATERMARK_RATIO)
+    os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", _MPS_HIGH_WATERMARK_RATIO)
 
 
 def _get_pool() -> ProcessPoolExecutor:
@@ -132,6 +146,9 @@ def _subprocess_init(parent_pid: int) -> None:
     """Initialize the subprocess with watchdog and signal handling."""
     import signal
     import faulthandler
+
+    if sys.platform == "darwin":
+        _configure_mps_allocator_defaults()
 
     global _in_subprocess
     _in_subprocess = True
@@ -482,7 +499,24 @@ class GPURunner(Runner):
             await self._release_gpu(gpu_id)
 
 
+class _MPSGPURunner(GPURunner):
+    """Internal GPU runner that isolates built-in MPS execution by default.
+
+    Unlike generic ``coco.GPU`` which defaults to in-process execution, this
+    runner defaults to subprocess isolation to contain PyTorch Metal allocator
+    memory growth on Apple Silicon.
+    """
+
+    def _should_use_subprocess(self) -> bool:
+        _configure_mps_allocator_defaults()
+        if self._use_subprocess is None:
+            configured = os.environ.get("COCOINDEX_RUN_GPU_IN_SUBPROCESS")
+            self._use_subprocess = configured == "1" if configured is not None else True
+        return self._use_subprocess
+
+
 GPU = GPURunner(fraction=1.0)
+_MPS_GPU = _MPSGPURunner(fraction=1.0)
 
 _subprocess_multi_gpu_warned = False
 

--- a/python/cocoindex/ops/sentence_transformers.py
+++ b/python/cocoindex/ops/sentence_transformers.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 __all__ = ["SentenceTransformerEmbedder"]
 
+import gc as _gc
+import os as _os
+import sys as _sys
 import threading as _threading
 import typing as _typing
 from typing import Any as _Any
@@ -16,6 +19,7 @@ import numpy as _np
 from numpy.typing import NDArray as _NDArray
 
 import cocoindex as coco
+from cocoindex._internal import runner as _runner
 from cocoindex.resources import schema as _schema
 
 if _typing.TYPE_CHECKING:
@@ -32,12 +36,62 @@ def _is_oom_error(error: BaseException) -> bool:
     return isinstance(error, MemoryError) or "out of memory" in str(error).lower()
 
 
-def _empty_accelerator_cache() -> None:
-    """Best-effort release of cached accelerator memory after an OOM.
+def _is_mps_device(device: str | None) -> bool:
+    return device == "mps" or (device is None and _sys.platform == "darwin")
 
-    Without this, allocator fragmentation often makes the retried halves OOM
-    as well. Never raises — failure to release just means the retry is less
-    likely to succeed.
+
+def _clear_mps_allocator_cache() -> None:
+    """Reclaim unused PyTorch MPS memory when driver allocations reach low watermark.
+
+    Performs garbage collection and flushes the MPS cache only under memory pressure
+    to avoid per-batch synchronization overhead on Apple Silicon.
+    """
+
+    try:
+        import torch
+
+        if not torch.backends.mps.is_available():
+            return
+        try:
+            configured_ratios = (
+                float(
+                    _os.environ.get(
+                        "PYTORCH_MPS_LOW_WATERMARK_RATIO",
+                        _runner._MPS_LOW_WATERMARK_RATIO,
+                    )
+                ),
+                float(
+                    _os.environ.get(
+                        "PYTORCH_MPS_HIGH_WATERMARK_RATIO",
+                        _runner._MPS_HIGH_WATERMARK_RATIO,
+                    )
+                ),
+            )
+            positive_ratios = [ratio for ratio in configured_ratios if ratio > 0]
+            if not positive_ratios:
+                return
+            cleanup_ratio = min(positive_ratios)
+            if (
+                torch.mps.driver_allocated_memory()
+                < torch.mps.recommended_max_memory() * cleanup_ratio
+            ):
+                return
+        except Exception:
+            # Fall back to cleanup if the PyTorch version lacks memory telemetry APIs.
+            pass
+        torch.mps.synchronize()
+        _gc.collect()
+        torch.mps.empty_cache()
+        torch.mps.synchronize()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _empty_accelerator_cache() -> None:
+    """Flush GPU/MPS memory caches prior to retrying a failed batch after an OOM.
+
+    Releases cached allocations to reduce fragmentation before batch splitting.
+    Swallows exceptions defensively to preserve the original exception context.
     """
     try:
         import torch
@@ -45,6 +99,7 @@ def _empty_accelerator_cache() -> None:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
         elif torch.backends.mps.is_available():
+            # Clear MPS cache before splitting and retrying the batch.
             torch.mps.empty_cache()
     except Exception:  # pragma: no cover - defensive
         pass
@@ -59,7 +114,7 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
     Args:
         model_name_or_path: Name of a pre-trained model from HuggingFace or path
             to a local model directory.
-        device: Device to load the model on (e.g., ``"cuda"``, ``"cpu"``).
+        device: Device to load the model on (e.g., ``"cuda"``, ``"mps"``, ``"cpu"``).
             Defaults to ``None`` to let SentenceTransformer auto-detect.
         trust_remote_code: Whether to allow loading models with custom code
             from the HuggingFace Hub (e.g., Jina models with custom pooling).
@@ -90,6 +145,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         self._trust_remote_code = trust_remote_code
         self._model: SentenceTransformer | None = None
         self._lock = _threading.Lock()
+        if self._uses_mps():
+            _runner._configure_mps_allocator_defaults()
 
     def __getstate__(self) -> dict[str, _Any]:
         return {
@@ -110,6 +167,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         if self._model is None:
             with self._lock:
                 if self._model is None:
+                    if self._uses_mps():
+                        _runner._configure_mps_allocator_defaults()
                     from sentence_transformers import SentenceTransformer
 
                     self._model = SentenceTransformer(
@@ -119,28 +178,15 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
                     )
         return self._model
 
-    @coco.fn.as_async(batching=True, runner=coco.GPU, max_batch_size=64)
-    def _embed(
+    def _uses_mps(self) -> bool:
+        return _is_mps_device(self._device)
+
+    def _encode(
         self,
         texts: list[str],
         prompt_name: str | None = None,
         normalize_embeddings: bool = True,
     ) -> list[_NDArray[_np.float32]]:
-        """Batched embedding. Concurrent single-text calls into :meth:`embed`
-        are grouped by the ``@coco.fn.as_async(batching=True)`` decorator;
-        this method is the per-batch body invoked by the decorator.
-
-        Args:
-            texts: Batch of text strings to embed (handled by the engine).
-            prompt_name: Prompt name for instruction following models that use
-                different prompts for queries vs documents.
-            normalize_embeddings: Whether to normalize embeddings to unit length.
-                Defaults to ``True`` for compatibility with cosine similarity.
-
-        Note:
-            Pass ``prompt_name`` and ``normalize_embeddings`` consistently across
-            calls — mixing explicit values with defaults creates separate batchers.
-        """
         model = self._get_model()
         try:
             embeddings: _NDArray[_np.float32] = model.encode(
@@ -151,18 +197,38 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
                 show_progress_bar=False,
             )  # type: ignore[assignment]
         except Exception as e:
-            # Out-of-memory scales with batch size × padded sequence length,
-            # so smaller batches may fit where this one didn't: ask the
-            # engine to halve and retry. Unlike remote providers, local
-            # failures are transparent — OOM is the one composition-dependent
-            # class, so everything else (config/model errors) propagates
-            # as-is. A single item that doesn't fit fails on its own: at
-            # size 1 the engine unwraps the signal and raises the OOM error.
+            # Memory consumption scales with batch_size * padded_seq_len.
+            # Signal the engine to split the batch and retry on OOM errors.
             if _is_oom_error(e):
                 _empty_accelerator_cache()
                 raise coco.RetryWithSmallerBatch() from e
             raise
         return list(embeddings)
+
+    @coco.fn.as_async(batching=True, runner=coco.GPU, max_batch_size=64)
+    def _embed(
+        self,
+        texts: list[str],
+        prompt_name: str | None = None,
+        normalize_embeddings: bool = True,
+    ) -> list[_NDArray[_np.float32]]:
+        """Execute non-MPS embedding batches on the default GPU runner."""
+
+        return self._encode(texts, prompt_name, normalize_embeddings)
+
+    @coco.fn.as_async(batching=True, runner=_runner._MPS_GPU, max_batch_size=64)
+    def _embed_mps(
+        self,
+        texts: list[str],
+        prompt_name: str | None = None,
+        normalize_embeddings: bool = True,
+    ) -> list[_NDArray[_np.float32]]:
+        """Execute MPS embedding batches inside an isolated worker with memory pressure checks."""
+
+        try:
+            return self._encode(texts, prompt_name, normalize_embeddings)
+        finally:
+            _clear_mps_allocator_cache()
 
     @coco.fn(memo=True, version=1, logic_tracking="self")
     async def embed(
@@ -185,7 +251,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         Returns:
             Numpy array of shape ``(dim,)`` containing the embedding vector.
         """
-        result: _NDArray[_np.float32] = await self._embed(  # type: ignore[arg-type]
+        scheduled_embed = self._embed_mps if self._uses_mps() else self._embed
+        result: _NDArray[_np.float32] = await scheduled_embed(  # type: ignore[arg-type]
             text, prompt_name, normalize_embeddings
         )
         return result
@@ -202,8 +269,31 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         dim = await self.dimension()
         return _schema.VectorSchema(dtype=_np.dtype(_np.float32), size=dim)
 
-    @coco.fn.as_async(runner=coco.GPU, memo=True)
-    def dimension(self) -> int:
+    @coco.fn.as_async(runner=coco.GPU)
+    def _dimension(self) -> int:
+        model = self._get_model()
+        dim = model.get_sentence_embedding_dimension()
+        if dim is None:
+            raise RuntimeError(
+                f"Embedding dimension is unknown for model {self._model_name_or_path}."
+            )
+        return int(dim)
+
+    @coco.fn.as_async(runner=_runner._MPS_GPU)
+    def _dimension_mps(self) -> int:
+        try:
+            model = self._get_model()
+            dim = model.get_sentence_embedding_dimension()
+            if dim is None:
+                raise RuntimeError(
+                    f"Embedding dimension is unknown for model {self._model_name_or_path}."
+                )
+            return int(dim)
+        finally:
+            _clear_mps_allocator_cache()
+
+    @coco.fn(memo=True)
+    async def dimension(self) -> int:
         """Return the embedding dimension for this model.
 
         Returns:
@@ -212,13 +302,10 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         Raises:
             RuntimeError: If the model's embedding dimension cannot be determined.
         """
-        model = self._get_model()
-        dim = model.get_sentence_embedding_dimension()
-        if dim is None:
-            raise RuntimeError(
-                f"Embedding dimension is unknown for model {self._model_name_or_path}."
-            )
-        return int(dim)
+        scheduled_dimension = (
+            self._dimension_mps if self._uses_mps() else self._dimension
+        )
+        return _typing.cast(int, await scheduled_dimension())
 
     def __coco_memo_key__(self) -> object:
         return (self._model_name_or_path, self._device, self._trust_remote_code)

--- a/python/tests/core/test_function_batching.py
+++ b/python/tests/core/test_function_batching.py
@@ -1,11 +1,17 @@
 """Tests for function batching and runner support."""
 
 import asyncio
+import os
+import sys
 from collections.abc import Iterator
 from typing import Any
 
 import cocoindex as coco
-from cocoindex._internal.runner import Runner
+from cocoindex._internal.runner import (
+    Runner,
+    _configure_mps_allocator_defaults,
+    _MPS_GPU,
+)
 import pytest
 
 
@@ -677,10 +683,22 @@ async def test_memo_with_runner() -> None:
 
 
 @pytest.fixture()
-def _reset_gpu_runner() -> Iterator[None]:
+def _reset_gpu_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset GPURunner's cached subprocess mode between tests."""
+    # Record absent variables with monkeypatch before runner setdefault calls so
+    # tests cannot leak allocator policy into the rest of the pytest process.
+    for env_var in (
+        "PYTORCH_MPS_LOW_WATERMARK_RATIO",
+        "PYTORCH_MPS_HIGH_WATERMARK_RATIO",
+    ):
+        if env_var not in os.environ:
+            monkeypatch.setenv(env_var, "")
+        monkeypatch.delenv(env_var)
+    coco.GPU._use_subprocess = None
+    _MPS_GPU._use_subprocess = None
     yield
     coco.GPU._use_subprocess = None
+    _MPS_GPU._use_subprocess = None
 
 
 # --- In-process mode (default) tests ---
@@ -896,6 +914,76 @@ async def test_gpu_runner_lazy_env_var(
     # Cached — changing env var without reset doesn't affect it
     monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS")
     assert coco.GPU._should_use_subprocess() is True  # still cached
+
+
+def test_mps_gpu_runner_default_is_independent_from_generic_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_gpu_runner: None,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+
+    assert coco.GPU._should_use_subprocess() is False
+    assert _MPS_GPU._should_use_subprocess() is True
+    assert coco.GPU._should_use_subprocess() is False
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"), [(None, True), ("0", False), ("1", True)]
+)
+def test_mps_gpu_runner_subprocess_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_gpu_runner: None,
+    configured: str | None,
+    expected: bool,
+) -> None:
+    """Built-in MPS work is isolated by default and honors explicit overrides."""
+    if configured is None:
+        monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    else:
+        monkeypatch.setenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", configured)
+    _MPS_GPU._use_subprocess = None
+
+    assert _MPS_GPU._should_use_subprocess() is expected
+
+
+def test_mps_allocator_defaults_preserve_explicit_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.25")
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.3")
+
+    _configure_mps_allocator_defaults()
+
+    assert os.environ["PYTORCH_MPS_LOW_WATERMARK_RATIO"] == "0.25"
+    assert os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] == "0.3"
+
+
+@coco.fn.as_async(runner=_MPS_GPU)
+def _mps_worker_environment() -> tuple[int, str | None, str | None]:
+    return (
+        os.getpid(),
+        os.environ.get("PYTORCH_MPS_LOW_WATERMARK_RATIO"),
+        os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "darwin", reason="MPS is only available on macOS")
+async def test_mps_worker_starts_with_allocator_defaults(
+    monkeypatch: pytest.MonkeyPatch, _reset_gpu_runner: None
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    monkeypatch.delenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", raising=False)
+    monkeypatch.delenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", raising=False)
+    _MPS_GPU._use_subprocess = None
+
+    first_worker_pid, low, high = await _mps_worker_environment()
+    second_worker_pid, _, _ = await _mps_worker_environment()
+
+    assert first_worker_pid != os.getpid()
+    assert second_worker_pid == first_worker_pid
+    assert low == "0.4"
+    assert high == "0.5"
 
 
 @coco.fn.as_async(batching=True)  # type: ignore[arg-type]

--- a/python/tests/ops/test_sentence_transformer_embedder.py
+++ b/python/tests/ops/test_sentence_transformer_embedder.py
@@ -9,13 +9,19 @@ classification and the batching engine's RetryWithSmallerBatch path
 from __future__ import annotations
 
 import asyncio
+import gc
+import sys
 import threading
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 import pytest
 
 import cocoindex as coco
+from cocoindex._internal import runner as runner_module
+from cocoindex.ops import sentence_transformers as sentence_transformers_module
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
 
 _OOM_MESSAGE = "CUDA out of memory. Tried to allocate 20.00 GiB"
@@ -48,7 +54,9 @@ class _FakeModel:
 
 
 def _make_embedder(model: Any) -> SentenceTransformerEmbedder:
-    embedder = SentenceTransformerEmbedder("fake-model")
+    # Keep the existing batching tests on the generic in-process path even when
+    # the suite runs on macOS. MPS routing has focused tests below.
+    embedder = SentenceTransformerEmbedder("fake-model", device="cpu")
     embedder._get_model = lambda: model  # type: ignore[method-assign]
     return embedder
 
@@ -112,3 +120,253 @@ def test_sentence_transformer_non_oom_error_propagates() -> None:
     embedder = _make_embedder(_AlwaysFailModel(KeyError("unknown prompt_name")))
     with pytest.raises(KeyError):
         embedder._embed._execute_orig_sync_fn(["a", "b"])
+
+
+@pytest.mark.parametrize(
+    ("device", "platform", "expected"),
+    [
+        ("mps", "linux", True),
+        ("cpu", "darwin", False),
+        ("cuda", "darwin", False),
+        (None, "darwin", True),
+        (None, "linux", False),
+    ],
+)
+def test_sentence_transformer_detects_mps_device(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str | None,
+    platform: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(sys, "platform", platform)
+
+    assert sentence_transformers_module._is_mps_device(device) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("device", "uses_mps"), [("mps", True), ("cpu", False)])
+async def test_sentence_transformer_routes_to_device_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str,
+    uses_mps: bool,
+) -> None:
+    monkeypatch.setattr(
+        runner_module,
+        "_configure_mps_allocator_defaults",
+        Mock(),
+    )
+    embedder = SentenceTransformerEmbedder("fake-model", device=device)
+    generic_embed = AsyncMock(return_value=np.array([1.0], dtype=np.float32))
+    mps_embed = AsyncMock(return_value=np.array([2.0], dtype=np.float32))
+    generic_dimension = AsyncMock(return_value=128)
+    mps_dimension = AsyncMock(return_value=256)
+    monkeypatch.setattr(embedder, "_embed", generic_embed)
+    monkeypatch.setattr(embedder, "_embed_mps", mps_embed)
+    monkeypatch.setattr(embedder, "_dimension", generic_dimension)
+    monkeypatch.setattr(embedder, "_dimension_mps", mps_dimension)
+
+    result = await embedder.embed._execute_orig_async_fn("text")
+    dimension = await embedder.dimension._execute_orig_async_fn()
+
+    assert result.tolist() == ([2.0] if uses_mps else [1.0])
+    assert dimension == (256 if uses_mps else 128)
+    assert mps_embed.await_count == int(uses_mps)
+    assert generic_embed.await_count == int(not uses_mps)
+    assert mps_dimension.await_count == int(uses_mps)
+    assert generic_dimension.await_count == int(not uses_mps)
+
+
+class _SuccessModel:
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        return np.array([[float(len(text))] for text in texts], dtype=np.float32)
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 384
+
+
+def _install_fake_mps(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+    *,
+    synchronize_error: BaseException | None = None,
+    allocated_memory: int = 50,
+    recommended_memory: int = 100,
+    low_watermark: str = "0.4",
+    high_watermark: str = "0.5",
+) -> None:
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", low_watermark)
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", high_watermark)
+
+    def synchronize() -> None:
+        events.append("synchronize")
+        if synchronize_error is not None:
+            raise synchronize_error
+
+    fake_torch: Any = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True)),
+        cuda=SimpleNamespace(is_available=lambda: False),
+        mps=SimpleNamespace(
+            synchronize=synchronize,
+            empty_cache=lambda: events.append("empty_cache"),
+            driver_allocated_memory=lambda: allocated_memory,
+            recommended_max_memory=lambda: recommended_memory,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(
+        gc,
+        "collect",
+        lambda: events.append("gc_collect"),
+    )
+
+
+def test_sentence_transformer_mps_clears_cache_after_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events)
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a", "bb"])
+
+    assert [item.tolist() for item in result] == [[1.0], [2.0]]
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+def test_sentence_transformer_mps_skips_cleanup_below_pressure_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events, allocated_memory=39)
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert result[0].tolist() == [1.0]
+    assert events == []
+
+
+def test_sentence_transformer_mps_cleanup_uses_explicit_watermark(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        allocated_memory=30,
+        low_watermark="0.25",
+        high_watermark="0.3",
+    )
+    embedder = _make_embedder(_SuccessModel())
+
+    embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+def test_sentence_transformer_mps_oom_clears_cache_below_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events, allocated_memory=1)
+    error = RuntimeError(_OOM_MESSAGE)
+    embedder = _make_embedder(_AlwaysFailModel(error))
+
+    with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+        embedder._embed_mps._execute_orig_sync_fn(["a", "b"])
+
+    assert exc_info.value.__cause__ is error
+    assert events == ["empty_cache"]
+
+
+def test_sentence_transformer_mps_cleanup_failure_does_not_mask_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        synchronize_error=RuntimeError("cleanup failed"),
+    )
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert result[0].tolist() == [1.0]
+    assert events == ["synchronize"]
+
+
+def test_sentence_transformer_mps_cleanup_does_not_mask_model_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        synchronize_error=RuntimeError("cleanup failed"),
+    )
+    embedder = _make_embedder(_AlwaysFailModel(KeyError("unknown prompt_name")))
+
+    with pytest.raises(KeyError, match="unknown prompt_name"):
+        embedder._embed_mps._execute_orig_sync_fn(["a"])
+    assert events == ["synchronize"]
+
+
+def test_sentence_transformer_mps_dimension_clears_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events)
+    embedder = _make_embedder(_SuccessModel())
+
+    dimension = embedder._dimension_mps._execute_orig_sync_fn()
+
+    assert dimension == 384
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+_subprocess_model_initializations = 0
+
+
+class _SubprocessFakeModel(_SuccessModel):
+    def __init__(self, initialization: int) -> None:
+        self._initialization = initialization
+
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        return np.array(
+            [[float(len(text)), float(self._initialization)] for text in texts],
+            dtype=np.float32,
+        )
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 2
+
+
+class _SubprocessFakeMPSEmbedder(SentenceTransformerEmbedder):
+    def _get_model(self) -> Any:
+        global _subprocess_model_initializations
+        if self._model is None:
+            _subprocess_model_initializations += 1
+            self._model = _SubprocessFakeModel(  # type: ignore[assignment]
+                _subprocess_model_initializations
+            )
+        return self._model
+
+
+@pytest.mark.asyncio
+async def test_sentence_transformer_mps_subprocess_keeps_model_warm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.4")
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.5")
+    monkeypatch.setattr(runner_module._MPS_GPU, "_use_subprocess", None)
+    embedder = _SubprocessFakeMPSEmbedder("fake-model", device="mps")
+
+    dimension = await embedder.dimension()
+    first = await embedder.embed("a")
+    second = await embedder.embed("bb")
+
+    assert dimension == 2
+    assert first.tolist() == [1.0, 1.0]
+    assert second.tolist() == [2.0, 1.0]


### PR DESCRIPTION
## Summary

Closes #2333.

Moves MPS memory safety for built-in SentenceTransformer embeddings into CocoIndex. Explicit `device="mps"` and automatic device selection on macOS now use a private persistent MPS runner with conservative allocator defaults and pressure-aware cache reclamation.

This replaces the application-level ownership demonstrated in [cocoindex-code#244](https://github.com/cocoindex-io/cocoindex-code/pull/244): callers should not need to configure process-wide PyTorch policy or manually flush allocator state after each indexing run.

## Stack and merge order

This is the lower change in a two-PR logical stack:

1. **This PR:** native MPS memory bounds.
2. **#2336:** bounded timeout, cancellation, and one hard-crash replay for the private MPS worker. It is intentionally draft until this PR merges and is then rebased onto `main`.

GitHub native stacked pull requests require all branches to live in the same repository and do not support cross-fork stacks. These branches therefore use two cross-linked PRs with an explicit merge and rebase sequence.

## Problem

PyTorch MPS uses unified system memory and may retain Metal allocations between embedding batches. The workaround in the application layer can cap allocator growth, but it has three structural problems:

- It makes every application know CocoIndex runner details.
- A process-wide subprocess switch changes unrelated `coco.GPU` functions.
- End-of-job cleanup does not place the policy next to the allocation and OOM retry path that it governs.

The built-in SentenceTransformer integration already knows the selected device, batch lifecycle, and OOM boundary, so it is the narrowest layer that can own this behavior safely.

## Design

- Route only built-in MPS embeddings through private `_MPS_GPU`; keep generic `coco.GPU`, CPU, and CUDA behavior unchanged.
- Install `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.4` and `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.5` with `setdefault` before MPS allocator initialization, so explicit user settings always win.
- Keep a persistent spawned worker and lazily reload the serialized model there, preserving warm-model reuse across batches.
- After each MPS batch, inspect allocator pressure and synchronize, collect Python garbage, and empty the MPS cache only when pressure reaches the configured cleanup threshold.
- On OOM, flush the accelerator cache before raising `RetryWithSmallerBatch`, preserving the existing split-and-retry contract.
- Keep all runner policy private. This PR adds no public configuration or API surface.

## Compatibility and operational behavior

- `device="mps"` and `device=None` on macOS take the isolated path.
- Explicit CPU and CUDA selection keep the existing path.
- `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0` remains an explicit opt-out.
- The default adds one persistent child process for built-in MPS embeddings; process startup is amortized while the model remains warm.

## Testing

- Added coverage for MPS device routing, model serialization and lazy reload, environment override precedence, pressure-triggered cleanup, cleanup fallback, and OOM retry behavior.
- Added batching coverage proving the private MPS runner does not change the generic GPU subprocess default.
- `uvx prek run --all-files` passes on the full stack, including Ruff, mypy, maturin build, Rust tests and checks, Python tests, and generated CLI documentation checks.