### PR TITLE
fix(runner): carry the GPU assignment into subprocess mode

### DIFF
--- a/docs/src/content/docs/programming_guide/function.mdx
+++ b/docs/src/content/docs/programming_guide/function.mdx
@@ -368,9 +368,19 @@ result = await gpu_inference(data)
 
 The `coco.GPU` runner:
 
-- By default, runs in-process with all functions sharing a queue for serial execution
+- Runs in-process by default. With one GPU and no fraction, calls share a queue and execute one at a time; multiple GPUs, or a fraction below `1.0`, run as many at once as the pool admits
 - Sync functions run on a dedicated GPU thread to avoid blocking the event loop
 - Set the environment variable `COCOINDEX_RUN_GPU_IN_SUBPROCESS=1` to run in a subprocess for GPU memory isolation
+
+:::caution[Subprocess mode and GPU memory]
+`coco.current_gpu()` reports the same assignment inside the subprocess as it does in-process, and calls run in parallel rather than queueing behind a single worker.
+
+The subprocess pool grows a worker per concurrent call, up to a cap, and workers stay resident for the life of the process. Each one is a separate interpreter holding its own CUDA context, costing hundreds of MB of device memory before your model allocates anything. So a fractional runner like `coco.GPU(0.25)`, which lets four calls share a card, can hold four such contexts.
+
+Workers are not pinned to a device: `CUDA_VISIBLE_DEVICES` is not set per worker, so a worker can serve different GPUs across calls, and a function that ignores `coco.current_gpu()` can reach a GPU it was not assigned.
+
+A dying worker takes the whole pool with it: `ProcessPoolExecutor` terminates every worker when one fails, so **other calls running at the same time can fail too**, not just the one that crashed. Whether a given call is caught depends on timing; one that finishes first returns normally. Failures surface as `BrokenProcessPool` and are not retried: the component fails, nothing is written or memoized for it, and the next `app.update()` retries it cleanly.
+:::
 
 You can combine batching with a runner:
 

--- a/python/cocoindex/_internal/runner.py
+++ b/python/cocoindex/_internal/runner.py
@@ -17,7 +17,6 @@ import pickle
 import subprocess
 import threading
 import multiprocessing as mp
-import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -97,13 +96,32 @@ _pool_lock = threading.Lock()
 _pool: ProcessPoolExecutor | None = None
 
 
+# Upper bound on subprocess workers. `GPUPool` is what actually gates GPU
+# concurrency; this only has to be wide enough not to be the tighter limit.
+# Workers spawn on demand, so a wide pool costs nothing until calls overlap.
+_MAX_SUBPROCESS_WORKERS = 32
+# Submissions to try when the pool breaks. One: no retry.
+#
+# `ProcessPoolExecutor` terminates *every* worker when one dies, failing all
+# calls in flight, not just the one that crashed. Retrying therefore re-runs
+# the innocent neighbours' functions, side effects included, and they still fail
+# if the poison call keeps crashing. Surfacing immediately is both safer and
+# consistent with how the engine already handles a failed component: nothing is
+# written or memoized for it, and the next update retries it cleanly.
+_MAX_POOL_ATTEMPTS = 1
+
+
 def _get_pool() -> ProcessPoolExecutor:
-    """Get or create the singleton subprocess pool."""
+    """Get or create the singleton subprocess pool.
+
+    Wide enough that the GPU pool, not this executor, decides how many calls run
+    at once. Otherwise every device serializes behind a single worker.
+    """
     global _pool
     with _pool_lock:
         if _pool is None:
             _pool = ProcessPoolExecutor(
-                max_workers=1,
+                max_workers=_MAX_SUBPROCESS_WORKERS,
                 initializer=_subprocess_init,
                 initargs=(os.getpid(),),
                 mp_context=mp.get_context("spawn"),
@@ -119,13 +137,14 @@ def _restart_pool(old_pool: ProcessPoolExecutor | None = None) -> None:
             return  # Another thread already restarted
         prev_pool = _pool
         _pool = ProcessPoolExecutor(
-            max_workers=1,
+            max_workers=_MAX_SUBPROCESS_WORKERS,
             initializer=_subprocess_init,
             initargs=(os.getpid(),),
             mp_context=mp.get_context("spawn"),
         )
         if prev_pool is not None:
-            prev_pool.shutdown(cancel_futures=True)
+            # `wait=False`: do not join the dead pool's workers on the event loop.
+            prev_pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _subprocess_init(parent_pid: int) -> None:
@@ -174,7 +193,11 @@ def _start_parent_watchdog(parent_pid: int) -> None:
 
 def _execute_in_subprocess(payload_bytes: bytes) -> bytes:
     """Run in subprocess: unpack, execute, return pickled result."""
-    fn, args, kwargs = pickle.loads(payload_bytes)
+    fn, args, kwargs, gpu_ids, fraction = pickle.loads(payload_bytes)
+    # ContextVars do not cross a process boundary, so the parent's assignment
+    # travels in the payload and is re-established here.
+    _current_gpus.set(gpu_ids)
+    _current_gpu_fraction.set(fraction)
     result = fn(*args, **kwargs)
     # Handle async callables (functions or callable objects with async __call__)
     if asyncio.iscoroutine(result):
@@ -185,20 +208,36 @@ def _execute_in_subprocess(payload_bytes: bytes) -> bytes:
 async def _submit_to_pool_async(fn: Callable[..., Any], *args: Any) -> Any:
     """Submit work to pool and wait asynchronously."""
     loop = asyncio.get_running_loop()
-    while True:
+    for attempt in range(_MAX_POOL_ATTEMPTS):
         pool = _get_pool()
         try:
             return await loop.run_in_executor(pool, fn, *args)
         except BrokenProcessPool:
+            # A worker can die for a reason unrelated to this call, so retry on
+            # a fresh one. Exhausting the attempts means the call itself kills
+            # its worker: surface it instead of respawning forever.
             _restart_pool(old_pool=pool)
+            if attempt == _MAX_POOL_ATTEMPTS - 1:
+                raise
+    raise AssertionError("unreachable: the loop returns or raises")
 
 
-async def execute_in_subprocess(fn: Callable[..., R], *args: Any, **kwargs: Any) -> R:
+async def execute_in_subprocess(
+    gpu_ids: list[int],
+    fraction: float,
+    fn: Callable[..., R],
+    *args: Any,
+    **kwargs: Any,
+) -> R:
     """Execute a function in a subprocess and return the result.
 
-    The function and all arguments must be picklable.
+    The function and all arguments must be picklable. ``gpu_ids`` and
+    ``fraction`` are the caller's GPU assignment, positional so a submitted
+    function is free to have parameters of any name.
     """
-    payload = pickle.dumps((fn, args, kwargs), protocol=pickle.HIGHEST_PROTOCOL)
+    payload = pickle.dumps(
+        (fn, args, kwargs, gpu_ids, fraction), protocol=pickle.HIGHEST_PROTOCOL
+    )
     result_bytes = await _submit_to_pool_async(_execute_in_subprocess, payload)
     return pickle.loads(result_bytes)  # type: ignore[no-any-return]
 
@@ -392,9 +431,10 @@ class GPURunner(Runner):
     The assigned GPU id(s) are available inside the function via
     ``coco.current_gpu()`` (first id) and ``coco.current_gpus()`` (full list).
     The allocated fraction is available via ``coco.current_gpu_fraction()``.
-    For multi-GPU subprocess mode (where ``CUDA_VISIBLE_DEVICES`` must be set
-    per-process), use in-process mode (the default) until per-GPU subprocess
-    pools are implemented.
+    Subprocess mode reports the same assignment as in-process mode: the id is
+    carried in the payload and re-established in the child. Workers are shared
+    rather than pinned per device, so ``CUDA_VISIBLE_DEVICES`` is not set per
+    worker and a worker can serve different GPUs across calls.
     """
 
     _fraction: float
@@ -447,9 +487,13 @@ class GPURunner(Runner):
         tok_frac = _current_gpu_fraction.set(self._fraction)
         try:
             if self._should_use_subprocess():
-                _warn_subprocess_multi_gpu()
-                # Type ignore: execute_in_subprocess handles async fns via asyncio.run() internally
-                return await execute_in_subprocess(fn, *args, **kwargs)  # type: ignore[arg-type]
+                return await execute_in_subprocess(
+                    gpu_ids,
+                    self._fraction,
+                    fn,  # type: ignore[arg-type]
+                    *args,
+                    **kwargs,
+                )
             return await fn(*args, **kwargs)
         finally:
             _current_gpus.reset(tok_gpus)
@@ -469,8 +513,9 @@ class GPURunner(Runner):
         gpu_ids = [gpu_id]
         try:
             if self._should_use_subprocess():
-                _warn_subprocess_multi_gpu()
-                return await execute_in_subprocess(fn, *args, **kwargs)
+                return await execute_in_subprocess(
+                    gpu_ids, self._fraction, fn, *args, **kwargs
+                )
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 self._get_gpu_executor(),
@@ -483,22 +528,3 @@ class GPURunner(Runner):
 
 
 GPU = GPURunner(fraction=1.0)
-
-_subprocess_multi_gpu_warned = False
-
-
-def _warn_subprocess_multi_gpu() -> None:
-    global _subprocess_multi_gpu_warned
-    if _subprocess_multi_gpu_warned:
-        return
-    _subprocess_multi_gpu_warned = True
-    pool = _get_default_gpu_pool()
-    if pool.num_gpus > 1:
-        warnings.warn(
-            f"COCOINDEX_RUN_GPU_IN_SUBPROCESS=1 with num_gpus={pool.num_gpus}: "
-            "subprocess mode does not yet support per-GPU CUDA_VISIBLE_DEVICES. "
-            "All subprocess calls run on the same GPU regardless of pool "
-            "assignment. Use in-process mode for multi-GPU support.",
-            UserWarning,
-            stacklevel=4,
-        )

--- a/python/tests/core/test_gpu_subprocess.py
+++ b/python/tests/core/test_gpu_subprocess.py
@@ -1,0 +1,199 @@
+"""Tests for GPU subprocess mode: assignment propagation and parallelism."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from concurrent.futures.process import BrokenProcessPool
+from pathlib import Path
+
+import pytest
+
+from cocoindex._internal import runner as _runner_mod
+from cocoindex._internal.runner import GPURunner, configure_gpu_pool
+
+# Seconds a call waits for its peers before declaring them serialized.
+_RENDEZVOUS_TIMEOUT = 30.0
+
+# Each test starts `spawn` interpreters that import the Rust extension, which the
+# project-wide 30s budget does not cover on a cold runner.
+pytestmark = pytest.mark.timeout(90)
+
+
+@pytest.fixture(autouse=True)
+def _subprocess_mode(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Run GPU work in subprocesses, from a fresh pool, and clean up after."""
+    monkeypatch.setenv("COCOINDEX_RUN_GPU_IN_SUBPROCESS", "1")
+    monkeypatch.setattr(_runner_mod, "_default_gpu_pool", None)
+    monkeypatch.setattr(_runner_mod, "_pool", None)
+    try:
+        yield
+    finally:
+        pool = _runner_mod._pool
+        if pool is not None:
+            # `wait=False`: joining workers has no timeout, and a wedged one
+            # would hang teardown until pytest-timeout kills the process.
+            pool.shutdown(wait=False, cancel_futures=True)
+
+
+def _probe() -> tuple[int | None, float | None, int]:
+    """Report the GPU context and pid visible inside the subprocess."""
+    import cocoindex as coco
+
+    return coco.current_gpu(), coco.current_gpu_fraction(), os.getpid()
+
+
+def _probe_together(rendezvous: str, expected: int) -> tuple[int | None, int]:
+    """Report the assignment, but only once every peer has also started.
+
+    Each call announces itself in `rendezvous` and waits for the others, so it
+    cannot return unless all `expected` calls are resident at the same time. Were
+    the pool to serialize them this raises, rather than merely running slowly.
+    """
+    import time
+    import uuid
+
+    import cocoindex as coco
+
+    gpu = coco.current_gpu()
+    open(os.path.join(rendezvous, uuid.uuid4().hex), "w").close()
+    deadline = time.monotonic() + _RENDEZVOUS_TIMEOUT
+    while len(os.listdir(rendezvous)) < expected:
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"only {len(os.listdir(rendezvous))} of {expected} calls "
+                "were running at once"
+            )
+        time.sleep(0.01)
+    return gpu, os.getpid()
+
+
+async def _aprobe() -> tuple[int | None, float | None, int]:
+    """Async probe: goes through `GPURunner.run` and the child's `asyncio.run`."""
+    import cocoindex as coco
+
+    return coco.current_gpu(), coco.current_gpu_fraction(), os.getpid()
+
+
+def _kill_worker() -> None:
+    """Take the worker process down, the way a native crash would."""
+    os._exit(7)
+
+
+def _cuda_probe() -> tuple[int | None, int | None, int]:
+    """Run a real CUDA kernel on the assigned device; report where it landed."""
+    import torch
+
+    import cocoindex as coco
+
+    assigned = coco.current_gpu()
+    if assigned is None:
+        return None, None, os.getpid()
+    x = torch.randn(256, 256, device=f"cuda:{assigned}")
+    (x @ x.T).sum().item()  # force a kernel launch
+    return assigned, x.device.index, os.getpid()
+
+
+def _cuda_device_count() -> int:
+    try:
+        import torch
+    except ImportError:
+        return 0
+    return torch.cuda.device_count() if torch.cuda.is_available() else 0
+
+
+@pytest.mark.asyncio
+async def test_subprocess_receives_gpu_assignment() -> None:
+    """current_gpu() in the subprocess is the id the GPU pool handed out."""
+    configure_gpu_pool(1)
+    gpu, fraction, pid = await GPURunner(fraction=1.0).run_sync_fn(_probe)
+    assert gpu == 0
+    assert fraction == 1.0
+    assert pid != os.getpid()  # it really did run in a subprocess
+
+
+@pytest.mark.asyncio
+async def test_subprocess_multi_gpu_runs_concurrently(tmp_path: Path) -> None:
+    """The motivating bug: one shared worker serialized every GPU behind it."""
+    configure_gpu_pool(4)
+    runner = GPURunner(fraction=1.0)
+    results = await asyncio.gather(
+        *(runner.run_sync_fn(_probe_together, str(tmp_path), 4) for _ in range(4))
+    )
+    assert sorted(gpu for gpu, _ in results if gpu is not None) == [0, 1, 2, 3]
+    assert len({pid for _, pid in results}) == 4
+
+
+@pytest.mark.asyncio
+async def test_fractional_calls_share_a_gpu_concurrently(tmp_path: Path) -> None:
+    """Calls sharing one GPU by fraction must also run at the same time."""
+    configure_gpu_pool(1)
+    runner = GPURunner(fraction=0.25)
+    results = await asyncio.gather(
+        *(runner.run_sync_fn(_probe_together, str(tmp_path), 4) for _ in range(4))
+    )
+    assert all(gpu == 0 for gpu, _ in results)
+    assert len({pid for _, pid in results}) == 4
+
+
+@pytest.mark.asyncio
+async def test_async_fn_receives_gpu_assignment() -> None:
+    """`run()` propagates the assignment too, not just `run_sync_fn()`."""
+    configure_gpu_pool(2)
+    gpu, fraction, pid = await GPURunner(fraction=1.0).run(_aprobe)
+    assert gpu in (0, 1)
+    assert fraction == 1.0
+    assert pid != os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_worker_reports_each_calls_own_assignment() -> None:
+    """A reused worker must not report the previous call's context."""
+    configure_gpu_pool(1)
+    half = GPURunner(fraction=0.5)
+    full = GPURunner(fraction=1.0)
+
+    seen = [
+        (await runner.run_sync_fn(_probe))[1] for runner in (half, full, half, full)
+    ]
+    assert seen == [0.5, 1.0, 0.5, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_crashing_call_surfaces_instead_of_respawning_forever() -> None:
+    """A call that kills its worker every time must fail, not retry endlessly."""
+    configure_gpu_pool(1)
+    runner = GPURunner(fraction=1.0)
+    with pytest.raises(BrokenProcessPool):
+        await runner.run_sync_fn(_kill_worker)
+    # The pool is usable again afterwards.
+    gpu, _, _ = await runner.run_sync_fn(_probe)
+    assert gpu == 0
+
+
+@pytest.mark.asyncio
+async def test_pool_stays_wide_after_a_crash(tmp_path: Path) -> None:
+    """Restarting a broken pool must not narrow it back to one worker."""
+    configure_gpu_pool(2)
+    runner = GPURunner(fraction=1.0)
+    with pytest.raises(BrokenProcessPool):
+        await runner.run_sync_fn(_kill_worker)
+
+    results = await asyncio.gather(
+        *(runner.run_sync_fn(_probe_together, str(tmp_path), 2) for _ in range(2))
+    )
+    assert len({pid for _, pid in results}) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(_cuda_device_count() == 0, reason="needs a CUDA device")
+async def test_real_cuda_work_lands_on_the_assigned_device() -> None:
+    """End to end on real hardware: the tensor lands on the assigned GPU."""
+    n = _cuda_device_count()
+    configure_gpu_pool(n)
+    runner = GPURunner(fraction=1.0)
+    assigned, ran_on, pid = await runner.run_sync_fn(_cuda_probe)
+    assert assigned is not None
+    assert ran_on == assigned
+    assert pid != os.getpid()


### PR DESCRIPTION
Fixes #2382. Happy to close or rework this if it belongs somewhere else; the scoping question at the bottom is a genuine one.

## Problem

In subprocess mode the GPU pool assigns a device, but `execute_in_subprocess()` pickles only `(fn, args, kwargs)`. `_current_gpus` is a ContextVar and does not cross a process boundary, so `current_gpu()` returns `None` in the child and work falls back to GPU 0. The in-process path propagates it through `_run_with_gpu_context()`.

`_get_pool()` was also a single `ProcessPoolExecutor(max_workers=1)`, so every GPU serialized behind one worker regardless of its assignment.

## Changes

- carry `(gpu_ids, fraction)` in the payload and restore them in the child
- size the pool so `GPUPool`, not the executor, gates concurrency. `_pool` is a singleton whose width freezes at first use, so deriving it from a GPU count that can change later locks in the wrong value; a fixed upper bound with on-demand worker spawn avoids that
- bound the crash retry. The previous `while True` respawns forever for a call that reliably kills its worker. `ProcessPoolExecutor` also terminates every worker when one dies, so retrying re-runs the calls that happened to be running alongside it, side effects included, and they still fail. Failing fast matches how a failed component is already handled: nothing written or memoized, retried on the next update
- drop `_warn_subprocess_multi_gpu`, which described the old behaviour

## Measurements

100 tasks of fixed work, 8 simulated GPUs:

| | wall | throughput | workers | GPUs the calls saw |
|---|---|---|---|---|
| before | 8.02s | 12.5 t/s | 1 | `[None]` |
| after | 1.30s | 77.2 t/s | 9 | `[0..7]` |

One GPU at `fraction=1.0` has no parallelism to unlock, so it is the overhead check: 6.48s before vs 6.36s after, one worker either way.

One GPU at `fraction=0.25`, on a workload that already saturates the card: 6.47s to 10.01s. The pool admits four concurrent calls because that is what the fraction asks for, and four CUDA contexts time-slicing one card is slower than one. Worth knowing before using a fractional runner for work that fills a device.

## Test plan

- `python/tests/core/test_gpu_subprocess.py`, 8 tests. Against the unmodified runner 5 of them fail (`assert None == 0`, `only 1 of 4 calls were running at once`)
- existing `test_gpu_pool.py` passes unchanged (33)
- `ruff format --check`, `ruff check`, `mypy --strict` clean
- verified on an RTX 4070 (`torch 2.14.0+cu126`) that a tensor lands on the device `current_gpu()` reports; that test is `skipif`-guarded so CI without a GPU skips it

Not verified: multi-device routing on real hardware, since I only have one card, so the 8-GPU numbers above are simulated. `prek run --all-files` also has not run here (no `uv`/`protoc` on this machine); the Python hooks it wraps are clean.

## Where should this live?

#2277 rewrites `GPUPool`, which decides which device a call gets, in Rust. It does not touch `_get_pool` / `execute_in_subprocess` / the `GPURunner` dispatch path, so I do not think the two overlap. #2336 names the same cancellation and crash-retry problems on this path but keeps generic `coco.GPU` on the existing executor.

So: in scope for #2277, a follow-up to it, or something that should wait for #2336's supervisor to generalise? Glad to rework or drop it whichever way.
