### PR TITLE
docs: LMDB map auto-resize and logic-fingerprint propagation

### DIFF
--- a/docs/src/content/docs/advanced_topics/internal_storage.mdx
+++ b/docs/src/content/docs/advanced_topics/internal_storage.mdx
@@ -1,9 +1,10 @@
 ---
 title: "*Internal storage* configuration"
 description: >
-  CocoIndex persists target states and memo results in LMDB. Tune map_size and
-  max_dbs via environment variables or programmatic settings, and understand
-  virtual address space considerations on 64-bit systems.
+  CocoIndex persists target states and memo results in LMDB. The database grows
+  automatically when a write runs out of space; tune the initial map_size and
+  max_dbs via environment variables or programmatic settings for large-scale
+  deployments.
 ---
 CocoIndex uses an [LMDB](http://www.lmdb.tech/doc/) database to persist its internal state. This database tracks target states and [memoization](../programming_guide/function) results from previous runs, enabling CocoIndex to detect what changed and apply only the necessary updates.
 
@@ -38,13 +39,19 @@ The LMDB database has two tunable settings, grouped under `coco.LmdbSettings` an
 
 | Setting | Default | Env Variable | Description |
 |---------|---------|-------------|-------------|
-| `max_dbs` | `1024` | `COCOINDEX_LMDB_MAX_DBS` | Maximum number of named LMDB databases. Must be &ge; 1. |
-| `map_size` | `4294967296` (4 GiB) | `COCOINDEX_LMDB_MAP_SIZE` | Maximum size of the LMDB memory map in bytes. Must be &gt; 0; rounded up to the nearest multiple of the system page size. |
+| `max_dbs` | `1024` | `COCOINDEX_LMDB_MAX_DBS` | Maximum number of apps (named LMDB sub-databases) sharing one `db_path`. Unlike `map_size`, this **is** a hard cap — creating one app beyond it fails. Applied at open time, so raising it takes effect on the next start. Must be &ge; 1. |
+| `map_size` | `4294967296` (4 GiB) | `COCOINDEX_LMDB_MAP_SIZE` | *Initial* size of the LMDB memory map in bytes. CocoIndex enlarges the map automatically as the state grows, so this is a starting point, not a cap. Must be &gt; 0; rounded up to the nearest multiple of the system page size. |
 
 ### When to adjust
 
-- **Increase `map_size`** if you encounter LMDB "map full" errors. This happens when the accumulated internal state (target states + memoization cache) exceeds 4 GiB. On 64-bit systems, `map_size` is a virtual address space reservation — setting it larger than needed is safe and does not consume physical memory.
-- **Increase `max_dbs`** if you have an unusually large number of apps sharing a single database directory.
+- **`map_size`** — most deployments never need to touch it. The map grows on its own and each step is cheap, so it is worth setting only when that growth actually costs you something: a large state re-climbing from 4 GiB on every restart, or resize pauses you can measure. If you do size it up, every enlargement logs `LMDB map full, auto-resizing to N bytes and retrying` — the largest `N` you see is the number to use. On 64-bit systems, `map_size` is a virtual address space reservation, so setting it larger than needed is safe and consumes neither physical memory nor disk.
+- **`max_dbs`** — raise it if you have an unusually large number of apps sharing a single database directory.
+
+:::note[How the map grows]
+When a write runs out of map space, CocoIndex doubles the map and retries, repeating until the write fits. The remap itself is cheap — no data copy, no file rewrite — but it needs exclusivity: it waits for every LMDB transaction open in the process to finish, and queues new ones behind it. That's imperceptible for ordinary reads and writes, but a long streaming read (`cocoindex show` over a large app) holds its transaction for the whole stream, and the resize waits that long.
+
+The enlarged size doesn't carry over. The next process opens at the configured `map_size`, raised to at least the space the data file already occupies — the file's high-water mark, not the live data, since LMDB reuses freed pages but never shrinks the file. So a database that outgrew its `map_size` still opens and reads fine, just with no headroom: the next write needing new space enlarges it again. A map that grew to 16 GiB over a 10 GiB file reopens at 10 GiB, not 16, then doubles to 20 GiB on the next write that needs space.
+:::
 
 ### Configuration
 

--- a/docs/src/content/docs/programming_guide/app.mdx
+++ b/docs/src/content/docs/programming_guide/app.mdx
@@ -119,7 +119,7 @@ app = coco.App("MyPipeline", app_main)
 app.update_blocking()  # Uses COCOINDEX_DB for storage
 ```
 
-For details on what the internal database stores and how to tune its LMDB settings (e.g., increasing the maximum database size beyond 4 GiB), see [Internal Storage](../advanced_topics/internal_storage).
+For details on what the internal database stores and how to tune its LMDB settings (the database grows automatically; `map_size` only sets where it starts), see [Internal Storage](../advanced_topics/internal_storage).
 
 ## Lifespan (optional)
 

--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -45,7 +45,7 @@ A function's behavior is determined by its **logic** (source code, [`deps`](#dep
 
 CocoIndex detects three kinds of changes:
 
-**Logic changes** — the function's source code, [`deps`](#deps) values, and explicit [`version`](#version) bumps. Tracked by `@coco.fn`. Logic fingerprints **propagate transitively** up the call chain — but only through `@coco.fn` boundaries. If `foo` (memoized) calls `bar` (also `@coco.fn`-decorated, with or without `memo=True`), and `bar`'s logic changes, `foo`'s memo is invalidated. A bare Python helper that isn't decorated is invisible to change detection: editing it will not invalidate `foo`. This is why `@coco.fn` matters for **any** function in the call chain, not just memoized ones — see [Common patterns](#common-patterns).
+**Logic changes** — a function's *logic* is its own source code (or, when you set [`version`](#version), that integer **instead of** the source), plus any [`deps`](#deps) values. Tracked by `@coco.fn`. Logic fingerprints **propagate transitively** up the call chain, following *runtime invocations* rather than the static call graph: every `@coco.fn` function reached during a memoized call — directly, or through plain undecorated helpers — contributes its logic to that call. So if `foo` (memoized) calls `bar` (also `@coco.fn`-decorated, with or without `memo=True`) and `bar`'s logic changes, `foo`'s memo is invalidated; undecorated helpers in between don't break the chain. What the decorator buys is having a function's *own* logic tracked: an undecorated helper is invisible to change detection, so editing it invalidates nothing. This is why `@coco.fn` matters for **any** function in the call chain, not just memoized ones — see [Common patterns](#common-patterns) and the [FAQ](../faq#how-does-logic-change-propagation-work). To stop propagation deliberately, set [`logic_tracking`](#logic_tracking) to `"self"` or `None`.
 
 **Input changes** — the function's arguments. Tracked by `@coco.fn`. When you call a function with different arguments, the fingerprints change. Input fingerprints do not propagate transitively.
 
@@ -135,8 +135,10 @@ These parameters control logic fingerprinting. Data fingerprinting (for argument
 The `logic_tracking` parameter controls whether and how logic changes are detected:
 
 - **`"full"` (default):** Track this function's logic AND all transitively called `@coco.fn` functions' logic. A change anywhere in the call chain invalidates dependent memos.
-- **`"self"`:** Track only this function's own logic. Changes in called functions do not propagate through this function.
-- **`None`:** Don't track this function's logic at all. Logic changes to this function are invisible to the change detection system.
+- **`"self"`:** Track only this function's own logic — its fingerprint still propagates to its callers, but the logic of functions it calls does not propagate through it.
+- **`None`:** Don't track logic through this function at all — neither its own logic nor its callees' reaches its callers.
+
+These settings govern nested *function calls*. A [mounted child component](./processing_component) is tracked through the component tree instead, so its logic reaches the parent regardless of the parent's `logic_tracking`.
 
 #### `version`
 
@@ -148,6 +150,10 @@ def process_chunk(chunk: Chunk) -> list[float]:
     # Bumping version invalidates all memoized callers, even if code looks the same
     return embed(chunk.text)
 ```
+
+:::caution[`version` replaces source tracking]
+Setting `version` makes the integer the function's logic **instead of** its source code — the body is no longer fingerprinted. Edits to a versioned function take effect only when you bump the number.
+:::
 
 #### `deps`
 

--- a/python/cocoindex/_internal/setting.py
+++ b/python/cocoindex/_internal/setting.py
@@ -22,7 +22,11 @@ def get_default_db_path() -> pathlib.Path | None:
 
 @dataclass
 class LmdbSettings:
-    """Settings for the internal LMDB-backed state store."""
+    """Settings for the internal LMDB-backed state store.
+
+    `map_size` is the *initial* size of the LMDB memory map, not a cap: the
+    engine doubles the map and retries whenever a write runs out of space.
+    """
 
     max_dbs: int = 1024
     map_size: int = 0x1_0000_0000  # 4 GiB

--- a/rust/core/src/state_store/storage.rs
+++ b/rust/core/src/state_store/storage.rs
@@ -630,8 +630,7 @@ mod tests {
 
     /// Integration test for `MDB_MAP_FULL` auto-resize on the `Storage::run_txn`
     /// path: one batched write txn is filled past the map limit, the runner
-    /// doubles the map, retries the same body, and commits. Run via
-    /// `dev/test_lmdb_auto_resize.sh`.
+    /// doubles the map, retries the same body, and commits.
     #[tokio::test]
     async fn auto_resizes_on_map_full() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- **Internal storage** — `map_size` is documented as the *initial* map size, not a cap: since #2231 a write that runs out of space doubles the map and retries. Adds a folded note covering the growth mechanism, the `LMDB map full, auto-resizing to N bytes` warning (the actionable signal for when to raise the setting), the resize's exclusivity cost against long-running reads, and what a restart opens at — `max(configured map_size, data file high-water mark)`, which is why a database that outgrew its setting reopens with zero headroom.
- **Change detection** — corrects "logic fingerprints propagate only through `@coco.fn` boundaries". Propagation follows runtime invocations, so an undecorated helper between two decorated functions does not break the chain; what leaving it undecorated costs is only that helper's own code being fingerprinted. Also: `version` *replaces* source tracking (a real footgun — set it once and your edits stop invalidating), cache-hit callees still contribute recorded deps, and `"self"` / `None` differ in what they drop, with mounted children exempt from both.
- Knock-ons: `app.mdx` still called 4 GiB "the maximum database size" in the link into the corrected page; a `storage.rs` doc comment pointed at a script that does not exist.

Behavioral claims were verified by running the engine rather than read off the PR — LMDB reopen sizing via a throwaway `storage.rs` test (grew to 4 MiB, reopened at the 2,195,456-byte high-water mark, doubled on the next write), and helper transparency via a throwaway memoization test.

## Test plan

CI. Locally: `npm run build` in `docs/` (Astro build + the relative-link/fragment checker), `prek run --all-files`, `cargo check -p cocoindex_core`.
