### PR TITLE
fix(surrealdb): expose vector index attachments

### DIFF
--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -658,10 +658,8 @@ class _RecordHandler(coco.TargetHandler[_RowValue, _RowFingerprint]):
         self._conn = conn
         self._sink = sink
 
-    def attachment(self, att_type: str) -> _VectorIndexHandler | None:
-        if att_type == "vector_index":
-            return _VectorIndexHandler(self._conn, self._table_name)
-        return None
+    def attachments(self) -> dict[str, _VectorIndexHandler]:
+        return {"vector_index": _VectorIndexHandler(self._conn, self._table_name)}
 
     def _encode_row(self, row_dict: dict[str, Any]) -> dict[str, Any]:
         """Apply column encoders from schema if present."""


### PR DESCRIPTION
## Summary
- migrate the SurrealDB record handler to the current plural `attachments()` target-handler contract
- restore `TableTarget.declare_vector_index()` for SurrealDB

The target-state attachment API changed from `attachment(type)` to an eagerly registered `attachments()` mapping in #1844. The SurrealDB handler retained the old method, so vector-index declarations fail with `Handler does not support attachment type: "vector_index"`.

## Verification
- `uv run mypy`
- `uv run ruff format --check python/cocoindex/connectors/surrealdb/_target.py`
- `uv run ruff check python/cocoindex/connectors/surrealdb/_target.py`
- SurrealDB vector-index tests: 3 passed (`mtree`, `hnsw`, update)
- full Python suite: 1063 passed, 228 skipped; one unrelated existing `managed_by="user"` SurrealDB failure against SurrealDB 3.2.4