### PR TITLE
test(core): cover sink-failure recovery for target-state ownership

### DIFF
--- a/python/tests/common/target_states.py
+++ b/python/tests/common/target_states.py
@@ -81,6 +81,10 @@ class DictTargetStateStore:
         tuple[str, DictDataWithPrev | coco.NonExistenceType]
     ]
     sink_exception: bool = False
+    # Simulates a partial failure: the actions reach the target, but the sink
+    # call still fails before the component lifecycle finalizes (e.g. the ack
+    # is lost after the write landed).
+    sink_exception_after_apply: bool = False
 
     def __init__(self, use_async: bool = False) -> None:
         self.data = {}
@@ -109,6 +113,8 @@ class DictTargetStateStore:
                     self.data[key] = value
                     self.metrics.increment("upsert")
             self.metrics.increment("sink")
+        if self.sink_exception_after_apply:
+            raise ValueError("injected sink exception after apply")
 
     async def _async_sink(
         self,

--- a/python/tests/core/test_flat_target_states.py
+++ b/python/tests/core/test_flat_target_states.py
@@ -276,3 +276,45 @@ def test_global_dict_target_state_proceed_with_exception() -> None:
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
     assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
+
+
+def test_global_dict_partial_sink_failure_then_undeclare() -> None:
+    """A fresh insert whose sink call applies but then fails, followed by
+    undeclaring the state: the next run must still delete it from the sink.
+
+    The failed lifecycle leaves the item's tracking in the fresh-insert
+    multi-state shape (a `Deleted` entry plus the attempted value), which
+    forces `prev_may_be_missing` — but the delete reconcile must still run,
+    because the sink may well hold the value (it does here). Skipping it
+    would permanently orphan the external state.
+    """
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_global_dict_partial_sink_failure_then_undeclare",
+            environment=coco_env,
+        ),
+        declare_global_dict_entries,
+    )
+
+    # Run 1: fresh insert of "a"; the write reaches the sink, but the sink
+    # call fails before the lifecycle finalizes.
+    _source_data["a"] = 1
+    try:
+        GlobalDictTarget.store.sink_exception_after_apply = True
+        with pytest.raises(Exception):
+            app.update_blocking()
+    finally:
+        GlobalDictTarget.store.sink_exception_after_apply = False
+    assert GlobalDictTarget.store.data == {
+        "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+
+    # Run 2: "a" is no longer declared. Its delete must reach the sink.
+    del _source_data["a"]
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import cocoindex as coco
 
 from tests import common
@@ -307,3 +309,115 @@ def test_component_delete_cleans_inverted_tracking() -> None:
     assert common.list_target_state_owners_sync(app) == {
         '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
     }
+
+
+@coco.fn
+async def _app_main_use_mount() -> None:
+    """Like _app_main but with use_mount, so a child's submit failure (e.g. a
+    sink exception) propagates to the root and surfaces from App.update —
+    plain mount() routes child failures to the exception-handler chain, which
+    logs and swallows by default."""
+    for name in sorted(_source_data):
+        await coco.use_mount(coco.component_subpath(name), _process_component, name)
+
+
+def test_ownership_transfer_sink_failure_then_retry() -> None:
+    """Sink failure mid-transfer, then retry: the next run re-reconciles from
+    the multi-state tracking record and converges.
+
+    The failed attempt's precommit already moved the item from C1's tracking
+    into C2's (multi-state) and claimed `__target` for C2 — the claim is
+    visible at precommit by design, so concurrent claimants can detect the
+    in-flight lifecycle. Recovery is "fix state on next run", not revert.
+    """
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_ownership_transfer_sink_failure_then_retry",
+            environment=coco_env,
+        ),
+        _app_main_use_mount,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+
+    # Run 2: C2 takes over, but the sink fails after precommit.
+    _source_data.clear()
+    _source_data["C2"] = {"x": 2}
+    try:
+        GlobalDictTarget.store.sink_exception = True
+        with pytest.raises(Exception):
+            app.update_blocking()
+    finally:
+        GlobalDictTarget.store.sink_exception = False
+    # Nothing reached the sink; the external state still holds C1's value.
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {}
+    # The `__target` claim landed at precommit, ahead of the failed sink apply.
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
+
+    # Run 3: retry with a healthy sink. C2 finds "x" in its own tracking with
+    # both candidate previous states (C1's applied value and C2's unapplied
+    # attempt) and re-issues the upsert. No delete is ever emitted — C1's
+    # GC'd tracking no longer contains "x".
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=2, prev=[1, 2], prev_may_be_missing=False),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
+
+
+def test_ownership_transfer_sink_failure_then_owner_deleted() -> None:
+    """Sink failure mid-transfer, then the claimant is unmounted: GC cleans up.
+
+    The failed claimant's precommit durably recorded the item in its own
+    tracking, so Delete-mode reconciliation still knows about the target
+    state and removes it from the sink — nothing is orphaned.
+    """
+    GlobalDictTarget.store.clear()
+    _source_data.clear()
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_ownership_transfer_sink_failure_then_owner_deleted",
+            environment=coco_env,
+        ),
+        _app_main_use_mount,
+    )
+
+    # Run 1: C1 owns "x"
+    _source_data["C1"] = {"x": 1}
+    app.update_blocking()
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 2: C2 takes over, but the sink fails after precommit.
+    _source_data.clear()
+    _source_data["C2"] = {"x": 2}
+    try:
+        GlobalDictTarget.store.sink_exception = True
+        with pytest.raises(Exception):
+            app.update_blocking()
+    finally:
+        GlobalDictTarget.store.sink_exception = False
+    GlobalDictTarget.store.metrics.collect()
+
+    # Run 3: both components are gone. C2's GC delete must remove "x" from
+    # the sink (using the multi-state previous states from the failed
+    # attempt) and drop the owner row.
+    _source_data.clear()
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
+    assert common.list_target_state_owners_sync(app) == {}


### PR DESCRIPTION
## Summary
- Add E2E tests for the sink-failure recovery model around target-state ownership transfer: failure mid-transfer then retry (converges from the multi-state tracking record; `__target` claim lands at precommit), and failure mid-transfer then claimant unmounted (GC Delete-mode cleans the sink and owner rows — nothing is orphaned).
- Add an E2E test for a fresh insert whose sink call applies but then fails, followed by undeclaring: the delete must still reach the sink despite the fresh-insert multi-state tracking shape.
- Add a `sink_exception_after_apply` mode to the shared test sink to simulate partial failures (write applied, ack lost before the lifecycle finalized).

These pin down the engine's "fix state on next run" recovery model (specs/target_state_ownership_transfer, specs/core/internal_states.md §5.2), closing the coverage gap that motivated the alternative design proposed in #2343 — which two of these tests demonstrably reject.

## Test plan
CI (`python/tests/core/test_ownership_transfer.py`, `python/tests/core/test_flat_target_states.py`). Also verified locally that applying #2343's diff makes `test_ownership_transfer_sink_failure_then_retry` and `test_global_dict_partial_sink_failure_then_undeclare` fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
