### PR TITLE
fix(core): preserve target invalidation through memoization

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -102,9 +102,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -120,9 +117,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -140,9 +134,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -158,9 +149,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -442,9 +430,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -457,9 +442,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -474,9 +456,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -489,9 +468,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1226,9 +1202,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1244,9 +1217,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1264,9 +1234,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1282,9 +1249,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1302,9 +1266,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1320,9 +1281,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1340,9 +1298,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1359,9 +1314,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1377,9 +1329,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1403,9 +1352,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1427,9 +1373,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1453,9 +1396,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1477,9 +1417,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1503,9 +1440,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1528,9 +1462,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1552,9 +1483,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1959,9 +1887,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1902,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1997,9 +1919,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2015,9 +1934,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2035,9 +1951,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,9 +1966,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4959,9 +4869,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4981,9 +4888,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5005,9 +4909,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5027,9 +4928,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -149,6 +149,9 @@ class FnCallMemoGuard:
         memo_states: list[Any] | None = None,
         context_memo_states: dict[Fingerprint, list[Any]] | None = None,
     ) -> None: ...
+    def join_cached_target_provider_deps(
+        self, parent_fn_ctx: FnCallContext
+    ) -> None: ...
     def resolve(
         self,
         fn_ctx: FnCallContext,

--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -788,8 +788,16 @@ class SyncFunction(Function[P, R_co]):
             finally:
                 _context_var.reset(tok)
 
+        # Create the fn call context (and record this function's own logic fp)
+        # BEFORE the memo probe, mirroring the async path: the `finally` below
+        # joins it into the parent unconditionally, so even a cache hit reports
+        # this function's logic fp upward. Otherwise a caller's memo entry
+        # re-stored after a hit would lose the dep and a later code change to
+        # this function would go undetected.
         propagate = self._logic_tracking == "full"
-        fn_ctx: core.FnCallContext | None = None
+        fn_ctx = core.FnCallContext(propagate_children_fn_logic=propagate)
+        if self._logic_fp is not None:
+            fn_ctx.add_fn_logic_dep(self._logic_fp)
         try:
             if self._memo:
                 state_methods: list[StateFnEntry] = []
@@ -845,6 +853,12 @@ class SyncFunction(Function[P, R_co]):
                     if use_cache:
                         _deadline_checkpoint()
                         parent_ctx._core_fn_call_ctx.join_child_memo(memo_fp)
+                        # The hit skips re-declaring this entry's target states,
+                        # so its provider-generation deps must ride into the
+                        # caller's memo entry explicitly.
+                        guard.join_cached_target_provider_deps(
+                            parent_ctx._core_fn_call_ctx
+                        )
                         assert guard.cached_value is not None
                         return cast(
                             R_co,
@@ -852,9 +866,6 @@ class SyncFunction(Function[P, R_co]):
                         )
 
                     # Execute (cache miss or stale states)
-                    fn_ctx = core.FnCallContext(propagate_children_fn_logic=propagate)
-                    if self._logic_fp is not None:
-                        fn_ctx.add_fn_logic_dep(self._logic_fp)
                     ret = _call_in_context(fn_ctx, in_memo_fn=True)
                     _deadline_checkpoint()
                     # Positional: collect only if not already set (cache-miss path).
@@ -881,15 +892,11 @@ class SyncFunction(Function[P, R_co]):
                 finally:
                     guard.close()
             else:
-                fn_ctx = core.FnCallContext(propagate_children_fn_logic=propagate)
-                if self._logic_fp is not None:
-                    fn_ctx.add_fn_logic_dep(self._logic_fp)
                 result = _call_in_context(fn_ctx, in_memo_fn=parent_ctx._in_memo_fn)
                 _deadline_checkpoint()
                 return result
         finally:
-            if fn_ctx is not None:
-                parent_ctx._core_fn_call_ctx.join_child(fn_ctx)
+            parent_ctx._core_fn_call_ctx.join_child(fn_ctx)
 
     async def as_async(self, *args: P.args, **kwargs: P.kwargs) -> R_co:
         """Call this sync function wrapped in async (runs via asyncio.to_thread)."""
@@ -1390,6 +1397,12 @@ class AsyncFunction(Function[P, R_co]):
                     if use_cache:
                         _deadline_checkpoint()
                         parent_ctx._core_fn_call_ctx.join_child_memo(memo_fp)
+                        # The hit skips re-declaring this entry's target states,
+                        # so its provider-generation deps must ride into the
+                        # caller's memo entry explicitly.
+                        guard.join_cached_target_provider_deps(
+                            parent_ctx._core_fn_call_ctx
+                        )
                         assert guard.cached_value is not None
                         return cast(
                             R_co,
@@ -1440,7 +1453,7 @@ class AsyncFunction(Function[P, R_co]):
         finally:
             if guard is not None:
                 guard.close()
-            if fn_ctx is not None and parent_ctx is not None:
+            if parent_ctx is not None:
                 parent_ctx._core_fn_call_ctx.join_child(fn_ctx)
 
     async def _execute(

--- a/python/cocoindex/connectors/bigquery/_target.py
+++ b/python/cocoindex/connectors/bigquery/_target.py
@@ -795,7 +795,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                             spec.table_schema,
                             if_not_exists=(action.main_action == "upsert"),
                         )
-                        continue
+                        # "insert" / "replace" just built the table from the desired
+                        # schema, so its columns already match. "upsert" may have
+                        # found a pre-existing table with an older column set — fall
+                        # through and reconcile it.
+                        if action.main_action != "upsert":
+                            continue
 
                     if action.column_actions:
                         _apply_column_actions(
@@ -837,8 +842,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `CREATE TABLE IF
+        # NOT EXISTS` can land on a table carrying the previous column set, so its
+        # columns still need reconciling. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -847,9 +856,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         child_invalidation: Literal["destructive", "lossy"] | None = None
         if main_action == "replace":
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             child_invalidation = "lossy"
 
         return coco.TargetReconcileOutput(

--- a/python/cocoindex/connectors/doris/_target.py
+++ b/python/cocoindex/connectors/doris/_target.py
@@ -1084,9 +1084,14 @@ def _apply_table_actions(
                     inverted_indexes=spec.inverted_indexes,
                 )
                 _execute_ddl_sync(config, ddl)
-                continue
+                # "insert" / "replace" just built the table from the desired schema,
+                # so its columns already match. "upsert" may have found a
+                # pre-existing table with an older column set — fall through and
+                # reconcile it.
+                if action.main_action != "upsert":
+                    continue
 
-            # No main change: reconcile non-PK columns incrementally
+            # Reconcile non-PK columns incrementally
             if action.column_actions:
                 for sub_key, col_action in action.column_actions.items():
                     if not sub_key.startswith(_COL_SUBKEY_PREFIX):
@@ -1157,8 +1162,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `CREATE TABLE IF
+        # NOT EXISTS` can land on a table carrying the previous column set, so its
+        # columns still need reconciling. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -1169,9 +1178,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         if main_action == "replace":
             # Table is dropped and recreated — all rows are destroyed.
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             # Column schema changes (other than adding new columns) may lose data.
             child_invalidation = "lossy"
 

--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -1185,8 +1185,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, sub_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `create_table` with
+        # `if_not_exists` can land on a table carrying the previous column set, so
+        # its columns still need checking. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to check.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in sub_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -1199,7 +1203,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
             child_invalidation = "destructive"
 
         if (
-            main_action is None
+            main_action in (None, "upsert")
             and column_actions
             and any(a not in ("insert", "upsert") for a in column_actions.values())
         ):

--- a/python/cocoindex/connectors/postgres/_target.py
+++ b/python/cocoindex/connectors/postgres/_target.py
@@ -1025,9 +1025,14 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                                 spec.table_schema,
                                 if_not_exists=(action.main_action == "upsert"),
                             )
-                            continue
+                            # "insert" / "replace" just built the table from the
+                            # desired schema, so its columns already match.
+                            # "upsert" may have found a pre-existing table with an
+                            # older column set — fall through and reconcile it.
+                            if action.main_action != "upsert":
+                                continue
 
-                        # No main change: reconcile non-PK columns incrementally.
+                        # Reconcile non-PK columns incrementally.
                         if action.column_actions:
                             await self._apply_column_actions(
                                 conn, key, spec.table_schema, action.column_actions
@@ -1214,8 +1219,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `CREATE TABLE IF
+        # NOT EXISTS` can land on a table carrying the previous column set, so its
+        # columns still need reconciling. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -1226,9 +1235,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         if main_action == "replace":
             # Table is dropped and recreated — all rows are destroyed.
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             # Column schema changes (other than adding new columns) may lose data.
             child_invalidation = "lossy"
 

--- a/python/cocoindex/connectors/snowflake/_target.py
+++ b/python/cocoindex/connectors/snowflake/_target.py
@@ -692,7 +692,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                                 spec.table_schema,
                                 if_not_exists=(action.main_action == "upsert"),
                             )
-                            continue
+                            # "insert" / "replace" just built the table from the
+                            # desired schema, so its columns already match.
+                            # "upsert" may have found a pre-existing table with an
+                            # older column set — fall through and reconcile it.
+                            if action.main_action != "upsert":
+                                continue
 
                         if action.column_actions:
                             _apply_column_actions(
@@ -741,8 +746,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `CREATE TABLE IF
+        # NOT EXISTS` can land on a table carrying the previous column set, so its
+        # columns still need reconciling. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -751,9 +760,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         child_invalidation: Literal["destructive", "lossy"] | None = None
         if main_action == "replace":
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             child_invalidation = "lossy"
 
         return coco.TargetReconcileOutput(

--- a/python/cocoindex/connectors/sqlite/_target.py
+++ b/python/cocoindex/connectors/sqlite/_target.py
@@ -902,7 +902,11 @@ def _apply_table_actions(
                 )
 
                 # Virtual tables can't use ALTER TABLE - force DROP+CREATE for column changes
-                if is_virtual and action.column_actions and action.main_action is None:
+                if (
+                    is_virtual
+                    and action.column_actions
+                    and action.main_action in (None, "upsert")
+                ):
                     # Upgrade to replace action
                     action = _TableAction(
                         key=action.key,
@@ -946,9 +950,14 @@ def _apply_table_actions(
                             if_not_exists=(action.main_action == "upsert"),
                             has_vec_extension=has_vec,
                         )
-                    continue
+                    # "insert" / "replace" just built the table from the desired
+                    # schema, so its columns already match. "upsert" may have found
+                    # a pre-existing table with an older column set — fall through
+                    # and reconcile it.
+                    if action.main_action != "upsert":
+                        continue
 
-                # No main change: reconcile non-PK columns incrementally.
+                # Reconcile non-PK columns incrementally.
                 # (Virtual tables never reach here - they're forced to replace above)
                 if action.column_actions:
                     _apply_column_actions(
@@ -1003,8 +1012,12 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: `CREATE TABLE IF
+        # NOT EXISTS` can land on a table carrying the previous column set, so its
+        # columns still need reconciling. "insert" / "replace" build the table from
+        # the desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -1015,9 +1028,7 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
         if main_action == "replace":
             # Table is dropped and recreated — all rows are destroyed.
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             # Column schema changes (other than adding new columns) may lose data.
             child_invalidation = "lossy"
 

--- a/python/cocoindex/connectors/surrealdb/_target.py
+++ b/python/cocoindex/connectors/surrealdb/_target.py
@@ -876,8 +876,12 @@ class _TableHandler(
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: the DDL can land on
+        # a table carrying the previous column set, so its columns still need
+        # reconciling. "insert" / "replace" define the table from the desired
+        # schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -894,9 +898,7 @@ class _TableHandler(
         child_invalidation: Literal["destructive", "lossy"] | None = None
         if main_action == "replace":
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             child_invalidation = "lossy"
 
         return coco.TargetReconcileOutput(
@@ -965,7 +967,11 @@ class _TableHandler(
 
                 if action.main_action in ("insert", "upsert", "replace"):
                     await self._create_table(conn, action.key, spec)
-                elif action.main_action is None and action.column_actions:
+                # "insert" / "replace" just defined the table from the desired
+                # schema. "upsert" may have landed on a pre-existing table, whose
+                # dropped fields `_create_table` does not remove — so reconcile
+                # columns for it as well as for the no-main-change case.
+                if action.main_action in (None, "upsert") and action.column_actions:
                     await self._apply_column_actions(
                         conn, action.key, spec, action.column_actions
                     )

--- a/python/tests/connectors/test_postgres_target.py
+++ b/python/tests/connectors/test_postgres_target.py
@@ -1117,3 +1117,78 @@ def test_sanitize_nul_preserves_dict() -> None:
     assert result == {"ab": "cd", "e": {"fg": "h"}}
     assert isinstance(result, dict)
     assert isinstance(result["e"], dict)
+
+
+@pytest.mark.asyncio
+async def test_schema_evolution_under_full_reprocess(pg_env: _PgEnv) -> None:
+    """A column type change must still be applied when the same update runs with
+    `full_reprocess=True`.
+
+    `full_reprocess` marks the table's previous state as maybe-missing, which
+    turns the table's own action into an "upsert" (`CREATE TABLE IF NOT EXISTS`).
+    That must not swallow the column reconcile: the new tracking record is
+    committed either way, so a skipped `ALTER` leaves the table permanently on
+    the old column type — later plain updates see prev == desired and never
+    catch up.
+    """
+    pool = pg_env.pool
+    coco_env = pg_env.coco_env
+    table_name = _unique_name("schema_reproc")
+
+    use_v2 = False
+
+    def _schema() -> "postgres.TableSchema[dict[str, Any]]":
+        return postgres.TableSchema(
+            columns={
+                "id": postgres.ColumnDef("text", nullable=False),
+                "val": postgres.ColumnDef(
+                    "text" if use_v2 else "varchar(50)", nullable=True
+                ),
+            },
+            primary_key=["id"],
+        )
+
+    async def _val_data_type() -> str | None:
+        async with pool.acquire() as conn:
+            val = await conn.fetchval(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = $1 AND column_name = $2",
+                table_name,
+                "val",
+            )
+            return str(val) if val is not None else None
+
+    try:
+
+        async def declare_fn() -> None:
+            table = await coco.use_mount(
+                coco.component_subpath("setup", "table"),
+                postgres.declare_table_target,
+                _PG_DB_KEY,
+                table_name,
+                _schema(),
+            )
+            table.declare_row(row={"id": "row1", "val": "data1"})
+
+        app = coco.App(
+            coco.AppConfig(
+                name=f"test_schema_reproc_{table_name}", environment=coco_env
+            ),
+            declare_fn,
+        )
+
+        await app.update()
+        assert await _val_data_type() == "character varying"
+
+        use_v2 = True
+        await app.update(full_reprocess=True)
+        assert await _val_data_type() == "text"
+
+        # The row survives the in-place type change.
+        async with pool.acquire() as conn:
+            val = await conn.fetchval(
+                f'SELECT "val" FROM "{table_name}" WHERE "id" = $1', "row1"
+            )
+        assert val == "data1"
+    finally:
+        await _drop_table(pool, table_name)

--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -1229,3 +1229,65 @@ def test_deps_rejected_with_logic_tracking_none() -> None:
         @coco.fn.as_async(memo=True, deps="ignored", logic_tracking=None)
         async def _g(x: str) -> str:
             return x
+
+
+# ---------------------------------------------------------------------------
+# Fn-memo HIT must still report the fn's own logic fp to the caller — on both
+# the sync and async call paths. Regression: the sync path used to create its
+# FnCallContext only on a miss, so a caller's memo entry rebuilt during a run
+# where the inner fn hit lost the dep, and a later code change to the inner fn
+# went undetected. (The async path always created the ctx before the probe.)
+# ---------------------------------------------------------------------------
+
+_hit_dep_runs: list[str] = []
+_hit_dep_n: dict[str, int] = {"n": 1}
+
+
+@coco.fn(memo=True)
+def _hit_dep_leaf_sync() -> int:
+    _hit_dep_runs.append("leaf")
+    return 1
+
+
+@coco.fn(memo=True)
+async def _hit_dep_mid(n: int) -> int:
+    _hit_dep_runs.append(f"mid{n}")
+    return _hit_dep_leaf_sync() + n
+
+
+async def _hit_dep_main() -> None:
+    await coco.use_mount(coco.component_subpath("mid"), _hit_dep_mid, _hit_dep_n["n"])
+
+
+def test_sync_fn_hit_still_reports_logic_dep_to_rebuilt_caller() -> None:
+    _hit_dep_runs.clear()
+    _hit_dep_n["n"] = 1
+    app: coco.App[[], None] = coco.App(
+        coco.AppConfig(name="test_sync_fn_hit_logic_dep", environment=coco_env),
+        _hit_dep_main,
+    )
+
+    # Run 1: everything executes.
+    app.update_blocking()
+    assert _hit_dep_runs == ["mid1", "leaf"]
+
+    # Run 2: mid's memo key changes -> mid re-executes, leaf HITS. Mid's
+    # rebuilt entry must still record leaf's logic fp.
+    _hit_dep_runs.clear()
+    _hit_dep_n["n"] = 2
+    app.update_blocking()
+    assert _hit_dep_runs == ["mid2"]
+
+    # Run 3: simulate leaf's code changing — its old fp leaves the registry.
+    leaf_fp = _hit_dep_leaf_sync._logic_fp  # type: ignore[attr-defined]
+    assert leaf_fp is not None
+    core.unregister_logic_fingerprint(leaf_fp)
+    try:
+        _hit_dep_runs.clear()
+        app.update_blocking()
+        assert _hit_dep_runs == [
+            "mid2",
+            "leaf",
+        ], f"leaf logic change not detected after hit-rebuild: {_hit_dep_runs}"
+    finally:
+        core.register_logic_fingerprint(leaf_fp)

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -2,18 +2,69 @@
 
 from __future__ import annotations
 
-import pytest
+import asyncio
+from collections.abc import Collection
 
 import cocoindex as coco
+import pytest
 
 from tests import common
-from tests.common.target_states import GlobalDictTarget, DictDataWithPrev, AtMost
+from tests.common.target_states import (
+    AtMost,
+    DictDataWithPrev,
+    DictTargetStateStore,
+    GlobalDictTarget,
+)
 
 coco_env = common.create_test_env(__file__)
 
 # Controls which component paths declare which target state keys+values.
 # Outer key = component name (becomes component subpath), inner key = target state key.
 _source_data: dict[str, dict[str, object]] = {}
+
+
+class _BlockingSinkStore(DictTargetStateStore):
+    def __init__(self) -> None:
+        self._block_next_apply = False
+        self._apply_started: asyncio.Event | None = None
+        self._release_apply: asyncio.Event | None = None
+        super().__init__(use_async=True)
+
+    def block_next_apply(self) -> None:
+        self._block_next_apply = True
+        self._apply_started = asyncio.Event()
+        self._release_apply = asyncio.Event()
+
+    async def wait_for_blocked_apply(self) -> None:
+        assert self._apply_started is not None
+        await self._apply_started.wait()
+
+    def release_blocked_apply(self) -> None:
+        assert self._release_apply is not None
+        self._release_apply.set()
+
+    async def _async_sink(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[str, DictDataWithPrev | coco.NonExistenceType]],
+        /,
+    ) -> None:
+        if self._block_next_apply:
+            self._block_next_apply = False
+            assert self._apply_started is not None
+            assert self._release_apply is not None
+            self._apply_started.set()
+            await self._release_apply.wait()
+        self._sink(context_provider, actions)
+
+
+_concurrent_claim_store = _BlockingSinkStore()
+_concurrent_claim_provider = coco.register_root_target_states_provider(
+    "test_target_state/concurrent_claim", _concurrent_claim_store
+)
+_concurrent_claim_values: dict[str, int] = {}
+_allow_c3_mount: asyncio.Event | None = None
+_c3_declared: asyncio.Event | None = None
 
 
 @coco.fn
@@ -26,6 +77,27 @@ async def _process_component(name: str) -> None:
 async def _app_main() -> None:
     for name in sorted(_source_data):
         await coco.mount(coco.component_subpath(name), _process_component, name)
+
+
+@coco.fn
+async def _process_concurrent_claimant(name: str) -> None:
+    coco.declare_target_state(
+        _concurrent_claim_provider.target_state("x", _concurrent_claim_values[name])
+    )
+    if name == "C3":
+        assert _c3_declared is not None
+        _c3_declared.set()
+
+
+@coco.fn
+async def _app_main_concurrent_claimants() -> None:
+    for name in sorted(_concurrent_claim_values):
+        if name == "C3":
+            assert _allow_c3_mount is not None
+            await _allow_c3_mount.wait()
+        await coco.mount(
+            coco.component_subpath(name), _process_concurrent_claimant, name
+        )
 
 
 def test_ownership_transfer_basic() -> None:
@@ -141,6 +213,63 @@ def test_ownership_transfer_ordering_independence() -> None:
     assert GlobalDictTarget.store.data["x"].data == 2
     assert common.list_target_state_owners_sync(app) == {
         '/@test_target_state/global_dict/"x"': coco.ROOT_PATH / "C2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claimant_sees_owner_during_sink_apply() -> None:
+    """A later claimant must see the owner whose sink action is in flight."""
+    global _allow_c3_mount, _c3_declared
+
+    _concurrent_claim_store.clear()
+    _concurrent_claim_values.clear()
+    test_env = common.create_test_env(
+        __file__, suffix="concurrent_claimant_sees_owner_during_sink_apply"
+    )
+    app = coco.App(
+        coco.AppConfig(
+            name="test_concurrent_claimant_sees_owner_during_sink_apply",
+            environment=test_env,
+        ),
+        _app_main_concurrent_claimants,
+    )
+
+    # Establish C1 as the committed owner.
+    _concurrent_claim_values["C1"] = 1
+    await app.update()
+    _concurrent_claim_store.metrics.collect()
+
+    # C2 claims x in precommit, then pauses inside sink.apply. C3 is mounted
+    # only after we have observed that in-flight claim.
+    _concurrent_claim_values.clear()
+    _concurrent_claim_values.update(C2=2, C3=3)
+    _allow_c3_mount = asyncio.Event()
+    _c3_declared = asyncio.Event()
+    _concurrent_claim_store.block_next_apply()
+    update_task = asyncio.ensure_future(app.update())
+    try:
+        await asyncio.wait_for(
+            _concurrent_claim_store.wait_for_blocked_apply(), timeout=5.0
+        )
+        assert await common.list_target_state_owners(app) == {
+            '/@test_target_state/concurrent_claim/"x"': coco.ROOT_PATH / "C2",
+        }
+
+        # Let C3 enter submission while C2 is still in sink.apply. The current
+        # protocol makes C3 observe C2's live claim and retry behind it.
+        _allow_c3_mount.set()
+        await asyncio.wait_for(_c3_declared.wait(), timeout=5.0)
+        await asyncio.sleep(0)
+    finally:
+        _allow_c3_mount.set()
+        _concurrent_claim_store.release_blocked_apply()
+        await update_task
+        _allow_c3_mount = None
+        _c3_declared = None
+
+    assert _concurrent_claim_store.data["x"].data == 3
+    assert await common.list_target_state_owners(app) == {
+        '/@test_target_state/concurrent_claim/"x"': coco.ROOT_PATH / "C3",
     }
 
 

--- a/python/tests/core/test_provider_generation.py
+++ b/python/tests/core/test_provider_generation.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 import cocoindex as coco
 
@@ -291,4 +291,222 @@ def test_lossy_change_invalidates_memo() -> None:
     _inner_exec_count = 0
     app.update_blocking()
     assert _inner_exec_count == 0
+    assert DictsTarget.store.collect_child_metrics() == {}
+
+
+# The tests above pass the provider as an argument, so an invalidation reaches
+# the memoized code through the memo key. The ones below capture the provider
+# from an enclosing scope instead — it is *not* part of the memo key, so the
+# invalidation has to travel through the provider generations recorded with the
+# memo entry. Without that channel a memo hit silently skips re-declaring the
+# rows, leaving cocoindex convinced they are written while the target has lost
+# them, and no later run ever repairs it.
+
+_captured_provider: Any = None
+
+
+@coco.fn(memo=True)
+async def _insert_rows_memo_captured(data: dict[str, Any]) -> None:
+    global _inner_exec_count
+    _inner_exec_count += 1
+    for key, value in data.items():
+        coco.declare_target_state(_captured_provider.target_state(key, value))
+
+
+async def _declare_dicts_with_captured_provider() -> None:
+    global _captured_provider
+    with coco.component_subpath("dict"):
+        for name, data in _source_data.items():
+            with coco.component_subpath(name):
+                _captured_provider = await coco.use_mount(
+                    coco.component_subpath("setup"),
+                    DictsTarget.declare_dict_target,
+                    name,
+                )
+                await coco.use_mount(  # type: ignore[call-overload]
+                    coco.component_subpath("rows"),
+                    _insert_rows_memo_captured,
+                    data,
+                )
+
+
+@coco.fn(memo=True)
+async def _insert_rows_fn_memo_captured(data: dict[str, Any]) -> None:
+    global _inner_exec_count
+    _inner_exec_count += 1
+    for key, value in data.items():
+        coco.declare_target_state(_captured_provider.target_state(key, value))
+
+
+async def _declare_dicts_with_captured_provider_fn_memo() -> None:
+    """Same, but the memoized function is *called*, not mounted — so it goes
+    through the function-call memo cache rather than the component memo."""
+    global _captured_provider
+    with coco.component_subpath("dict"):
+        for name, data in _source_data.items():
+            with coco.component_subpath(name):
+                _captured_provider = await coco.use_mount(
+                    coco.component_subpath("setup"),
+                    DictsTarget.declare_dict_target,
+                    name,
+                )
+                await _insert_rows_fn_memo_captured(data)
+
+
+def _new_captured_provider_app(
+    name: str, main: Any = _declare_dicts_with_captured_provider
+) -> coco.App[[], None]:
+    global _inner_exec_count, _captured_provider
+    DictsTarget.store.clear()
+    _source_data.clear()
+    DictsTarget.store.child_invalidation = None
+    _inner_exec_count = 0
+    _captured_provider = None
+    return coco.App(coco.AppConfig(name=name, environment=coco_env), main)
+
+
+def _assert_invalidates_memo_without_provider_arg(
+    app: coco.App[[], None], invalidation: Literal["destructive", "lossy"]
+) -> None:
+    global _inner_exec_count
+    _source_data["D1"] = {"a": 1}
+
+    # Run 1: initial insert — the memoized function executes.
+    app.update_blocking()
+    assert _inner_exec_count == 1
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
+
+    # Run 2: same data, no invalidation — memo hit.
+    _inner_exec_count = 0
+    app.update_blocking()
+    assert _inner_exec_count == 0
+    assert DictsTarget.store.collect_child_metrics() == {}
+
+    # Run 3: the provider generation moves. The provider is not in the memo key,
+    # so only the recorded generation dep can force the re-execution.
+    DictsTarget.store.child_invalidation = invalidation
+    _inner_exec_count = 0
+    try:
+        app.update_blocking()
+    finally:
+        DictsTarget.store.child_invalidation = None
+    assert _inner_exec_count == 1
+    assert DictsTarget.store.collect_child_metrics() == {"sink": AtMost(1), "upsert": 1}
+
+    # Run 4: the generation is stable again — back to a memo hit. An invalidation
+    # must not leave the entry permanently unmemoizable.
+    _inner_exec_count = 0
+    app.update_blocking()
+    assert _inner_exec_count == 0
+    assert DictsTarget.store.collect_child_metrics() == {}
+
+
+def test_destructive_change_invalidates_memo_without_provider_arg() -> None:
+    _assert_invalidates_memo_without_provider_arg(
+        _new_captured_provider_app(
+            "test_destructive_change_invalidates_memo_without_provider_arg"
+        ),
+        "destructive",
+    )
+
+
+def test_lossy_change_invalidates_memo_without_provider_arg() -> None:
+    _assert_invalidates_memo_without_provider_arg(
+        _new_captured_provider_app(
+            "test_lossy_change_invalidates_memo_without_provider_arg"
+        ),
+        "lossy",
+    )
+
+
+def test_lossy_change_invalidates_fn_memo_without_provider_arg() -> None:
+    _assert_invalidates_memo_without_provider_arg(
+        _new_captured_provider_app(
+            "test_lossy_change_invalidates_fn_memo_without_provider_arg",
+            _declare_dicts_with_captured_provider_fn_memo,
+        ),
+        "lossy",
+    )
+
+
+# --- Composed scenario: a memoized intermediate component re-executes while an
+# inner memoized fn HITS. The hit skips the fn's declarations, so its provider
+# deps must be merged from the stored entry into the intermediate's rebuilt
+# memo (via FnCallMemoGuard.join_cached_target_provider_deps) — otherwise the
+# intermediate's new entry loses the dep and a later lossy/destructive change
+# is silently ignored.
+
+_leaf_runs: list[str] = []
+
+
+@coco.fn(memo=True)
+async def _composed_leaf() -> None:
+    _leaf_runs.append("leaf")
+    coco.declare_target_state(_captured_provider.target_state("a", 1))
+
+
+@coco.fn(memo=True)
+async def _composed_mid(n: int) -> None:
+    _leaf_runs.append(f"mid{n}")
+    await _composed_leaf()
+
+
+_composed_n: dict[str, int] = {"n": 1}
+
+
+async def _declare_composed() -> None:
+    global _captured_provider
+    with coco.component_subpath("dict"):
+        _captured_provider = await coco.use_mount(
+            coco.component_subpath("setup"), DictsTarget.declare_dict_target, "D1"
+        )
+        await coco.use_mount(
+            coco.component_subpath("rows"), _composed_mid, _composed_n["n"]
+        )
+
+
+def test_lossy_change_after_intermediate_rebuild_with_fn_hit() -> None:
+    global _captured_provider
+    DictsTarget.store.clear()
+    DictsTarget.store.child_invalidation = None
+    _leaf_runs.clear()
+    _captured_provider = None
+    _composed_n["n"] = 1
+    app: coco.App[[], None] = coco.App(
+        coco.AppConfig(
+            name="test_lossy_composed_fn_hit",
+            environment=coco_env,
+        ),
+        _declare_composed,
+    )
+
+    # Run 1: everything executes; deps recorded everywhere.
+    app.update_blocking()
+    assert _leaf_runs == ["mid1", "leaf"]
+    DictsTarget.store.collect_child_metrics()
+
+    # Run 2: mid's memo key changes -> mid re-executes, leaf HITS. Mid's
+    # rebuilt entry must retain leaf's provider dep via the stored-entry merge.
+    _leaf_runs.clear()
+    _composed_n["n"] = 2
+    app.update_blocking()
+    assert _leaf_runs == ["mid2"]
+    DictsTarget.store.collect_child_metrics()
+
+    # Run 3: lossy provider change. Both mid and leaf must re-execute so the
+    # row is re-upserted.
+    _leaf_runs.clear()
+    DictsTarget.store.child_invalidation = "lossy"
+    try:
+        app.update_blocking()
+    finally:
+        DictsTarget.store.child_invalidation = None
+    assert _leaf_runs == ["mid2", "leaf"]
+    metrics = DictsTarget.store.collect_child_metrics()
+    assert metrics.get("upsert", 0) == 1
+
+    # Run 4: stable again — memo hits all the way down.
+    _leaf_runs.clear()
+    app.update_blocking()
+    assert _leaf_runs == []
     assert DictsTarget.store.collect_child_metrics() == {}

--- a/rust/core/src/engine/component.rs
+++ b/rust/core/src/engine/component.rs
@@ -19,7 +19,7 @@ use crate::engine::stats::ProcessingStats;
 use crate::engine::target_state::{TargetStateProvider, TargetStateProviderRegistry};
 use crate::state::stable_path::{StablePath, StablePathRef};
 use crate::state::stable_path_set::StablePathSet;
-use crate::state::target_state_path::TargetStatePath;
+use crate::state::target_state_path::{TargetProviderDeps, TargetStatePath};
 use cocoindex_utils::error::{SharedError, SharedResult, SharedResultExt};
 use cocoindex_utils::fingerprint::Fingerprint;
 
@@ -198,6 +198,7 @@ impl ComponentBgChildReadinessState {
 pub(crate) struct ComponentRunOutcome {
     has_exception: bool,
     logic_deps: HashSet<Fingerprint>,
+    target_provider_deps: TargetProviderDeps,
 }
 
 impl ComponentRunOutcome {
@@ -210,17 +211,21 @@ impl ComponentRunOutcome {
 
     /// Outcome for a component that hit its memo cache: no exception, but it
     /// still reports the stored logic dependency set so a mounting parent's
-    /// memo depends on this subtree.
-    fn reused(logic_deps: Vec<Fingerprint>) -> Self {
+    /// memo depends on this subtree — and likewise its target-provider deps, so
+    /// a parent that later memo-hits (and therefore never mounts this child)
+    /// still re-checks the provider generations this child declared against.
+    fn reused(logic_deps: Vec<Fingerprint>, target_provider_deps: TargetProviderDeps) -> Self {
         Self {
             has_exception: false,
             logic_deps: logic_deps.into_iter().collect(),
+            target_provider_deps,
         }
     }
 
     fn merge(&mut self, other: Self) {
         self.has_exception |= other.has_exception;
         self.logic_deps.extend(other.logic_deps);
+        self.target_provider_deps.extend(other.target_provider_deps);
     }
 }
 
@@ -912,7 +917,7 @@ impl<Prof: EngineProfile> Component<Prof> {
 
             match use_or_invalidate_component_memoization(processor_context, memo_fp_to_store).await
             {
-                Ok(Some((ret, memo_states, stored_logic_deps))) => {
+                Ok(Some((ret, memo_states, stored_logic_deps, stored_provider_deps))) => {
                     // If processor has state handler and there are stored states, validate them.
                     if processor.has_memo_state_handler() && !memo_states.is_empty() {
                         let fut = processor.handle_memo_states(
@@ -935,7 +940,10 @@ impl<Prof: EngineProfile> Component<Prof> {
                             // memo hit, so a mounting parent's memo depends on
                             // this whole subtree (see `merge_logic_deps` below).
                             return Ok((
-                                ComponentRunOutcome::reused(stored_logic_deps),
+                                ComponentRunOutcome::reused(
+                                    stored_logic_deps,
+                                    stored_provider_deps,
+                                ),
                                 Some(ComponentBuildOutput {
                                     ret,
                                     built_target_states_providers: Default::default(),
@@ -951,7 +959,7 @@ impl<Prof: EngineProfile> Component<Prof> {
                             stats.num_unchanged += 1;
                         });
                         return Ok((
-                            ComponentRunOutcome::reused(stored_logic_deps),
+                            ComponentRunOutcome::reused(stored_logic_deps, stored_provider_deps),
                             Some(ComponentBuildOutput {
                                 ret,
                                 built_target_states_providers: Default::default(),
@@ -1041,6 +1049,9 @@ impl<Prof: EngineProfile> Component<Prof> {
                     // own memo and the outcome reported to its parent.
                     processor_context
                         .merge_logic_deps(std::mem::take(&mut children_outcome.logic_deps));
+                    processor_context.merge_target_provider_deps(std::mem::take(
+                        &mut children_outcome.target_provider_deps,
+                    ));
 
                     let ret = ret?;
                     deadline.check()?;
@@ -1102,9 +1113,17 @@ impl<Prof: EngineProfile> Component<Prof> {
                             // boundary — so the parent's memo depends on this whole
                             // subtree's logic.
                             let logic_deps = processor_context.take_logic_deps();
-                            post_submit_for_build(processor_context, comp_memo, &logic_deps)
-                                .await?;
+                            let target_provider_deps =
+                                processor_context.take_target_provider_deps();
+                            post_submit_for_build(
+                                processor_context,
+                                comp_memo,
+                                &logic_deps,
+                                &target_provider_deps,
+                            )
+                            .await?;
                             children_outcome.logic_deps = logic_deps;
+                            children_outcome.target_provider_deps = target_provider_deps;
                         }
                         Some(ComponentBuildOutput {
                             ret,

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -15,7 +15,9 @@ use crate::state::stable_path::StableKey;
 pub(crate) static TARGET_ID_KEY: LazyLock<StableKey> =
     LazyLock::new(|| StableKey::Symbol("cocoindex/_internal/target_id".into()));
 use crate::state::stable_path_set::ChildStablePathSet;
-use crate::state::target_state_path::TargetStatePath;
+use crate::state::target_state_path::{
+    TargetProviderDeps, TargetStatePath, TargetStateProviderGeneration,
+};
 use crate::{
     engine::environment::{AppRegistration, Environment},
     state::stable_path::StablePath,
@@ -183,6 +185,7 @@ pub(crate) struct ComponentTargetStatesContext<Prof: EngineProfile> {
 pub struct FnCallMemo<Prof: EngineProfile> {
     pub ret: Prof::FunctionData,
     pub(crate) target_state_paths: Vec<TargetStatePath>,
+    pub(crate) target_provider_deps: TargetProviderDeps,
     pub(crate) dependency_memo_entries: HashSet<Fingerprint>,
     pub(crate) logic_deps: HashSet<Fingerprint>,
     pub memo_states: Vec<Prof::FunctionData>,
@@ -359,6 +362,8 @@ impl<Prof: EngineProfile> FnMemoCache<Prof> {
                         )),
                         child_components: vec![],
                         target_state_paths: memo.target_state_paths,
+                        // Already sorted — `TargetProviderDeps` is a `BTreeMap`.
+                        target_provider_deps: memo.target_provider_deps.into_iter().collect(),
                         dependency_memo_entries: memo.dependency_memo_entries.into_iter().collect(),
                         logic_deps: memo.logic_deps.into_iter().collect(),
                         memo_states: memo_states_serialized,
@@ -411,6 +416,12 @@ impl<Prof: EngineProfile> Default for FnMemoCache<Prof> {
 /// legacy form with `child_components`, the result is `Ready(None)` so
 /// the entry is treated as a deletion at flush time.
 ///
+/// Target-provider generation deps are deliberately NOT checked here — the
+/// finalize dep walk also decodes entries to collect their contained target
+/// state paths, and invalidating on a generation mismatch there would drop
+/// live paths from the contained set. That check lives in
+/// `reserve_memoization`, the probe path proper.
+///
 /// This helper is shared between `reserve_memoization` (probe path) and
 /// the finalize dep walk; both call it under the per-entry write lock.
 ///
@@ -444,6 +455,7 @@ pub(crate) fn decode_stored_entry<Prof: EngineProfile>(
     *entry = FnCallMemoEntry::Ready(Some(FnCallMemo {
         ret,
         target_state_paths: decoded.target_state_paths,
+        target_provider_deps: decoded.target_provider_deps.into_iter().collect(),
         dependency_memo_entries: decoded.dependency_memo_entries.into_iter().collect(),
         logic_deps: decoded.logic_deps.into_iter().collect(),
         memo_states,
@@ -679,6 +691,11 @@ struct ComponentProcessorContextInner<Prof: EngineProfile> {
     /// Logic fingerprints accumulated from function calls and child components.
     logic_deps: Mutex<HashSet<Fingerprint>>,
 
+    /// Target-state provider generations this component declared against,
+    /// accumulated from its own declarations and from child components. Stored
+    /// with this component's memo entry and re-checked on the next probe.
+    target_provider_deps: Mutex<TargetProviderDeps>,
+
     /// Opaque per-operation context (e.g. ContextProvider on the Python side).
     host_ctx: Arc<Prof::HostCtx>,
 }
@@ -716,6 +733,7 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
                 processing_action,
                 inflight_permit: Mutex::new(None),
                 logic_deps: Mutex::new(HashSet::new()),
+                target_provider_deps: Mutex::new(TargetProviderDeps::new()),
                 host_ctx,
             }),
             processing_stats,
@@ -833,6 +851,21 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
         self.inner.parent_context.as_ref()
     }
 
+    /// The target-state providers visible to this component: everything
+    /// inherited from ancestors at mount time plus anything its own subtree has
+    /// built so far. Cloning is O(1) — the map is structurally shared.
+    pub(crate) fn target_states_providers(
+        &self,
+    ) -> Result<rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>> {
+        self.update_building_state(|building_state| {
+            Ok(building_state
+                .target_states
+                .provider_registry
+                .providers
+                .clone())
+        })
+    }
+
     /// Access the building state under a single lock acquisition.
     /// Callers should access all needed fields within `f` rather than wrapping
     /// this in convenience methods — the caller decides the lock granularity.
@@ -916,15 +949,37 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
     }
 
     pub fn join_fn_call(&self, fn_ctx: &FnCallContext) {
-        let (fn_logic_deps, context_change_deps) = fn_ctx.update(|inner| {
+        let (fn_logic_deps, context_change_deps, target_provider_deps) = fn_ctx.update(|inner| {
             (
                 inner.fn_logic_deps.clone(),
                 inner.context_change_deps.clone(),
+                inner.target_provider_deps.clone(),
             )
         });
         let mut deps = self.inner.logic_deps.lock().unwrap();
         deps.extend(fn_logic_deps);
         deps.extend(context_change_deps);
+        drop(deps);
+        self.merge_target_provider_deps(target_provider_deps);
+    }
+
+    /// Merge target-provider generation deps (from this component's own
+    /// declarations, or propagated up from a mounted child) into this
+    /// component's set.
+    pub(crate) fn merge_target_provider_deps(
+        &self,
+        deps: impl IntoIterator<Item = (TargetStatePath, TargetStateProviderGeneration)>,
+    ) {
+        self.inner.target_provider_deps.lock().unwrap().extend(deps);
+    }
+
+    /// Take the accumulated target-provider deps out of this context. Like
+    /// [`take_logic_deps`](Self::take_logic_deps), the single set serves both
+    /// this component's own memo entry and the `ComponentRunOutcome` reported
+    /// to the parent — a parent that memo-hits never mounts its children, so it
+    /// must carry their provider deps to catch an invalidation on their behalf.
+    pub(crate) fn take_target_provider_deps(&self) -> TargetProviderDeps {
+        std::mem::take(&mut *self.inner.target_provider_deps.lock().unwrap())
     }
 
     /// Merge additional logic deps (e.g. from child components) into this component's set.
@@ -1004,6 +1059,10 @@ impl<Prof: EngineProfile> ComponentProcessorContext<Prof> {
 pub struct FnCallContextInner {
     /// Target states that are declared by the function.
     pub target_state_paths: Vec<TargetStatePath>,
+    /// Generations of the providers those target states were declared against.
+    /// Re-checked when this call's memo entry is probed — see
+    /// [`TargetProviderDeps`].
+    pub target_provider_deps: TargetProviderDeps,
     /// Dependency entries that are declared by the function. Only needs to keep dependencies with side effects (target states / dependency entries with side effects).
     pub dependency_memo_entries: HashSet<Fingerprint>,
 
@@ -1048,6 +1107,9 @@ impl FnCallContext {
             inner
                 .target_state_paths
                 .extend(child_inner.target_state_paths);
+            inner
+                .target_provider_deps
+                .extend(child_inner.target_provider_deps);
             inner
                 .dependency_memo_entries
                 .extend(child_inner.dependency_memo_entries);

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -20,7 +20,8 @@ use crate::engine::target_state::{
 use crate::state::stable_path::{StableKey, StablePath, StablePathRef};
 use crate::state::stable_path_set::ChildStablePathSet;
 use crate::state::target_state_path::{
-    TargetStatePath, TargetStatePathWithProviderId, TargetStateProviderGeneration,
+    TargetProviderDeps, TargetStatePath, TargetStatePathWithProviderId,
+    TargetStateProviderGeneration,
 };
 use crate::state_store::{
     AppStore, CommitPlan, ExistenceReconciler, OwnerStateForPreempt, PrecommitClaimTargetsPlan,
@@ -87,6 +88,7 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
         Prof::FunctionData,
         MemoStatesPayload<Prof>,
         Vec<Fingerprint>,
+        TargetProviderDeps,
     )>,
 > {
     // Short-circuit to miss under full_reprocess
@@ -107,6 +109,10 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
                     &memo_info.logic_deps,
                     comp_ctx.app_ctx().env(),
                 )
+                && target_provider_deps_still_valid(
+                    memo_info.target_provider_deps.iter().map(|(p, g)| (p, g)),
+                    &comp_ctx.target_states_providers()?,
+                )
             {
                 let bytes = match memo_info.return_value {
                     db_schema::MemoizedValue::Inlined(b) => b,
@@ -122,7 +128,8 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
                         // can still report this subtree's dependency set to the
                         // parent — otherwise a parent that mounts this component
                         // would not depend on it (or its descendants) and would
-                        // wrongly stay a memo hit when their code changes.
+                        // wrongly stay a memo hit when their code changes. The
+                        // target-provider deps ride along for the same reason.
                         return Ok(Some((
                             ret,
                             MemoStatesPayload {
@@ -130,6 +137,7 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
                                 by_context_fp: context_memo_states,
                             },
                             memo_info.logic_deps.to_vec(),
+                            memo_info.target_provider_deps.into_iter().collect(),
                         )));
                     }
                     Err(e) => {
@@ -166,7 +174,8 @@ pub(crate) async fn use_or_invalidate_component_memoization<Prof: EngineProfile>
 /// Used when memo state validation indicates `can_reuse=true` but states have changed
 /// (e.g. mtime changed but content fingerprint is unchanged). Reads the existing entry,
 /// replaces the `memo_states` / `context_memo_states` fields, and writes it back —
-/// preserving `processor_fp`, `return_value`, and `logic_deps`.
+/// preserving `processor_fp`, `return_value`, `logic_deps`, and
+/// `target_provider_deps`.
 pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
     comp_ctx: &ComponentProcessorContext<Prof>,
     new_states: &MemoStatesPayload<Prof>,
@@ -209,6 +218,7 @@ pub(crate) async fn update_component_memo_states<Prof: EngineProfile>(
                         processor_fp: existing.processor_fp,
                         return_value: existing.return_value,
                         logic_deps: existing.logic_deps,
+                        target_provider_deps: existing.target_provider_deps,
                         memo_states: memo_states_borrowed,
                         context_memo_states: context_memo_states_borrowed,
                     };
@@ -259,6 +269,7 @@ pub fn declare_target_state<Prof: EngineProfile>(
     value: Prof::TargetStateValue,
 ) -> Result<()> {
     let target_state_path = provider.target_state_path().concat(&key);
+    let provider_dep = target_provider_dep(&provider);
     let declared_target_state = DeclaredTargetState {
         provider,
         item_key: key,
@@ -283,8 +294,47 @@ pub fn declare_target_state<Prof: EngineProfile>(
         }
         Ok(())
     })?;
-    fn_ctx.update(|inner| inner.target_state_paths.push(target_state_path));
+    fn_ctx.update(|inner| {
+        inner.target_state_paths.push(target_state_path);
+        if let Some((path, generation)) = provider_dep {
+            inner.target_provider_deps.insert(path, generation);
+        }
+    });
     Ok(())
+}
+
+/// Whether every recorded target-provider dependency still matches the live
+/// provider generation, i.e. whether a memo entry carrying `deps` may be reused.
+///
+/// A provider missing from `providers` is deliberately *not* a mismatch. Either
+/// it is built inside the memoized subtree itself — in which case reusing the
+/// memo means nothing in there ran, so nothing bumped its generation — or the
+/// target is gone entirely, and its leftover target states are the delete pass's
+/// business, not a reason to re-run this code. Treating "absent" as a mismatch
+/// would instead make every component that mounts its own target permanently
+/// unmemoizable.
+pub(crate) fn target_provider_deps_still_valid<'a, Prof: EngineProfile>(
+    deps: impl IntoIterator<Item = (&'a TargetStatePath, &'a TargetStateProviderGeneration)>,
+    providers: &rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
+) -> bool {
+    deps.into_iter().all(|(path, recorded)| {
+        match providers.get(path).and_then(|p| p.provider_generation()) {
+            Some(current) => current == recorded,
+            None => true,
+        }
+    })
+}
+
+/// The `(provider path, generation)` pair to record as a memo dependency for a
+/// declaration made against `provider`, or `None` when the provider has no
+/// generation yet (it only gets one once it has been through a pre-commit, and
+/// a provider that never had one cannot have been invalidated).
+fn target_provider_dep<Prof: EngineProfile>(
+    provider: &TargetStateProvider<Prof>,
+) -> Option<(TargetStatePath, TargetStateProviderGeneration)> {
+    provider
+        .provider_generation()
+        .map(|generation| (provider.target_state_path().clone(), generation.clone()))
 }
 
 pub fn register_root_target_state_provider<Prof: EngineProfile>(
@@ -307,6 +357,7 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
     key: StableKey,
     value: Prof::TargetStateValue,
 ) -> Result<TargetStateProvider<Prof>> {
+    let provider_dep = target_provider_dep(&provider);
     let child_provider = comp_ctx.update_building_state(|building_state| {
         let child_provider = building_state
             .target_states
@@ -339,6 +390,9 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
         inner
             .target_state_paths
             .push(child_provider.target_state_path().clone());
+        if let Some((path, generation)) = provider_dep {
+            inner.target_provider_deps.insert(path, generation);
+        }
     });
     Ok(child_provider)
 }
@@ -1789,6 +1843,7 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
         &'_ MemoStatesPayload<Prof>,
     )>,
     logic_deps: &HashSet<Fingerprint>,
+    target_provider_deps: &TargetProviderDeps,
 ) -> Result<()> {
     let Some((fp, ret, memo_states)) = comp_memo else {
         return Ok(());
@@ -1806,6 +1861,11 @@ pub(crate) async fn post_submit_for_build<Prof: EngineProfile>(
         processor_fp: fp,
         return_value: db_schema::MemoizedValue::Inlined(Cow::Borrowed(ret_bytes.as_ref())),
         logic_deps: logic_deps_sorted,
+        // Already sorted — `TargetProviderDeps` is a `BTreeMap`.
+        target_provider_deps: target_provider_deps
+            .iter()
+            .map(|(path, generation)| (path.clone(), generation.clone()))
+            .collect(),
         memo_states: memo_states_serialized,
         context_memo_states: context_memo_states_serialized,
     };

--- a/rust/core/src/engine/function.rs
+++ b/rust/core/src/engine/function.rs
@@ -2,6 +2,7 @@ use crate::engine::context::{
     ComponentProcessorContext, FnCallContext, FnCallMemo, FnCallMemoEntry, MemoStatesPayload,
     decode_stored_entry,
 };
+use crate::engine::execution::target_provider_deps_still_valid;
 use crate::engine::profile::EngineProfile;
 use crate::prelude::*;
 
@@ -19,6 +20,7 @@ fn build_fn_call_memo<Prof: EngineProfile>(
         Some(FnCallMemo {
             ret,
             target_state_paths: inner.target_state_paths.clone(),
+            target_provider_deps: inner.target_provider_deps.clone(),
             dependency_memo_entries: inner.dependency_memo_entries.clone(),
             logic_deps,
             memo_states: memo_states.positional,
@@ -60,6 +62,32 @@ impl<Prof: EngineProfile> FnCallMemoGuard<Prof> {
                 context_memo_states: &memo.context_memo_states,
             }),
             _ => None,
+        }
+    }
+
+    /// On a cache hit, merge the stored entry's target-provider deps into the
+    /// calling context.
+    ///
+    /// A hit skips re-declaring the entry's target states, so the caller's own
+    /// memo entry (a component or an enclosing memoized function) would
+    /// otherwise be re-stored *without* these deps — and a later provider
+    /// generation bump would no longer invalidate it. Each entry stores the
+    /// full dep set of its subtree (accumulated via `join_child` at record
+    /// time), so this single merge keeps propagation transitive across
+    /// arbitrarily nested hits. Call it exactly when the cached value is used;
+    /// the deps were validated against live generations at reserve time, so
+    /// the merged values always match what a fresh declaration would record.
+    pub fn join_cached_target_provider_deps(&self, parent_fn_ctx: &FnCallContext) {
+        if let FnCallMemoEntry::Ready(Some(memo)) = &*self.guard
+            && !memo.target_provider_deps.is_empty()
+        {
+            parent_fn_ctx.update(|inner| {
+                inner.target_provider_deps.extend(
+                    memo.target_provider_deps
+                        .iter()
+                        .map(|(path, generation)| (path.clone(), generation.clone())),
+                );
+            });
         }
     }
 
@@ -126,6 +154,22 @@ pub async fn reserve_memoization<Prof: EngineProfile>(
     // a legacy entry with `child_components` — both cases force re-execution.
     if matches!(&*guard, FnCallMemoEntry::Stored(_)) {
         decode_stored_entry::<Prof>(&mut guard, comp_exec_ctx.app_ctx().env())?;
+    }
+
+    // A hit would skip re-declaring the target states this entry covers, so it
+    // is only reusable while the providers it declared against are still at the
+    // generations it recorded. Checked here rather than in `decode_stored_entry`
+    // because the finalize dep walk decodes entries to collect their contained
+    // target state paths — invalidating there would drop those paths from the
+    // contained set and let the delete pass remove live target states.
+    if let FnCallMemoEntry::Ready(Some(memo)) = &*guard
+        && !memo.target_provider_deps.is_empty()
+        && !target_provider_deps_still_valid(
+            memo.target_provider_deps.iter(),
+            &comp_exec_ctx.target_states_providers()?,
+        )
+    {
+        *guard = FnCallMemoEntry::Ready(None);
     }
 
     Ok(FnCallMemoGuard { guard })

--- a/rust/core/src/state/db_schema.rs
+++ b/rust/core/src/state/db_schema.rs
@@ -275,6 +275,12 @@ pub struct ComponentMemoizationInfo<'a> {
     pub return_value: MemoizedValue<'a>,
     #[serde(rename = "L", default, skip_serializing_if = "Vec::is_empty")]
     pub logic_deps: Vec<Fingerprint>,
+    /// Generations of the target-state providers this component declared
+    /// against, sorted by path. Re-checked on the next probe so a lossy or
+    /// destructive schema change invalidates the memo even when the target
+    /// isn't part of the memo key. See `TargetProviderDeps`.
+    #[serde(rename = "TP", default, skip_serializing_if = "Vec::is_empty")]
+    pub target_provider_deps: Vec<(TargetStatePath, TargetStateProviderGeneration)>,
     #[serde(rename = "S", default, skip_serializing_if = "Vec::is_empty", borrow)]
     pub memo_states: Vec<MemoizedValue<'a>>,
     /// Context-borne memo states, keyed by the tracked-context value's fingerprint.
@@ -299,6 +305,10 @@ pub struct FunctionMemoizationEntry<'a> {
     /// Target states that are declared by the function.
     #[serde(rename = "E", default, skip_serializing_if = "Vec::is_empty")]
     pub target_state_paths: Vec<TargetStatePath>,
+    /// Generations of the providers those target states were declared against,
+    /// sorted by path. See `ComponentMemoizationInfo::target_provider_deps`.
+    #[serde(rename = "TP", default, skip_serializing_if = "Vec::is_empty")]
+    pub target_provider_deps: Vec<(TargetStatePath, TargetStateProviderGeneration)>,
     /// Dependency entries that are declared by the function.
     /// Only needs to keep dependencies with side effects other than return value (child components / target states / dependency entries with side effects).
     #[serde(rename = "D", default, skip_serializing_if = "Vec::is_empty")]

--- a/rust/core/src/state/target_state_path.rs
+++ b/rust/core/src/state/target_state_path.rs
@@ -75,11 +75,24 @@ impl TargetStatePath {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TargetStateProviderGeneration {
     pub provider_id: u64,
     pub provider_schema_version: u64,
 }
+
+/// A memoized component's (or function call's) dependency on the generations of
+/// the target-state providers it declared against, keyed by provider path.
+///
+/// Recorded while the declarations happen and re-checked when the memo entry is
+/// probed. A memo hit skips re-declaring everything the entry covers; if the
+/// provider's generation has moved on since (a lossy or destructive schema
+/// change), those declarations are no longer known to be in sync with the
+/// target, so the entry must not be reused. Without this, the invalidation
+/// reaches memoized code only when the target happens to be part of the memo
+/// key — e.g. passed as an argument — and is silently dropped otherwise.
+pub type TargetProviderDeps =
+    std::collections::BTreeMap<TargetStatePath, TargetStateProviderGeneration>;
 
 impl Serialize for TargetStateProviderGeneration {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/rust/py/src/function.rs
+++ b/rust/py/src/function.rs
@@ -189,6 +189,15 @@ impl PyFnCallMemoGuard {
         Ok(resolved)
     }
 
+    /// On a cache hit, merge the stored entry's target-provider generation deps
+    /// into the calling context. Call exactly when the cached value is used
+    /// (next to `join_child_memo`) — see the core method for the rationale.
+    pub fn join_cached_target_provider_deps(&self, parent_fn_ctx: &PyFnCallContext) {
+        if let Some(guard) = &self.guard {
+            guard.join_cached_target_provider_deps(&parent_fn_ctx.0);
+        }
+    }
+
     /// Release the underlying Rust write lock without resolving the memo entry.
     ///
     /// Users should call this in a `finally` block if they don't end up calling `resolve(...)`.

--- a/rust/sdk/cocoindex/src/doris.rs
+++ b/rust/sdk/cocoindex/src/doris.rs
@@ -753,9 +753,14 @@ impl TargetHandler<TableSpec> for TableHandler {
                     MutualTrackingRecord::new(table_composite_record(&spec), spec.managed_by);
                 let resolved =
                     resolve_system_transition(Some(tracking.clone()), prev, prev_may_be_missing);
+                // `insert` / `replace` build the table from the desired schema, so
+                // every column is already correct. `upsert` means the table may or
+                // may not exist: `CREATE TABLE IF NOT EXISTS` can land on a table
+                // carrying the previous column set, so its columns still need
+                // reconciling.
                 let (main_action, column_transitions) = diff_composite(resolved.as_ref());
                 let mut column_actions = BTreeMap::new();
-                if main_action.is_none() {
+                if matches!(main_action, None | Some(DiffAction::Upsert)) {
                     for (sub_key, transition) in &column_transitions {
                         if let Some(action) = diff(Some(transition)) {
                             column_actions.insert(sub_key.clone(), action);
@@ -767,10 +772,9 @@ impl TargetHandler<TableSpec> for TableHandler {
                 // column change other than a pure add → may lose data → lossy.
                 let child_invalidation = if matches!(main_action, Some(DiffAction::Replace)) {
                     Some(TargetChildInvalidation::Destructive)
-                } else if main_action.is_none()
-                    && column_actions
-                        .values()
-                        .any(|a| !matches!(a, DiffAction::Insert))
+                } else if column_actions
+                    .values()
+                    .any(|a| !matches!(a, DiffAction::Insert))
                 {
                     Some(TargetChildInvalidation::Lossy)
                 } else {
@@ -868,15 +872,17 @@ async fn apply_table_action(
         return Ok(None);
     };
 
-    match main_action {
-        Some(DiffAction::Insert | DiffAction::Upsert | DiffAction::Replace) => {
-            create_table(conn, &spec).await?;
-        }
-        _ => {
-            if !column_actions.is_empty() {
-                apply_column_actions(conn, &spec, &column_actions).await?;
-            }
-        }
+    if matches!(
+        main_action,
+        Some(DiffAction::Insert | DiffAction::Upsert | DiffAction::Replace)
+    ) {
+        // `create_table` uses `IF NOT EXISTS`, so an `upsert` against an
+        // already-present table is a no-op — which is why an `upsert` still
+        // falls through to the column reconcile below.
+        create_table(conn, &spec).await?;
+    }
+    if matches!(main_action, None | Some(DiffAction::Upsert)) && !column_actions.is_empty() {
+        apply_column_actions(conn, &spec, &column_actions).await?;
     }
 
     Ok(Some(ChildTargetDef::new::<RowState, _>(RowHandler {

--- a/rust/sdk/cocoindex/src/sqlite.rs
+++ b/rust/sdk/cocoindex/src/sqlite.rs
@@ -508,11 +508,14 @@ impl TargetHandler<TableSpec> for TableHandler {
                 let resolved =
                     resolve_system_transition(Some(tracking.clone()), prev, prev_may_be_missing);
                 // Split the diff into a structural (main) action plus per-column
-                // transitions. Per-column actions only apply when the table
-                // itself is unchanged — a main rewrite recreates every column.
+                // transitions. `insert` / `replace` build the table from the
+                // desired schema, so every column is already correct. `upsert`
+                // means the table may or may not exist: `CREATE TABLE IF NOT
+                // EXISTS` can land on a table carrying the previous column set,
+                // so its columns still need reconciling.
                 let (main_action, column_transitions) = diff_composite(resolved.as_ref());
                 let mut column_actions = BTreeMap::new();
-                if main_action.is_none() {
+                if matches!(main_action, None | Some(DiffAction::Upsert)) {
                     for (sub_key, transition) in &column_transitions {
                         if let Some(action) = diff(Some(transition)) {
                             column_actions.insert(sub_key.clone(), action);
@@ -525,10 +528,9 @@ impl TargetHandler<TableSpec> for TableHandler {
                 //   - column change other than a pure add → may lose data → lossy.
                 let child_invalidation = if matches!(main_action, Some(DiffAction::Replace)) {
                     Some(TargetChildInvalidation::Destructive)
-                } else if main_action.is_none()
-                    && column_actions
-                        .values()
-                        .any(|a| !matches!(a, DiffAction::Insert))
+                } else if column_actions
+                    .values()
+                    .any(|a| !matches!(a, DiffAction::Insert))
                 {
                     Some(TargetChildInvalidation::Lossy)
                 } else {
@@ -626,7 +628,10 @@ async fn apply_table_action(
     // Virtual (vec0) tables can't use ALTER TABLE — any column change is
     // upgraded to a full DROP+CREATE, matching Python.
     let is_virtual = spec.as_ref().is_some_and(|s| s.virtual_table_def.is_some());
-    if is_virtual && main_action.is_none() && !column_actions.is_empty() {
+    if is_virtual
+        && matches!(main_action, None | Some(DiffAction::Upsert))
+        && !column_actions.is_empty()
+    {
         main_action = Some(DiffAction::Replace);
         column_actions.clear();
     }
@@ -649,19 +654,20 @@ async fn apply_table_action(
         return Ok(None);
     };
 
-    match main_action {
-        Some(DiffAction::Insert | DiffAction::Upsert | DiffAction::Replace) => {
-            // (Re)create the whole table. `create_table` uses `IF NOT EXISTS`,
-            // so an `upsert` against an already-present table is a no-op.
-            create_table(db, &spec).await?;
-        }
-        _ => {
-            // No structural change: reconcile non-PK columns incrementally,
-            // preserving existing rows. (Virtual tables never reach here.)
-            if !column_actions.is_empty() {
-                apply_column_actions(db, &spec, &column_actions).await?;
-            }
-        }
+    if matches!(
+        main_action,
+        Some(DiffAction::Insert | DiffAction::Upsert | DiffAction::Replace)
+    ) {
+        // (Re)create the whole table. `create_table` uses `IF NOT EXISTS`,
+        // so an `upsert` against an already-present table is a no-op — which
+        // is exactly why an `upsert` still falls through to the column
+        // reconcile below.
+        create_table(db, &spec).await?;
+    }
+    if matches!(main_action, None | Some(DiffAction::Upsert)) && !column_actions.is_empty() {
+        // Reconcile non-PK columns incrementally, preserving existing rows.
+        // (Virtual tables never reach here — upgraded to Replace above.)
+        apply_column_actions(db, &spec, &column_actions).await?;
     }
 
     Ok(Some(ChildTargetDef::new::<RowState, _>(RowHandler {


### PR DESCRIPTION
## Summary

- persist target-provider generation dependencies with component and function memo entries, validate them on probe, and propagate them transitively through nested cache hits
- preserve sync function logic dependencies when an inner memoized call hits while its caller rebuilds
- keep per-column schema reconciliation active for full-reprocess table upserts across the Python table connectors and Rust Doris/SQLite SDK targets
- add regressions for captured providers, nested memo hits, full-reprocess schema evolution, and owner visibility while a sink action is in flight
- normalize the tracked docs lockfile's platform metadata

## Why

A lossy or destructive target-provider change can invalidate child target states without changing a memoized function's ordinary arguments. When the provider is captured rather than passed as an argument, the memo key alone cannot observe that change, so a cache hit can skip the declarations needed to restore invalidated data. Nested cache hits could also drop both provider-generation and logic dependencies when rebuilding an enclosing memo entry.

Separately, `full_reprocess=True` makes an existing table reconcile as an upsert. `CREATE TABLE IF NOT EXISTS` is a no-op for that table, so suppressing its column actions commits the desired tracking schema without applying the corresponding DDL. The connectors now carry those column actions through the upsert path.

## Validation

- `prek run --all-files`
- includes the full Rust and Python test suites, mypy, Rust/Python build checks, formatting/lint hooks, example and benchmark checks, lockfile validation, secret scanning, and generated CLI docs
