### PR TITLE
ci: reclaim runner disk space before Linux build-test jobs

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -36,6 +36,29 @@ jobs:
           RUSTC_WRAPPER: "sccache"
 
         steps:
+        # GitHub guarantees only ~14 GB free on Linux runners, and a push to a
+        # release branch runs `prek --all-files` -- every hook, including the
+        # `cargo check` over the external example/benchmark workspaces -- so the
+        # combined `target/` trees crowd the root volume. `CARGO_INCREMENTAL=0`
+        # and `-C debuginfo=0` below already keep `target/` as small as it gets,
+        # so the remaining headroom has to come from the runner image itself.
+        # Reclaiming the preinstalled runtimes we never use buys ~20 GB.
+        #
+        # `large-packages` is the apt-get path: it dominates this action's
+        # runtime for a comparatively small win, so it stays off. `tool-cache`
+        # (default false) must stay off too -- it deletes $AGENT_TOOLSDIRECTORY,
+        # which is where the sccache/protoc/Python/prek steps below live.
+        - name: Free disk space
+          if: runner.os == 'Linux'
+          uses: jlumbroso/free-disk-space@v1.3.1
+          with:
+            android: true
+            dotnet: true
+            haskell: true
+            docker-images: true
+            large-packages: false
+            tool-cache: false
+
         - name: Disable Git autocrlf on Windows
           if: runner.os == 'Windows'
           shell: bash


### PR DESCRIPTION
## Problem

Linux runners [guarantee only ~14 GB free](https://github.com/actions/runner-images/discussions/9329), and a push to a release branch runs `prek --all-files` — every hook, including `cargo check (rust examples + benchmarks)`, which builds 27 external workspaces into `target/rust-externs` on top of the main workspace's `target/`. That leaves very little headroom on the root volume, and the failure mode when it runs out is indirect and slow to diagnose: `No space left on device` in the `Post Setup Rust Cache` post-step (with every hook reporting `Passed`), or a testcontainers image pull failing with `ImageNotFound` because the write silently failed.

This is preventive hardening — buying back headroom before the ceiling is hit, since the diagnosis is expensive once it is.

## Fix

Reclaim the preinstalled runtimes we never use, as the first step on Linux runners.

The runner-images maintainers [locked that discussion without a fix](https://github.com/actions/runner-images/discussions/9329), so a cleanup action is the community-standard remedy. The jobs already set `CARGO_INCREMENTAL=0` and `-C debuginfo=0` — the two cargo-side levers for `target/` bloat — so the remaining headroom has to come from the image itself.

Flags chosen deliberately:

- `large-packages: false` — this is the `apt-get` path, which dominates the action's runtime for a comparatively small win.
- `tool-cache: false` (the default) — it deletes `$AGENT_TOOLSDIRECTORY`, which is exactly where the sccache, protoc, Python and prek steps live.
- `android` / `dotnet` / `haskell` / `docker-images` — plain `rm -rf` of runtimes this workflow never touches, ~20 GB combined.

No effect on caching: nothing removed is read by any step, so `Swatinem/rust-cache` restore and partial rebuilds are unchanged.

## Verification

This PR touches `.github/workflows/*.yml`, which is in the CI path filter, so the full matrix runs against the new step.