### PR TITLE
feat(code_ast): wire tree-sitter Lua grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -12001,6 +12002,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/docs/src/content/docs/ops/text.mdx
+++ b/docs/src/content/docs/ops/text.mdx
@@ -155,6 +155,7 @@ Languages with syntax-aware (tree-sitter) splitting — splits at logical bounda
 | JSON | `"json"` | `.json`, `.jsonl`, `.geojson` |
 | Julia | `"julia"` | `.jl` |
 | Kotlin | `"kotlin"` | `.kt`, `.kts`, `.ktm` |
+| Lua | `"lua"` | `.lua`, `.nse`, `.p8`, `.pd_lua`, `.rbxs`, `.rockspec`, `.wlua` |
 | Markdown | `"markdown"` | `.md`, `.markdown`, `.mdx` |
 | Pascal / Delphi | `"pascal"` | `.pas`, `.dpr`, `.lpr`, `.dfm` |
 | PHP | `"php"` | `.php` |
@@ -176,7 +177,7 @@ Languages with syntax-aware (tree-sitter) splitting — splits at logical bounda
 
 Note that `.h` maps to C++, not C — the C++ grammar also parses C headers. Pass `language="c"` explicitly to force the C grammar.
 
-Over 110 additional languages use separator-based splitting (e.g. `"elixir"`, `"erlang"`, `"haskell"`, `"lua"`, `"nix"`, `"perl"`, `"powershell"`, `"proto"`, `"zig"`, and more). A `language=` value that matches no known language also falls back to separator-based splitting rather than raising.
+110 additional languages use separator-based splitting (e.g. `"elixir"`, `"erlang"`, `"haskell"`, `"nix"`, `"perl"`, `"powershell"`, `"proto"`, `"zig"`, and more). A `language=` value that matches no known language also falls back to separator-based splitting rather than raising.
 
 ### `CustomLanguageConfig`
 

--- a/examples/rust/amazon_s3_embedding/Cargo.lock
+++ b/examples/rust/amazon_s3_embedding/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -5630,6 +5631,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/code_embedding/Cargo.lock
+++ b/examples/rust/code_embedding/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4669,6 +4670,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/code_embedding_lancedb/Cargo.lock
+++ b/examples/rust/code_embedding_lancedb/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -7269,6 +7270,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/gdrive_text_embedding/Cargo.lock
+++ b/examples/rust/gdrive_text_embedding/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4674,6 +4675,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/oci_object_storage_embedding/Cargo.lock
+++ b/examples/rust/oci_object_storage_embedding/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4674,6 +4675,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/paper_metadata/Cargo.lock
+++ b/examples/rust/paper_metadata/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4785,6 +4786,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/pdf_embedding/Cargo.lock
+++ b/examples/rust/pdf_embedding/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4783,6 +4784,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/text_embedding/Cargo.lock
+++ b/examples/rust/text_embedding/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4669,6 +4670,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/text_embedding_lancedb/Cargo.lock
+++ b/examples/rust/text_embedding_lancedb/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -7269,6 +7270,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/text_embedding_qdrant/Cargo.lock
+++ b/examples/rust/text_embedding_qdrant/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4477,6 +4478,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/examples/rust/text_embedding_turbopuffer/Cargo.lock
+++ b/examples/rust/text_embedding_turbopuffer/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-language",
+ "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
  "tree-sitter-php",
@@ -4128,6 +4129,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-md"

--- a/python/tests/ops/test_text.py
+++ b/python/tests/ops/test_text.py
@@ -19,6 +19,7 @@ def test_detect_code_language_known_extensions() -> None:
     assert detect_code_language(filename="App.vue") == "vue"
     assert detect_code_language(filename="script.jl") == "julia"
     assert detect_code_language(filename="main.dart") == "dart"
+    assert detect_code_language(filename="init.lua") == "lua"
     assert detect_code_language(filename="Main.elm") == "elm"
     assert detect_code_language(filename="index.astro") == "astro"
     assert detect_code_language(filename="deploy.sh") == "bash"
@@ -227,6 +228,54 @@ def test_recursive_splitter_with_dart() -> None:
 
     assert len(chunks) >= 1
     assert all(isinstance(c, Chunk) for c in chunks)
