### PR TITLE
fix(lancedb): apply column schema evolution under full reprocess

### DIFF
--- a/python/cocoindex/connectors/lancedb/_target.py
+++ b/python/cocoindex/connectors/lancedb/_target.py
@@ -1012,8 +1012,22 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                     continue
 
                 spec = action.spec
+
+                if action.main_action in ("insert", "upsert", "replace"):
+                    await self._create_table(
+                        conn,
+                        key.table_name,
+                        spec.table_schema,
+                        if_not_exists=(action.main_action == "upsert"),
+                    )
+
+                # "insert" / "replace" just built the table from the desired
+                # schema, so its columns already match. "upsert" may have
+                # landed on a pre-existing table carrying an older column set
+                # (created above with `if_not_exists`), so fall through and
+                # reconcile non-PK columns in place.
                 null_backfilled_columns: frozenset[str] = frozenset()
-                if action.main_action is None and action.column_actions:
+                if action.main_action in (None, "upsert") and action.column_actions:
                     null_backfilled_columns = await self._apply_column_actions(
                         conn,
                         key.table_name,
@@ -1028,14 +1042,6 @@ class _TableHandler(coco.TargetHandler[_TableSpec, _TableTrackingRecord, _RowHan
                     null_backfilled_columns=null_backfilled_columns,
                 )
                 outputs[i] = coco.ChildTargetDef(handler=handler)
-
-                if action.main_action in ("insert", "upsert", "replace"):
-                    await self._create_table(
-                        conn,
-                        key.table_name,
-                        spec.table_schema,
-                        if_not_exists=(action.main_action == "upsert"),
-                    )
         return outputs
 
     async def _drop_table(

--- a/python/tests/connectors/test_lancedb_target.py
+++ b/python/tests/connectors/test_lancedb_target.py
@@ -363,6 +363,67 @@ async def test_add_column_keeps_old_rows_before_backfill(lancedb_dir: Path) -> N
     assert "extra" in await _read_column_names(conn, table_name)
 
 
+@pytest.mark.asyncio
+@requires_lancedb
+async def test_schema_evolution_under_full_reprocess(lancedb_dir: Path) -> None:
+    """A schema change must still be applied when the same update runs with
+    `full_reprocess=True`.
+
+    `full_reprocess` marks the table's previous state as maybe-missing, which
+    turns the table's own action into an "upsert" (`create_table` with
+    `if_not_exists`). That must not swallow the column reconcile: the new
+    tracking record is committed either way, so a skipped `add_columns` leaves
+    the table permanently on the old column set — later plain updates see
+    prev == desired and never catch up.
+    """
+    conn = await lancedb.connect_async(str(lancedb_dir))
+    table_name = "test_full_reprocess_add_column"
+    source_rows: list[Any] = []
+    row_type: type[Any] = SimpleRow
+
+    async def declare_table_and_rows() -> None:
+        table = await coco.use_mount(
+            coco.component_subpath("setup", "table"),
+            lancedb.declare_table_target,
+            LANCEDB_DB,
+            table_name,
+            await lancedb.TableSchema.from_class(row_type, primary_key=["id"]),
+        )
+        for row in source_rows:
+            table.declare_row(row=row)
+
+    env = _make_env(conn, "test_schema_evolution_under_full_reprocess")
+    app = coco.App(
+        coco.AppConfig(name="test_lancedb_full_reprocess", environment=env),
+        declare_table_and_rows,
+    )
+
+    source_rows = [
+        SimpleRow(id="1", name="Alice"),
+        SimpleRow(id="2", name="Bob"),
+    ]
+    await app.update()
+    assert await _read_column_names(conn, table_name) == ["id", "name"]
+
+    row_type = ExtendedRow
+    source_rows = [
+        ExtendedRow(id="1", name="Alice", extra="vip"),
+        ExtendedRow(id="2", name="Bob", extra="std"),
+    ]
+    await app.update(full_reprocess=True)
+
+    assert await _read_column_names(conn, table_name) == ["id", "name", "extra"]
+    assert sorted(await _read_rows(conn, table_name), key=lambda row: row["id"]) == [
+        {"id": "1", "name": "Alice", "extra": "vip"},
+        {"id": "2", "name": "Bob", "extra": "std"},
+    ]
+
+    # The drift is gone: a follow-up plain update is a no-op.
+    version = await _read_table_version(conn, table_name)
+    await app.update()
+    assert await _read_table_version(conn, table_name) == version
+
+
 @requires_lancedb
 def test_row_reconcile_tracks_only_nulls_from_new_nullable_columns() -> None:
     table_schema = lancedb.TableSchema(


### PR DESCRIPTION
## Summary

Fixes a gap left by #2346 in the LanceDB connector: schema evolution is silently skipped when the same update that changes the schema runs with `full_reprocess=True`.

`full_reprocess` marks the table's previous state as maybe-missing, which turns the table's own action into an `"upsert"` (`create_table` with `if_not_exists`). #2346 fixed the *reconcile* side to still compute `column_actions` for upserts, but the *apply* side in `_TableHandler._apply_actions` still gated in-place column changes on `main_action is None` — so `add_columns` was never executed.

Because the new tracking record is committed either way, the table is then permanently stuck on the old column set: subsequent row upserts fail with `ValueError: Field 'extra' not found in target schema`, and once that error surfaces, plain updates see `prev == desired` and silently "succeed" without ever converging.

## Changes

- `python/cocoindex/connectors/lancedb/_target.py`: apply column actions for `"upsert"` main actions as well as `None`; create the table first (`if_not_exists`) so the action also converges when the table itself was missing (e.g. dropped externally). This mirrors the ordering already used by the postgres connector.
- `python/tests/connectors/test_lancedb_target.py`: regression test `test_schema_evolution_under_full_reprocess` — add a column + rows with `full_reprocess=True`, assert the column lands on the real table and a follow-up plain update is a no-op. Verified it fails on current `main` (before this fix) with the schema-mismatch error above.

## Testing

- `uv run pytest python/tests/connectors/test_lancedb_target.py` — 41 passed
- `uv run mypy` — clean
- `uv run ruff format --check` / `uv run ruff check` — clean
