### PR TITLE
docs: memoization placement — component vs fn-level memos, entry costs, full-reprocess semantics

### DIFF
--- a/docs/src/content/docs/advanced_topics/internal_storage.mdx
+++ b/docs/src/content/docs/advanced_topics/internal_storage.mdx
@@ -53,6 +53,8 @@ When a write runs out of map space, CocoIndex doubles the map and retries, repea
 The enlarged size doesn't carry over. The next process opens at the configured `map_size`, raised to at least the space the data file already occupies — the file's high-water mark, not the live data, since LMDB reuses freed pages but never shrinks the file. So a database that outgrew its `map_size` still opens and reads fine, just with no headroom: the next write needing new space enlarges it again. A map that grew to 16 GiB over a 10 GiB file reopens at 10 GiB, not 16, then doubles to 20 GiB on the next write that needs space.
 :::
 
+**What grows the store.** Largest first: memoized calls' cache entries (each stores the return value — large returns like embedding vectors dominate quickly — and, for inline calls, one path per target state declared during the call), target-state tracking (proportional to the number of declared states), and per-component records. If internal state is growing faster than your targets, oversized or misplaced memo entries are a common cause — see the cost note and placement rule in [When to memoize](../programming_guide/function#memoization).
+
 ### Configuration
 
 Via environment variables:

--- a/docs/src/content/docs/advanced_topics/internal_storage.mdx
+++ b/docs/src/content/docs/advanced_topics/internal_storage.mdx
@@ -53,7 +53,12 @@ When a write runs out of map space, CocoIndex doubles the map and retries, repea
 The enlarged size doesn't carry over. The next process opens at the configured `map_size`, raised to at least the space the data file already occupies — the file's high-water mark, not the live data, since LMDB reuses freed pages but never shrinks the file. So a database that outgrew its `map_size` still opens and reads fine, just with no headroom: the next write needing new space enlarges it again. A map that grew to 16 GiB over a 10 GiB file reopens at 10 GiB, not 16, then doubles to 20 GiB on the next write that needs space.
 :::
 
