### PR TITLE
fix(cli): parse Windows app target paths

### DIFF
--- a/python/cocoindex/cli.py
+++ b/python/cocoindex/cli.py
@@ -117,9 +117,22 @@ def _parse_app_target(specifier: str) -> AppSpecifier:
         './main.py:app2' -> AppSpecifier('./main.py', 'app2', None)
         './main.py:app2@alpha' -> AppSpecifier('./main.py', 'app2', 'alpha')
         'mymodule:my_app@default' -> AppSpecifier('mymodule', 'my_app', 'default')
+        'C:\\project\\main.py:app2' -> AppSpecifier('C:\\project\\main.py', 'app2', None)
     """
-    parts = specifier.split(":", 1)
-    module_ref = parts[0]
+    # A Windows absolute path starts with a drive-letter colon, which is part
+    # of the path rather than the app-name separator.
+    search_start = (
+        2
+        if len(specifier) > 2 and specifier[1] == ":" and specifier[2] in ("/", "\\")
+        else 0
+    )
+    separator_index = specifier.find(":", search_start)
+    if separator_index == -1:
+        module_ref = specifier
+        app_part = None
+    else:
+        module_ref = specifier[:separator_index]
+        app_part = specifier[separator_index + 1 :]
 
     if not module_ref:
         raise click.BadParameter(
@@ -128,10 +141,9 @@ def _parse_app_target(specifier: str) -> AppSpecifier:
             param_hint="APP_TARGET",
         )
 
-    if len(parts) == 1:
+    if app_part is None:
         return AppSpecifier(module_ref=module_ref)
 
-    app_part = parts[1]
     if not app_part:
         return AppSpecifier(module_ref=module_ref)
 

--- a/python/tests/cli/test_app_target.py
+++ b/python/tests/cli/test_app_target.py
@@ -1,0 +1,23 @@
+import pytest
+
+from cocoindex.cli import AppSpecifier, _parse_app_target
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        (r"C:\project\main.py", AppSpecifier(r"C:\project\main.py")),
+        (
+            r"C:\project\main.py:app2",
+            AppSpecifier(r"C:\project\main.py", "app2"),
+        ),
+        (
+            r"C:\project\main.py:app2@alpha",
+            AppSpecifier(r"C:\project\main.py", "app2", "alpha"),
+        ),
+    ],
+)
+def test_parse_app_target_preserves_windows_drive(
+    target: str, expected: AppSpecifier
+) -> None:
+    assert _parse_app_target(target) == expected


### PR DESCRIPTION
## Summary

The CLI splits app targets at the first colon. On Windows, that colon can be the drive separator, so targets such as `C:\project\main.py:app2` are parsed as module `C`.

Skip the drive-letter colon for absolute Windows paths, then locate the optional app-name separator.

## Testing

- Added parameterized coverage for a bare Windows path, an app name, and an app name with environment.
- Verified all three parser cases against the changed function.
- Ruff check, formatting check, and `compileall` on both changed files.