### PR TITLE
fix(engine): use exact equality for the TERMINATED_VERSION check

### DIFF
--- a/rust/core/src/engine/progress_display.rs
+++ b/rust/core/src/engine/progress_display.rs
@@ -427,7 +427,7 @@ async fn show_progress_pty<T: Send + 'static>(
         tokio::select! {
             result = handle.changed() => {
                 let version = result?;
-                if version >= TERMINATED_VERSION {
+                if version == TERMINATED_VERSION {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- Change the `TERMINATED_VERSION` comparison in the progress-display loop from `>=` to `==`. `TERMINATED_VERSION` is `u64::MAX`, so the two are equivalent, but `>=` trips clippy's deny-by-default `absurd_extreme_comparisons` lint, making `cargo clippy --workspace --all-targets` fail to compile `cocoindex_core`. Pre-existing on `main`.

## Test plan
- `cargo clippy --workspace --all-targets` completes with no errors (pre-existing warnings only)
- `cargo test -p cocoindex_core` passes
- CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