-**What grows the store.** Largest first: memoized calls' cache entries (each stores the return value — large returns like embedding vectors dominate quickly — and, for inline calls, one path per target state declared during the call), target-state tracking (proportional to the number of declared states), and per-component records. If internal state is growing faster than your targets, oversized or misplaced memo entries are a common cause — see the cost note and placement rule in [When to memoize](../programming_guide/function#memoization).
+:::note[What typically grows the store]
+- **The memoization cache** — usually the bulk. Each entry stores its call's return value, so memoized functions that return large values (e.g., embedding vectors) dominate quickly.
+- **Target-state bookkeeping** — grows with the number of target states your app declares.
+
+If internal state grows faster than your targets, oversized memoized return values are the first thing to check — see the cost note and placement rule in [When to memoize](../programming_guide/function#when-to-memoize).
+:::
 
 ### Configuration
 

--- a/docs/src/content/docs/cli.mdx
+++ b/docs/src/content/docs/cli.mdx
@@ -188,7 +188,7 @@ cocoindex update [OPTIONS] APP_TARGET
 | `-f, --force` | Skip confirmation prompt. |
 | `-q, --quiet` | Avoid printing anything to the standard output, e.g. statistics. |
 | `--reset` | Drop existing setup before updating (equivalent to running 'cocoindex drop' first). |
-| `--full-reprocess` | Reprocess everything and invalidate existing caches. |
+| `--full-reprocess` | Reprocess everything, bypassing all memoization caches: every component and memoized function executes again (external calls such as embeddings included). To force just one function's work to run again, bump its version= instead. |
 | `-L, --live` | Run in live mode (live components continue processing after initial update). |
 | `--preview` | Compute target actions without applying them. Prints planned actions. |
 | `--help` | Show this message and exit. |

--- a/docs/src/content/docs/cli_commands.mdx
+++ b/docs/src/content/docs/cli_commands.mdx
@@ -135,7 +135,7 @@ cocoindex update [OPTIONS] APP_TARGET
 | `-f, --force` | Skip confirmation prompt. |
 | `-q, --quiet` | Avoid printing anything to the standard output, e.g. statistics. |
 | `--reset` | Drop existing setup before updating (equivalent to running 'cocoindex drop' first). |
-| `--full-reprocess` | Reprocess everything and invalidate existing caches. |
+| `--full-reprocess` | Reprocess everything, bypassing all memoization caches: every component and memoized function executes again (external calls such as embeddings included). To force just one function's work to run again, bump its version= instead. |
 | `-L, --live` | Run in live mode (live components continue processing after initial update). |
 | `--help` | Show this message and exit. |
 

--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -63,6 +63,10 @@ embedding = await embedder.embed("Hello, world!")
 table.declare_row(row=DocEmbedding(text="Hello, world!", embedding=embedding))
 ```
 
+:::note[Built-in memoization]
+`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged text — this is what makes the common per-file-component pattern incremental. The memo stores one full vector per distinct text, so mind the [memoization placement rule](../programming_guide/function#memoization) if your components are already keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
+:::
+
 ### Using as a type annotation
 
 The `LiteLLMEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.

--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -64,7 +64,7 @@ table.declare_row(row=DocEmbedding(text="Hello, world!", embedding=embedding))
 ```
 
 :::note[Built-in memoization]
-`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged text — this is what makes the common per-file-component pattern incremental. The memo stores one full vector per distinct text, so mind the [memoization placement rule](../programming_guide/function#memoization) if your components are already keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
+`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged text — this is what makes the common per-file-component pattern incremental. The memo stores one full vector per distinct text, so mind the [memoization placement rule](../programming_guide/function#when-to-memoize) if your components are already keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
 :::
 
 ### Using as a type annotation

--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -52,6 +52,10 @@ embedding = await embedder.embed("Hello, world!")
 table.declare_row(row=CodeEmbedding(code="Hello, world!", embedding=embedding))
 ```
 
+:::note[Built-in memoization]
+`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't recompute unchanged text — the tradeoff is model compute vs. cache storage (one full vector per distinct text). This composes well with the per-file component in the example below; mind the [memoization placement rule](../programming_guide/function#memoization) if your components are instead keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
+:::
+
 ### Using as a type annotation
 
 The `SentenceTransformerEmbedder` implements [`VectorSchemaProvider`](../common_resources/vector_schema#vectorschemaprovider), which means it can be used directly as metadata in `Annotated` type annotations. This is the recommended way to declare vector columns — CocoIndex connectors automatically extract the vector dimension and dtype from the annotation when creating tables.

--- a/docs/src/content/docs/ops/sentence_transformers.mdx
+++ b/docs/src/content/docs/ops/sentence_transformers.mdx
@@ -53,7 +53,7 @@ table.declare_row(row=CodeEmbedding(code="Hello, world!", embedding=embedding))
 ```
 
 :::note[Built-in memoization]
-`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't recompute unchanged text — the tradeoff is model compute vs. cache storage (one full vector per distinct text). This composes well with the per-file component in the example below; mind the [memoization placement rule](../programming_guide/function#memoization) if your components are instead keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
+`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't recompute unchanged text — the tradeoff is model compute vs. cache storage (one full vector per distinct text). This composes well with the per-file component in the example below; mind the [memoization placement rule](../programming_guide/function#when-to-memoize) if your components are instead keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
 :::
 
 ### Using as a type annotation

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -62,7 +62,7 @@ result = app.update_blocking()
 
 - `live` option keeps the app running after the initial scan so live components can continue watching for changes. See [Live Mode](./live_mode).
 - `report_to_stdout` option prints periodic progress updates during execution. Pass `True` for the default refresh interval, or a `timedelta` to set it.
-- `full_reprocess` option reprocesses everything and invalidates existing caches. This forces all components to re-execute and all target states to be re-applied, even if they haven't changed.
+- `full_reprocess` option reprocesses everything, bypassing all memoization: every component **and** every memoized function re-executes, and all target states are re-applied even if unchanged. Mind the cost — this includes every paid external call (embedding and LLM APIs re-run for all content). To force re-running just one function's work, bump its [`version`](./function#version) instead.
 
 When you update an App, CocoIndex:
 

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -69,8 +69,8 @@ Add a **return type annotation** to memoized functions so CocoIndex can properly
 :::caution[`memo=True` constraints]
 A memoized function:
 
-- **Must run inside a [processing component](./processing_component)** for memoization to take effect. Outside a component context (e.g., called directly from a script or test), the function still executes correctly but the cache is bypassed silently — every call runs the body.
-- **Cannot mount child components when called inline** (`coco.mount(...)` / `coco.use_mount(...)` inside the body of an inline memoized *call*). Mounting is a side effect an inline call's cache cannot replay; CocoIndex raises an error if an inline memoized call attempts it. The restriction is call-level, not function-level — the fix, which the error message itself suggests, is to **mount the memoized function as a component**: a [memoized component](./processing_component#memoized-components) may mount children freely (a cache hit carries its child mounts over along with its target states). Alternatively, drop `memo=True`, or restructure so the mount happens in a non-memoized caller.
+- **Must run inside a [processing component](./processing_component)** for memoization to take effect. Outside a component context (e.g., invoked from a script or a test), the function still executes correctly but the cache is bypassed silently — every call runs the body.
+- **Cannot mount child components when called directly** (`coco.mount(...)` / `coco.use_mount(...)` inside the body of a memoized function invoked as a plain call). Mounting is a side effect the call's cache cannot replay; CocoIndex raises an error if a directly-called memoized function attempts it. The restriction applies to the call, not the function — the fix, which the error message itself suggests, is to **mount the memoized function as a component**: a [memoized component](./processing_component#memoized-components) may mount children freely (a cache hit carries its child mounts over along with its target states). Alternatively, drop `memo=True`, or restructure so the mount happens in a non-memoized caller.
 :::
 
 #### Cache-hit semantics
@@ -102,9 +102,9 @@ Propagation (logic, `deps`, context) is recorded during the **previous** invocat
 If a memoized function raises, no cache entry is written for that call. The next invocation with the same inputs sees a cache miss and re-executes the body — exceptions never poison the cache, so you don't need to wrap calls defensively.
 :::
 
-:::tip[When to memoize]
+#### When to memoize
 
-**Cost:** A memoized call's cache entry must store everything needed to serve a hit — the return value, plus the *path* of every [target state](./target_state) it declared during the call (the state values themselves stay in the enclosing component's tracking; the recorded paths are what keep those states alive on a hit). Large return values, or a call that declares many target states, mean large entries. (A function *mounted* as a component avoids the per-state paths entirely: a [memoized component](./processing_component#memoized-components)'s entry holds fingerprints plus its return value — `None` for a typical mounted declarer.)
+**Cost:** A directly-called memoized function's cache entry must store everything needed to serve a hit — the return value, plus the *path* of every [target state](./target_state) it declared during the call (the state values themselves stay in the enclosing component's tracking; the recorded paths are what keep those states alive on a hit). Large return values, or a call that declares many target states, mean large entries. (A function *mounted* as a component avoids the per-state paths entirely: a [memoized component](./processing_component#memoized-components)'s entry holds fingerprints plus its return value — `None` for a typical mounted declarer.)
 
 **Benefit:** Memoization saves more when:
 
@@ -120,8 +120,6 @@ If a memoized function raises, no cache entry is written for that call. The next
 - ✅ **Processing component for files that are mostly stable between runs** — very beneficial to memoize, since unchanged files are skipped entirely. We can save the cost of reading file content and processing them when they haven't changed.
 - 🤔 **Chunk embedding when file-level memoization is already enabled** — still beneficial, but less so for stable files. The benefit increases for files that change frequently, or when your code evolves (e.g., adding more features per file triggers file-level reprocessing, but unchanged chunks can still skip embedding).
 - ❌ **Chunk embedding inside a *memoized* component keyed by the chunk's content hash** — usually redundant by the placement rule: the component memo already commits to the text, so the inner memo serves only reruns caused by the component's own code or `version` changes — at the cost of storing every vector twice.
-
-:::
 
 ### Controlling change detection scope
 

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -70,7 +70,7 @@ Add a **return type annotation** to memoized functions so CocoIndex can properly
 A memoized function:
 
 - **Must run inside a [processing component](./processing_component)** for memoization to take effect. Outside a component context (e.g., called directly from a script or test), the function still executes correctly but the cache is bypassed silently — every call runs the body.
-- **Cannot mount child components** (`coco.mount(...)` / `coco.use_mount(...)` inside the body). Mounting is a side effect the cache cannot replay; CocoIndex raises an error if a memoized function attempts it. Either drop `memo=True`, or restructure so the mount happens in a non-memoized caller.
+- **Cannot mount child components when called inline** (`coco.mount(...)` / `coco.use_mount(...)` inside the body of an inline memoized *call*). Mounting is a side effect an inline call's cache cannot replay; CocoIndex raises an error if an inline memoized call attempts it. The restriction is call-level, not function-level — the fix, which the error message itself suggests, is to **mount the memoized function as a component**: a [memoized component](./processing_component#memoized-components) may mount children freely (a cache hit carries its child mounts over along with its target states). Alternatively, drop `memo=True`, or restructure so the mount happens in a non-memoized caller.
 :::
 
 #### Cache-hit semantics
@@ -104,19 +104,22 @@ If a memoized function raises, no cache entry is written for that call. The next
 
 :::tip[When to memoize]
 
-**Cost:** Function return values must be stored for memoization. Larger return values mean higher storage costs.
+**Cost:** A memoized call's cache entry must store everything needed to serve a hit — the return value, plus the *path* of every [target state](./target_state) it declared during the call (the state values themselves stay in the enclosing component's tracking; the recorded paths are what keep those states alive on a hit). Large return values, or a call that declares many target states, mean large entries. (A function *mounted* as a component avoids the per-state paths entirely: a [memoized component](./processing_component#memoized-components)'s entry holds fingerprints plus its return value — `None` for a typical mounted declarer.)
 
 **Benefit:** Memoization saves more when:
 
 - The computation is expensive
 - The function's caller is reprocessed frequently (due to logic or input changes)
 
+**Placement — one rule:** memoize at a boundary only if its key can hit while every *enclosing* memo boundary misses. Stacked levels pay off exactly when the outer boundary is keyed more coarsely than the inner one's inputs — a per-file component plus a per-chunk embedding memo composes well, because an edited file re-runs its component while its unchanged chunks still skip embedding. But if an enclosing *memoized* component's identity already commits to this function's inputs — say, the component path is keyed by a hash of the very content the function transforms — the inner memo can never hit on a *content-driven* rerun: the component memo shadows all of those. What remains is insurance against reruns of the enclosing component itself (its code edited, its `version` bumped): each entry permanently stores a value — often one your target also stores — that only such reruns can read. The arithmetic bites at scale: a 1536-dim float32 vector is ~6 KB, so an embedding memo under content-hash-keyed components costs ~600 MB per 100k chunks to insure against those rare reruns — usually a bad trade.
+
 **Examples:**
 
-- ✅ **Embedding functions** — good to memoize. Computation is heavy; return value is fixed-size and not too large.
+- ✅ **Embedding functions** — good to memoize when callers can re-run with the same text (e.g., per-file components re-running on edits). Computation is heavy; return value is fixed-size and not too large.
 - ❌ **Splitting text into fixed-size chunks** — usually not worth memoizing. Computation is light; return value can be large.
 - ✅ **Processing component for files that are mostly stable between runs** — very beneficial to memoize, since unchanged files are skipped entirely. We can save the cost of reading file content and processing them when they haven't changed.
 - 🤔 **Chunk embedding when file-level memoization is already enabled** — still beneficial, but less so for stable files. The benefit increases for files that change frequently, or when your code evolves (e.g., adding more features per file triggers file-level reprocessing, but unchanged chunks can still skip embedding).
+- ❌ **Chunk embedding inside a *memoized* component keyed by the chunk's content hash** — usually redundant by the placement rule: the component memo already commits to the text, so the inner memo serves only reruns caused by the component's own code or `version` changes — at the cost of storing every vector twice.
 
 :::
 

--- a/docs/src/content/docs/programming_guide/processing_component.mdx
+++ b/docs/src/content/docs/programming_guide/processing_component.mdx
@@ -211,6 +211,25 @@ for f in files:
 When iterating over keyed items, prefer [`mount_each()`](#mount_each) — it handles the loop and subpath creation for you.
 :::
 
+## Memoized components
+
+`memo=True` on a function you **mount** memoizes the whole component. On a cache hit the body doesn't run, and everything the previous run produced is carried over as a unit: the component's declared [target states](./target_state) **and** its child mounts. Cleanup of no-longer-mounted children only applies when the body actually *runs* — a run that no longer mounts a child removes that child's subtree, while a cache hit retains it.
+
+```python
+@coco.fn(memo=True)
+async def process_file(file: FileLike, table: postgres.TableTarget[DocEmbedding]) -> None:
+    ...
+
+await coco.mount_each(process_file, files.items(), table)
+```
+
+Two properties make this the cheapest way to skip stable items:
+
+- **The cache entry is small.** A mounted component's declared target states live in the component's own tracking (needed for [sync](#how-target-states-sync) regardless), so its entry holds fingerprints plus the return value — `None` for a typical mounted declarer. An *inline* memoized call additionally records one path per declared target state, so a component declaring many states is much cheaper to memoize at the mount than inline — see the cost note in [When to memoize](./function#memoization).
+- **A memoized component may mount children.** The inline-call mount restriction ([`memo=True` constraints](./function#memoization)) is call-level only. A memoized parent that mounts children still invalidates when a child's logic changes — the child's fingerprint is part of the parent's recorded logic deps.
+
+Where to put `memo=True` follows the [placement rule in When to memoize](./function#memoization): the per-file pipeline above composes a file-level component memo with a chunk-level embedding memo, while a *memoized* component keyed by a content hash of its input makes any inner memo over the same content mostly redundant.
+
 ## How target states sync
 
 The component path tree determines ownership. When a component is no longer mounted at a path (e.g., a source file is deleted), CocoIndex automatically cleans up its target states — and recursively for all its sub-paths.

--- a/docs/src/content/docs/programming_guide/processing_component.mdx
+++ b/docs/src/content/docs/programming_guide/processing_component.mdx
@@ -213,7 +213,7 @@ When iterating over keyed items, prefer [`mount_each()`](#mount_each) — it han
 
 ## Memoized components
 
-`memo=True` on a function you **mount** memoizes the whole component. On a cache hit the body doesn't run, and everything the previous run produced is carried over as a unit: the component's declared [target states](./target_state) **and** its child mounts. Cleanup of no-longer-mounted children only applies when the body actually *runs* — a run that no longer mounts a child removes that child's subtree, while a cache hit retains it.
+`memo=True` on a function you **mount** memoizes the whole component — the *processing-component-level* memoization introduced in [Core Concepts](./core_concepts#function-memoization-skip-unchanged-computations). On a cache hit the body doesn't run, and everything the previous run produced is carried over as a unit: the component's declared [target states](./target_state) **and** its child mounts. Cleanup of no-longer-mounted children only applies when the body actually *runs* — a run that no longer mounts a child removes that child's subtree, while a cache hit retains it.
 
 ```python
 @coco.fn(memo=True)
@@ -223,12 +223,12 @@ async def process_file(file: FileLike, table: postgres.TableTarget[DocEmbedding]
 await coco.mount_each(process_file, files.items(), table)
 ```
 
-Two properties make this the cheapest way to skip stable items:
+Skipping a stable item this way costs almost nothing in storage, provided you follow one principle:
 
-- **The cache entry is small.** A mounted component's declared target states live in the component's own tracking (needed for [sync](#how-target-states-sync) regardless), so its entry holds fingerprints plus the return value — `None` for a typical mounted declarer. An *inline* memoized call additionally records one path per declared target state, so a component declaring many states is much cheaper to memoize at the mount than inline — see the cost note in [When to memoize](./function#memoization).
-- **A memoized component may mount children.** The inline-call mount restriction ([`memo=True` constraints](./function#memoization)) is call-level only. A memoized parent that mounts children still invalidates when a child's logic changes — the child's fingerprint is part of the parent's recorded logic deps.
+- **Declare large values as target states; don't return them.** Every memo entry — whether for a memoized component or for a memoized function called directly inside one (the *transform-level* memoization from Core Concepts) — must store its return value in order to serve a cache hit. A component that outputs via [`declare_row(...)`](./target_state) and returns `None` keeps its entry tiny: the declared values live in the component's own tracking, which [sync](#how-target-states-sync) needs regardless. A memoized function that *returns* a large value (an embedding vector, a parsed document) stores that value in every entry. A secondary difference: a directly-called memoized function's entry also records a reference to each target state it declared, so a hit can keep those states alive — a per-state cost that mounting avoids. See the cost note in [When to memoize](./function#when-to-memoize).
+- **A memoized component may mount children.** A memoized function *called directly* cannot mount — mounting is a side effect its cache can't replay ([`memo=True` constraints](./function#memoization)) — but the restriction doesn't apply once the function is mounted as a component. A memoized parent that mounts children still invalidates when a child's logic changes — the child's fingerprint is part of the parent's recorded logic deps.
 
-Where to put `memo=True` follows the [placement rule in When to memoize](./function#memoization): the per-file pipeline above composes a file-level component memo with a chunk-level embedding memo, while a *memoized* component keyed by a content hash of its input makes any inner memo over the same content mostly redundant.
+Where to put `memo=True` follows the placement rule in [When to memoize](./function#when-to-memoize) — *memoize a boundary only if its key can hit while every enclosing memo boundary misses*: the per-file pipeline above composes a file-level component memo with a chunk-level embedding memo, while a *memoized* component whose path is keyed by a content hash of its input makes any inner memo over the same content mostly redundant.
 
 ## How target states sync
 

--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -1012,7 +1012,12 @@ async def _stop_all_environments() -> None:
     is_flag=True,
     show_default=True,
     default=False,
-    help="Reprocess everything and invalidate existing caches.",
+    help=(
+        "Reprocess everything, bypassing all memoization caches: every "
+        "component and memoized function executes again (external calls such "
+        "as embeddings included). To force just one function's work to run "
+        "again, bump its version= instead."
+    ),
 )
 @click.option(
     "--live",


### PR DESCRIPTION
Documents memoization **placement** — where to put `memo=True` relative to component structure — plus the honest cache-entry cost model and `full_reprocess` semantics. The docs were already strong on the knobs (`version` / `logic_tracking` / `deps`); these are the questions a production deployment's storage analysis showed they didn't answer (in one case, the existing guidance pointed at a pattern that duplicated every embedding vector in the memo store).

Every claim added here was verified against the engine source and core tests (`rust/core/src/engine/`, `python/tests/core/`).

## Changes

- **`programming_guide/function.mdx`**
  - New **placement rule** in "When to memoize": *memoize at a boundary only if its key can hit while every enclosing memo boundary misses* — with the composing case (per-file component + per-chunk embedding memo) and the redundant case (embedding memo inside a *memoized* component keyed by the content's hash: it can never hit on a content-driven rerun; what remains is insurance against the enclosing component's own code/`version` reruns, at ~6 KB per 1536-dim float32 vector — ~600 MB per 100k chunks).
  - Honest **cache-entry cost model**: an inline memoized call's entry stores the return value plus one *path* per declared target state (the state values stay in component tracking; the paths keep them alive on a hit). A function mounted as a component avoids the per-state paths entirely.
  - **Corrected the `memo=True` constraints box**: the mount restriction is call-level, not function-level — the fix the engine error itself suggests (*"Either mount the function as a component, or set memo=False"*, `rust/core/src/engine/function.rs`) was missing from the listed remedies.
  - Logic-fingerprint propagation **crosses mount boundaries** (per `test_logic_change_detection.py`).
- **`programming_guide/processing_component.mdx`** — new **"Memoized components"** section: hit semantics (declared target states *and* child mounts carried over; uncalled-child cleanup applies only when the body runs), the entry-size asymmetry vs. inline calls, and that a memoized component may mount children.
- **`programming_guide/app.mdx` + CLI help** (`cli.mdx` regenerated via `dev/generate_cli_docs.py`; `cli_commands.mdx` aligned): `full_reprocess` bypasses **both** memo levels — every memoized function and component executes again, paid external calls (embeddings/LLM) included; to force just one function's work, bump its `version=` instead.
- **`ops/litellm.mdx`, `ops/sentence_transformers.mdx`** — document the embedders' built-in `embed()` memo (one vector per distinct text, per component), when it composes with per-file components, and when content-keyed components make it redundant (callsite control tracked in #2275).
- **`advanced_topics/internal_storage.mdx`** — what grows the store, largest first.

## Review process

Three independent fresh-context reviewers:

- **First-time-reader comprehension** — six probe questions (e.g. "can a memoized function mount children?", "what survives a component memo hit?", "what does `--full-reprocess` cost at 100k chunks?"): all six answerable, five rated *easy*; its three friction findings are fixed in this diff.
- **Adversarial fact-check against the source** — confirmed the claims with file:line evidence and caught two overclaims in the draft, both corrected here: target-state *paths vs. values* in inline entries, and the inner memo's residual role on code/`version`-driven reruns.
- **Style/mechanics** — caught that `cli.mdx`'s flag table is auto-generated (this PR regenerates it from the updated click help instead of hand-editing), de-duplicated the placement-rule prose to one canonical home with pointer clauses, and verified every added link/anchor.

Docs build (`astro build` + the remark link checker + `check-agent-output`) passes: 98 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
