### PR TITLE
fix(runner): bound MPS worker failures

### DIFF
--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -196,6 +196,25 @@ embedder = SentenceTransformerEmbedder("sentence-transformers/paraphrase-multili
 embedder = SentenceTransformerEmbedder("/path/to/local/model")
 ```
 
+### Memory management on Apple Silicon (MPS)
+
+PyTorch's MPS allocator on Apple Silicon uses unified system memory and can retain allocated Metal buffers longer than expected across embedding runs. To prevent host memory growth during indexing jobs, `SentenceTransformerEmbedder` executes MPS workloads (`device="mps"` or default `device=None` on macOS) inside a persistent worker process by default. The model stays loaded in memory between batches, while Metal allocations remain isolated from the main process.
+
+When allocator memory usage exceeds the low watermark ratio, CocoIndex automatically synchronizes the device and purges unused PyTorch and Python heap caches. If an out-of-memory (OOM) error occurs, the MPS cache is immediately flushed before splitting and retrying the batch.
+
+By default, worker processes configure conservative PyTorch allocator thresholds:
+
+- `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.4`
+- `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.5`
+
+Pre-existing environment variables are respected. If your workload requires custom memory thresholds, set these variables before initializing GPU operations.
+
+To run MPS workloads in the main process instead of a worker process, set:
+
+```bash
+export COCOINDEX_RUN_GPU_IN_SUBPROCESS=0
+```
+
 ### Normalization
 
 By default, embeddings are normalized to unit length (suitable for cosine similarity):

--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -202,6 +202,8 @@ PyTorch's MPS allocator on Apple Silicon uses unified system memory and can reta
 
 When allocator memory usage exceeds the low watermark ratio, CocoIndex automatically synchronizes the device and purges unused PyTorch and Python heap caches. If an out-of-memory (OOM) error occurs, the MPS cache is immediately flushed before splitting and retrying the batch.
 
+The persistent worker is also supervised. If it exits unexpectedly, CocoIndex fully reaps it and replays the interrupted embedding call once in a fresh worker. An internal five-minute deadline covers supervisor queueing, worker startup, lazy model loading, execution, and the optional crash replay. Exceeding that deadline terminates and reaps the worker without replaying the timed-out call. Replacing a worker discards its warm model cache, so the next attempt or call includes process startup and model-loading latency.
+
 By default, worker processes configure conservative PyTorch allocator thresholds:
 
 - `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.4`

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -385,5 +385,7 @@ embeddings = await asyncio.gather(
 ```
 
 :::note
-By default, `coco.GPU` runs functions in-process, so no pickling is required. When using subprocess mode (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`), the function and all its arguments must be picklable since they are serialized for subprocess execution.
+By default, `coco.GPU` executes functions in-process without argument serialization. When subprocess mode is enabled (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`), function arguments and return values must be picklable.
+
+On Apple Silicon (macOS), `SentenceTransformerEmbedder` overrides this default to run MPS workloads in a persistent worker process, mitigating PyTorch Metal allocator memory growth. You can opt out by setting `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0`. Custom functions using `runner=coco.GPU` directly remain in-process by default.
 :::

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -387,5 +387,5 @@ embeddings = await asyncio.gather(
 :::note
 By default, `coco.GPU` executes functions in-process without argument serialization. When subprocess mode is enabled (`COCOINDEX_RUN_GPU_IN_SUBPROCESS=1`), function arguments and return values must be picklable.
 
-On Apple Silicon (macOS), `SentenceTransformerEmbedder` overrides this default to run MPS workloads in a persistent worker process, mitigating PyTorch Metal allocator memory growth. You can opt out by setting `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0`. Custom functions using `runner=coco.GPU` directly remain in-process by default.
+On Apple Silicon (macOS), `SentenceTransformerEmbedder` overrides this default to run MPS workloads in a supervised persistent worker process, mitigating PyTorch Metal allocator memory growth. CocoIndex enforces an internal five-minute execution deadline and replaces an unexpectedly crashed worker with at most one replay of the interrupted embedding call. You can opt out by setting `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0`; opting out also disables these worker-lifecycle guarantees. Custom functions using `runner=coco.GPU` directly remain in-process by default and do not use the MPS supervisor.
 :::

--- a/python/cocoindex/_internal/process_supervisor.py
+++ b/python/cocoindex/_internal/process_supervisor.py
@@ -1,0 +1,552 @@
+"""Lifecycle supervision for one persistent spawned worker process.
+
+The supervisor deliberately owns both the process and its pipe.  This lets an
+async caller cancel a live call and know that the child has been reaped before
+the cancellation is propagated.  Policy such as timeouts and retries belongs
+to the caller; this module performs exactly one execution attempt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import os
+import pickle
+import queue
+import threading
+import time
+import traceback
+from collections.abc import Callable
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from multiprocessing.connection import Connection
+from multiprocessing.process import BaseProcess
+from typing import Any, NoReturn
+
+
+_POLL_INTERVAL_SECONDS = 0.02
+_TERMINATE_GRACE_SECONDS = 1.0
+_KILL_GRACE_SECONDS = 1.0
+_MANAGER_JOIN_SECONDS = 3.0
+
+_READY = "ready"
+_RUN = "run"
+_RESULT = "result"
+_ERROR = "error"
+_STOP = "stop"
+_STOPPED = "stopped"
+
+_WorkerFunction = Callable[[bytes], bytes]
+_WorkerInitializer = Callable[[int], None]
+
+
+class _WorkerCrashedError(RuntimeError):
+    """The worker exited without returning a result for the active call."""
+
+    generation_id: int
+    exit_code: int | None
+
+    def __init__(self, generation_id: int, exit_code: int | None, detail: str) -> None:
+        self.generation_id = generation_id
+        self.exit_code = exit_code
+        super().__init__(
+            f"Worker generation {generation_id} crashed ({detail}); "
+            f"exit code: {exit_code}"
+        )
+
+
+class _RemoteExecutionError(RuntimeError):
+    """Fallback for a worker exception that could not be serialized."""
+
+
+class _RemoteTraceback(Exception):
+    """Traceback captured in the worker process."""
+
+    def __init__(self, traceback_text: str) -> None:
+        super().__init__(f'\n"""\n{traceback_text}"""')
+
+
+class _ProcessSupervisorError(RuntimeError):
+    """The supervisor itself can no longer execute requests safely."""
+
+
+class _ProcessSupervisorClosedError(_ProcessSupervisorError):
+    """The supervisor was closed while a request was pending."""
+
+
+class _ProcessSupervisorPoisonedError(_ProcessSupervisorError):
+    """A worker could not be reaped, so starting another would be unsafe."""
+
+
+class _RequestCancelledError(Exception):
+    """Internal acknowledgement that cancellation cleanup is complete."""
+
+
+@dataclass(slots=True)
+class _Request:
+    call_id: int
+    payload: bytes
+    outcome: Future[bytes] = field(default_factory=Future)
+    cancel_requested: threading.Event = field(default_factory=threading.Event)
+    _state_lock: threading.Lock = field(default_factory=threading.Lock)
+    _started: bool = False
+
+    def mark_started(self) -> bool:
+        """Claim this request for the manager, unless it was cancelled queued."""
+        with self._state_lock:
+            if self.outcome.done() or self.cancel_requested.is_set():
+                if not self.outcome.done():
+                    self.outcome.set_exception(_RequestCancelledError())
+                return False
+            self._started = True
+            return True
+
+    def request_cancellation(self) -> None:
+        """Cancel queued work immediately; active work is reaped by the manager."""
+        self.cancel_requested.set()
+        with self._state_lock:
+            if not self._started and not self.outcome.done():
+                self.outcome.set_exception(_RequestCancelledError())
+
+    def set_result(self, result: bytes) -> None:
+        """Complete the request exactly once across manager/caller races."""
+        with self._state_lock:
+            if not self.outcome.done():
+                self.outcome.set_result(result)
+
+    def set_exception(self, error: BaseException) -> None:
+        """Fail the request exactly once across manager/caller races."""
+        with self._state_lock:
+            if not self.outcome.done():
+                self.outcome.set_exception(error)
+
+
+@dataclass(slots=True)
+class _WorkerGeneration:
+    generation_id: int
+    process: BaseProcess
+    connection: Connection
+    ready: bool = False
+
+
+@dataclass(slots=True)
+class _CallOutcome:
+    result: bytes | None = None
+    error: BaseException | None = None
+
+
+_QUEUE_STOP = object()
+
+
+def _encode_message(message: tuple[Any, ...]) -> bytes:
+    return pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _safe_exception_text(error: BaseException) -> str:
+    try:
+        return str(error)
+    except BaseException:
+        return "<exception string conversion failed>"
+
+
+def _worker_main(
+    connection: Connection,
+    parent_pid: int,
+    generation_id: int,
+    worker_fn: _WorkerFunction,
+    initializer: _WorkerInitializer | None,
+) -> None:
+    """Receive calls until the parent closes the pipe or requests shutdown."""
+    try:
+        if initializer is not None:
+            initializer(parent_pid)
+        connection.send_bytes(_encode_message((_READY, generation_id)))
+
+        while True:
+            message = pickle.loads(connection.recv_bytes())
+            kind = message[0]
+            if kind == _STOP:
+                if message != (_STOP, generation_id):
+                    raise RuntimeError("Invalid worker stop message")
+                connection.send_bytes(_encode_message((_STOPPED, generation_id)))
+                return
+            if kind != _RUN or len(message) != 4:
+                raise RuntimeError("Invalid worker request message")
+
+            _, request_generation, call_id, payload = message
+            if request_generation != generation_id or not isinstance(payload, bytes):
+                raise RuntimeError("Worker request belongs to a different generation")
+
+            try:
+                result = worker_fn(payload)
+            except BaseException as error:
+                remote_traceback = traceback.format_exc()
+                try:
+                    serialized_error: bytes | None = pickle.dumps(
+                        error, protocol=pickle.HIGHEST_PROTOCOL
+                    )
+                except BaseException:
+                    serialized_error = None
+                error_type = f"{type(error).__module__}.{type(error).__qualname__}"
+                response: tuple[Any, ...] = (
+                    _ERROR,
+                    generation_id,
+                    call_id,
+                    serialized_error,
+                    error_type,
+                    _safe_exception_text(error),
+                    remote_traceback,
+                )
+            else:
+                response = (_RESULT, generation_id, call_id, result)
+            connection.send_bytes(_encode_message(response))
+    except (BrokenPipeError, EOFError, OSError):
+        # The parent went away or retired this generation.
+        return
+    finally:
+        connection.close()
+
+
+class _SingleProcessSupervisor:
+    """Own one persistent worker behind a small async execution interface.
+
+    A dedicated daemon thread is the sole owner of the parent pipe endpoint and
+    process handle.  Requests may therefore originate from different asyncio
+    event loops without binding supervisor state to any one loop.
+    """
+
+    def __init__(
+        self,
+        worker_fn: _WorkerFunction,
+        *,
+        initializer: _WorkerInitializer | None = None,
+        process_name: str = "cocoindex-isolated-worker",
+    ) -> None:
+        self._worker_fn = worker_fn
+        self._initializer = initializer
+        self._process_name = process_name
+        self._context = mp.get_context("spawn")
+        self._owner_pid = os.getpid()
+        self._requests: queue.Queue[_Request | object] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._shutdown_requested = threading.Event()
+        self._manager_thread: threading.Thread | None = None
+        self._closed = False
+        self._next_call_id = 1
+
+    async def execute(self, payload: bytes) -> bytes:
+        """Execute one payload, reaping active work before propagating cancellation."""
+        request = self._enqueue(payload)
+        wrapped_outcome = asyncio.wrap_future(request.outcome)
+        try:
+            return await asyncio.shield(wrapped_outcome)
+        except asyncio.CancelledError as cancelled:
+            request.request_cancellation()
+            # asyncio.wait_for waits for this acknowledgement.  Do not let a
+            # second cancellation release the caller before the child is gone.
+            while not wrapped_outcome.done():
+                try:
+                    await asyncio.shield(wrapped_outcome)
+                except asyncio.CancelledError:
+                    continue
+                except BaseException:
+                    break
+            raise cancelled
+
+    async def aclose(self) -> None:
+        """Close the supervisor and wait without blocking the current event loop."""
+        thread = self._begin_close()
+        if thread is None or thread is threading.current_thread():
+            return
+        await asyncio.to_thread(thread.join, _MANAGER_JOIN_SECONDS)
+        if thread.is_alive():
+            raise _ProcessSupervisorError("Process supervisor did not stop in time")
+
+    def close(self) -> None:
+        """Synchronous, idempotent shutdown used by interpreter cleanup."""
+        thread = self._begin_close()
+        if thread is None or thread is threading.current_thread():
+            return
+        thread.join(_MANAGER_JOIN_SECONDS)
+        if thread.is_alive():
+            raise _ProcessSupervisorError("Process supervisor did not stop in time")
+
+    def _enqueue(self, payload: bytes) -> _Request:
+        if os.getpid() != self._owner_pid:
+            raise _ProcessSupervisorError(
+                "Process supervisor cannot be reused after the parent forks"
+            )
+        if not isinstance(payload, bytes):
+            raise TypeError("Process supervisor payload must be bytes")
+
+        with self._state_lock:
+            if self._closed:
+                raise _ProcessSupervisorClosedError("Process supervisor is closed")
+            request = _Request(call_id=self._next_call_id, payload=payload)
+            self._next_call_id += 1
+            if self._manager_thread is None:
+                self._manager_thread = threading.Thread(
+                    target=self._run_manager,
+                    name=f"{self._process_name}-supervisor",
+                    daemon=True,
+                )
+                self._manager_thread.start()
+            self._requests.put(request)
+            return request
+
+    def _begin_close(self) -> threading.Thread | None:
+        with self._state_lock:
+            if not self._closed:
+                self._closed = True
+                self._shutdown_requested.set()
+                self._requests.put(_QUEUE_STOP)
+            return self._manager_thread
+
+    def _run_manager(self) -> None:
+        worker: _WorkerGeneration | None = None
+        generation_id = 0
+        poisoned_error: _ProcessSupervisorPoisonedError | None = None
+        try:
+            while True:
+                item = self._requests.get()
+                if item is _QUEUE_STOP:
+                    break
+                assert isinstance(item, _Request)
+                request = item
+                if not request.mark_started():
+                    continue
+                if poisoned_error is not None:
+                    self._set_request_exception(request, poisoned_error)
+                    continue
+                if self._shutdown_requested.is_set():
+                    self._set_request_exception(
+                        request,
+                        _ProcessSupervisorClosedError("Process supervisor is closing"),
+                    )
+                    break
+
+                try:
+                    if worker is None:
+                        generation_id += 1
+                        worker = self._start_worker(generation_id)
+                        self._wait_until_ready(worker, request)
+                    outcome = self._execute_request(worker, request)
+                except (_RequestCancelledError, _ProcessSupervisorClosedError) as error:
+                    worker = None
+                    self._set_request_exception(request, error)
+                except _WorkerCrashedError as error:
+                    worker = None
+                    self._set_request_exception(request, error)
+                except _ProcessSupervisorPoisonedError as error:
+                    poisoned_error = error
+                    self._set_request_exception(request, error)
+                except BaseException as error:
+                    if worker is not None:
+                        try:
+                            self._retire_worker(worker, graceful=False)
+                        except _ProcessSupervisorPoisonedError as retire_error:
+                            poisoned_error = retire_error
+                    worker = None
+                    self._set_request_exception(request, error)
+                else:
+                    if outcome.error is not None:
+                        self._set_request_exception(request, outcome.error)
+                    else:
+                        assert outcome.result is not None
+                        self._set_request_result(request, outcome.result)
+
+                if self._shutdown_requested.is_set():
+                    break
+        finally:
+            if worker is not None:
+                try:
+                    self._retire_worker(worker, graceful=True)
+                except _ProcessSupervisorPoisonedError:
+                    pass
+            self._fail_queued_requests()
+
+    def _start_worker(self, generation_id: int) -> _WorkerGeneration:
+        parent_connection, child_connection = self._context.Pipe(duplex=True)
+        process = self._context.Process(
+            target=_worker_main,
+            args=(
+                child_connection,
+                self._owner_pid,
+                generation_id,
+                self._worker_fn,
+                self._initializer,
+            ),
+            name=self._process_name,
+            daemon=False,
+        )
+        try:
+            process.start()
+        except BaseException:
+            parent_connection.close()
+            child_connection.close()
+            raise
+        child_connection.close()
+        return _WorkerGeneration(generation_id, process, parent_connection)
+
+    def _wait_until_ready(self, worker: _WorkerGeneration, request: _Request) -> None:
+        while True:
+            self._abort_if_requested(worker, request)
+            message = self._receive_if_available(worker)
+            if message is not None:
+                if message == (_READY, worker.generation_id):
+                    worker.ready = True
+                    return
+                self._raise_worker_crashed(worker, "invalid startup response")
+            if not worker.process.is_alive():
+                self._raise_worker_crashed(worker, "exited during startup")
+
+    def _execute_request(
+        self, worker: _WorkerGeneration, request: _Request
+    ) -> _CallOutcome:
+        assert worker.ready
+        try:
+            worker.connection.send_bytes(
+                _encode_message(
+                    (_RUN, worker.generation_id, request.call_id, request.payload)
+                )
+            )
+        except (BrokenPipeError, EOFError, OSError):
+            self._raise_worker_crashed(worker, "request pipe closed")
+
+        while True:
+            self._abort_if_requested(worker, request)
+            message = self._receive_if_available(worker)
+            if message is not None:
+                # Cancellation wins if it raced with a just-arrived response.
+                self._abort_if_requested(worker, request)
+                return self._decode_call_response(worker, request, message)
+            if not worker.process.is_alive():
+                self._raise_worker_crashed(worker, "exited while executing")
+
+    def _receive_if_available(
+        self, worker: _WorkerGeneration
+    ) -> tuple[Any, ...] | None:
+        try:
+            if not worker.connection.poll(_POLL_INTERVAL_SECONDS):
+                return None
+            message: object = pickle.loads(worker.connection.recv_bytes())
+        except (BrokenPipeError, EOFError, OSError, ValueError):
+            self._raise_worker_crashed(worker, "response pipe closed")
+        except BaseException:
+            self._raise_worker_crashed(worker, "invalid response payload")
+        if not isinstance(message, tuple):
+            self._raise_worker_crashed(worker, "invalid response message")
+        return message
+
+    def _decode_call_response(
+        self,
+        worker: _WorkerGeneration,
+        request: _Request,
+        message: tuple[Any, ...],
+    ) -> _CallOutcome:
+        if len(message) < 3:
+            self._raise_worker_crashed(worker, "truncated response")
+        kind, generation_id, call_id = message[:3]
+        if generation_id != worker.generation_id or call_id != request.call_id:
+            self._raise_worker_crashed(worker, "response identity mismatch")
+
+        if kind == _RESULT and len(message) == 4 and isinstance(message[3], bytes):
+            return _CallOutcome(result=message[3])
+        if kind != _ERROR or len(message) != 7:
+            self._raise_worker_crashed(worker, "unknown response kind")
+
+        _, _, _, serialized_error, error_type, error_message, remote_traceback = message
+        error: BaseException
+        if isinstance(serialized_error, bytes):
+            try:
+                restored = pickle.loads(serialized_error)
+            except BaseException:
+                restored = None
+            if isinstance(restored, BaseException):
+                error = restored
+            else:
+                error = _RemoteExecutionError(f"Remote {error_type}: {error_message}")
+        else:
+            error = _RemoteExecutionError(f"Remote {error_type}: {error_message}")
+        if isinstance(remote_traceback, str):
+            error.__cause__ = _RemoteTraceback(remote_traceback)
+        return _CallOutcome(error=error)
+
+    def _abort_if_requested(self, worker: _WorkerGeneration, request: _Request) -> None:
+        if request.cancel_requested.is_set():
+            self._retire_worker(worker, graceful=False)
+            raise _RequestCancelledError()
+        if self._shutdown_requested.is_set():
+            self._retire_worker(worker, graceful=False)
+            raise _ProcessSupervisorClosedError("Process supervisor is closing")
+
+    def _raise_worker_crashed(self, worker: _WorkerGeneration, detail: str) -> NoReturn:
+        exit_code = self._retire_worker(worker, graceful=False)
+        raise _WorkerCrashedError(worker.generation_id, exit_code, detail)
+
+    def _retire_worker(
+        self, worker: _WorkerGeneration, *, graceful: bool
+    ) -> int | None:
+        process = worker.process
+        connection = worker.connection
+        exit_code: int | None = None
+        try:
+            if graceful and process.is_alive():
+                try:
+                    connection.send_bytes(
+                        _encode_message((_STOP, worker.generation_id))
+                    )
+                except (BrokenPipeError, EOFError, OSError):
+                    pass
+                deadline = time.monotonic() + _TERMINATE_GRACE_SECONDS
+                while process.is_alive() and time.monotonic() < deadline:
+                    try:
+                        response_available = connection.poll(_POLL_INTERVAL_SECONDS)
+                    except (OSError, ValueError):
+                        break
+                    if response_available:
+                        try:
+                            message = pickle.loads(connection.recv_bytes())
+                        except BaseException:
+                            break
+                        if message == (_STOPPED, worker.generation_id):
+                            break
+                    process.join(timeout=0)
+                process.join(timeout=max(0.0, deadline - time.monotonic()))
+
+            if process.is_alive():
+                process.terminate()
+                process.join(_TERMINATE_GRACE_SECONDS)
+            if process.is_alive():
+                process.kill()
+                process.join(_KILL_GRACE_SECONDS)
+            if process.is_alive():
+                raise _ProcessSupervisorPoisonedError(
+                    f"Worker generation {worker.generation_id} could not be reaped"
+                )
+        finally:
+            connection.close()
+            if not process.is_alive():
+                exit_code = process.exitcode
+                process.close()
+        return exit_code
+
+    def _fail_queued_requests(self) -> None:
+        while True:
+            try:
+                item = self._requests.get_nowait()
+            except queue.Empty:
+                return
+            if isinstance(item, _Request):
+                self._set_request_exception(
+                    item,
+                    _ProcessSupervisorClosedError("Process supervisor is closed"),
+                )
+
+    @staticmethod
+    def _set_request_result(request: _Request, result: bytes) -> None:
+        request.set_result(result)
+
+    @staticmethod
+    def _set_request_exception(request: _Request, error: BaseException) -> None:
+        request.set_exception(error)

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -10,6 +10,7 @@ Configure the GPU pool size via the COCOINDEX_NUM_GPUS environment variable
 
 from __future__ import annotations
 
+import atexit
 import asyncio
 import functools
 import os
@@ -23,9 +24,11 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from contextvars import ContextVar
+from datetime import timedelta
 from typing import Any, Callable, Coroutine, TypeVar, ParamSpec
 
-from . import core
+from . import core, deadline as _deadline
+from .process_supervisor import _SingleProcessSupervisor, _WorkerCrashedError
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -96,8 +99,15 @@ class Runner(ABC):
 _WATCHDOG_INTERVAL_SECONDS = 10.0
 _MPS_LOW_WATERMARK_RATIO = "0.4"
 _MPS_HIGH_WATERMARK_RATIO = "0.5"
+# This private wall covers queueing inside the supervisor, worker startup,
+# lazy model loading, and the optional crash replay. Keep it conservative: a
+# cold SentenceTransformer worker may download model artifacts on first use.
+_MPS_FALLBACK_TIMEOUT = timedelta(seconds=300)
+_MPS_MAX_PROCESS_ATTEMPTS = 2
 _pool_lock = threading.Lock()
 _pool: ProcessPoolExecutor | None = None
+_mps_process_supervisor_lock = threading.Lock()
+_mps_process_supervisor: _SingleProcessSupervisor | None = None
 
 
 def _configure_mps_allocator_defaults() -> None:
@@ -197,6 +207,34 @@ def _execute_in_subprocess(payload_bytes: bytes) -> bytes:
     if asyncio.iscoroutine(result):
         result = asyncio.run(result)
     return pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _get_mps_process_supervisor() -> _SingleProcessSupervisor:
+    """Get the MPS-only worker whose lifecycle CocoIndex owns directly."""
+    global _mps_process_supervisor
+    with _mps_process_supervisor_lock:
+        if _mps_process_supervisor is None:
+            _mps_process_supervisor = _SingleProcessSupervisor(
+                _execute_in_subprocess,
+                initializer=_subprocess_init,
+                process_name="cocoindex-mps-worker",
+            )
+        return _mps_process_supervisor
+
+
+def _shutdown_mps_process_supervisor() -> None:
+    """Stop the MPS worker without coupling it to any one Environment."""
+    global _mps_process_supervisor
+    with _mps_process_supervisor_lock:
+        supervisor = _mps_process_supervisor
+    if supervisor is not None:
+        supervisor.close()
+        with _mps_process_supervisor_lock:
+            if _mps_process_supervisor is supervisor:
+                _mps_process_supervisor = None
+
+
+atexit.register(_shutdown_mps_process_supervisor)
 
 
 async def _submit_to_pool_async(fn: Callable[..., Any], *args: Any) -> Any:
@@ -449,6 +487,12 @@ class GPURunner(Runner):
     async def _release_gpu(self, gpu_id: int) -> None:
         await _get_default_gpu_pool().release(gpu_id, self._fraction)
 
+    async def _execute_subprocess(
+        self, fn: Callable[..., R], *args: Any, **kwargs: Any
+    ) -> R:
+        """Dispatch through the existing generic ProcessPoolExecutor path."""
+        return await execute_in_subprocess(fn, *args, **kwargs)
+
     async def run(
         self, fn: Callable[P, Coroutine[Any, Any, R]], *args: P.args, **kwargs: P.kwargs
     ) -> R:
@@ -466,7 +510,7 @@ class GPURunner(Runner):
             if self._should_use_subprocess():
                 _warn_subprocess_multi_gpu()
                 # Type ignore: execute_in_subprocess handles async fns via asyncio.run() internally
-                return await execute_in_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
+                return await self._execute_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
             return await fn(*args, **kwargs)
         finally:
             _current_gpus.reset(tok_gpus)
@@ -487,7 +531,7 @@ class GPURunner(Runner):
         try:
             if self._should_use_subprocess():
                 _warn_subprocess_multi_gpu()
-                return await execute_in_subprocess(fn, *args, **kwargs)
+                return await self._execute_subprocess(fn, *args, **kwargs)
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 self._get_gpu_executor(),
@@ -513,6 +557,23 @@ class _MPSGPURunner(GPURunner):
             configured = os.environ.get("COCOINDEX_RUN_GPU_IN_SUBPROCESS")
             self._use_subprocess = configured == "1" if configured is not None else True
         return self._use_subprocess
+
+    async def _execute_subprocess(
+        self, fn: Callable[..., R], *args: Any, **kwargs: Any
+    ) -> R:
+        """Run built-in MPS work with a bounded, destructive failure policy."""
+        payload = pickle.dumps((fn, args, kwargs), protocol=pickle.HIGHEST_PROTOCOL)
+        supervisor = _get_mps_process_supervisor()
+        result_bytes = await _deadline.retry_transient(
+            lambda: supervisor.execute(payload),
+            retry_on=(_WorkerCrashedError,),
+            max_attempts=_MPS_MAX_PROCESS_ATTEMPTS,
+            timeout=_MPS_FALLBACK_TIMEOUT,
+            backoff=lambda _attempt: 0.0,
+            bound_attempt=True,
+            operation_name="MPS subprocess execution",
+        )
+        return pickle.loads(result_bytes)  # type: ignore[no-any-return]
 
 
 GPU = GPURunner(fraction=1.0)

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -15,6 +15,7 @@ import functools
 import os
 import pickle
 import subprocess
+import sys
 import threading
 import multiprocessing as mp
 import warnings
@@ -93,8 +94,21 @@ class Runner(ABC):
 # ============================================================================
 
 _WATCHDOG_INTERVAL_SECONDS = 10.0
+_MPS_LOW_WATERMARK_RATIO = "0.4"
+_MPS_HIGH_WATERMARK_RATIO = "0.5"
 _pool_lock = threading.Lock()
 _pool: ProcessPoolExecutor | None = None
+
+
+def _configure_mps_allocator_defaults() -> None:
+    """Configure conservative PyTorch MPS allocator defaults if not explicitly set.
+
+    PyTorch evaluates watermark variables when initializing the MPS allocator.
+    This function is idempotent and respects pre-existing user environment settings.
+    """
+
+    os.environ.setdefault("PYTORCH_MPS_LOW_WATERMARK_RATIO", _MPS_LOW_WATERMARK_RATIO)
+    os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", _MPS_HIGH_WATERMARK_RATIO)
 
 
 def _get_pool() -> ProcessPoolExecutor:
@@ -132,6 +146,9 @@ def _subprocess_init(parent_pid: int) -> None:
     """Initialize the subprocess with watchdog and signal handling."""
     import signal
     import faulthandler
+
+    if sys.platform == "darwin":
+        _configure_mps_allocator_defaults()
 
     global _in_subprocess
     _in_subprocess = True
@@ -482,7 +499,24 @@ class GPURunner(Runner):
             await self._release_gpu(gpu_id)
 
 
+class _MPSGPURunner(GPURunner):
+    """Internal GPU runner that isolates built-in MPS execution by default.
+
+    Unlike generic ``coco.GPU`` which defaults to in-process execution, this
+    runner defaults to subprocess isolation to contain PyTorch Metal allocator
+    memory growth on Apple Silicon.
+    """
+
+    def _should_use_subprocess(self) -> bool:
+        _configure_mps_allocator_defaults()
+        if self._use_subprocess is None:
+            configured = os.environ.get("COCOINDEX_RUN_GPU_IN_SUBPROCESS")
+            self._use_subprocess = configured == "1" if configured is not None else True
+        return self._use_subprocess
+
+
 GPU = GPURunner(fraction=1.0)
+_MPS_GPU = _MPSGPURunner(fraction=1.0)
 
 _subprocess_multi_gpu_warned = False
 

--- a/python/cocoindex/ops/sentence_transformers.py
+++ b/python/cocoindex/ops/sentence_transformers.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 __all__ = ["SentenceTransformerEmbedder"]
 
+import gc as _gc
+import os as _os
+import sys as _sys
 import threading as _threading
 import typing as _typing
 from typing import Any as _Any
@@ -16,6 +19,7 @@ import numpy as _np
 from numpy.typing import NDArray as _NDArray
 
 import cocoindex as coco
+from cocoindex._internal import runner as _runner
 from cocoindex.resources import schema as _schema
 
 if _typing.TYPE_CHECKING:
@@ -32,12 +36,62 @@ def _is_oom_error(error: BaseException) -> bool:
     return isinstance(error, MemoryError) or "out of memory" in str(error).lower()
 
 
-def _empty_accelerator_cache() -> None:
-    """Best-effort release of cached accelerator memory after an OOM.
+def _is_mps_device(device: str | None) -> bool:
+    return device == "mps" or (device is None and _sys.platform == "darwin")
 
-    Without this, allocator fragmentation often makes the retried halves OOM
-    as well. Never raises — failure to release just means the retry is less
-    likely to succeed.
+
+def _clear_mps_allocator_cache() -> None:
+    """Reclaim unused PyTorch MPS memory when driver allocations reach low watermark.
+
+    Performs garbage collection and flushes the MPS cache only under memory pressure
+    to avoid per-batch synchronization overhead on Apple Silicon.
+    """
+
+    try:
+        import torch
+
+        if not torch.backends.mps.is_available():
+            return
+        try:
+            configured_ratios = (
+                float(
+                    _os.environ.get(
+                        "PYTORCH_MPS_LOW_WATERMARK_RATIO",
+                        _runner._MPS_LOW_WATERMARK_RATIO,
+                    )
+                ),
+                float(
+                    _os.environ.get(
+                        "PYTORCH_MPS_HIGH_WATERMARK_RATIO",
+                        _runner._MPS_HIGH_WATERMARK_RATIO,
+                    )
+                ),
+            )
+            positive_ratios = [ratio for ratio in configured_ratios if ratio > 0]
+            if not positive_ratios:
+                return
+            cleanup_ratio = min(positive_ratios)
+            if (
+                torch.mps.driver_allocated_memory()
+                < torch.mps.recommended_max_memory() * cleanup_ratio
+            ):
+                return
+        except Exception:
+            # Fall back to cleanup if the PyTorch version lacks memory telemetry APIs.
+            pass
+        torch.mps.synchronize()
+        _gc.collect()
+        torch.mps.empty_cache()
+        torch.mps.synchronize()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _empty_accelerator_cache() -> None:
+    """Flush GPU/MPS memory caches prior to retrying a failed batch after an OOM.
+
+    Releases cached allocations to reduce fragmentation before batch splitting.
+    Swallows exceptions defensively to preserve the original exception context.
     """
     try:
         import torch
@@ -45,6 +99,7 @@ def _empty_accelerator_cache() -> None:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
         elif torch.backends.mps.is_available():
+            # Clear MPS cache before splitting and retrying the batch.
             torch.mps.empty_cache()
     except Exception:  # pragma: no cover - defensive
         pass
@@ -59,7 +114,7 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
     Args:
         model_name_or_path: Name of a pre-trained model from HuggingFace or path
             to a local model directory.
-        device: Device to load the model on (e.g., ``"cuda"``, ``"cpu"``).
+        device: Device to load the model on (e.g., ``"cuda"``, ``"mps"``, ``"cpu"``).
             Defaults to ``None`` to let SentenceTransformer auto-detect.
         trust_remote_code: Whether to allow loading models with custom code
             from the HuggingFace Hub (e.g., Jina models with custom pooling).
@@ -90,6 +145,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         self._trust_remote_code = trust_remote_code
         self._model: SentenceTransformer | None = None
         self._lock = _threading.Lock()
+        if self._uses_mps():
+            _runner._configure_mps_allocator_defaults()
 
     def __getstate__(self) -> dict[str, _Any]:
         return {
@@ -110,6 +167,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         if self._model is None:
             with self._lock:
                 if self._model is None:
+                    if self._uses_mps():
+                        _runner._configure_mps_allocator_defaults()
                     from sentence_transformers import SentenceTransformer
 
                     self._model = SentenceTransformer(
@@ -119,28 +178,15 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
                     )
         return self._model
 
-    @coco.fn.as_async(batching=True, runner=coco.GPU, max_batch_size=64)
-    def _embed(
+    def _uses_mps(self) -> bool:
+        return _is_mps_device(self._device)
+
+    def _encode(
         self,
         texts: list[str],
         prompt_name: str | None = None,
         normalize_embeddings: bool = True,
     ) -> list[_NDArray[_np.float32]]:
-        """Batched embedding. Concurrent single-text calls into :meth:`embed`
-        are grouped by the ``@coco.fn.as_async(batching=True)`` decorator;
-        this method is the per-batch body invoked by the decorator.
-
-        Args:
-            texts: Batch of text strings to embed (handled by the engine).
-            prompt_name: Prompt name for instruction following models that use
-                different prompts for queries vs documents.
-            normalize_embeddings: Whether to normalize embeddings to unit length.
-                Defaults to ``True`` for compatibility with cosine similarity.
-
-        Note:
-            Pass ``prompt_name`` and ``normalize_embeddings`` consistently across
-            calls — mixing explicit values with defaults creates separate batchers.
-        """
         model = self._get_model()
         try:
             embeddings: _NDArray[_np.float32] = model.encode(
@@ -151,18 +197,38 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
                 show_progress_bar=False,
             )  # type: ignore[assignment]
         except Exception as e:
-            # Out-of-memory scales with batch size × padded sequence length,
-            # so smaller batches may fit where this one didn't: ask the
-            # engine to halve and retry. Unlike remote providers, local
-            # failures are transparent — OOM is the one composition-dependent
-            # class, so everything else (config/model errors) propagates
-            # as-is. A single item that doesn't fit fails on its own: at
-            # size 1 the engine unwraps the signal and raises the OOM error.
+            # Memory consumption scales with batch_size * padded_seq_len.
+            # Signal the engine to split the batch and retry on OOM errors.
             if _is_oom_error(e):
                 _empty_accelerator_cache()
                 raise coco.RetryWithSmallerBatch() from e
             raise
         return list(embeddings)
+
+    @coco.fn.as_async(batching=True, runner=coco.GPU, max_batch_size=64)
+    def _embed(
+        self,
+        texts: list[str],
+        prompt_name: str | None = None,
+        normalize_embeddings: bool = True,
+    ) -> list[_NDArray[_np.float32]]:
+        """Execute non-MPS embedding batches on the default GPU runner."""
+
+        return self._encode(texts, prompt_name, normalize_embeddings)
+
+    @coco.fn.as_async(batching=True, runner=_runner._MPS_GPU, max_batch_size=64)
+    def _embed_mps(
+        self,
+        texts: list[str],
+        prompt_name: str | None = None,
+        normalize_embeddings: bool = True,
+    ) -> list[_NDArray[_np.float32]]:
+        """Execute MPS embedding batches inside an isolated worker with memory pressure checks."""
+
+        try:
+            return self._encode(texts, prompt_name, normalize_embeddings)
+        finally:
+            _clear_mps_allocator_cache()
 
     @coco.fn(memo=True, version=1, logic_tracking="self")
     async def embed(
@@ -185,7 +251,8 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         Returns:
             Numpy array of shape ``(dim,)`` containing the embedding vector.
         """
-        result: _NDArray[_np.float32] = await self._embed(  # type: ignore[arg-type]
+        scheduled_embed = self._embed_mps if self._uses_mps() else self._embed
+        result: _NDArray[_np.float32] = await scheduled_embed(  # type: ignore[arg-type]
             text, prompt_name, normalize_embeddings
         )
         return result
@@ -202,8 +269,31 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         dim = await self.dimension()
         return _schema.VectorSchema(dtype=_np.dtype(_np.float32), size=dim)
 
-    @coco.fn.as_async(runner=coco.GPU, memo=True)
-    def dimension(self) -> int:
+    @coco.fn.as_async(runner=coco.GPU)
+    def _dimension(self) -> int:
+        model = self._get_model()
+        dim = model.get_sentence_embedding_dimension()
+        if dim is None:
+            raise RuntimeError(
+                f"Embedding dimension is unknown for model {self._model_name_or_path}."
+            )
+        return int(dim)
+
+    @coco.fn.as_async(runner=_runner._MPS_GPU)
+    def _dimension_mps(self) -> int:
+        try:
+            model = self._get_model()
+            dim = model.get_sentence_embedding_dimension()
+            if dim is None:
+                raise RuntimeError(
+                    f"Embedding dimension is unknown for model {self._model_name_or_path}."
+                )
+            return int(dim)
+        finally:
+            _clear_mps_allocator_cache()
+
+    @coco.fn(memo=True)
+    async def dimension(self) -> int:
         """Return the embedding dimension for this model.
 
         Returns:
@@ -212,13 +302,10 @@ class SentenceTransformerEmbedder(_schema.VectorSchemaProvider):
         Raises:
             RuntimeError: If the model's embedding dimension cannot be determined.
         """
-        model = self._get_model()
-        dim = model.get_sentence_embedding_dimension()
-        if dim is None:
-            raise RuntimeError(
-                f"Embedding dimension is unknown for model {self._model_name_or_path}."
-            )
-        return int(dim)
+        scheduled_dimension = (
+            self._dimension_mps if self._uses_mps() else self._dimension
+        )
+        return _typing.cast(int, await scheduled_dimension())
 
     def __coco_memo_key__(self) -> object:
         return (self._model_name_or_path, self._device, self._trust_remote_code)

--- a/python/tests/core/test_function_batching.py
+++ b/python/tests/core/test_function_batching.py
@@ -11,6 +11,7 @@ from cocoindex._internal.runner import (
     Runner,
     _configure_mps_allocator_defaults,
     _MPS_GPU,
+    _shutdown_mps_process_supervisor,
 )
 import pytest
 
@@ -685,6 +686,7 @@ async def test_memo_with_runner() -> None:
 @pytest.fixture()
 def _reset_gpu_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset GPURunner's cached subprocess mode between tests."""
+    _shutdown_mps_process_supervisor()
     # Record absent variables with monkeypatch before runner setdefault calls so
     # tests cannot leak allocator policy into the rest of the pytest process.
     for env_var in (
@@ -697,6 +699,7 @@ def _reset_gpu_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     coco.GPU._use_subprocess = None
     _MPS_GPU._use_subprocess = None
     yield
+    _shutdown_mps_process_supervisor()
     coco.GPU._use_subprocess = None
     _MPS_GPU._use_subprocess = None
 

--- a/python/tests/core/test_function_batching.py
+++ b/python/tests/core/test_function_batching.py
@@ -1,11 +1,17 @@
 """Tests for function batching and runner support."""
 
 import asyncio
+import os
+import sys
 from collections.abc import Iterator
 from typing import Any
 
 import cocoindex as coco
-from cocoindex._internal.runner import Runner
+from cocoindex._internal.runner import (
+    Runner,
+    _configure_mps_allocator_defaults,
+    _MPS_GPU,
+)
 import pytest
 
 
@@ -677,10 +683,22 @@ async def test_memo_with_runner() -> None:
 
 
 @pytest.fixture()
-def _reset_gpu_runner() -> Iterator[None]:
+def _reset_gpu_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset GPURunner's cached subprocess mode between tests."""
+    # Record absent variables with monkeypatch before runner setdefault calls so
+    # tests cannot leak allocator policy into the rest of the pytest process.
+    for env_var in (
+        "PYTORCH_MPS_LOW_WATERMARK_RATIO",
+        "PYTORCH_MPS_HIGH_WATERMARK_RATIO",
+    ):
+        if env_var not in os.environ:
+            monkeypatch.setenv(env_var, "")
+        monkeypatch.delenv(env_var)
+    coco.GPU._use_subprocess = None
+    _MPS_GPU._use_subprocess = None
     yield
     coco.GPU._use_subprocess = None
+    _MPS_GPU._use_subprocess = None
 
 
 # --- In-process mode (default) tests ---
@@ -896,6 +914,76 @@ async def test_gpu_runner_lazy_env_var(
     # Cached — changing env var without reset doesn't affect it
     monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS")
     assert coco.GPU._should_use_subprocess() is True  # still cached
+
+
+def test_mps_gpu_runner_default_is_independent_from_generic_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_gpu_runner: None,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+
+    assert coco.GPU._should_use_subprocess() is False
+    assert _MPS_GPU._should_use_subprocess() is True
+    assert coco.GPU._should_use_subprocess() is False
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"), [(None, True), ("0", False), ("1", True)]
+)
+def test_mps_gpu_runner_subprocess_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_gpu_runner: None,
+    configured: str | None,
+    expected: bool,
+) -> None:
+    """Built-in MPS work is isolated by default and honors explicit overrides."""
+    if configured is None:
+        monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    else:
+        monkeypatch.setenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", configured)
+    _MPS_GPU._use_subprocess = None
+
+    assert _MPS_GPU._should_use_subprocess() is expected
+
+
+def test_mps_allocator_defaults_preserve_explicit_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.25")
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.3")
+
+    _configure_mps_allocator_defaults()
+
+    assert os.environ["PYTORCH_MPS_LOW_WATERMARK_RATIO"] == "0.25"
+    assert os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] == "0.3"
+
+
+@coco.fn.as_async(runner=_MPS_GPU)
+def _mps_worker_environment() -> tuple[int, str | None, str | None]:
+    return (
+        os.getpid(),
+        os.environ.get("PYTORCH_MPS_LOW_WATERMARK_RATIO"),
+        os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "darwin", reason="MPS is only available on macOS")
+async def test_mps_worker_starts_with_allocator_defaults(
+    monkeypatch: pytest.MonkeyPatch, _reset_gpu_runner: None
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    monkeypatch.delenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", raising=False)
+    monkeypatch.delenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", raising=False)
+    _MPS_GPU._use_subprocess = None
+
+    first_worker_pid, low, high = await _mps_worker_environment()
+    second_worker_pid, _, _ = await _mps_worker_environment()
+
+    assert first_worker_pid != os.getpid()
+    assert second_worker_pid == first_worker_pid
+    assert low == "0.4"
+    assert high == "0.5"
 
 
 @coco.fn.as_async(batching=True)  # type: ignore[arg-type]

--- a/python/tests/core/test_process_supervisor.py
+++ b/python/tests/core/test_process_supervisor.py
@@ -1,0 +1,415 @@
+"""Real-process tests for the MPS-only owned subprocess supervisor."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pickle
+import time
+from collections.abc import AsyncIterator, Iterator
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import cocoindex as coco
+import psutil
+import pytest
+import pytest_asyncio
+from cocoindex._internal import runner as runner_module
+from cocoindex._internal.batching import RetryWithSmallerBatch
+from cocoindex._internal.process_supervisor import (
+    _ProcessSupervisorClosedError,
+    _RemoteExecutionError,
+    _RemoteTraceback,
+    _SingleProcessSupervisor,
+    _WorkerCrashedError,
+)
+
+
+_worker_call_count = 0
+
+
+class _WorkerUserError(Exception):
+    pass
+
+
+class _UnpicklableWorkerError(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.unpicklable = lambda: None
+
+
+def _worker_identity() -> tuple[int, int]:
+    global _worker_call_count
+    _worker_call_count += 1
+    return os.getpid(), _worker_call_count
+
+
+def _return_pid() -> int:
+    return os.getpid()
+
+
+def _record_attempt(path: str) -> int:
+    pid = os.getpid()
+    with Path(path).open("a", encoding="utf-8") as file:
+        file.write(f"{pid}\n")
+        file.flush()
+        os.fsync(file.fileno())
+    return pid
+
+
+def _crash_once(attempts_path: str) -> int:
+    path = Path(attempts_path)
+    should_crash = not path.exists()
+    pid = _record_attempt(attempts_path)
+    if should_crash:
+        os._exit(86)
+    return pid
+
+
+def _always_crash(attempts_path: str) -> None:
+    _record_attempt(attempts_path)
+    os._exit(87)
+
+
+def _hang(attempts_path: str) -> None:
+    _record_attempt(attempts_path)
+    while True:
+        time.sleep(60)
+
+
+def _wait_for_release(attempts_path: str, release_path: str) -> int:
+    pid = _record_attempt(attempts_path)
+    while not Path(release_path).exists():
+        time.sleep(0.01)
+    return pid
+
+
+def _raise_user_error(attempts_path: str) -> None:
+    _record_attempt(attempts_path)
+    raise _WorkerUserError("worker failure")
+
+
+def _raise_unpicklable_error() -> None:
+    raise _UnpicklableWorkerError("cannot pickle me")
+
+
+def _raise_retry_with_smaller_batch() -> None:
+    try:
+        raise ValueError("original batch failure")
+    except ValueError as error:
+        raise RetryWithSmallerBatch() from error
+
+
+async def _execute(
+    supervisor: _SingleProcessSupervisor,
+    fn: Any,
+    *args: Any,
+) -> Any:
+    payload = pickle.dumps((fn, args, {}), protocol=pickle.HIGHEST_PROTOCOL)
+    result = await supervisor.execute(payload)
+    return pickle.loads(result)
+
+
+def _read_attempts(path: Path) -> list[int]:
+    if not path.exists():
+        return []
+    return [int(line) for line in path.read_text().splitlines() if line]
+
+
+async def _wait_for_attempts(
+    path: Path, count: int, *, timeout: float = 5.0
+) -> list[int]:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        attempts = _read_attempts(path)
+        if len(attempts) >= count:
+            return attempts
+        await asyncio.sleep(0.01)
+    raise TimeoutError(f"Expected {count} attempts in {path}")
+
+
+async def _assert_pid_gone(pid: int, *, timeout: float = 5.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if not psutil.pid_exists(pid):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"Worker PID {pid} is still alive")
+
+
+@pytest_asyncio.fixture
+async def supervisor() -> AsyncIterator[_SingleProcessSupervisor]:
+    instance = _SingleProcessSupervisor(
+        runner_module._execute_in_subprocess,
+        process_name="cocoindex-supervisor-test-worker",
+    )
+    try:
+        yield instance
+    finally:
+        await instance.aclose()
+
+
+@pytest.fixture
+def mps_runner() -> Iterator[None]:
+    old_use_subprocess = runner_module._MPS_GPU._use_subprocess
+    runner_module._shutdown_mps_process_supervisor()
+    runner_module._MPS_GPU._use_subprocess = True
+    try:
+        yield
+    finally:
+        runner_module._shutdown_mps_process_supervisor()
+        runner_module._MPS_GPU._use_subprocess = old_use_subprocess
+
+
+@pytest.mark.asyncio
+async def test_success_reuses_worker_state(
+    supervisor: _SingleProcessSupervisor,
+) -> None:
+    first_pid, first_count = await _execute(supervisor, _worker_identity)
+    second_pid, second_count = await _execute(supervisor, _worker_identity)
+
+    assert second_pid == first_pid
+    assert (first_count, second_count) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test_requests_from_different_event_loops_share_worker(
+    supervisor: _SingleProcessSupervisor,
+) -> None:
+    def run_from_thread() -> int:
+        result = asyncio.run(_execute(supervisor, _return_pid))
+        assert isinstance(result, int)
+        return result
+
+    first_pid, second_pid = await asyncio.gather(
+        asyncio.to_thread(run_from_thread),
+        asyncio.to_thread(run_from_thread),
+    )
+
+    assert second_pid == first_pid
+
+
+@pytest.mark.asyncio
+async def test_user_exception_keeps_worker(
+    supervisor: _SingleProcessSupervisor, tmp_path: Path
+) -> None:
+    first_pid = await _execute(supervisor, _return_pid)
+    attempts_path = tmp_path / "user-error-attempts"
+
+    with pytest.raises(_WorkerUserError, match="worker failure") as exc_info:
+        await _execute(supervisor, _raise_user_error, str(attempts_path))
+
+    assert isinstance(exc_info.value.__cause__, _RemoteTraceback)
+    assert _read_attempts(attempts_path) == [first_pid]
+    assert await _execute(supervisor, _return_pid) == first_pid
+
+
+@pytest.mark.asyncio
+async def test_unpicklable_exception_falls_back_without_recycling(
+    supervisor: _SingleProcessSupervisor,
+) -> None:
+    first_pid = await _execute(supervisor, _return_pid)
+
+    with pytest.raises(_RemoteExecutionError, match="cannot pickle me"):
+        await _execute(supervisor, _raise_unpicklable_error)
+
+    assert await _execute(supervisor, _return_pid) == first_pid
+
+
+@pytest.mark.asyncio
+async def test_queued_cancellation_does_not_kill_active_worker(
+    supervisor: _SingleProcessSupervisor, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "active-attempts"
+    release_path = tmp_path / "release"
+    active = asyncio.create_task(
+        _execute(
+            supervisor,
+            _wait_for_release,
+            str(attempts_path),
+            str(release_path),
+        )
+    )
+    active_pid = (await _wait_for_attempts(attempts_path, 1))[0]
+
+    queued = asyncio.create_task(_execute(supervisor, _return_pid))
+    await asyncio.sleep(0)
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(queued, timeout=1)
+
+    release_path.touch()
+    assert await asyncio.wait_for(active, timeout=5) == active_pid
+    assert await _execute(supervisor, _return_pid) == active_pid
+
+
+@pytest.mark.asyncio
+async def test_running_cancellation_reaps_worker_before_propagating(
+    supervisor: _SingleProcessSupervisor, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "cancel-attempts"
+    task = asyncio.create_task(_execute(supervisor, _hang, str(attempts_path)))
+    cancelled_pid = (await _wait_for_attempts(attempts_path, 1))[0]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5)
+
+    await _assert_pid_gone(cancelled_pid)
+    assert await _execute(supervisor, _return_pid) != cancelled_pid
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_active_worker(
+    supervisor: _SingleProcessSupervisor, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "close-attempts"
+    task = asyncio.create_task(_execute(supervisor, _hang, str(attempts_path)))
+    active_pid = (await _wait_for_attempts(attempts_path, 1))[0]
+
+    await supervisor.aclose()
+
+    with pytest.raises(_ProcessSupervisorClosedError):
+        await task
+    await _assert_pid_gone(active_pid)
+    await supervisor.aclose()
+
+
+@pytest.mark.asyncio
+async def test_close_racing_queued_cancellations_drains_every_request(
+    supervisor: _SingleProcessSupervisor, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "close-race-attempts"
+    active = asyncio.create_task(_execute(supervisor, _hang, str(attempts_path)))
+    active_pid = (await _wait_for_attempts(attempts_path, 1))[0]
+    queued = [asyncio.create_task(_execute(supervisor, _return_pid)) for _ in range(50)]
+    await asyncio.sleep(0)
+
+    close_task = asyncio.create_task(supervisor.aclose())
+    for task in queued:
+        task.cancel()
+
+    queued_outcomes = await asyncio.wait_for(
+        asyncio.gather(*queued, return_exceptions=True), timeout=5
+    )
+    await asyncio.wait_for(close_task, timeout=5)
+
+    assert all(isinstance(error, asyncio.CancelledError) for error in queued_outcomes)
+    with pytest.raises(_ProcessSupervisorClosedError):
+        await active
+    await _assert_pid_gone(active_pid)
+
+
+@pytest.mark.asyncio
+async def test_mps_hard_crash_replays_once(mps_runner: None, tmp_path: Path) -> None:
+    attempts_path = tmp_path / "crash-once-attempts"
+
+    result_pid = await runner_module._MPS_GPU.run_sync_fn(
+        _crash_once, str(attempts_path)
+    )
+
+    attempts = _read_attempts(attempts_path)
+    assert len(attempts) == 2
+    assert result_pid == attempts[1]
+    assert attempts[0] != attempts[1]
+    await _assert_pid_gone(attempts[0])
+
+
+@pytest.mark.asyncio
+async def test_mps_repeated_crash_is_bounded_and_recovers(
+    mps_runner: None, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "repeated-crash-attempts"
+
+    with pytest.raises(_WorkerCrashedError) as exc_info:
+        await runner_module._MPS_GPU.run_sync_fn(_always_crash, str(attempts_path))
+
+    attempts = _read_attempts(attempts_path)
+    assert len(attempts) == 2
+    assert exc_info.value.exit_code == 87
+    for pid in attempts:
+        await _assert_pid_gone(pid)
+    assert await runner_module._MPS_GPU.run_sync_fn(_return_pid) not in attempts
+
+
+@pytest.mark.asyncio
+async def test_mps_timeout_does_not_replay_and_recovers(
+    mps_runner: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    warm_pid = await runner_module._MPS_GPU.run_sync_fn(_return_pid)
+    attempts_path = tmp_path / "timeout-attempts"
+    monkeypatch.setattr(
+        runner_module, "_MPS_FALLBACK_TIMEOUT", timedelta(milliseconds=200)
+    )
+
+    with pytest.raises(coco.DeadlineExceededError):
+        await asyncio.wait_for(
+            runner_module._MPS_GPU.run_sync_fn(_hang, str(attempts_path)),
+            timeout=5,
+        )
+
+    assert _read_attempts(attempts_path) == [warm_pid]
+    await _assert_pid_gone(warm_pid)
+    assert await runner_module._MPS_GPU.run_sync_fn(_return_pid) != warm_pid
+
+
+@pytest.mark.asyncio
+async def test_mps_cancellation_reaps_without_replay(
+    mps_runner: None, tmp_path: Path
+) -> None:
+    attempts_path = tmp_path / "mps-cancel-attempts"
+    task = asyncio.create_task(
+        runner_module._MPS_GPU.run_sync_fn(_hang, str(attempts_path))
+    )
+    cancelled_pid = (await _wait_for_attempts(attempts_path, 1))[0]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5)
+
+    assert _read_attempts(attempts_path) == [cancelled_pid]
+    await _assert_pid_gone(cancelled_pid)
+    assert await runner_module._MPS_GPU.run_sync_fn(_return_pid) != cancelled_pid
+
+
+@pytest.mark.asyncio
+async def test_mps_user_exception_is_not_replayed_or_recycled(
+    mps_runner: None, tmp_path: Path
+) -> None:
+    worker_pid = await runner_module._MPS_GPU.run_sync_fn(_return_pid)
+    attempts_path = tmp_path / "mps-user-error-attempts"
+
+    with pytest.raises(_WorkerUserError, match="worker failure"):
+        await runner_module._MPS_GPU.run_sync_fn(_raise_user_error, str(attempts_path))
+
+    assert _read_attempts(attempts_path) == [worker_pid]
+    assert await runner_module._MPS_GPU.run_sync_fn(_return_pid) == worker_pid
+
+
+@pytest.mark.asyncio
+async def test_mps_preserves_retry_with_smaller_batch_cause(
+    mps_runner: None,
+) -> None:
+    with pytest.raises(RetryWithSmallerBatch) as exc_info:
+        await runner_module._MPS_GPU.run_sync_fn(_raise_retry_with_smaller_batch)
+
+    assert isinstance(exc_info.value._restored_cause, ValueError)
+    assert str(exc_info.value._restored_cause) == "original batch failure"
+
+
+@pytest.mark.asyncio
+async def test_generic_gpu_keeps_existing_subprocess_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generic_runner = runner_module.GPURunner()
+    generic_runner._use_subprocess = True
+
+    def fail_if_mps_supervisor_is_used() -> None:
+        raise AssertionError("generic GPU used the MPS supervisor")
+
+    monkeypatch.setattr(
+        runner_module, "_get_mps_process_supervisor", fail_if_mps_supervisor_is_used
+    )
+
+    assert await generic_runner.run_sync_fn(_return_pid) != os.getpid()

--- a/python/tests/ops/test_sentence_transformer_embedder.py
+++ b/python/tests/ops/test_sentence_transformer_embedder.py
@@ -9,13 +9,19 @@ classification and the batching engine's RetryWithSmallerBatch path
 from __future__ import annotations
 
 import asyncio
+import gc
+import sys
 import threading
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 import pytest
 
 import cocoindex as coco
+from cocoindex._internal import runner as runner_module
+from cocoindex.ops import sentence_transformers as sentence_transformers_module
 from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
 
 _OOM_MESSAGE = "CUDA out of memory. Tried to allocate 20.00 GiB"
@@ -48,7 +54,9 @@ class _FakeModel:
 
 
 def _make_embedder(model: Any) -> SentenceTransformerEmbedder:
-    embedder = SentenceTransformerEmbedder("fake-model")
+    # Keep the existing batching tests on the generic in-process path even when
+    # the suite runs on macOS. MPS routing has focused tests below.
+    embedder = SentenceTransformerEmbedder("fake-model", device="cpu")
     embedder._get_model = lambda: model  # type: ignore[method-assign]
     return embedder
 
@@ -112,3 +120,253 @@ def test_sentence_transformer_non_oom_error_propagates() -> None:
     embedder = _make_embedder(_AlwaysFailModel(KeyError("unknown prompt_name")))
     with pytest.raises(KeyError):
         embedder._embed._execute_orig_sync_fn(["a", "b"])
+
+
+@pytest.mark.parametrize(
+    ("device", "platform", "expected"),
+    [
+        ("mps", "linux", True),
+        ("cpu", "darwin", False),
+        ("cuda", "darwin", False),
+        (None, "darwin", True),
+        (None, "linux", False),
+    ],
+)
+def test_sentence_transformer_detects_mps_device(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str | None,
+    platform: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(sys, "platform", platform)
+
+    assert sentence_transformers_module._is_mps_device(device) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("device", "uses_mps"), [("mps", True), ("cpu", False)])
+async def test_sentence_transformer_routes_to_device_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str,
+    uses_mps: bool,
+) -> None:
+    monkeypatch.setattr(
+        runner_module,
+        "_configure_mps_allocator_defaults",
+        Mock(),
+    )
+    embedder = SentenceTransformerEmbedder("fake-model", device=device)
+    generic_embed = AsyncMock(return_value=np.array([1.0], dtype=np.float32))
+    mps_embed = AsyncMock(return_value=np.array([2.0], dtype=np.float32))
+    generic_dimension = AsyncMock(return_value=128)
+    mps_dimension = AsyncMock(return_value=256)
+    monkeypatch.setattr(embedder, "_embed", generic_embed)
+    monkeypatch.setattr(embedder, "_embed_mps", mps_embed)
+    monkeypatch.setattr(embedder, "_dimension", generic_dimension)
+    monkeypatch.setattr(embedder, "_dimension_mps", mps_dimension)
+
+    result = await embedder.embed._execute_orig_async_fn("text")
+    dimension = await embedder.dimension._execute_orig_async_fn()
+
+    assert result.tolist() == ([2.0] if uses_mps else [1.0])
+    assert dimension == (256 if uses_mps else 128)
+    assert mps_embed.await_count == int(uses_mps)
+    assert generic_embed.await_count == int(not uses_mps)
+    assert mps_dimension.await_count == int(uses_mps)
+    assert generic_dimension.await_count == int(not uses_mps)
+
+
+class _SuccessModel:
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        return np.array([[float(len(text))] for text in texts], dtype=np.float32)
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 384
+
+
+def _install_fake_mps(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+    *,
+    synchronize_error: BaseException | None = None,
+    allocated_memory: int = 50,
+    recommended_memory: int = 100,
+    low_watermark: str = "0.4",
+    high_watermark: str = "0.5",
+) -> None:
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", low_watermark)
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", high_watermark)
+
+    def synchronize() -> None:
+        events.append("synchronize")
+        if synchronize_error is not None:
+            raise synchronize_error
+
+    fake_torch: Any = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True)),
+        cuda=SimpleNamespace(is_available=lambda: False),
+        mps=SimpleNamespace(
+            synchronize=synchronize,
+            empty_cache=lambda: events.append("empty_cache"),
+            driver_allocated_memory=lambda: allocated_memory,
+            recommended_max_memory=lambda: recommended_memory,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(
+        gc,
+        "collect",
+        lambda: events.append("gc_collect"),
+    )
+
+
+def test_sentence_transformer_mps_clears_cache_after_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events)
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a", "bb"])
+
+    assert [item.tolist() for item in result] == [[1.0], [2.0]]
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+def test_sentence_transformer_mps_skips_cleanup_below_pressure_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events, allocated_memory=39)
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert result[0].tolist() == [1.0]
+    assert events == []
+
+
+def test_sentence_transformer_mps_cleanup_uses_explicit_watermark(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        allocated_memory=30,
+        low_watermark="0.25",
+        high_watermark="0.3",
+    )
+    embedder = _make_embedder(_SuccessModel())
+
+    embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+def test_sentence_transformer_mps_oom_clears_cache_below_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events, allocated_memory=1)
+    error = RuntimeError(_OOM_MESSAGE)
+    embedder = _make_embedder(_AlwaysFailModel(error))
+
+    with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+        embedder._embed_mps._execute_orig_sync_fn(["a", "b"])
+
+    assert exc_info.value.__cause__ is error
+    assert events == ["empty_cache"]
+
+
+def test_sentence_transformer_mps_cleanup_failure_does_not_mask_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        synchronize_error=RuntimeError("cleanup failed"),
+    )
+    embedder = _make_embedder(_SuccessModel())
+
+    result = embedder._embed_mps._execute_orig_sync_fn(["a"])
+
+    assert result[0].tolist() == [1.0]
+    assert events == ["synchronize"]
+
+
+def test_sentence_transformer_mps_cleanup_does_not_mask_model_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(
+        monkeypatch,
+        events,
+        synchronize_error=RuntimeError("cleanup failed"),
+    )
+    embedder = _make_embedder(_AlwaysFailModel(KeyError("unknown prompt_name")))
+
+    with pytest.raises(KeyError, match="unknown prompt_name"):
+        embedder._embed_mps._execute_orig_sync_fn(["a"])
+    assert events == ["synchronize"]
+
+
+def test_sentence_transformer_mps_dimension_clears_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _install_fake_mps(monkeypatch, events)
+    embedder = _make_embedder(_SuccessModel())
+
+    dimension = embedder._dimension_mps._execute_orig_sync_fn()
+
+    assert dimension == 384
+    assert events == ["synchronize", "gc_collect", "empty_cache", "synchronize"]
+
+
+_subprocess_model_initializations = 0
+
+
+class _SubprocessFakeModel(_SuccessModel):
+    def __init__(self, initialization: int) -> None:
+        self._initialization = initialization
+
+    def encode(self, texts: list[str], **kwargs: Any) -> np.ndarray:
+        return np.array(
+            [[float(len(text)), float(self._initialization)] for text in texts],
+            dtype=np.float32,
+        )
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 2
+
+
+class _SubprocessFakeMPSEmbedder(SentenceTransformerEmbedder):
+    def _get_model(self) -> Any:
+        global _subprocess_model_initializations
+        if self._model is None:
+            _subprocess_model_initializations += 1
+            self._model = _SubprocessFakeModel(  # type: ignore[assignment]
+                _subprocess_model_initializations
+            )
+        return self._model
+
+
+@pytest.mark.asyncio
+async def test_sentence_transformer_mps_subprocess_keeps_model_warm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
+    monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.4")
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.5")
+    monkeypatch.setattr(runner_module._MPS_GPU, "_use_subprocess", None)
+    embedder = _SubprocessFakeMPSEmbedder("fake-model", device="mps")
+
+    dimension = await embedder.dimension()
+    first = await embedder.embed("a")
+    second = await embedder.embed("bb")
+
+    assert dimension == 2
+    assert first.tolist() == [1.0, 1.0]
+    assert second.tolist() == [2.0, 1.0]

--- a/python/tests/ops/test_sentence_transformer_embedder.py
+++ b/python/tests/ops/test_sentence_transformer_embedder.py
@@ -357,16 +357,20 @@ class _SubprocessFakeMPSEmbedder(SentenceTransformerEmbedder):
 async def test_sentence_transformer_mps_subprocess_keeps_model_warm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    runner_module._shutdown_mps_process_supervisor()
     monkeypatch.delenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", raising=False)
     monkeypatch.setenv("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.4")
     monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.5")
     monkeypatch.setattr(runner_module._MPS_GPU, "_use_subprocess", None)
     embedder = _SubprocessFakeMPSEmbedder("fake-model", device="mps")
 
-    dimension = await embedder.dimension()
-    first = await embedder.embed("a")
-    second = await embedder.embed("bb")
+    try:
+        dimension = await embedder.dimension()
+        first = await embedder.embed("a")
+        second = await embedder.embed("bb")
 
-    assert dimension == 2
-    assert first.tolist() == [1.0, 1.0]
-    assert second.tolist() == [2.0, 1.0]
+        assert dimension == 2
+        assert first.tolist() == [1.0, 1.0]
+        assert second.tolist() == [2.0, 1.0]
+    finally:
+        runner_module._shutdown_mps_process_supervisor()


### PR DESCRIPTION
## Summary

Follow-up to #2335.

Adds a private, Python 3.11-compatible process supervisor for built-in MPS SentenceTransformer work. The supervisor owns the worker process and IPC lifecycle, which makes timeout and cancellation enforceable, guarantees that a failed worker is reaped before its GPU permit is released, and bounds hard-crash recovery to one replay.

Generic `coco.GPU` execution deliberately remains on the existing `ProcessPoolExecutor` path.

## Stack and review scope

This is the upper change in a two-PR logical stack:

1. Merge #2335, which introduces the native MPS memory-bound path.
2. Rebase this branch onto the updated `main` and force-push it.
3. Mark this PR ready and merge it after the resilience-only diff is reviewed.

GitHub native stacked pull requests do not support branches across a fork boundary, so this PR is opened against `main` as a draft. Until #2335 merges, the GitHub diff includes both commits. Review the resilience layer independently at:

https://github.com/fml09/cocoindex/compare/g/2333-native-mps-memory-safety...g/2333-mps-runner-resilience

## Problem

`ProcessPoolExecutor` is suitable for the existing generic subprocess mode, but on Python 3.11 it does not expose ownership primitives that can reliably terminate one running call and prove that its worker has exited. That leaves three failure modes unbounded for an MPS worker:

- A hung call can retain unified memory and a CocoIndex GPU permit indefinitely.
- Cancelling the awaiting task does not guarantee that the child process stops.
- Repeated hard crashes can repeatedly restart the pool without a per-call recovery bound.

A timeout wrapped only around the future would bound the caller wait, but not the lifetime of the GPU work. The implementation therefore needs to own the process and IPC that carry the call.

## Failure contract

For private MPS calls, this PR establishes the following contract:

- A five-minute absolute wall-clock deadline is shared by the original attempt and any replay. It includes supervisor queueing, worker startup, lazy model loading, execution, and replay.
- An unexpected hard worker crash is replayed at most once. A second crash fails the call.
- Timeout, cancellation, and user-code exceptions are never replayed.
- Timeout and cancellation retire the active worker with terminate, join, kill, join escalation before the GPU permit is released.
- Idle shutdown uses a graceful `STOP` and `STOPPED` handshake before hard-stop fallback.
- Picklable user exceptions preserve their original type and receive the remote traceback; unpicklable exceptions use a stable transport fallback.

The hard-crash budget is intentionally per call, not a cross-call circuit breaker. This bounds one request without introducing global health state or new public policy.

## Implementation

- Add private `_SingleProcessSupervisor`, backed by a spawned `multiprocessing.Process`, a duplex pipe, and a dedicated manager thread.
- Tag messages with worker generation and call identifiers so stale responses cannot complete a newer request.
- Serialize request outcome transitions under one lock to make close and cancellation races exactly-once.
- Replace only `_MPS_GPU` subprocess execution with the owned supervisor.
- Preserve the generic `coco.GPU` subprocess implementation and its environment-controlled behavior.
- Add no public API, configuration knob, or dependency.

## Operational trade-offs

- Replacing a crashed or timed-out worker incurs a cold model reload on the next attempt.
- A hard-crash replay has at-least-once execution semantics. The scoped built-in embedding operation is computation-only, so it has no external commit boundary.
- A process using both generic subprocess GPU execution and built-in MPS execution may keep two persistent child processes, one for each intentionally separate path.
- Setting `COCOINDEX_RUN_GPU_IN_SUBPROCESS=0` opts out of the private supervisor and therefore also opts out of these timeout and hard-reap guarantees.
- A slow first model download can consume the five-minute budget; the deadline is an absolute execution bound, not heartbeat-based hang detection.

## Testing

- Added 15 real spawned-process tests covering success, exception transport, unpicklable exceptions, timeout, cancellation, idle and active close, graceful shutdown, crash replay, repeated crash failure, stale messages, cross-event-loop use, and shutdown races.
- Repeated the real-process supervisor suite five times to exercise timing-sensitive paths.
- Added runner and SentenceTransformer tests proving only the private MPS route changes.
- `uvx prek run --all-files` passes, including Ruff, mypy, maturin build, Rust tests and checks, the full Python test suite, and generated CLI documentation checks.