### PR TITLE
fix: preserve typed Python exceptions in component exception handlers

### DIFF
--- a/docs/src/content/docs/advanced_topics/exception_handlers.mdx
+++ b/docs/src/content/docs/advanced_topics/exception_handlers.mdx
@@ -144,6 +144,29 @@ ExceptionHandler = Callable[
 ]
 ```
 
+### What `exc` is
+
+Handlers receive the same exception object that a foreground call such as `await coco.use_mount(...)` would raise for the same failure:
+
+- **Python-originated failures** (your component, or a target connector, raised) arrive as the original exception. `type(exc)` is what was raised, `exc.__traceback__` is intact, and `exc.__cause__` / `exc.__context__` are preserved. Route by type with `isinstance`; render the traceback with `traceback.format_exception(exc)` or `logger.error(..., exc_info=exc)`.
+- **Engine-native failures** map to Python types: client-side misuse becomes `ValueError`, cooperative deadline expiry becomes `coco.DeadlineExceededError`, and internal engine errors become `RuntimeError`. The engine never delivers cancellation of the component itself to handlers.
+
+An exception raised by a handler keeps its type as well: `await handle.ready()` raises exactly what the last handler in the chain raised, so `except MyDeadLetterError:` or `except coco.DeadlineExceededError:` work as expected on the awaiting side.
+
+Earlier releases handed every component failure to handlers as a `RuntimeError` whose message embedded the formatted traceback, and re-wrapped handler-raised exceptions the same way. A handler that checked `isinstance(exc, RuntimeError)` or parsed `str(exc)` for the traceback should switch to the checks above.
+
+```python
+import traceback
+
+def on_error(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+    if isinstance(exc, ConnectionError):
+        schedule_retry(ctx.stable_path)  # transient: swallow, retry later
+    elif isinstance(exc, ValueError):
+        dead_letter(ctx.stable_path, "".join(traceback.format_exception(exc)))
+    else:
+        raise exc  # propagate through handle.ready()
+```
+
 ### `ExceptionContext` fields
 
 Your handler receives an `ExceptionContext` dataclass with information about the failure:
@@ -165,7 +188,7 @@ Handlers are stacked: the most specific (innermost) handler runs first.
 
 If the innermost handler raises an exception, the next outer handler is called with that new exception. In this case `ctx.source` is `"handler"` and `ctx.original_exception` holds the original component error.
 
-This continues up the stack. If all handlers raise (or no handler is registered), CocoIndex falls back to the built-in behavior: logging the error at `ERROR` level, with no crash.
+This continues up the stack. If every handler raises, the last handler's exception propagates through `handle.ready()` (see [How to opt into propagation](#how-to-opt-into-propagation)). If no handler is registered, CocoIndex falls back to the built-in behavior: logging the error at `ERROR` level, with no crash.
 
 ```python
 @coco.lifespan

--- a/python/cocoindex/_internal/api.py
+++ b/python/cocoindex/_internal/api.py
@@ -804,9 +804,9 @@ def use_state(
 
     The value is serialized lazily, once, when the component commits — not at
     assignment. Two consequences: (1) if the value is not serializable, the
-    error surfaces at commit (identifying the state key) rather than at the
-    `handle.value = ...` line; (2) the persisted value reflects the object as it
-    is at commit, so mutating it in place after assignment is captured.
+    error surfaces at commit rather than at the `handle.value = ...` line;
+    (2) the persisted value reflects the object as it is at commit, so
+    mutating it in place after assignment is captured.
 
     Args:
         key: Unique StableKey within this component (None, bool, int, str,

--- a/python/cocoindex/_internal/component_ctx.py
+++ b/python/cocoindex/_internal/component_ctx.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import inspect
 import logging
@@ -192,6 +193,10 @@ class ComponentContext:
                     if inspect.isawaitable(ret):
                         await ret
                     return  # Handler swallowed → don't propagate.
+                except asyncio.CancelledError:
+                    # Cancellation is not a handler failure: never feed it
+                    # to outer handlers (which could swallow it).
+                    raise
                 except BaseException as handler_exc:
                     current_exc = handler_exc
                     source = "handler"

--- a/python/cocoindex/_internal/component_ctx.py
+++ b/python/cocoindex/_internal/component_ctx.py
@@ -132,10 +132,15 @@ class ComponentContext:
         stable_path: str,
         processor_name: str | None,
         mount_kind: MountKind,
-    ) -> Callable[[str], Awaitable[None]]:
+    ) -> Callable[[BaseException], Awaitable[None]]:
         """Build the exception-handler resolver for a child mounted under this context.
 
-        Returns a callable that takes a stringified error and:
+        Returns a callable that takes the failure as a Python exception
+        (a Python-originated failure arrives as its original exception
+        object with traceback intact; engine-native failures arrive as
+        ``RuntimeError`` / ``ValueError`` / ``DeadlineExceededError``, the
+        same mapping ``use_mount`` uses; the engine filters cancellation
+        before calling this) and:
         - walks this context's handler chain (innermost first);
         - if a handler raises, calls the next outer handler with the
           new exception;
@@ -158,18 +163,18 @@ class ComponentContext:
         # captured implicitly. `self._core_path.to_string()` in particular
         # is a PyO3 → Rust → string allocation we don't want to pay on
         # every mount.
-        async def _run(err_str: str) -> None:
+        async def _run(exc: BaseException) -> None:
             node = self._exception_handler_chain
             if node is None:
                 # No handlers registered — log directly without building
                 # the ExceptionContext metadata at all. Don't propagate.
-                _logger.error("component build failed:\n%s", err_str)
+                _logger.error("component build failed: %s", exc, exc_info=exc)
                 return
 
             env_name = self._env.name
             parent_stable_path = self._core_path.to_string()
-            original_exc: BaseException = RuntimeError(err_str)
-            current_exc: BaseException = original_exc
+            original_exc = exc
+            current_exc = exc
             source: Literal["component", "handler"] = "component"
             while node is not None:
                 ctx = ExceptionContext(

--- a/python/cocoindex/_internal/core.pyi
+++ b/python/cocoindex/_internal/core.pyi
@@ -349,18 +349,18 @@ class LiveComponentController:
     def update_full_async(
         self,
         processor: ComponentProcessor[Any],
-        handler_callback: Callable[[str], Awaitable[None]] | None = None,
+        handler_callback: Callable[[BaseException], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, None]: ...
     def update_async(
         self,
         stable_path: StablePath,
         processor: ComponentProcessor[Any],
-        handler_callback: Callable[[str], Awaitable[None]] | None = None,
+        handler_callback: Callable[[BaseException], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
     def delete_async(
         self,
         stable_path: StablePath,
-        handler_callback: Callable[[str], Awaitable[None]] | None = None,
+        handler_callback: Callable[[BaseException], Awaitable[None]] | None = None,
     ) -> Coroutine[Any, Any, ComponentMountHandle]: ...
     def mark_ready_async(self) -> Coroutine[Any, Any, None]: ...
     def read_committed_state_async(
@@ -424,7 +424,7 @@ async def mount_async(
     stable_path: StablePath,
     comp_ctx: ComponentProcessorContext,
     fn_ctx: FnCallContext,
-    handler_callback: Any | None = None,
+    handler_callback: Callable[[BaseException], Awaitable[None]] | None = None,
 ) -> ComponentMountHandle: ...
 async def use_mount_async(
     processor: ComponentProcessor[T_co],

--- a/python/cocoindex/_internal/live_component.py
+++ b/python/cocoindex/_internal/live_component.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import datetime
 import inspect
-import traceback
 from collections.abc import AsyncIterator
 from contextvars import ContextVar
 from typing import (
@@ -271,7 +270,9 @@ class LiveComponentOperator:
             )
         return ctrl
 
-    def _resolve_exception_handler(self) -> Callable[[str], Awaitable[None]]:
+    def _resolve_exception_handler(
+        self,
+    ) -> Callable[[BaseException], Awaitable[None]]:
         """Build a resolver for the parent's exception handler chain.
 
         Delegates to :meth:`ComponentContext.resolve_exception_handler`
@@ -279,7 +280,7 @@ class LiveComponentOperator:
         so component-failure logs go through one canonical Python
         fallback. Always non-None. Used both by :meth:`update_full`
         (passes to Rust as ``on_error``) and :meth:`report_exception`
-        (invokes directly with a stringified exception).
+        (invokes directly with the reported exception).
         """
         return get_context_from_ctx().resolve_exception_handler(
             stable_path=self._path.to_string(),
@@ -450,20 +451,19 @@ class LiveComponentOperator:
         cycle failures from initial build failures (``"mount"`` /
         ``"mount_each"``).
 
-        The exception is formatted via :func:`traceback.format_exception`
-        so handlers and the fallback log both see the full Python
-        traceback (when ``exc.__traceback__`` is set — i.e. when the
-        caller is reporting a caught exception). This matches the
-        text-with-trace shape that the Rust-side ``on_error`` path
-        produces for background ``mount`` / ``mount_each`` failures.
+        Handlers receive ``exc`` itself, so they can route by type and
+        recover the traceback via :func:`traceback.format_exception` (when
+        ``exc.__traceback__`` is set, i.e. when the caller is reporting a
+        caught exception). This matches what the Rust-side ``on_error``
+        path delivers for background ``mount`` / ``mount_each`` failures.
 
-        Falls back to ERROR-level logging if no handler is registered or
-        every handler re-raises. Intended for surfacing recoverable errors
-        (e.g. an external watcher emits a malformed event) without
-        tearing down the live component.
+        Falls back to ERROR-level logging if no handler is registered. If
+        every handler re-raises, the final handler's exception propagates
+        to the caller. Intended for surfacing recoverable errors (e.g. an
+        external watcher emits a malformed event) without tearing down the
+        live component.
         """
-        err_text = "".join(traceback.format_exception(exc))
-        await self._resolve_exception_handler()(err_text)
+        await self._resolve_exception_handler()(exc)
 
 
 @runtime_checkable

--- a/python/tests/core/test_exception_handlers.py
+++ b/python/tests/core/test_exception_handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 import traceback
 from typing import Iterator
 
@@ -323,3 +324,47 @@ def test_handler_raised_deadline_exceeded_propagates_through_ready() -> None:
     assert isinstance(caught[0], coco.DeadlineExceededError)
     assert isinstance(caught[0], TimeoutError)
     assert str(caught[0]) == "handler deadline"
+
+
+def test_cancellation_in_handler_skips_outer_handlers() -> None:
+    """``CancelledError`` raised while a handler runs is not treated as a
+    handler failure: outer handlers never see it and it propagates as-is."""
+    envmod.reset_default_env_for_tests()
+
+    outer_calls: list[str] = []
+    caught: list[BaseException] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_cancel_skips_outer"
+        )
+
+        def outer(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            outer_calls.append(type(exc).__name__)
+
+        builder.set_exception_handler(outer)
+        yield
+
+    @coco.fn
+    async def _child() -> None:
+        raise ValueError("boom")
+
+    @coco.fn
+    async def _root() -> None:
+        def inner(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            raise asyncio.CancelledError()
+
+        async with coco.exception_handler(inner):
+            handle = await coco.mount(coco.component_subpath("child"), _child)
+        try:
+            await handle.ready()
+        except BaseException as exc:
+            caught.append(exc)
+
+    app = coco.App("test_exception_handlers_cancel_skips_outer", _root)
+    app.update_blocking()
+
+    assert outer_calls == []
+    assert len(caught) == 1
+    assert isinstance(caught[0], asyncio.CancelledError)

--- a/python/tests/core/test_exception_handlers.py
+++ b/python/tests/core/test_exception_handlers.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Iterator
 
 import cocoindex as coco
@@ -36,7 +37,7 @@ def test_global_exception_handler_invoked_for_background_mount() -> None:
     app = coco.App("test_exception_handlers_global", _root)
     app.update_blocking()
 
-    assert seen == [("RuntimeError", "mount")]
+    assert seen == [("ValueError", "mount")]
 
 
 def test_scoped_handler_overrides_global_and_fallback_on_handler_error() -> None:
@@ -74,7 +75,7 @@ def test_scoped_handler_overrides_global_and_fallback_on_handler_error() -> None
 
     # Inner sees component exception, then raises; global receives handler exception.
     assert calls == [
-        "inner:component:RuntimeError",
+        "inner:component:ValueError",
         "global:handler:RuntimeError",
     ]
 
@@ -154,16 +155,18 @@ def test_orphan_delete_failure_routes_through_parent_handler() -> None:
     # `coco.mount(..., parent_fn)` at the parent's mount time.
     assert len(seen) == 1, f"expected one handler call; got {seen}"
     exc_name, mount_kind = seen[0]
-    assert exc_name == "RuntimeError"
+    # The sink raises a Python ValueError; it reaches the handler as-is.
+    assert exc_name == "ValueError"
     assert mount_kind == "mount"
 
 
-def test_background_mount_failure_surfaces_python_traceback() -> None:
-    """The handler should see the full Python traceback for a background mount failure,
-    not just the exception message — the trace is what makes the error actionable."""
+def test_background_mount_failure_preserves_exception_and_traceback() -> None:
+    """The handler receives the component's original Python exception, so it
+    can route by type (``isinstance``) and still recover the full traceback via
+    ``traceback.format_exception`` / ``logging(..., exc_info=exc)``."""
     envmod.reset_default_env_for_tests()
 
-    seen_messages: list[str] = []
+    seen: list[BaseException] = []
 
     @coco.lifespan
     def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
@@ -172,7 +175,7 @@ def test_background_mount_failure_surfaces_python_traceback() -> None:
         )
 
         def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
-            seen_messages.append(str(exc))
+            seen.append(exc)
 
         builder.set_exception_handler(handler)
         yield
@@ -188,9 +191,135 @@ def test_background_mount_failure_surfaces_python_traceback() -> None:
     app = coco.App("test_exception_handlers_trace", _root)
     app.update_blocking()
 
-    assert len(seen_messages) == 1
-    msg = seen_messages[0]
-    assert "ValueError" in msg
-    assert "traceful boom" in msg
-    assert "Traceback (most recent call last)" in msg
-    assert "_raise_for_trace_test" in msg
+    assert len(seen) == 1
+    exc = seen[0]
+    assert isinstance(exc, ValueError)
+    assert str(exc) == "traceful boom"
+    assert exc.__traceback__ is not None
+    formatted = "".join(traceback.format_exception(exc))
+    assert "Traceback (most recent call last)" in formatted
+    assert "_raise_for_trace_test" in formatted
+
+
+def test_engine_native_failure_keeps_cerror_mapping() -> None:
+    """An engine-side client error (here: declaring the same target state key
+    twice) reaches the handler as the ``ValueError`` that ``cerror_to_pyerr``
+    maps it to, not as a flattened ``RuntimeError``."""
+    envmod.reset_default_env_for_tests()
+
+    seen: list[BaseException] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_engine_native"
+        )
+
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            seen.append(exc)
+
+        builder.set_exception_handler(handler)
+        yield
+
+    @coco.fn
+    async def _child() -> None:
+        coco.declare_target_state(GlobalDictTarget.target_state("dup", 1))
+        coco.declare_target_state(GlobalDictTarget.target_state("dup", 2))
+
+    @coco.fn
+    async def _root() -> None:
+        await coco.mount(coco.component_subpath("child"), _child)
+
+    app = coco.App("test_exception_handlers_engine_native", _root)
+    app.update_blocking()
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], ValueError)
+    assert "Target state already declared" in str(seen[0])
+
+
+class _DeadLetterError(Exception):
+    pass
+
+
+def test_handler_raise_preserves_type_through_ready() -> None:
+    """An exception raised by a handler propagates through ``handle.ready()``
+    with its Python type (and ``__cause__``) intact, so callers can catch it
+    by type rather than string-matching a flattened RuntimeError."""
+    envmod.reset_default_env_for_tests()
+
+    caught: list[BaseException] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_typed_raise"
+        )
+
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            if isinstance(exc, ValueError):
+                raise _DeadLetterError("dead-letter") from exc
+            raise exc
+
+        builder.set_exception_handler(handler)
+        yield
+
+    @coco.fn
+    async def _child() -> None:
+        raise ValueError("boom")
+
+    @coco.fn
+    async def _root() -> None:
+        handle = await coco.mount(coco.component_subpath("child"), _child)
+        try:
+            await handle.ready()
+        except BaseException as exc:
+            caught.append(exc)
+
+    app = coco.App("test_exception_handlers_typed_raise", _root)
+    app.update_blocking()
+
+    assert len(caught) == 1
+    assert isinstance(caught[0], _DeadLetterError)
+    assert isinstance(caught[0].__cause__, ValueError)
+
+
+def test_handler_raised_deadline_exceeded_propagates_through_ready() -> None:
+    """A handler that raises ``coco.DeadlineExceededError`` surfaces it through
+    ``handle.ready()`` as that type (still a ``TimeoutError``), not as a
+    flattened ``RuntimeError``."""
+    envmod.reset_default_env_for_tests()
+
+    caught: list[BaseException] = []
+
+    @coco.lifespan
+    def _lifespan(builder: coco.EnvironmentBuilder) -> Iterator[None]:
+        builder.settings.db_path = common.get_env_db_path(
+            "test_exception_handlers_deadline_raise"
+        )
+
+        def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+            raise coco.DeadlineExceededError("handler deadline")
+
+        builder.set_exception_handler(handler)
+        yield
+
+    @coco.fn
+    async def _child() -> None:
+        raise ValueError("boom")
+
+    @coco.fn
+    async def _root() -> None:
+        handle = await coco.mount(coco.component_subpath("child"), _child)
+        try:
+            await handle.ready()
+        except BaseException as exc:
+            caught.append(exc)
+
+    app = coco.App("test_exception_handlers_deadline_raise", _root)
+    app.update_blocking()
+
+    assert len(caught) == 1
+    assert isinstance(caught[0], coco.DeadlineExceededError)
+    assert isinstance(caught[0], TimeoutError)
+    assert str(caught[0]) == "handler deadline"