+
+
+def test_recursive_splitter_with_lua() -> None:
+    """Lua splitting is syntax-aware, not separator-based.
+
+    The sample is one line, so separators give the fallback path no function
+    boundaries at all. Only the grammar can find them.
+    """
+    splitter = RecursiveSplitter()
+    code = (
+        "local function f(a) return a+1 end "
+        "local function g(b) return b*2 end "
+        "local function h(c) return c-3 end"
+    )
+    chunks = splitter.split(code, chunk_size=45, min_chunk_size=10, language="lua")
+
+    assert len(chunks) > 1, "sample must split for the check below to mean anything"
+    assert all(isinstance(c, Chunk) for c in chunks)
+    for chunk in chunks:
+        text = chunk.text.strip()
+        assert text.startswith("local function") and text.endswith("end"), (
+            f"chunk straddles a function boundary: {text!r}"
+        )
+
+
+def test_recursive_splitter_lua_keeps_table_constructor_whole() -> None:
+    """A Lua table constructor is not severed at a comma between its fields.
+
+    Separator fallback cuts `{ x = x, y = y }` at the comma, because a comma is
+    a separator to it and a table field to the grammar. A constructor longer
+    than `chunk_size` is still split, here as in every other grammar-backed
+    language.
+    """
+    splitter = RecursiveSplitter()
+    code = (
+        "local function clamp(v, lo, hi) return math.min(math.max(v, lo), hi) end\n"
+        "local Point = {}\n"
+        "Point.__index = Point\n"
+        "function Point.new(x, y) return setmetatable({ x = x, y = y }, Point) end\n"
+        "function Point:norm() return math.sqrt(self.x * self.x + self.y * self.y) end\n"
+        "return Point\n"
+    )
+    chunks = splitter.split(code, chunk_size=60, min_chunk_size=10, language="lua")
+
+    assert len(chunks) > 1, "sample must split for the check below to mean anything"
+    assert any("setmetatable({ x = x, y = y }, Point)" in c.text for c in chunks), (
+        "table constructor was severed across chunks"
+    )
 
 
 def test_recursive_splitter_with_vue() -> None:

--- a/rust/code_ast/Cargo.toml
+++ b/rust/code_ast/Cargo.toml
@@ -30,6 +30,7 @@ tree-sitter-json = "0.24.8"
 tree-sitter-julia = "0.23.1"
 # The other more popular crate tree-sitter-kotlin requires tree-sitter < 0.23 for now
 tree-sitter-kotlin-ng = "1.1.0"
+tree-sitter-lua = "0.5.0"
 tree-sitter-md = "0.5.3"
 tree-sitter-pascal = "0.10.2"
 tree-sitter-php = "0.23.11"

--- a/rust/code_ast/src/prog_langs.rs
+++ b/rust/code_ast/src/prog_langs.rs
@@ -328,7 +328,7 @@ static LANGUAGE_INFO_BY_NAME: LazyLock<HashMap<UniCase<String>, &'static Program
                 ".rockspec",
                 ".wlua",
             ],
-            None,
+            Some(TreeSitterLanguageInfo::new(tree_sitter_lua::LANGUAGE, [])),
         );
         add("luau", &[".luau"], None);
         add("magik", &[".magik"], None);
@@ -620,6 +620,13 @@ mod tests {
         let dart = get_language_info(".dart").unwrap();
         assert_eq!(dart.name.as_ref(), "dart");
         assert!(dart.treesitter_info.is_some());
+    }
+
+    #[test]
+    fn test_lua_has_treesitter() {
+        let lua = get_language_info(".lua").unwrap();
+        assert_eq!(lua.name.as_ref(), "lua");
+        assert!(lua.treesitter_info.is_some());
     }
 
     #[test]

--- a/rust/ops_text/src/split/recursive.rs
+++ b/rust/ops_text/src/split/recursive.rs
@@ -933,6 +933,64 @@ class Point {
     }
 
     #[test]
