### PR TITLE
docs: correct and complete the RecursiveSplitter supported-languages table

### DIFF
--- a/docs/src/content/docs/ops/text.mdx
+++ b/docs/src/content/docs/ops/text.mdx
@@ -130,27 +130,35 @@ defs = CodePattern(r"def \NAME(\(A*\)):", language="python").match_source(src)  
 
 **Supported languages:**
 
+`language=` accepts a language name, an alternate name, or a file extension — `"python"`, `"py"` and `".py"` all select Python. Matching is case-insensitive. Use [`detect_code_language()`](#detect_code_language) to infer the value from a filename.
+
 Languages with syntax-aware (tree-sitter) splitting — splits at logical boundaries like functions, classes, and blocks:
 
 | Language | `language=` value | Extensions |
 |---|---|---|
 | Astro | `"astro"` | `.astro` |
-| C | `"c"` | `.c`, `.h` |
-| C++ | `"cpp"` | `.cpp`, `.cc`, `.cxx`, `.c++` |
-| C# | `"c_sharp"` | `.cs` |
-| CSS | `"css"` | `.css` |
-| Fortran | `"fortran"` | `.f`, `.f90`, `.f95` |
+| Bash | `"bash"` | `.sh`, `.bash` |
+| C | `"c"` | `.c`, `.cats`, `.idc` |
+| C# | `"csharp"` | `.cs`, `.csx`, `.cake`, `.linq` |
+| C++ | `"cpp"` | `.cpp`, `.cc`, `.cxx`, `.c++`, `.h`, `.hpp`, `.hh`, `.hxx` |
+| CMake | `"cmake"` | `.cmake`, `.cmake.in` |
+| CSS | `"css"` | `.css`, `.scss` |
+| Dart | `"dart"` | `.dart` |
+| DTD | `"dtd"` | `.dtd` |
+| Elm | `"elm"` | `.elm` |
+| Fortran | `"fortran"` | `.f`, `.f90`, `.f95`, `.f03` |
 | Go | `"go"` | `.go` |
-| HTML | `"html"` | `.html`, `.htm` |
-| Java | `"java"` | `.java` |
+| HCL / Terraform | `"hcl"` | `.hcl`, `.tf` |
+| HTML | `"html"` | `.html`, `.htm`, `.xhtml` |
+| Java | `"java"` | `.java`, `.jav`, `.jsh` |
 | JavaScript | `"javascript"` | `.js`, `.mjs`, `.cjs`, `.jsx` |
-| JSON | `"json"` | `.json`, `.jsonc` |
+| JSON | `"json"` | `.json`, `.jsonl`, `.geojson` |
 | Julia | `"julia"` | `.jl` |
-| Kotlin | `"kotlin"` | `.kt`, `.kts` |
-| Markdown | `"markdown"` | `.md` |
-| Pascal | `"pascal"` | `.pas` |
+| Kotlin | `"kotlin"` | `.kt`, `.kts`, `.ktm` |
+| Markdown | `"markdown"` | `.md`, `.markdown`, `.mdx` |
+| Pascal / Delphi | `"pascal"` | `.pas`, `.dpr`, `.lpr`, `.dfm` |
 | PHP | `"php"` | `.php` |
-| Python | `"python"` | `.py` |
+| Python | `"python"` | `.py`, `.pyi`, `.pyw`, `.pyx`, `.pxd` |
 | R | `"r"` | `.r`, `.R` |
 | Ruby | `"ruby"` | `.rb` |
 | Rust | `"rust"` | `.rs` |
@@ -166,7 +174,9 @@ Languages with syntax-aware (tree-sitter) splitting — splits at logical bounda
 | XML | `"xml"` | `.xml` |
 | YAML | `"yaml"` | `.yaml`, `.yml` |
 
-Many additional languages use separator-based splitting (e.g. `"bash"`, `"dart"`, `"elixir"`, `"elm"`, `"go"`, `"haskell"`, `"lua"`, `"perl"`, `"swift"`, and more). Pass the language name string to `language=` — use [`detect_code_language()`](#detect_code_language) to infer it from a filename.
+Note that `.h` maps to C++, not C — the C++ grammar also parses C headers. Pass `language="c"` explicitly to force the C grammar.
+
+Over 110 additional languages use separator-based splitting (e.g. `"elixir"`, `"erlang"`, `"haskell"`, `"lua"`, `"nix"`, `"perl"`, `"powershell"`, `"proto"`, `"zig"`, and more). A `language=` value that matches no known language also falls back to separator-based splitting rather than raising.
 
 ### `CustomLanguageConfig`
 


### PR DESCRIPTION
## Summary

The `RecursiveSplitter` supported-languages table on `/docs/ops/text/` listed 31 tree-sitter languages; the registry in [`rust/code_ast/src/prog_langs.rs`](rust/code_ast/src/prog_langs.rs) has **37**.

- **Adds the 6 missing languages:** Bash, CMake, Dart, DTD, Elm, HCL/Terraform.
- **Fixes 3 factual errors:**
  - C# was documented as `"c_sharp"`, which is **not a registered name**. An unrecognized `language=` doesn't raise — it silently falls back to separator splitting — so anyone following the docs got degraded chunking with no error. Verified: `"c_sharp"` produces byte-identical output to a nonsense language string, while `"csharp"` / `"c#"` / `"cs"` / `".cs"` all parse.
  - `.jsonc` was listed for JSON but isn't registered (replaced with the real `.jsonl` / `.geojson`).
  - `.h` was listed under C, but resolves to **C++** (C owns `.c`, `.cats`, `.h.in`, `.idc`).
- **Fixes the trailing sentence**, which listed `"bash"`, `"dart"`, `"elm"`, `"go"` and `"swift"` as separator-based — all five have tree-sitter grammars, and Go and Swift were simultaneously present in the table above it.
- **Documents two previously-undocumented behaviors:** `language=` accepts names, alternate names and file extensions case-insensitively (`"python"` / `"py"` / `".py"`), and an unknown value falls back to separator splitting rather than raising — the behavior that made the `"c_sharp"` error invisible.

Also completes truncated extension lists (`.pyi`/`.pyx`, `.hpp`/`.hh`, `.scss`, `.mdx`, `.xhtml`, `.f03`, `.dpr`, `.jav`, `.ktm`).

## Test plan

- Parsed the registry out of `prog_langs.rs` and cross-checked **all 115** documented name/extension tokens: every one resolves to the grammar its row claims, no tree-sitter language is left undocumented, and no documented value lacks a grammar.
- Spot-checked through the real Python API that the corrected values parse and the removed one doesn't (`"c_sharp"` ≡ fallback baseline).
- `npm run build` in `docs/` passes (98 pages, agent-output check OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
