### PR TITLE
fix(engine): skip child-existence reconciliation on demote-only deletes

### DIFF
--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -1532,3 +1532,23 @@ def test_component_to_directory_transition() -> None:
     paths = coco_inspect.list_stable_paths_sync(app)
     assert old_component in paths
     assert deeper_component in paths
+
+    # Transition back from Directory to Component at the same path: D1 is a
+    # component again, so its former child -- and that child's target
+    # states -- are gone.
+    _transition_to_directory_mode = False
+    app.update_blocking()
+    assert DictsTarget.store.data == {
+        "D1": {
+            "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+            "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+        },
+    }
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': container_owner,
+        '/@test_target_state/dicts/"D1"/"a"': old_component,
+        '/@test_target_state/dicts/"D1"/"b"': old_component,
+    }
+    paths = coco_inspect.list_stable_paths_sync(app)
+    assert old_component in paths
+    assert deeper_component not in paths

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -1441,3 +1441,94 @@ def test_directory_to_component_transition() -> None:
     assert coco.ROOT_PATH / "transition_test" in paths
     assert coco.ROOT_PATH / "transition_test" / "D1" in paths
     assert coco.ROOT_PATH / "transition_test" / "D1" / "a" not in paths
+
+
+##################################################################################
+# Test: Component -> Directory transition child existence reconciliation
+##################################################################################
+
+_transition_to_directory_mode = False
+
+
+def _declare_dict_entries(
+    provider: coco.TargetStateProvider[Any], entries: dict[str, Any]
+) -> None:
+    for key, value in entries.items():
+        coco.declare_target_state(provider.target_state(key, value))
+
+
+async def _declare_transition_to_directory() -> None:
+    provider = await coco.mount_target(DictsTarget.dict_target("D1"))
+    with coco.component_subpath("transition_test"):
+        if not _transition_to_directory_mode:
+            await coco.mount(
+                coco.component_subpath("D1"),
+                _declare_dict_entries,
+                provider,
+                {"a": 1, "b": 2},
+            )
+        else:
+            await coco.mount(
+                coco.component_subpath("D1", "child"),
+                _declare_dict_entries,
+                provider,
+                {"c": 3},
+            )
+
+
+def test_component_to_directory_transition() -> None:
+    global _transition_to_directory_mode
+    DictsTarget.store.clear()
+    _transition_to_directory_mode = False
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_component_to_directory_transition", environment=coco_env
+        ),
+        _declare_transition_to_directory,
+    )
+
+    app.update_blocking()
+    assert DictsTarget.store.data == {
+        "D1": {
+            "a": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+            "b": DictDataWithPrev(data=2, prev=[], prev_may_be_missing=True),
+        },
+    }
+    container_owner = (
+        coco.ROOT_PATH
+        / coco.Symbol("cocoindex/mount_target")
+        / (coco.Symbol("test_target_state/dicts"), "D1")
+    )
+    old_component = coco.ROOT_PATH / "transition_test" / "D1"
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': container_owner,
+        '/@test_target_state/dicts/"D1"/"a"': old_component,
+        '/@test_target_state/dicts/"D1"/"b"': old_component,
+    }
+
+    # Transition from Component to Directory: the component at
+    # transition_test/D1 is no longer mounted; instead a deeper component is
+    # mounted under it, so D1 stays in the child-existence tree as a
+    # Directory node whose only child is the new component.
+    _transition_to_directory_mode = True
+    app.update_blocking()
+
+    # D1's own target states are gone, while the deeper component's target
+    # states -- written in this same update -- must survive D1's demotion.
+    deeper_component = old_component / "child"
+    assert DictsTarget.store.data == {
+        "D1": {
+            "c": DictDataWithPrev(data=3, prev=[], prev_may_be_missing=True),
+        },
+    }
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/dicts/"D1"': container_owner,
+        '/@test_target_state/dicts/"D1"/"c"': deeper_component,
+    }
+
+    # D1 is still present (now as a Directory node) with the deeper component
+    # below it.
+    paths = coco_inspect.list_stable_paths_sync(app)
+    assert old_component in paths
+    assert deeper_component in paths