+    fn test_split_with_lua_language() {
+        let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
+        // One line, so line/whitespace separators give the fallback path no
+        // function boundaries at all. Only the grammar can find them.
+        let text = "local function f(a) return a+1 end \
+                    local function g(b) return b*2 end \
+                    local function h(c) return c-3 end";
+        let config = RecursiveChunkConfig {
+            chunk_size: 45,
+            min_chunk_size: Some(10),
+            chunk_overlap: Some(0),
+        };
+        let chunks = chunker.split(&CodeSource::with_language(text, "lua"), config);
+        assert!(
+            chunks.len() > 1,
+            "sample must split for the check below to mean anything"
+        );
+        for chunk in &chunks {
+            let chunk_text = text[chunk.range.start..chunk.range.end].trim();
+            assert!(
+                chunk_text.starts_with("local function") && chunk_text.ends_with("end"),
+                "chunk straddles a function boundary: {chunk_text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_split_lua_keeps_table_constructor_whole() {
+        let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
+        // Asserts one thing: the argument list of `setmetatable` stays whole.
+        // Separator fallback cuts it at the comma between `x = x` and `y = y`,
+        // because a comma is a separator to it and a table field to the
+        // grammar. A constructor longer than `chunk_size` is still split, here
+        // as in every other grammar-backed language.
+        let text = "local function clamp(v, lo, hi) return math.min(math.max(v, lo), hi) end\n\
+                    local Point = {}\n\
+                    Point.__index = Point\n\
+                    function Point.new(x, y) return setmetatable({ x = x, y = y }, Point) end\n\
+                    function Point:norm() return math.sqrt(self.x * self.x + self.y * self.y) end\n\
+                    return Point\n";
+        let config = RecursiveChunkConfig {
+            chunk_size: 60,
+            min_chunk_size: Some(10),
+            chunk_overlap: Some(0),
+        };
+        let chunks = chunker.split(&CodeSource::with_language(text, "lua"), config);
+        assert!(
+            chunks.len() > 1,
+            "sample must split for the check below to mean anything"
+        );
+        assert!(
+            chunks.iter().any(|c| text[c.range.start..c.range.end]
+                .contains("setmetatable({ x = x, y = y }, Point)")),
+            "table constructor was severed across chunks"
+        );
+    }
+
+    #[test]
     fn test_split_positions() {
         let chunker = RecursiveChunker::new(RecursiveSplitConfig::default()).unwrap();
         let text = "Chunk1\n\nChunk2";


### PR DESCRIPTION
## Summary

Adds the `tree-sitter-lua` grammar to `cocoindex_code_ast` and wires it into the existing `lua` language entry, so `.lua` files get syntax-aware splitting in `RecursiveSplitter` on par with the other grammar-backed languages. Previously Lua was registered with its seven extensions but `None` for `treesitter_info`, so it silently fell back to separator-based splitting: functions cut mid-body, chunks starting with no signature above them.

## Changes

- Add `tree-sitter-lua = "0.5.0"` dependency to `rust/code_ast`, exact-pinned like the other 35 grammar crates
- Attach `TreeSitterLanguageInfo` to the `lua` entry in `prog_langs.rs`; name and alias list untouched, so `detect_code_language()` is unchanged by construction
- Rust tests: `test_lua_has_treesitter` (prog_langs), `test_split_with_lua_language` and `test_split_lua_keeps_table_constructor_whole` (recursive splitter)
- Python tests: `detect_code_language` for `.lua`, plus the same two splitter tests through `RecursiveSplitter`
- Docs: add the Lua row to the syntax-aware table in `ops/text.mdx`, drop `"lua"` from the separator-fallback list, correct that list's count to 110
- Lock files: workspace `Cargo.lock` plus the 11 example locks via `dev/update_rust_extern_locks.sh`

The existing splitter tests for other languages assert only that the chunk list is non-empty, which passes identically with a grammar unwired (separator fallback also returns chunks). The new splitter tests use samples with no blank lines, so they fail if the grammar is ever unwired: one asserts every chunk is a whole `local function ... end`, one asserts a `setmetatable({ x = x, y = y }, Point)` constructor is not cut at the comma between its fields. Verified by unwiring the grammar and re-running.

## Testing

- `cargo test -p cocoindex_code_ast -p cocoindex_ops_text`: 42 + 36 passed
- `uv run pytest python/tests/ops/test_text.py`: 37 passed
- `ruff format --check .`: 283 files already formatted; `ruff check` clean on the touched file