--- a/python/tests/core/test_live_component.py
+++ b/python/tests/core/test_live_component.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
@@ -744,8 +745,8 @@ def test_report_exception_routes_to_global_handler() -> None:
 
     assert len(seen) == 1
     exc_name, mount_kind, stable_path, parent_path, processor_name = seen[0]
-    # resolve_handler synthesizes a RuntimeError from the stringified error
-    assert exc_name == "RuntimeError"
+    # report_exception passes the original exception through unchanged
+    assert exc_name == "ValueError"
     assert mount_kind == "process_live"
     # The live component's path includes the "live" subpath component
     assert "live" in stable_path
@@ -755,13 +756,13 @@ def test_report_exception_routes_to_global_handler() -> None:
 
 
 def test_report_exception_surfaces_python_traceback() -> None:
-    """The handler should see the original Python traceback, not just the message."""
+    """The handler should see the original exception with its traceback intact."""
     GlobalDictTarget.store.clear()
 
-    seen_messages: list[str] = []
+    seen: list[BaseException] = []
 
     def handler(exc: BaseException, ctx: coco.ExceptionContext) -> None:
-        seen_messages.append(str(exc))
+        seen.append(exc)
 
     env = common.create_test_env(
         __file__, suffix="report_exc_trace", exception_handler=handler
@@ -773,12 +774,14 @@ def test_report_exception_surfaces_python_traceback() -> None:
     app = coco.App(coco.AppConfig(name="test_report_exc_trace", environment=env), _root)
     app.update_blocking(live=True)
 
-    assert len(seen_messages) == 1
-    msg = seen_messages[0]
-    assert "ValueError" in msg
-    assert "traceful boom" in msg
-    assert "Traceback (most recent call last)" in msg
-    assert "_raise_for_trace_test" in msg
+    assert len(seen) == 1
+    exc = seen[0]
+    assert isinstance(exc, ValueError)
+    assert str(exc) == "traceful boom"
+    assert exc.__traceback__ is not None
+    formatted = "".join(traceback.format_exception(exc))
+    assert "Traceback (most recent call last)" in formatted
+    assert "_raise_for_trace_test" in formatted
 
 
 async def _failing_child(value: int) -> None:
@@ -840,7 +843,7 @@ def test_operator_delete_failure_routes_to_handler() -> None:
 
     assert len(seen) == 1
     exc_name, mount_kind, stable_path = seen[0]
-    assert exc_name == "RuntimeError"
+    assert exc_name == "ValueError"
     assert mount_kind == "process_live"
     assert "c" in stable_path
 
@@ -958,7 +961,7 @@ def test_operator_update_child_failure_routes_to_handler() -> None:
 
     assert len(seen) == 1
     exc_name, mount_kind, stable_path = seen[0]
-    assert exc_name == "RuntimeError"
+    assert exc_name == "ValueError"
     assert mount_kind == "process_live"
     assert "bad_child" in stable_path
     # Swallowing handler → no propagation
@@ -1012,7 +1015,13 @@ def test_report_exception_falls_back_to_log_when_no_handler(
     with caplog.at_level("ERROR"):
         app.update_blocking(live=True)
 
-    assert any("no handler boom" in record.getMessage() for record in caplog.records)
+    assert any(
+        record.levelname == "ERROR"
+        and "no handler boom" in record.getMessage()
+        and record.exc_info is not None
+        and "no handler boom" in str(record.exc_info[1])
+        for record in caplog.records
+    )
 
 
 # ============================================================================

--- a/python/tests/core/test_use_state.py
+++ b/python/tests/core/test_use_state.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 import msgspec
 import pytest
 import cocoindex as coco
+from cocoindex._internal.serde import DeserializationError
 
 from tests import common
 
@@ -313,10 +314,10 @@ def test_use_state_reload_deserializes_lazily_once() -> None:
     assert _info["a"] == 1  # deserialized exactly once despite three reads
 
 
-def test_use_state_unserializable_value_errors_at_commit_with_key() -> None:
+def test_use_state_unserializable_value_errors_at_commit() -> None:
     # Serialization is deferred to commit, so a non-serializable state value
     # fails there (not at assignment). The failure must reach the exception
-    # handler (i.e. not be silently dropped) and name the offending key.
+    # handler (i.e. not be silently dropped) as the serializer's exception.
     _source_items.clear()
 
     class _Unserializable:  # not registered for serialization
@@ -347,7 +348,8 @@ def test_use_state_unserializable_value_errors_at_commit_with_key() -> None:
     app.update_blocking()
 
     assert len(captured) == 1
-    assert "bad_key" in str(captured[0])  # error identifies the failing key
+    exc = captured[0]
+    assert isinstance(exc, NotImplementedError)
 
 
 def test_use_state_raises_inside_memoized_function() -> None:
@@ -888,6 +890,6 @@ def test_use_state_type_hint_mismatch_raises_deserialization_error() -> None:
     captured.clear()
     app.update_blocking()
     assert len(captured) == 1
-    exc_text = str(captured[0])
-    assert "DeserializationError" in exc_text
-    assert "use_state key 'cur'" in exc_text
+    exc = captured[0]
+    assert isinstance(exc, DeserializationError)
+    assert "use_state key 'cur'" in str(exc)

--- a/rust/py/src/runtime.rs
+++ b/rust/py/src/runtime.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 use cocoindex_core::engine::runtime::{
     cancel_all, get_runtime, reset_global_cancellation, shutdown_runtime,
 };
-use cocoindex_py_utils::from_py_future;
+use cocoindex_py_utils::{cerror_to_pyerr, from_py_future};
 use futures::FutureExt;
 use pyo3::{call::PyCallArgs, exceptions::PyException};
 use pyo3_async_runtimes::TaskLocals;
@@ -163,7 +163,7 @@ impl PyCallback {
     }
 }
 
-/// Wrap an optional Python async callback `(err_str) -> Awaitable[None]`
+/// Wrap an optional Python async callback `(exc) -> Awaitable[None]`
 /// as the Rust `OnError` closure expected by `Component::run_in_background`,
 /// `Component::delete`, and the live-component controller.
 ///
@@ -171,11 +171,16 @@ impl PyCallback {
 /// `update_async`, and `delete_async` (live-component ops). The propagation
 /// semantics are uniform across all of them:
 ///
+/// - The engine error is converted with [`cerror_to_pyerr`], the same mapping
+///   foreground paths (`use_mount`, `handle.ready()`) use: a Python-originated
+///   failure reaches the callback as its original exception object (type +
+///   traceback intact); engine-native failures map to the usual Python types.
 /// - Coroutine returns normally (handler chain swallows) → `Ok(())` →
 ///   spawned task swallows.
 /// - Coroutine raises (chain exhausted via raises) → `Err(...)` → spawned
-///   task propagates via `handle.ready()`. Lets the Python exception
-///   handler chain control propagation.
+///   task propagates via `handle.ready()`. The error is the `HostedPyErr`
+///   produced by `PyCallback::call`, so the exception the handler raised
+///   re-surfaces in Python with its type intact.
 /// - Dispatch-level failures (couldn't schedule the coroutine) are logged
 ///   and converted to `Err` so they surface rather than disappearing.
 pub fn build_on_error(
@@ -188,22 +193,15 @@ pub fn build_on_error(
         let cb = cb.clone();
         let host_runtime_ctx = host_runtime_ctx.clone();
         Box::pin(async move {
-            let err_str = format!("{err:?}");
-            let fut = match cb.call(&host_runtime_ctx, (err_str,)) {
+            let exc = Python::attach(|py| cerror_to_pyerr(err).into_value(py));
+            let fut = match cb.call(&host_runtime_ctx, (exc,)) {
                 Ok(fut) => fut,
                 Err(e) => {
                     error!("exception handler dispatch failed:\n{e:?}");
-                    return Err(cocoindex_utils::prelude::Error::internal_msg(format!(
-                        "exception handler dispatch failed: {e:?}"
-                    )));
+                    return Err(e.context("exception handler dispatch failed"));
                 }
             };
-            match fut.await {
-                Ok(_) => Ok(()),
-                Err(e) => Err(cocoindex_utils::prelude::Error::internal_msg(format!(
-                    "{e:?}"
-                ))),
-            }
+            fut.await.map(|_| ())
         })
     }))
 }

--- a/rust/py_utils/src/error.rs
+++ b/rust/py_utils/src/error.rs
@@ -85,7 +85,13 @@ impl cocoindex_utils::error::HostError for HostedPyErr {
     }
 }
 