--- a/rust/core/src/engine/context.rs
+++ b/rust/core/src/engine/context.rs
@@ -1294,8 +1294,7 @@ mod tests {
         path: &StablePath,
         cache: UserStateCache<TestData>,
     ) {
-        use crate::state_store::{CommitPlan, ExistenceReconciler};
-        use futures::future::BoxFuture;
+        use crate::state_store::CommitPlan;
 
         let plan_data = cache.into_flush_plan().unwrap();
         let plan = CommitPlan {
@@ -1309,13 +1308,8 @@ mod tests {
             user_state_writes: plan_data.writes,
             user_state_deletes: plan_data.deletes,
             user_state_clear_live: false,
-            child_path_set: None,
         };
-        let reconciler: ExistenceReconciler =
-            Box::new(|_wtxn| -> BoxFuture<'_, crate::prelude::Result<()>> {
-                Box::pin(async { Ok(()) })
-            });
-        store.commit(path, plan, reconciler).await.unwrap();
+        store.commit(path, plan, None).await.unwrap();
     }
 
     #[tokio::test]

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -427,9 +427,9 @@ impl<Prof: EngineProfile> Committer<Prof> {
     /// them through [`AppStore::commit`](crate::state_store::AppStore::commit).
     /// The AppStore opens its own write txn, applies the plan's writes
     /// (tracking-info, fn-memo flush, user-state flush, target-owner cleanup),
-    /// and invokes the `ExistenceReconciler` callback to walk the
-    /// child-existence tree atomically inside the same txn. Then
-    /// launches Phase 5 GC.
+    /// and — unless this is a `demote_component_only` delete — invokes the
+    /// `ExistenceReconciler` callback to walk the child-existence tree
+    /// atomically inside the same txn. Then launches Phase 5 GC.
 
     async fn commit(
         self,
@@ -452,12 +452,6 @@ impl<Prof: EngineProfile> Committer<Prof> {
         let (new_tracking_info, target_owners_to_delete) =
             self.build_commit_writes(curr_version).await?;
 
-        let child_path_set = if self.demote_component_only {
-            None
-        } else {
-            child_path_set.map(Arc::new)
-        };
-
         // On whole-component deletion, also clear the `Live` user-state
         // keyspace. The regular flush (clear_all_first / writes / deletes)
         // only touches `Regular`, so without this the live-machinery
@@ -478,30 +472,50 @@ impl<Prof: EngineProfile> Committer<Prof> {
             user_state_writes: user_state_plan.writes,
             user_state_deletes: user_state_plan.deletes,
             user_state_clear_live,
-            child_path_set: child_path_set.clone(),
         };
 
-        // Reconciler closure: walks `child_path_set` against on-disk
-        // `__cex` rows, writes diffs and tombstones. Runs inside the
-        // AppStore's commit txn so the existence diff is atomic with
-        // the rest of the commit plan.
-        let app_store = self.app_store.clone();
-        let component_path = self.component_path.clone();
-        let cps = child_path_set;
-        // `Fn` (not `FnOnce`) so a backend that re-runs its commit txn can
-        // re-invoke it — clone the (cheap, `Arc`/owned) captures per call
-        // rather than moving them into the future.
-        let reconciler: ExistenceReconciler = Box::new(move |wtxn| {
-            let app_store = app_store.clone();
-            let component_path = component_path.clone();
-            let cps = cps.clone();
-            Box::pin(async move {
-                reconcile_child_existence(wtxn, &app_store, &component_path, cps.as_deref()).await
-            })
-        });
+        // Child-existence reconciliation runs inside the AppStore's commit
+        // txn so the `__cex` diff is atomic with the rest of the plan:
+        //
+        // * Build: diff the declared `child_path_set` against the on-disk
+        //   `__cex` rows.
+        // * Whole-component delete: `child_path_set` is `None` — nothing is
+        //   declared, so every on-disk child is removed and tombstoned. This
+        //   is the cascade `launch_child_component_gc` relies on.
+        // * `demote_component_only`: this path stays in the tree as a
+        //   Directory node whose `__cex` children were declared — and
+        //   already reconciled — by the parent's current build. They are
+        //   live, so skip reconciliation entirely: walking them against an
+        //   empty set would tombstone them, and the GC sweep would then
+        //   delete target states they wrote in this same update.
+        let existence_reconciler: Option<ExistenceReconciler> = if self.demote_component_only {
+            None
+        } else {
+            let app_store = self.app_store.clone();
+            let component_path = self.component_path.clone();
+            let child_path_set = child_path_set.map(Arc::new);
+            // `Fn` (not `FnOnce`) so a backend that re-runs its commit txn can
+            // re-invoke it — clone the (cheap, `Arc`/owned) captures per call
+            // rather than moving them into the future.
+            let reconciler: ExistenceReconciler = Box::new(move |wtxn| {
+                let app_store = app_store.clone();
+                let component_path = component_path.clone();
+                let child_path_set = child_path_set.clone();
+                Box::pin(async move {
+                    reconcile_child_existence(
+                        wtxn,
+                        &app_store,
+                        &component_path,
+                        child_path_set.as_deref(),
+                    )
+                    .await
+                })
+            });
+            Some(reconciler)
+        };
 
         self.app_store
-            .commit(&self.component_path, plan, reconciler)
+            .commit(&self.component_path, plan, existence_reconciler)
             .await?;
 
         // Phase 5 GC: snapshot-read tombstones and spawn child delete

--- a/rust/core/src/engine/execution.rs
+++ b/rust/core/src/engine/execution.rs
@@ -397,21 +397,38 @@ pub fn declare_target_state_with_child<Prof: EngineProfile>(
     Ok(child_provider)
 }
 
+/// What a commit does to the child-existence (`__cex`) subtree under the
+/// component. Decided once in [`submit`], after the processing action and
+/// the delete-mode preflight are both known.
+enum ChildExistenceAction {
+    /// Build: diff the children this build declared against the on-disk
+    /// rows, tombstoning the Component leaves that disappeared.
+    Reconcile(ChildStablePathSet),
+    /// Whole-component delete: nothing is declared, so every on-disk child
+    /// is removed and tombstoned — the cascade `launch_child_component_gc`
+    /// relies on.
+    RemoveAll,
+    /// Demote-only delete: the path stays in the tree as a Directory node
+    /// whose children were declared — and already reconciled — by the
+    /// parent's current build. They are live, so the subtree is left as
+    /// is: walking it against an empty set would tombstone them, and the
+    /// GC sweep would then delete target states they wrote in this same
+    /// update.
+    Keep,
+}
+
 struct Committer<Prof: EngineProfile> {
     component_ctx: ComponentProcessorContext<Prof>,
     app_store: AppStore,
     target_states_providers: rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
 
     component_path: StablePath,
-
-    demote_component_only: bool,
 }
 
 impl<Prof: EngineProfile> Committer<Prof> {
     fn new(
         component_ctx: &ComponentProcessorContext<Prof>,
         target_states_providers: &rpds::HashTrieMapSync<TargetStatePath, TargetStateProvider<Prof>>,
-        demote_component_only: bool,
     ) -> Result<Self> {
         let component_path = component_ctx.stable_path().clone();
         Ok(Self {
@@ -419,7 +436,6 @@ impl<Prof: EngineProfile> Committer<Prof> {
             app_store: component_ctx.app_ctx().app_store().clone(),
             target_states_providers: target_states_providers.clone(),
             component_path,
-            demote_component_only,
         })
     }
 
@@ -427,13 +443,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
     /// them through [`AppStore::commit`](crate::state_store::AppStore::commit).
     /// The AppStore opens its own write txn, applies the plan's writes
     /// (tracking-info, fn-memo flush, user-state flush, target-owner cleanup),
-    /// and — unless this is a `demote_component_only` delete — invokes the
-    /// `ExistenceReconciler` callback to walk the child-existence tree
-    /// atomically inside the same txn. Then launches Phase 5 GC.
+    /// and — unless `child_existence` is [`ChildExistenceAction::Keep`] —
+    /// invokes the `ExistenceReconciler` callback to walk the
+    /// child-existence tree atomically inside the same txn. Then launches
+    /// Phase 5 GC.
 
     async fn commit(
         self,
-        child_path_set: Option<ChildStablePathSet>,
+        child_existence: ChildExistenceAction,
         fn_memos: FnMemoCache<Prof>,
         user_states: UserStateCache<Prof::FunctionData>,
         curr_version: Option<u64>,
@@ -474,44 +491,14 @@ impl<Prof: EngineProfile> Committer<Prof> {
             user_state_clear_live,
         };
 
-        // Child-existence reconciliation runs inside the AppStore's commit
-        // txn so the `__cex` diff is atomic with the rest of the plan:
-        //
-        // * Build: diff the declared `child_path_set` against the on-disk
-        //   `__cex` rows.
-        // * Whole-component delete: `child_path_set` is `None` — nothing is
-        //   declared, so every on-disk child is removed and tombstoned. This
-        //   is the cascade `launch_child_component_gc` relies on.
-        // * `demote_component_only`: this path stays in the tree as a
-        //   Directory node whose `__cex` children were declared — and
-        //   already reconciled — by the parent's current build. They are
-        //   live, so skip reconciliation entirely: walking them against an
-        //   empty set would tombstone them, and the GC sweep would then
-        //   delete target states they wrote in this same update.
-        let existence_reconciler: Option<ExistenceReconciler> = if self.demote_component_only {
-            None
-        } else {
-            let app_store = self.app_store.clone();
-            let component_path = self.component_path.clone();
-            let child_path_set = child_path_set.map(Arc::new);
-            // `Fn` (not `FnOnce`) so a backend that re-runs its commit txn can
-            // re-invoke it — clone the (cheap, `Arc`/owned) captures per call
-            // rather than moving them into the future.
-            let reconciler: ExistenceReconciler = Box::new(move |wtxn| {
-                let app_store = app_store.clone();
-                let component_path = component_path.clone();
-                let child_path_set = child_path_set.clone();
-                Box::pin(async move {
-                    reconcile_child_existence(
-                        wtxn,
-                        &app_store,
-                        &component_path,
-                        child_path_set.as_deref(),
-                    )
-                    .await
-                })
-            });
-            Some(reconciler)
+        // The reconciler runs inside the AppStore's commit txn so the
+        // `__cex` diff is atomic with the rest of the plan.
+        let existence_reconciler = match child_existence {
+            ChildExistenceAction::Reconcile(declared) => {
+                Some(self.existence_reconciler(Some(Arc::new(declared))))
+            }
+            ChildExistenceAction::RemoveAll => Some(self.existence_reconciler(None)),
+            ChildExistenceAction::Keep => None,
         };
 
         self.app_store
@@ -522,6 +509,34 @@ impl<Prof: EngineProfile> Committer<Prof> {
         // operations. Outside the commit txn — tombstones are durable
         // and the GC sweep is idempotent.
         self.launch_child_component_gc().await
+    }
+
+    /// Closure that walks `declared_children` (`None`: nothing declared)
+    /// against the on-disk `__cex` rows under this component — see
+    /// [`reconcile_child_existence`]. `Fn` (not `FnOnce`) so a backend
+    /// that re-runs its commit txn can re-invoke it: the cheap
+    /// (`Arc`/owned) captures are cloned per call rather than moved into
+    /// the future.
+    fn existence_reconciler(
+        &self,
+        declared_children: Option<Arc<ChildStablePathSet>>,
+    ) -> ExistenceReconciler {
+        let app_store = self.app_store.clone();
+        let component_path = self.component_path.clone();
+        Box::new(move |wtxn| {
+            let app_store = app_store.clone();
+            let component_path = component_path.clone();
+            let declared_children = declared_children.clone();
+            Box::pin(async move {
+                reconcile_child_existence(
+                    wtxn,
+                    &app_store,
+                    &component_path,
+                    declared_children.as_deref(),
+                )
+                .await
+            })
+        })
     }
 
     /// Engine-side reconcile that produces the `(new_tracking_info,
@@ -766,7 +781,8 @@ struct PreCommitCaptures<Prof: EngineProfile> {
 ///
 /// Delete-mode preflight (`delete_component_memo` + node-type check)
 /// runs outside, in [`submit`], before the precommit txn is opened —
-/// the `demote_component_only` decision lives there too.
+/// the demote-only ([`ChildExistenceAction::Keep`]) decision lives
+/// there too.
 #[allow(clippy::too_many_arguments)]
 async fn pre_commit<'tracking, Prof: EngineProfile>(
     app_store: &AppStore,
@@ -1542,9 +1558,9 @@ pub(crate) async fn submit<Prof: EngineProfile>(
     }
 
     // Delete-mode preflight (was in `pre_commit` body pre-Session).
-    // The early-return / `demote_component_only` decision needs to
-    // happen before opening the submit session so the early-return
-    // case doesn't write a stage marker.
+    // The early-return / demote-only decision needs to happen before
+    // opening the submit session so the early-return case doesn't
+    // write a stage marker.
     let mut demote_component_only = false;
     if comp_mode == ComponentProcessingMode::Delete {
         app_store.delete_component_memo(&stable_path).await?;
@@ -1563,6 +1579,14 @@ pub(crate) async fn submit<Prof: EngineProfile>(
             }
         }
     }
+    let child_existence = if demote_component_only {
+        ChildExistenceAction::Keep
+    } else {
+        match child_path_set {
+            Some(declared) => ChildExistenceAction::Reconcile(declared),
+            None => ChildExistenceAction::RemoveAll,
+        }
+    };
 
     let contained_target_state_paths = Arc::new(contained_target_state_paths);
     // `declared_target_states` is shared across retries via
@@ -1791,9 +1815,9 @@ pub(crate) async fn submit<Prof: EngineProfile>(
 
     // Commit. `AppStore::commit` is a normal trait method — no
     // session handoff needed.
-    let committer = Committer::new(comp_ctx, &target_states_providers, demote_component_only)?;
+    let committer = Committer::new(comp_ctx, &target_states_providers)?;
     if let Err(e) = committer
-        .commit(child_path_set, fn_memos, user_states, curr_version)
+        .commit(child_existence, fn_memos, user_states, curr_version)
         .await
     {
         // The commit txn either committed or rolled back before

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -348,21 +348,17 @@ pub struct CommitPlan {
     /// removes the live-machinery committed state alongside the regular
     /// state (the regular flush above never clears `Live`).
     pub user_state_clear_live: bool,
-    /// In-memory child tree after this build. AppStore feeds it to
-    /// `existence_reconciler` (see [`AppStore::commit`]) inside its
-    /// commit txn, so the children-`__cex` read + tombstone writes
-    /// happen atomically with the other commit writes. `None` skips
-    /// existence reconciliation (e.g. `demote_component_only`).
-    pub child_path_set: Option<Arc<ChildStablePathSet>>,
 }
 
 /// Callback the AppStore invokes inside its commit txn to run the
 /// child-existence diff. Engine constructs this closure with all
 /// captures it needs (component path, child_path_set, an `AppStore`
-/// clone) and passes it to [`AppStore::commit`]. The closure receives
-/// the open `WriteTxn` and walks the in-memory tree, reads `__cex` per
-/// parent, writes deltas + tombstones — see
-/// [`reconcile_child_existence`].
+/// clone) and passes it to [`AppStore::commit`] — or passes `None`
+/// there to leave the `__cex` subtree untouched (a
+/// `demote_component_only` delete, whose children belong to the
+/// parent's current build). The closure receives the open `WriteTxn`
+/// and walks the in-memory tree, reads `__cex` per parent, writes
+/// deltas + tombstones — see [`reconcile_child_existence`].
 ///
 /// Lifetime: the closure runs strictly inside the commit txn, so the
 /// `&'a mut WriteTxn<'env>` borrow is bounded by the callback's await
@@ -460,14 +456,16 @@ impl AppStore {
     }
 
     /// Phase 4 success: open commit txn, apply finalized writes, invoke
-    /// `existence_reconciler` for the child-existence diff — all in one
-    /// write txn so the reconciler's per-parent `__cex` reads see the
-    /// same snapshot as the plan writes that just happened.
+    /// `existence_reconciler` (when given) for the child-existence diff —
+    /// all in one write txn so the reconciler's per-parent `__cex` reads
+    /// see the same snapshot as the plan writes that just happened.
+    /// `None` skips child-existence reconciliation entirely, leaving the
+    /// `__cex` subtree under `component_path` as it is.
     pub async fn commit(
         &self,
         component_path: &StablePath,
         plan: CommitPlan,
-        existence_reconciler: ExistenceReconciler,
+        existence_reconciler: Option<ExistenceReconciler>,
     ) -> Result<()> {
         let app_store = self.clone();
         let component_path = component_path.clone();
@@ -543,7 +541,9 @@ impl AppStore {
                             .write_user_state(wtxn, &component_path, StateKind::Regular, key, bytes)
                             .await?;
                     }
-                    existence_reconciler(wtxn).await?;
+                    if let Some(reconcile) = existence_reconciler.as_ref() {
+                        reconcile(wtxn).await?;
+                    }
                     Ok(())
                 })
             })
@@ -580,6 +580,10 @@ impl AppStore {
 ///
 /// Sibling-by-sibling sorted-merge per level so each `__cex` read is
 /// O(N children) per parent and the writes are bounded by changes.
+///
+/// `child_path_set == None` means the component declares no children
+/// at all (whole-component delete): every on-disk child is removed and
+/// every Component leaf below it tombstoned, cascading the delete.
 ///
 /// Used by [`AppStore::commit`]: the AppStore opens the commit txn,
 /// then invokes the engine-supplied [`ExistenceReconciler`] which in

--- a/rust/core/src/state_store/submit_session.rs
+++ b/rust/core/src/state_store/submit_session.rs
@@ -354,8 +354,8 @@ pub struct CommitPlan {
 /// child-existence diff. Engine constructs this closure with all
 /// captures it needs (component path, child_path_set, an `AppStore`
 /// clone) and passes it to [`AppStore::commit`] — or passes `None`
-/// there to leave the `__cex` subtree untouched (a
-/// `demote_component_only` delete, whose children belong to the
+/// there to leave the `__cex` subtree untouched (a demote-only delete:
+/// the component became a Directory node whose children belong to the
 /// parent's current build). The closure receives the open `WriteTxn`
 /// and walks the in-memory tree, reads `__cex` per parent, writes
 /// deltas + tombstones — see [`reconcile_child_existence`].

--- a/rust/core/tests/target_owner_cleanup.rs
+++ b/rust/core/tests/target_owner_cleanup.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 
 use cocoindex_core::state::stable_path::{StableKey, StablePath};
 use cocoindex_core::state::target_state_path::TargetStatePath;
-use cocoindex_core::state_store::{
-    AppStore, CommitPlan, ExistenceReconciler, Storage, StorageSettings,
-};
+use cocoindex_core::state_store::{AppStore, CommitPlan, Storage, StorageSettings};
 use cocoindex_utils::fingerprint::Fingerprint;
 use tempfile::TempDir;
 
@@ -93,13 +91,8 @@ async fn commit_owner_deletes(
         user_state_writes: Vec::new(),
         user_state_deletes: Vec::new(),
         user_state_clear_live: false,
-        child_path_set: None,
     };
-    let reconciler: ExistenceReconciler = Box::new(|_wtxn| Box::pin(async { Ok(()) }));
-    store
-        .commit(component_path, plan, reconciler)
-        .await
-        .unwrap();
+    store.commit(component_path, plan, None).await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Regression in the v1 engine's Component → Directory transition. When a component at `a/b` from a previous run is replaced by a deeper component `a/b/c`, the parent's commit-time reconciler demotes `a/b` to a Directory node and tombstones it, and the GC sweep deletes `a/b` in "demote only" mode: remove `a/b`'s own target states, leave its live descendants alone.

Since the submit() rewrite (#2030) that mode was a no-op. Delete mode already passed `child_path_set = None`, and `Committer::commit` always handed an `ExistenceReconciler` to `AppStore::commit`. `reconcile_child_existence` treats `None` as "no declared children", so the demote deleted every `__cex` child row under `a/b` and tombstoned `a/b/c`; the following GC sweep then ran a full delete of `a/b/c`, removing target states it had written in the very same update.

## Changes

- `AppStore::commit` takes `Option<ExistenceReconciler>`; `None` leaves the `__cex` subtree untouched.
- The engine decides once, in `submit()` right after the delete-mode preflight, what the commit does to the subtree: `ChildExistenceAction::Reconcile(declared)` for builds, `RemoveAll` for whole-component deletes (the cascade the GC sweep relies on), `Keep` for demote-only deletes. `Committer` no longer carries a `demote_component_only` flag beside an `Option` child set.
- `CommitPlan::child_path_set` is removed: `AppStore::commit` never read it (the reconciler closure owns the set) and its doc comment still claimed a skip semantics the code no longer had. `reconcile_child_existence` documents what `None` means there.
- New end-to-end test `test_component_to_directory_transition` in `python/tests/core/test_component_target_states.py`, the reverse of `test_directory_to_component_transition`. Update 1 mounts a component at `transition_test/D1` declaring entries into a dict target; update 2 mounts `transition_test/D1/child` declaring its own entry and asserts it survives, owned by the deeper path, with `D1`'s own entries gone; update 3 re-mounts `D1` as a component and asserts the Directory node is promoted back and the former child's entry is removed.

## Test plan

- [x] New test fails on unmodified main (`{'D1': {}}`: the deeper component's entry was deleted) and passes with the fix
- [x] `uv run maturin develop && cargo test` (54 suites, 588 passed) `&& uv run pytest python/tests/core/test_component_target_states.py` (23 passed)
- [x] `uv run mypy`
- [x] `prek run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
