### PR TITLE
fix(targets): reconcile schema changes during full reprocess for neo4j and falkordb

### DIFF
--- a/python/cocoindex/connectors/falkordb/_target.py
+++ b/python/cocoindex/connectors/falkordb/_target.py
@@ -17,7 +17,6 @@ import base64
 import datetime
 import decimal
 import logging
-import re
 import uuid as uuid_mod
 from dataclasses import dataclass
 from typing import (
@@ -34,7 +33,7 @@ from typing import (
 from typing_extensions import TypeVar
 
 try:
-    import falkordb as _falkordb  # type: ignore[import-untyped]
+    import falkordb as _falkordb  # noqa: F401  # type: ignore[import-untyped]
     import falkordb.asyncio as _falkordb_asyncio  # type: ignore[import-untyped]
 except ImportError as e:
     raise ImportError(
@@ -965,8 +964,12 @@ class _TableHandler(
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: the DDL can
+        # land on a table carrying the previous column set, so its columns still
+        # need reconciling. "insert" / "replace" define the table from the
+        # desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -994,9 +997,7 @@ class _TableHandler(
         if main_action == "replace":
             # Index is dropped and recreated — all rows lose their tracking.
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             # FalkorDB has no per-field DDL so column changes don't actually
             # destroy data, but mark lossy so dependents re-upsert to be safe.
             child_invalidation = "lossy"

--- a/python/cocoindex/connectors/neo4j/_target.py
+++ b/python/cocoindex/connectors/neo4j/_target.py
@@ -1015,8 +1015,12 @@ class _TableHandler(
         )
         main_action, column_transitions = statediff.diff_composite(resolved)
 
+        # "upsert" means the table may or may not already exist: the DDL can
+        # land on a table carrying the previous column set, so its columns still
+        # need reconciling. "insert" / "replace" define the table from the
+        # desired schema, so there is nothing left to reconcile.
         column_actions: dict[str, statediff.DiffAction] = {}
-        if main_action is None:
+        if main_action is None or main_action == "upsert":
             for sub_key, t in column_transitions.items():
                 action = statediff.diff(t)
                 if action is not None:
@@ -1043,9 +1047,7 @@ class _TableHandler(
         child_invalidation: Literal["destructive", "lossy"] | None = None
         if main_action == "replace":
             child_invalidation = "destructive"
-        elif main_action is None and any(
-            a != "insert" for a in column_actions.values()
-        ):
+        elif any(a != "insert" for a in column_actions.values()):
             # No incremental property DDL emitted in v1; treat column
             # changes as lossy so dependents re-upsert defensively.
             child_invalidation = "lossy"

--- a/python/tests/connectors/test_falkordb_target.py
+++ b/python/tests/connectors/test_falkordb_target.py
@@ -300,6 +300,173 @@ class TestTableSchemaFromClass:
 
 
 # =============================================================================
+# Table reconciliation unit tests (no DB needed)
+# =============================================================================
+
+
+@requires_falkordb
+class TestTableReconcile:
+    def test_schema_evolution_under_full_reprocess(self) -> None:
+        """Schema evolution during full reprocess must compute column actions and mark lossy."""
+        from cocoindex.connectorkits import statediff, target
+        from cocoindex.connectors.falkordb import _target as falkor_target
+
+        handler = falkor_target._TableHandler()
+        schema_v1 = falkor.TableSchema(
+            columns={
+                "id": falkor.ColumnDef("string"),
+                "a": falkor.ColumnDef("string"),
+                "b": falkor.ColumnDef("string"),
+            },
+            primary_key="id",
+        )
+        spec_v1 = falkor_target._TableSpec(
+            table_schema=schema_v1,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_v1 = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"), spec_v1, [], False
+        )
+        assert out_v1 is not None
+        assert out_v1.action.main_action is None
+        assert isinstance(out_v1.tracking_record, statediff.MutualTrackingRecord)
+        tracking_v1 = out_v1.tracking_record
+
+        # Evolve schema: drop 'b', add 'c'
+        schema_v2 = falkor.TableSchema(
+            columns={
+                "id": falkor.ColumnDef("string"),
+                "a": falkor.ColumnDef("string"),
+                "c": falkor.ColumnDef("string"),
+            },
+            primary_key="id",
+        )
+        spec_v2 = falkor_target._TableSpec(
+            table_schema=schema_v2,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        # Incremental run
+        out_inc = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            False,
+        )
+        assert out_inc is not None
+        assert out_inc.action.main_action is None
+        assert out_inc.action.column_actions == {
+            "field:b": "delete",
+            "field:c": "insert",
+        }
+        assert out_inc.child_invalidation == "lossy"
+
+        # Full reprocess run (prev_may_be_missing=True)
+        out_reproc = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            True,
+        )
+        assert out_reproc is not None
+        assert out_reproc.action.main_action == "upsert"
+        assert out_reproc.action.column_actions == {
+            "field:a": "upsert",
+            "field:b": "delete",
+            "field:c": "insert",
+        }
+        assert out_reproc.child_invalidation == "lossy"
+
+    def test_column_addition_only_not_lossy_on_incremental(self) -> None:
+        """Adding a column on incremental update is not lossy, but under full reprocess re-upserts."""
+        from cocoindex.connectorkits import statediff, target
+        from cocoindex.connectors.falkordb import _target as falkor_target
+
+        handler = falkor_target._TableHandler()
+        schema_v1 = falkor.TableSchema(
+            columns={
+                "id": falkor.ColumnDef("string"),
+                "a": falkor.ColumnDef("string"),
+            },
+            primary_key="id",
+        )
+        spec_v1 = falkor_target._TableSpec(
+            table_schema=schema_v1,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_v1 = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"), spec_v1, [], False
+        )
+        assert out_v1 is not None
+        assert isinstance(out_v1.tracking_record, statediff.MutualTrackingRecord)
+        tracking_v1 = out_v1.tracking_record
+
+        schema_v2 = falkor.TableSchema(
+            columns={
+                "id": falkor.ColumnDef("string"),
+                "a": falkor.ColumnDef("string"),
+                "b": falkor.ColumnDef("string"),
+            },
+            primary_key="id",
+        )
+        spec_v2 = falkor_target._TableSpec(
+            table_schema=schema_v2,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_inc = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            False,
+        )
+        assert out_inc is not None
+        assert out_inc.action.main_action is None
+        assert out_inc.action.column_actions == {"field:b": "insert"}
+        assert out_inc.child_invalidation is None
+
+        out_reproc = handler.reconcile(
+            falkor_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            True,
+        )
+        assert out_reproc is not None
+        assert out_reproc.action.main_action == "upsert"
+        assert out_reproc.action.column_actions == {
+            "field:a": "upsert",
+            "field:b": "insert",
+        }
+        assert out_reproc.child_invalidation == "lossy"
+
+
+# =============================================================================
 # Integration tests — require running FalkorDB
 # =============================================================================
 
@@ -598,3 +765,72 @@ async def test_vector_index_attached(falkor_graph_name: str) -> None:
             break
     await client.aclose()
     assert found, "Expected vector index on VecDoc.summary"
+
+
+@requires_falkordb_server
+@pytest.mark.asyncio
+async def test_falkordb_table_schema_evolution_under_full_reprocess(
+    falkor_graph_name: str,
+) -> None:
+    """A schema change must still be applied and child records re-upserted when running with full_reprocess=True."""
+    global _current_graph
+    _current_graph = falkor_graph_name
+
+    @dataclass
+    class _DocV1:
+        filename: str
+        title: str
+        extra: str
+
+    @dataclass
+    class _DocV2:
+        filename: str
+        title: str
+        summary: str
+
+    doc_type: type[Any] = _DocV1
+    docs: list[Any] = [
+        _DocV1(filename="doc1.md", title="Title 1", extra="extra 1"),
+        _DocV1(filename="doc2.md", title="Title 2", extra="extra 2"),
+    ]
+
+    async def _declare_docs() -> None:
+        schema = await falkor.TableSchema.from_class(doc_type, primary_key="filename")
+        table: Any = await coco.use_mount(
+            coco.component_subpath("setup", "doc_table"),
+            falkor.mount_table_target,
+            KG_DB,
+            "DocEvolve",
+            schema,
+            primary_key="filename",
+        )
+        for doc in docs:
+            table.declare_record(row=doc)
+
+    coco_env.context_provider.provide(
+        KG_DB, falkor.ConnectionFactory(uri=_FALKORDB_URI, graph=falkor_graph_name)
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_falkordb_schema_reprocess", environment=coco_env),
+        _declare_docs,
+    )
+    await app.update()
+
+    nodes_v1 = await _read_nodes(falkor_graph_name, "DocEvolve")
+    assert len(nodes_v1) == 2
+    by_fn = {r["filename"]: r for r in nodes_v1}
+    assert by_fn["doc1.md"]["extra"] == "extra 1"
+
+    # Evolve schema to V2: drop 'extra', add 'summary' and run under full_reprocess=True
+    doc_type = _DocV2
+    docs = [
+        _DocV2(filename="doc1.md", title="Title 1", summary="summary 1"),
+        _DocV2(filename="doc2.md", title="Title 2", summary="summary 2"),
+    ]
+    await app.update(full_reprocess=True)
+
+    nodes_v2 = await _read_nodes(falkor_graph_name, "DocEvolve")
+    assert len(nodes_v2) == 2
+    by_fn2 = {r["filename"]: r for r in nodes_v2}
+    assert by_fn2["doc1.md"]["summary"] == "summary 1"
+    assert by_fn2["doc2.md"]["summary"] == "summary 2"

--- a/python/tests/connectors/test_neo4j_target.py
+++ b/python/tests/connectors/test_neo4j_target.py
@@ -367,6 +367,173 @@ class TestTableSchemaFromClass:
 
 
 # =============================================================================
+# Table reconciliation unit tests (no DB needed)
+# =============================================================================
+
+
+@requires_neo4j
+class TestTableReconcile:
+    def test_schema_evolution_under_full_reprocess(self) -> None:
+        """Schema evolution during full reprocess must compute column actions and mark lossy."""
+        from cocoindex.connectorkits import statediff, target
+        from cocoindex.connectors.neo4j import _target as neo_target
+
+        handler = neo_target._TableHandler()
+        schema_v1 = neo.TableSchema(
+            columns={
+                "id": neo.ColumnDef("STRING"),
+                "a": neo.ColumnDef("STRING"),
+                "b": neo.ColumnDef("STRING"),
+            },
+            primary_key="id",
+        )
+        spec_v1 = neo_target._TableSpec(
+            table_schema=schema_v1,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_v1 = handler.reconcile(
+            neo_target._TableKey("db", "Doc"), spec_v1, [], False
+        )
+        assert out_v1 is not None
+        assert out_v1.action.main_action is None
+        assert isinstance(out_v1.tracking_record, statediff.MutualTrackingRecord)
+        tracking_v1 = out_v1.tracking_record
+
+        # Evolve schema: drop 'b', add 'c'
+        schema_v2 = neo.TableSchema(
+            columns={
+                "id": neo.ColumnDef("STRING"),
+                "a": neo.ColumnDef("STRING"),
+                "c": neo.ColumnDef("STRING"),
+            },
+            primary_key="id",
+        )
+        spec_v2 = neo_target._TableSpec(
+            table_schema=schema_v2,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        # Incremental run
+        out_inc = handler.reconcile(
+            neo_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            False,
+        )
+        assert out_inc is not None
+        assert out_inc.action.main_action is None
+        assert out_inc.action.column_actions == {
+            "field:b": "delete",
+            "field:c": "insert",
+        }
+        assert out_inc.child_invalidation == "lossy"
+
+        # Full reprocess run (prev_may_be_missing=True)
+        out_reproc = handler.reconcile(
+            neo_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            True,
+        )
+        assert out_reproc is not None
+        assert out_reproc.action.main_action == "upsert"
+        assert out_reproc.action.column_actions == {
+            "field:a": "upsert",
+            "field:b": "delete",
+            "field:c": "insert",
+        }
+        assert out_reproc.child_invalidation == "lossy"
+
+    def test_column_addition_only_not_lossy_on_incremental(self) -> None:
+        """Adding a column on incremental update is not lossy, but under full reprocess re-upserts."""
+        from cocoindex.connectorkits import statediff, target
+        from cocoindex.connectors.neo4j import _target as neo_target
+
+        handler = neo_target._TableHandler()
+        schema_v1 = neo.TableSchema(
+            columns={
+                "id": neo.ColumnDef("STRING"),
+                "a": neo.ColumnDef("STRING"),
+            },
+            primary_key="id",
+        )
+        spec_v1 = neo_target._TableSpec(
+            table_schema=schema_v1,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_v1 = handler.reconcile(
+            neo_target._TableKey("db", "Doc"), spec_v1, [], False
+        )
+        assert out_v1 is not None
+        assert isinstance(out_v1.tracking_record, statediff.MutualTrackingRecord)
+        tracking_v1 = out_v1.tracking_record
+
+        schema_v2 = neo.TableSchema(
+            columns={
+                "id": neo.ColumnDef("STRING"),
+                "a": neo.ColumnDef("STRING"),
+                "b": neo.ColumnDef("STRING"),
+            },
+            primary_key="id",
+        )
+        spec_v2 = neo_target._TableSpec(
+            table_schema=schema_v2,
+            primary_key="id",
+            is_relation=False,
+            from_label=None,
+            from_pk_field=None,
+            to_label=None,
+            to_pk_field=None,
+            managed_by=target.ManagedBy.SYSTEM,
+        )
+
+        out_inc = handler.reconcile(
+            neo_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            False,
+        )
+        assert out_inc is not None
+        assert out_inc.action.main_action is None
+        assert out_inc.action.column_actions == {"field:b": "insert"}
+        assert out_inc.child_invalidation is None
+
+        out_reproc = handler.reconcile(
+            neo_target._TableKey("db", "Doc"),
+            spec_v2,
+            [tracking_v1],
+            True,
+        )
+        assert out_reproc is not None
+        assert out_reproc.action.main_action == "upsert"
+        assert out_reproc.action.column_actions == {
+            "field:a": "upsert",
+            "field:b": "insert",
+        }
+        assert out_reproc.child_invalidation == "lossy"
+
+
+# =============================================================================
 # Integration tests — require running Neo4j (testcontainers spins one up)
 # =============================================================================
 
@@ -705,3 +872,71 @@ async def test_vector_index_attached(
             found = True
             break
     assert found, f"Expected vector index on VecDoc.summary; got {rows}"
+
+
+@requires_neo4j_server
+@pytest.mark.asyncio
+async def test_neo4j_table_schema_evolution_under_full_reprocess(
+    neo4j_clean: tuple[str, tuple[str, str]],
+) -> None:
+    """A schema change must still be applied and child records re-upserted when running with full_reprocess=True."""
+
+    @dataclass
+    class _DocV1:
+        filename: str
+        title: str
+        extra: str
+
+    @dataclass
+    class _DocV2:
+        filename: str
+        title: str
+        summary: str
+
+    doc_type: type[Any] = _DocV1
+    docs: list[Any] = [
+        _DocV1(filename="doc1.md", title="Title 1", extra="extra 1"),
+        _DocV1(filename="doc2.md", title="Title 2", extra="extra 2"),
+    ]
+
+    async def _declare_docs() -> None:
+        schema = await neo.TableSchema.from_class(doc_type, primary_key="filename")
+        table: Any = await coco.use_mount(
+            coco.component_subpath("setup", "doc_table"),
+            neo.mount_table_target,
+            KG_DB,
+            "DocEvolve",
+            schema,
+            primary_key="filename",
+        )
+        for doc in docs:
+            table.declare_record(row=doc)
+
+    uri, auth = neo4j_clean
+    coco_env.context_provider.provide(
+        KG_DB, neo.ConnectionFactory(uri=uri, auth=auth, database="neo4j")
+    )
+    app = coco.App(
+        coco.AppConfig(name="test_neo4j_schema_reprocess", environment=coco_env),
+        _declare_docs,
+    )
+    await app.update()
+
+    nodes_v1 = await _read_nodes(uri, auth, "DocEvolve")
+    assert len(nodes_v1) == 2
+    by_fn = {r["filename"]: r for r in nodes_v1}
+    assert by_fn["doc1.md"]["extra"] == "extra 1"
+
+    # Evolve schema to V2: drop 'extra', add 'summary' and run under full_reprocess=True
+    doc_type = _DocV2
+    docs = [
+        _DocV2(filename="doc1.md", title="Title 1", summary="summary 1"),
+        _DocV2(filename="doc2.md", title="Title 2", summary="summary 2"),
+    ]
+    await app.update(full_reprocess=True)
+
+    nodes_v2 = await _read_nodes(uri, auth, "DocEvolve")
+    assert len(nodes_v2) == 2
+    by_fn2 = {r["filename"]: r for r in nodes_v2}
+    assert by_fn2["doc1.md"]["summary"] == "summary 1"
+    assert by_fn2["doc2.md"]["summary"] == "summary 2"


### PR DESCRIPTION
## Summary

This PR fixes a schema reconciliation bug in the Neo4j and FalkorDB target connectors during full reprocess or when previous tracking state may be missing (`full_reprocess=True` or `prev_may_be_missing=True`).

### Background & Root Cause

When `statediff.diff_composite()` executes under `prev_may_be_missing=True` (triggered during `full_reprocess=True` or when an ancestor container state is invalidated), it returns `main_action == "upsert"` to indicate that the underlying table or property graph artifact may or may not already exist in the target database.

PRs #2346 and #2352 previously updated the relational and vector target connectors (PostgreSQL, SQLite, Doris, LanceDB, Snowflake, BigQuery, and SurrealDB) to reconcile `column_transitions` when `main_action in (None, "upsert")`. However, the Neo4j (`python/cocoindex/connectors/neo4j/_target.py`) and FalkorDB (`python/cocoindex/connectors/falkordb/_target.py`) target handlers were missed and still strictly checked `if main_action is None:`.

### Impact Before This Fix

When schema evolution occurred under `full_reprocess=True` (e.g. dropping property `b` and adding property `c`):
1. **Empty Column Transitions**: `if main_action is None:` evaluated to `False` because `main_action == "upsert"`, causing `column_actions` to be left empty (`{}`).
2. **Missing Lossy Invalidation**: `child_invalidation` evaluated to `None` instead of `"lossy"`, failing to signal the committer to bump provider schema versions and defensively re-run and re-upsert child node and relationship records against the new schema.

### Comparison Table

| Connector | Reconciles Columns on `"upsert"`? | Emits `lossy` Invalidation on Schema Change? |
|---|---|---|
| PostgreSQL | ✅ Yes (`main_action in (None, "upsert")`) | ✅ Yes (`any(a != "insert" ...)`) |
| SQLite | ✅ Yes (`main_action in (None, "upsert")`) | ✅ Yes (`any(a != "insert" ...)`) |
| LanceDB | ✅ Yes (`main_action in (None, "upsert")`) | ✅ Yes (`any(a != "insert" ...)`) |
| Doris / Snowflake / BigQuery / SurrealDB | ✅ Yes (`main_action in (None, "upsert")`) | ✅ Yes (`any(a != "insert" ...)`) |
| **Neo4j (Before)** | ❌ No (`if main_action is None:`) | ❌ No (Skipped) |
| **Neo4j (After)** | ✅ **Yes (`main_action is None or main_action == "upsert"`)** | ✅ **Yes (`child_invalidation = "lossy"`)** |
| **FalkorDB (Before)** | ❌ No (`if main_action is None:`) | ❌ No (Skipped) |
| **FalkorDB (After)** | ✅ **Yes (`main_action is None or main_action == "upsert"`)** | ✅ **Yes (`child_invalidation = "lossy"`)** |

---

## Changes

1. **`python/cocoindex/connectors/neo4j/_target.py`**:
   - In `_TableHandler.reconcile`: Compute `column_actions` when `main_action is None or main_action == "upsert"`.
   - Set `child_invalidation = "lossy"` whenever `any(a != "insert" for a in column_actions.values())`.

2. **`python/cocoindex/connectors/falkordb/_target.py`**:
   - In `_TableHandler.reconcile`: Compute `column_actions` when `main_action is None or main_action == "upsert"`.
   - Set `child_invalidation = "lossy"` whenever `any(a != "insert" for a in column_actions.values())`.
   - Cleaned unused imports.

3. **`python/tests/connectors/test_neo4j_target.py`**:
   - Added unit test suite `TestTableReconcile` testing `_TableHandler.reconcile` directly for schema transitions and lossy child invalidations under incremental vs full reprocess (`prev_may_be_missing=True`).
   - Added integration test `test_neo4j_table_schema_evolution_under_full_reprocess`.

4. **`python/tests/connectors/test_falkordb_target.py`**:
   - Added unit test suite `TestTableReconcile` testing `_TableHandler.reconcile` directly for schema transitions and lossy child invalidations under incremental vs full reprocess (`prev_may_be_missing=True`).
   - Added integration test `test_falkordb_table_schema_evolution_under_full_reprocess`.

---

## Validation

- **Unit Tests**: `uv run pytest python/tests/connectors/test_neo4j_target.py python/tests/connectors/test_falkordb_target.py` passed (94 passed, 14 skipped).
- **Full Connector Suite**: `uv run pytest python/tests/connectors/` passed (356 passed, 219 skipped).
- **Type Checking**: `uv run mypy` passed cleanly across all 280 source files (0 errors).
- **Code Quality**: `uv run ruff format --check` and `uv run ruff check` passed with zero errors or warnings.