-fn cerror_to_pyerr(err: CError) -> PyErr {
+/// Convert an engine error into the Python exception surfaced to callers.
+///
+/// Tunneled Python exceptions (`HostedPyErr`) pass through as the original
+/// object, including type, traceback and `__cause__`. Engine-native errors
+/// map to `asyncio.CancelledError` / `DeadlineExceededError` / `ValueError`
+/// (client) / `RuntimeError` (internal).
+pub fn cerror_to_pyerr(err: CError) -> PyErr {
     let inner = err.without_contexts();
     if let CError::HostLang(host_err) = inner {
         // Pass through tunneled Python errors as-is — preserves the


### PR DESCRIPTION
Closes #2380.

Component exception handlers now receive the component's original Python exception instead of a `RuntimeError` wrapping a formatted string, and an exception raised by a handler keeps its Python type through `await handle.ready()`.

## Changes

- `build_on_error` converts the engine error with `cerror_to_pyerr` and passes the exception object to the handler callback. A raising handler's error propagates as-is, so `handle.ready()` re-raises it with its Python type intact.
- Tunneled Python exceptions pass through unchanged, the same as `use_mount` and `handle.ready()` already do. Engine-native failures map to `ValueError` / `DeadlineExceededError` / `RuntimeError`.
- `resolve_exception_handler` and `report_exception` take `BaseException`. The no-handler fallback logs the exception summary in the message and the traceback via `exc_info`.
- Docs describe the exception semantics; `core.pyi` stubs updated.

Rebased onto main with #2385. The earlier revision's Python-side workaround for a retained exception pinning a finished component (`_CoreProcessorCtxSlot`, `del comp_ctx`, `StateHandle` holding the `ComponentContext`) is dropped: the engine now guarantees that, and `test_component_ctx_release.py` on main covers it.

## Behavior change

Handlers that relied on the flattened representation will see a difference:
- `isinstance(exc, RuntimeError)` now sees the original type for Python-originated failures.
- The traceback is no longer inside `str(exc)`; use `traceback.format_exception(exc)` or `logging(..., exc_info=exc)`.
- Engine-side context around a Python-originated failure (for example which `use_state` key failed to serialize) is no longer in the delivered exception, matching `use_mount`.

## Tests

New or updated in `python/tests/core/test_exception_handlers.py`, `test_live_component.py`, `test_use_state.py`:
- `ValueError` reaches the handler as `ValueError` with its traceback intact (build and live mode).
- Handler-raised exceptions, including `DeadlineExceededError`, preserve their type through `handle.ready()`.
- Engine-side client error reaches the handler as `ValueError`.

Verified locally: `cargo test --workspace`, `uv run mypy`, `uv run pytest python/` (1095 passed, 303 skipped), `prek run --all-files`.
