### PR TITLE
docs(ops): document OrcaRouter as a LiteLLM model provider

### DIFF
--- a/docs/src/content/docs/ops/entity_resolution.mdx
+++ b/docs/src/content/docs/ops/entity_resolution.mdx
@@ -179,6 +179,9 @@ Uses the same litellm model-string format as [`LiteLLMEmbedder`](./litellm):
 | Anthropic | `anthropic/claude-haiku-4-5` |
 | Google (Gemini) | `gemini/gemini-2.0-flash` |
 | Groq | `groq/llama-3.3-70b-versatile` |
+| OrcaRouter | `openai/openai/gpt-5.5` |
+
+For an OpenAI-compatible gateway such as [OrcaRouter](https://www.orcarouter.ai), use the `openai/` provider prefix with a namespaced model id (the outer `openai/` selects the protocol; the inner `openai/…` is the router's model id) and point `api_base` at `https://api.orcarouter.ai/v1`.
 
 See the [LiteLLM docs](https://docs.litellm.ai/docs/providers) for the full list of 100+ supported providers.
 

--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -181,6 +181,25 @@ embedder = LiteLLMEmbedder("ollama/nomic-embed-text", api_base="http://localhost
 embedder = LiteLLMEmbedder("text-embedding-3-small")
 ```
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. Route embeddings through it with the `openai/` provider prefix and a namespaced model id:
+
+| Model | Model string |
+|-------|-------------|
+| Text Embedding 3 Small | `openai/openai/text-embedding-3-small` |
+| Text Embedding 3 Large | `openai/openai/text-embedding-3-large` |
+
+The outer `openai/` selects the OpenAI-compatible protocol; the inner `openai/…` is the router's namespaced model id. Pass the gateway's base URL and API key directly:
+
+```python
+embedder = LiteLLMEmbedder(
+    "openai/openai/text-embedding-3-small",
+    api_base="https://api.orcarouter.ai/v1",
+    api_key="sk-orca-...",
+)
+```
+
 ### Azure OpenAI
 
 | Model | Model string |


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) to the LiteLLM provider docs. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `docs/src/content/docs/ops/litellm.mdx`: adds an `### OrcaRouter` subsection under "Supported providers", alongside the existing OpenAI / Azure / Gemini entries, showing the `LiteLLMEmbedder` wiring with `api_base` and `api_key`.
- `docs/src/content/docs/ops/entity_resolution.mdx`: adds an OrcaRouter row to the `LlmPairResolver` model strings table, with a one-line note on the namespaced model-id form.

## How to use it

```python
from cocoindex.ops.litellm import LiteLLMEmbedder

embedder = LiteLLMEmbedder(
    "openai/openai/text-embedding-3-small",
    api_base="https://api.orcarouter.ai/v1",
    api_key="sk-orca-...",
)
```

The outer `openai/` prefix selects the OpenAI-compatible protocol; the inner `openai/…` is the router's namespaced model id (passed through verbatim). The same shape works for `LlmPairResolver(model="openai/openai/gpt-5.5", ...)` in entity resolution.

## Verification

- `npm run build` in `docs/` passes (98 pages; the 5 pre-existing `missing .md twin` notices for `index.mdx` pages are unchanged by this PR).
- Live connectivity against `https://api.orcarouter.ai/v1` with an `sk-orca-` key:
  - `litellm.aembedding("openai/openai/text-embedding-3-small", api_base=..., api_key=...)` → 200, 1536-dim vector.
  - `litellm.acompletion("openai/openai/gpt-5.5", ...)` → 200.
  - Negative control: a bare `text-embedding-3-small` (no `openai/` prefix) → 503 `No available channel`, which is why the docs show the namespaced form.
