### PR TITLE
fix(litellm): align embedding responses to inputs by index

### DIFF
--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -21,6 +21,7 @@ from collections.abc import Awaitable as _Awaitable
 from collections.abc import Callable as _Callable
 from typing import Any as _Any
 from typing import TypeVar as _TypeVar
+from typing import cast as _cast
 
 import litellm as litellm
 
@@ -170,28 +171,33 @@ async def _retry_litellm_call(
 def _aligned_embeddings(data: list[_Any], n: int) -> list[_NDArray[_np.float32]]:
     """Map embedding response items back to the ``n`` inputs they embed.
 
-    Items carrying an ``index`` are reordered by it. If no item carries one
+    Items carrying an ``index`` are placed by it; if no item carries one
     (missing or ``None``), the response is taken positionally. Mixing the two,
     or an index set that is not a permutation of ``0..n-1``, raises so a
     misordered response fails loudly instead of silently misaligning
     embeddings with their texts.
     """
-    indices = [item.get("index") for item in data]
-    if all(i is None for i in indices):
-        ordered = data
-    elif any(i is None for i in indices):
+    if len(data) != n:
         raise RuntimeError(
-            "litellm embedding response mixes items with and without `index`: "
-            f"got {indices}"
+            f"litellm embedding response has {len(data)} items for {n} inputs"
         )
-    elif any(type(i) is not int for i in indices) or sorted(indices) != list(range(n)):
-        raise RuntimeError(
-            "litellm embedding response indices are not a permutation of "
-            f"0..{n - 1}: got {indices}"
-        )
-    else:
-        ordered = sorted(data, key=lambda item: item["index"])
-    return [_np.array(item["embedding"], dtype=_np.float32) for item in ordered]
+    out: list[_NDArray[_np.float32] | None] = [None] * n
+    indexed = n > 0 and data[0].get("index") is not None
+    for pos, item in enumerate(data):
+        index = item.get("index")
+        if (index is not None) != indexed:
+            raise RuntimeError(
+                "litellm embedding response mixes items with and without `index`"
+            )
+        if not indexed:
+            index = pos
+        elif type(index) is not int or not 0 <= index < n or out[index] is not None:
+            raise RuntimeError(
+                "litellm embedding response indices are not a permutation of "
+                f"0..{n - 1}: got {[item.get('index') for item in data]}"
+            )
+        out[index] = _np.array(item["embedding"], dtype=_np.float32)
+    return _cast(list[_NDArray[_np.float32]], out)
 
 
 class LiteLLMEmbedder(_schema.VectorSchemaProvider):

--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -167,6 +167,33 @@ async def _retry_litellm_call(
     )
 
 
+def _aligned_embeddings(data: list[_Any], n: int) -> list[_NDArray[_np.float32]]:
+    """Map embedding response items back to the ``n`` inputs they embed.
+
+    Items carrying an ``index`` are reordered by it. If no item carries one
+    (missing or ``None``), the response is taken positionally. Mixing the two,
+    or an index set that is not a permutation of ``0..n-1``, raises so a
+    misordered response fails loudly instead of silently misaligning
+    embeddings with their texts.
+    """
+    indices = [item.get("index") for item in data]
+    if all(i is None for i in indices):
+        ordered = data
+    elif any(i is None for i in indices):
+        raise RuntimeError(
+            "litellm embedding response mixes items with and without `index`: "
+            f"got {indices}"
+        )
+    elif any(type(i) is not int for i in indices) or sorted(indices) != list(range(n)):
+        raise RuntimeError(
+            "litellm embedding response indices are not a permutation of "
+            f"0..{n - 1}: got {indices}"
+        )
+    else:
+        ordered = sorted(data, key=lambda item: item["index"])
+    return [_np.array(item["embedding"], dtype=_np.float32) for item in ordered]
+
+
 class LiteLLMEmbedder(_schema.VectorSchemaProvider):
     """Wrapper for LiteLLM embedding models that implements VectorSchemaProvider.
 
@@ -282,9 +309,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
             if not _is_global_litellm_error(e):
                 raise coco.RetryWithSmallerBatch() from e
             raise
-        return [
-            _np.array(item["embedding"], dtype=_np.float32) for item in response.data
-        ]
+        return _aligned_embeddings(response.data, len(texts))
 
     @coco.fn(memo=True, version=1, logic_tracking="self")
     async def embed(

--- a/python/tests/ops/test_embedder_refactor.py
+++ b/python/tests/ops/test_embedder_refactor.py
@@ -325,7 +325,7 @@ async def test_litellm_embedder_aligns_batch_by_index() -> None:
     [
         pytest.param([0, None], 2, "with and without", id="partial"),
         pytest.param([0, 0], 2, "not a permutation", id="duplicate"),
-        pytest.param([0, 1], 3, "not a permutation", id="missing"),
+        pytest.param([0, 1], 3, "2 items for 3 inputs", id="missing"),
         pytest.param([-1, 0], 2, "not a permutation", id="negative"),
         pytest.param([0, 2], 2, "not a permutation", id="out-of-range"),
         pytest.param([0, "1"], 2, "not a permutation", id="non-int"),

--- a/python/tests/ops/test_embedder_refactor.py
+++ b/python/tests/ops/test_embedder_refactor.py
@@ -21,7 +21,7 @@ pytest.importorskip("litellm", reason="litellm not installed")
 from litellm.exceptions import AuthenticationError  # noqa: E402
 
 import cocoindex as coco  # noqa: E402
-from cocoindex.ops.litellm import LiteLLMEmbedder  # noqa: E402
+from cocoindex.ops.litellm import LiteLLMEmbedder, _aligned_embeddings  # noqa: E402
 
 # Note on the sleep patch target below: retry sleeps now happen inside
 # cocoindex._internal.deadline via a late `asyncio.sleep` lookup. Patching
@@ -282,3 +282,71 @@ async def test_litellm_embedder_does_not_retry_missing_credentials_server_error(
 
     mocked_embedding.assert_awaited_once()
     sleep.assert_not_called()
+
+
+# ============================================================================
+# Response items are aligned to inputs by `index` when the provider sends one
+# ============================================================================
+
+
+def test_aligned_embeddings_positional_when_no_index() -> None:
+    # A missing key and an explicit None are both "no index".
+    data = [{"embedding": [1.0]}, {"index": None, "embedding": [2.0]}]
+    assert [v.tolist() for v in _aligned_embeddings(data, 2)] == [[1.0], [2.0]]
+
+
+def test_aligned_embeddings_reorders_by_index() -> None:
+    data = [
+        {"index": 2, "embedding": [2.0]},
+        {"index": 0, "embedding": [0.0]},
+        {"index": 1, "embedding": [1.0]},
+    ]
+    assert [v.tolist() for v in _aligned_embeddings(data, 3)] == [[0.0], [1.0], [2.0]]
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_aligns_batch_by_index() -> None:
+    """The batch body maps a provider response that arrives out of order
+    back onto the input texts by ``index``."""
+    texts = ["a", "bb", "ccc"]
+    response = SimpleNamespace(
+        data=[{"index": i, "embedding": [float(len(texts[i]))]} for i in (2, 0, 1)]
+    )
+    embedder = LiteLLMEmbedder("fake-model")
+    with patch(
+        "cocoindex.ops.litellm.litellm.aembedding", new=AsyncMock(return_value=response)
+    ):
+        vecs = await embedder._embed._execute_orig_async_fn(texts)
+    assert [v.tolist() for v in vecs] == [[1.0], [2.0], [3.0]]
+
+
+@pytest.mark.parametrize(
+    ("indices", "n", "match"),
+    [
+        pytest.param([0, None], 2, "with and without", id="partial"),
+        pytest.param([0, 0], 2, "not a permutation", id="duplicate"),
+        pytest.param([0, 1], 3, "not a permutation", id="missing"),
+        pytest.param([-1, 0], 2, "not a permutation", id="negative"),
+        pytest.param([0, 2], 2, "not a permutation", id="out-of-range"),
+        pytest.param([0, "1"], 2, "not a permutation", id="non-int"),
+    ],
+)
+def test_aligned_embeddings_rejects_bad_indices(
+    indices: list[Any], n: int, match: str
+) -> None:
+    data = [{"index": i, "embedding": [0.0]} for i in indices]
+    with pytest.raises(RuntimeError, match=match):
+        _aligned_embeddings(data, n)
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_bad_index_fails_whole_batch() -> None:
+    """A malformed index set is a provider bug: it surfaces as-is rather than
+    as RetryWithSmallerBatch, since splitting would only hide the misorder."""
+    response = SimpleNamespace(data=[{"index": 0, "embedding": [0.0]}] * 2)
+    embedder = LiteLLMEmbedder("fake-model")
+    with patch(
+        "cocoindex.ops.litellm.litellm.aembedding", new=AsyncMock(return_value=response)
+    ):
+        with pytest.raises(RuntimeError, match="not a permutation"):
+            await embedder._embed._execute_orig_async_fn(["a", "b"])


### PR DESCRIPTION
## Problem

`LiteLLMEmbedder._embed` mapped `response.data` back onto the input batch
positionally. LiteLLM passes the provider's `data` list through unsorted,
and each item may carry an `index`. A provider (or proxy) that returns
items out of order silently attached embeddings to the wrong texts. A count
mismatch was already rejected by the Rust batcher, so same-count reordering
was the only silent failure.

## Change

- New private `_aligned_embeddings(data, n)` in `ops/litellm.py`; `_embed`
  routes through it.
- Single pass over `data`: each item is placed into a preallocated list of
  `n` slots by its `index`. No sorting.
- `len(data) != n` raises `RuntimeError` up front, naming both counts. This
  moves the count check from the Rust batcher into Python. With the count
  fixed, a full placement is a permutation by construction, so no separate
  completeness scan is needed.
- Every item lacks `index` (missing or `None`): positional mapping, same
  vectors as before for providers that omit it.
- Any item has `index`: all must. Presence is taken from the first item;
  an item that disagrees raises `RuntimeError` ("mixes items with and
  without `index`").
- Indexed items must be `int` (not `bool`), in `0..n-1`, and unused.
  Duplicate, negative, out-of-range, or non-int indices raise `RuntimeError`
  naming the expected range and the received indices.
- Raised after the retry handler, so a malformed response is never
  converted to `RetryWithSmallerBatch` (splitting to size 1 would hide the
  provider bug). At the root call this fails the whole batch. Inside a
  sub-batch produced by an earlier `RetryWithSmallerBatch` it fails that
  sub-batch only; sibling sub-batches are unaffected.

## Not changed

- Memo `version` stays at 1. This avoids forcing a full re-embed for all
  users. Previously cached outputs that were misaligned, if any, will not
  be invalidated automatically.
- Memo key, `api_key` / `api_base` handling, and public API are untouched.

## Tests

`python/tests/ops/test_embedder_refactor.py`: helper unit tests for
positional, reorder, and each rejection case (partial index, duplicate,
count mismatch, negative, out-of-range, non-int); two tests through the
`_embed` body for realignment and for a bad index set surfacing as
`RuntimeError` rather than `RetryWithSmallerBatch`. Existing index-less
fakes are unchanged and cover the compatibility path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)