### PR TITLE
feat(litellm): bound concurrent embedding requests to the backend

### DIFF
--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -49,6 +49,9 @@ embedder = LiteLLMEmbedder("text-embedding-3-small", dimensions=512)
 
 # With a timeout (seconds)
 embedder = LiteLLMEmbedder("text-embedding-3-small", timeout=30)
+
+# With a cap on concurrent requests to the backend
+embedder = LiteLLMEmbedder("text-embedding-3-small", max_inflight_requests=8)
 ```
 
 ### Embedding text
@@ -66,6 +69,26 @@ table.declare_row(row=DocEmbedding(text="Hello, world!", embedding=embedding))
 :::note[Built-in memoization]
 `embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged text — this is what makes the common per-file-component pattern incremental. The memo stores one full vector per distinct text, so mind the [memoization placement rule](../programming_guide/function#when-to-memoize) if your components are already keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
 :::
+
+### Limiting concurrent requests
+
+Concurrent `embed()` calls are batched: CocoIndex groups them into requests of
+up to 64 texts each, and sends as many such requests in parallel as there is
+work queued. `max_inflight_requests` caps how many requests this embedder keeps
+open against the backend at once — useful for a self-hosted endpoint (Infinity,
+TEI, Ollama, vLLM, …) that rejects bursts with 429s:
+
+```python
+embedder = LiteLLMEmbedder(
+    "openai/bge-m3",
+    api_base="http://localhost:7997",
+    max_inflight_requests=8,
+)
+```
+
+The default is `None` (no cap). The cap is per embedder instance: two
+embedders pointed at the same endpoint have independent limits, so share one
+instance when you want one limit.
 
 ### Using as a type annotation
 

--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -14,8 +14,10 @@ __all__ = [
 ]
 
 import asyncio as _asyncio
+import contextlib as _contextlib
 import io as _io
 import logging as _logging
+from contextlib import AbstractAsyncContextManager as _AbstractAsyncContextManager
 from datetime import timedelta as _timedelta
 from collections.abc import Awaitable as _Awaitable
 from collections.abc import Callable as _Callable
@@ -209,6 +211,10 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
     Args:
         model: LiteLLM model name (e.g., ``"text-embedding-ada-002"``,
             ``"vertex_ai/textembedding-gecko"``).
+        max_inflight_requests: Cap on how many requests this embedder keeps
+            open against the backend at once, or ``None`` (the default) for
+            no cap. Useful for self-hosted endpoints that reject bursts with
+            429s. The cap is per instance.
         **kwargs: Additional keyword arguments passed through to every
             ``litellm.aembedding`` call (e.g., ``api_key``, ``api_base``,
             ``dimensions``).
@@ -226,18 +232,57 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         >>> print(f"Shape: {embedding.shape}, dtype: {embedding.dtype}")
     """
 
-    def __init__(self, model: str, **kwargs: _Any) -> None:
+    def __init__(
+        self,
+        model: str,
+        *,
+        max_inflight_requests: int | None = None,
+        **kwargs: _Any,
+    ) -> None:
         """Initialize the LiteLLM embedder."""
+        if max_inflight_requests is not None and max_inflight_requests < 1:
+            raise ValueError(
+                "max_inflight_requests must be a positive int or None, got "
+                f"{max_inflight_requests!r}"
+            )
         self._model = model
         self._kwargs = kwargs
+        self._max_inflight_requests = max_inflight_requests
         self._dim: int | None = None
         self._lock: _asyncio.Lock | None = None
+        self._inflight_semaphore: _asyncio.Semaphore | None = None
+        self._inflight_loop: _asyncio.AbstractEventLoop | None = None
 
     def _get_lock(self) -> _asyncio.Lock:
         """Get or create the asyncio lock (must be called from async context)."""
         if self._lock is None:
             self._lock = _asyncio.Lock()
         return self._lock
+
+    def _inflight_permit(self) -> _AbstractAsyncContextManager[None]:
+        """A permit to hold for one in-flight request to the backend.
+
+        The semaphore is built on first use, and rebuilt whenever the running
+        loop changes. An ``asyncio.Semaphore`` binds to the loop that first
+        blocks on it and raises ``RuntimeError`` if it is then awaited from
+        another — and an embedder routinely outlives a loop: the documented
+        usage constructs one at module scope, while each ``Environment`` gets
+        a fresh loop (and, under pytest-asyncio, each test does).
+
+        Rebinding makes the cap per loop rather than per instance. That is
+        exact for the sequential case this guards (one loop replaced by the
+        next, nothing left in flight on the old one). Two loops running
+        *concurrently* against one embedder would get a budget each, which is
+        the same way the instance-scoped cap already behaves for two
+        embedders sharing a backend.
+        """
+        if self._max_inflight_requests is None:
+            return _contextlib.nullcontext()
+        loop = _asyncio.get_running_loop()
+        if self._inflight_semaphore is None or self._inflight_loop is not loop:
+            self._inflight_semaphore = _asyncio.Semaphore(self._max_inflight_requests)
+            self._inflight_loop = loop
+        return self._inflight_semaphore
 
     def _build_call_kwargs(self, **extra: _Any) -> dict[str, _Any]:
         # voyage/ and bedrock/ reject `encoding_format="float"` (voyage requires
@@ -253,11 +298,27 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
 
     async def _aembedding_with_retry(self, texts: list[str], **extra: _Any) -> _Any:
         async def _call() -> _Any:
-            return await litellm.aembedding(
-                model=self._model,
-                input=texts,
-                **self._build_call_kwargs(**extra),
-            )
+            # The permit is scoped to one backend request, deliberately as
+            # tight as possible around it:
+            #
+            # * Inside the retry loop, not around it — an attempt sleeping
+            #   out a 30s backoff would otherwise hold a slot it isn't using.
+            # * Inside the batch body, not at the batcher — the whole
+            #   `RetryWithSmallerBatch` split tree runs within one batch
+            #   dispatch (the split wrapper is applied before the runner
+            #   reaches the batcher), so a batcher-level bound would cap
+            #   top-level batches while their sub-batches fanned out freely.
+            # * Never held across a split. `_run_split_async` only gathers
+            #   the two halves after `await fn(inputs)` has already raised,
+            #   so the parent's permit is released before the halves ask for
+            #   theirs. Holding it across the split would deadlock outright
+            #   at a limit of 1.
+            async with self._inflight_permit():
+                return await litellm.aembedding(
+                    model=self._model,
+                    input=texts,
+                    **self._build_call_kwargs(**extra),
+                )
 
         return await _retry_litellm_call(_call, "litellm.aembedding")
 
@@ -350,6 +411,9 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         return _schema.VectorSchema(dtype=_np.dtype(_np.float32), size=dim)
 
     def __coco_memo_key__(self) -> object:
+        # `max_inflight_requests` is deliberately absent: it paces requests
+        # but cannot change an embedding, so tuning it must not invalidate
+        # every cached vector.
         return (self._model, self._kwargs)
 
 

--- a/python/tests/ops/conftest.py
+++ b/python/tests/ops/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for the ``cocoindex.ops`` tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def litellm_module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """``cocoindex.ops.litellm`` loaded against a stub ``litellm`` package.
+
+    Lets tests exercise the module's own logic without the optional
+    dependency — which CI does not install, so tests gated on the real
+    ``litellm`` never run there.
+
+    Each test gets a fresh module object, so decorator-level state (memo
+    caches, batchers keyed by function identity) never leaks between tests,
+    and none of it touches the real ``cocoindex.ops.litellm``. The name is
+    made unique per test only so the ``sys.modules`` entry cannot collide
+    with a concurrently-registered one.
+    """
+    fake_litellm: Any = types.ModuleType("litellm")
+    fake_litellm.aembedding = object()
+    fake_litellm.atranscription = object()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    module_path = pathlib.Path(__file__).parents[2] / "cocoindex" / "ops" / "litellm.py"
+    module_name = f"_test_litellm_{id(monkeypatch)}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module

--- a/python/tests/ops/test_litellm_concurrency.py
+++ b/python/tests/ops/test_litellm_concurrency.py
@@ -1,0 +1,240 @@
+"""``LiteLLMEmbedder(max_inflight_requests=...)``: bound concurrent requests
+to the embedding backend.
+
+Batching bounds how many texts ride in one request, never how many requests
+are open at once — and a batch that fails splits into halves that run
+concurrently *inside* the same batch dispatch. So the permit is taken per
+backend request, inside the batch body and inside the retry loop. These tests
+pin that placement down.
+
+Most of them drive the split wrapper directly rather than going through the
+batcher. Coalescing N concurrent ``embed()`` callers into one batch is
+timing-dependent — under load the batcher may dispatch a subset — which makes
+any assertion about the resulting split tree flaky. Driving the wrapper gives
+an exact tree, and ``test_limit_holds_through_the_public_api`` covers the real
+``embed()`` path with a flake-proof upper-bound assertion.
+
+Runs against the stub ``litellm`` module from the ``litellm_module`` fixture
+so it exercises the real split driver without the optional dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from cocoindex._internal.batching import (  # noqa: E402
+    BatchItemFailure,
+    wrap_batch_fn_async,
+)
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code: int, message: str | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message or f"HTTP {status_code}")
+
+
+def _fake_embedding_response(texts: list[str]) -> Any:
+    # Embedding derived from the text so tests can verify item alignment.
+    return SimpleNamespace(data=[{"embedding": [float(len(t))]} for t in texts])
+
+
+def _texts(n: int) -> list[str]:
+    """``n`` texts of distinct length, so each maps to a distinct embedding."""
+    return ["x" * (i + 1) for i in range(n)]
+
+
+class _ConcurrencyProbe:
+    """Fake ``litellm.aembedding`` that records how many calls overlap."""
+
+    def __init__(self, *, split_above: int) -> None:
+        self._split_above = split_above
+        self._inflight = 0
+        self.peak_inflight = 0
+        self.batch_sizes: list[int] = []
+
+    async def __call__(self, *, model: str, input: list[str], **kwargs: Any) -> Any:
+        self.batch_sizes.append(len(input))
+        self._inflight += 1
+        self.peak_inflight = max(self.peak_inflight, self._inflight)
+        try:
+            # A real suspension point, so concurrent calls genuinely overlap
+            # and `peak_inflight` measures something.
+            await asyncio.sleep(0.02)
+            if len(input) > self._split_above:
+                raise _FakeHTTPError(400, "TOO_MANY_TOKENS_IN_BATCH")
+            return _fake_embedding_response(input)
+        finally:
+            self._inflight -= 1
+
+
+def _split_runner(embedder: Any) -> Any:
+    """The batch body wrapped in the engine's split-and-retry driver.
+
+    This is what a single batcher dispatch runs, minus the batcher — so the
+    split tree is exact instead of depending on how many callers coalesced.
+    """
+    return wrap_batch_fn_async(embedder._embed._execute_orig_async_fn)
+
+
+async def _run_batch(
+    module: Any, embedder: Any, probe: Any, texts: list[str]
+) -> list[float]:
+    with patch.object(module.litellm, "aembedding", new=probe):
+        out = await asyncio.wait_for(_split_runner(embedder)(texts), timeout=10.0)
+    return [vec.tolist()[0] for vec in out]
+
+
+@pytest.mark.asyncio
+async def test_bounds_inflight_requests_across_split(litellm_module: Any) -> None:
+    """The split tree is the fan-out that floods a backend: one batch of 16
+    rejected above size 2 becomes 8 leaf requests, all open at once — while
+    the batcher sees a single dispatch. `max_inflight_requests` bounds them;
+    the default (None) leaves them unbounded."""
+    texts = _texts(16)
+    expected = [float(len(t)) for t in texts]
+
+    unbounded_probe = _ConcurrencyProbe(split_above=2)
+    unbounded = await _run_batch(
+        litellm_module,
+        litellm_module.LiteLLMEmbedder("fake-model"),
+        unbounded_probe,
+        texts,
+    )
+    assert unbounded == expected
+    assert unbounded_probe.peak_inflight == 8  # 16 -> 8+8 -> 4s -> eight 2s
+
+    bounded_probe = _ConcurrencyProbe(split_above=2)
+    bounded = await _run_batch(
+        litellm_module,
+        litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=2),
+        bounded_probe,
+        texts,
+    )
+    assert bounded == expected
+    assert bounded_probe.peak_inflight == 2
+    # Same requests, only paced differently — the split tree is untouched.
+    assert bounded_probe.batch_sizes == unbounded_probe.batch_sizes
+
+
+@pytest.mark.asyncio
+async def test_inflight_limit_of_one_survives_split(litellm_module: Any) -> None:
+    """Regression: at a limit of 1, a batch that splits must still finish.
+
+    A permit held across the split would deadlock — the split driver waits on
+    both halves, and the halves would wait on the permit their parent only
+    releases once they are done. Taking the permit per request avoids it: the
+    parent's body has already raised, and released, before the halves start.
+    """
+    texts = _texts(8)
+    probe = _ConcurrencyProbe(split_above=1)  # split all the way to singletons
+    embedder = litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=1)
+
+    values = await _run_batch(litellm_module, embedder, probe, texts)
+
+    assert values == [float(len(t)) for t in texts]
+    assert probe.peak_inflight == 1
+    # 8 -> 4+4 -> four 2s -> eight singletons, each request taken one at a time.
+    assert probe.batch_sizes == [8, 4, 4, 2, 2, 2, 2] + [1] * 8
+
+
+@pytest.mark.asyncio
+async def test_releases_permit_during_retry_backoff(
+    litellm_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The permit wraps one request, not the retry loop around it.
+
+    A sub-batch sleeping off a 429 backoff holds no slot, so at a limit of 1
+    the sibling the split dispatched alongside it runs during that sleep.
+    Taken around the retry loop instead, the permit would keep that sibling
+    out until the first sub-batch had finished retrying — turning a 30s
+    backoff into 30s of stalled throughput for everything else.
+    """
+    monkeypatch.setattr(litellm_module, "_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS", 0.3)
+    order: list[str] = []
+    rate_limited = False
+
+    async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        nonlocal rate_limited
+        order.append(input[0])
+        if len(input) > 2:  # the batch of 4: too big, so it gets split
+            raise _FakeHTTPError(400, "TOO_MANY_TOKENS_IN_BATCH")
+        if not rate_limited:  # first half: rate-limited once, backs off, retries
+            rate_limited = True
+            raise _FakeHTTPError(429)
+        return _fake_embedding_response(input)
+
+    embedder = litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=1)
+    texts = ["a", "bb", "ccc", "dddd"]
+    with patch.object(litellm_module.litellm, "aembedding", new=fake_aembedding):
+        out = await asyncio.wait_for(_split_runner(embedder)(texts), timeout=10.0)
+
+    assert [vec.tolist()[0] for vec in out] == [1.0, 2.0, 3.0, 4.0]
+    # The batch of 4, the rate-limited half ["a","bb"], then its sibling
+    # ["ccc","dddd"] *during* the backoff, and only then the half's retry.
+    assert order == ["a", "a", "ccc", "a"]
+
+
+@pytest.mark.asyncio
+async def test_limit_holds_through_the_public_api(litellm_module: Any) -> None:
+    """End-to-end over the real `embed()` path, batcher included.
+
+    Nothing is asserted about the shape of the split tree: how many callers
+    the batcher coalesces is timing-dependent. Only that every text comes
+    back correct, that no scheduling pushed concurrency past the limit, and
+    that nothing deadlocked.
+    """
+    texts = _texts(8)
+    probe = _ConcurrencyProbe(split_above=1)
+    embedder = litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=1)
+
+    with patch.object(litellm_module.litellm, "aembedding", new=probe):
+        results = await asyncio.wait_for(
+            asyncio.gather(*(embedder.embed(t) for t in texts)), timeout=10.0
+        )
+
+    assert [vec.tolist()[0] for vec in results] == [float(len(t)) for t in texts]
+    assert probe.peak_inflight == 1
+
+
+def test_permit_survives_a_new_event_loop(litellm_module: Any) -> None:
+    """Regression: an embedder outlives any one event loop.
+
+    An `asyncio.Semaphore` binds to the loop that first blocks on it, and a
+    module-level embedder — the documented usage — is reused across the fresh
+    loop each `Environment` (or pytest-asyncio test) brings up. Without
+    rebinding, the second loop raised `RuntimeError: ... is bound to a
+    different event loop`, surfacing as a failure for every text.
+
+    Sync on purpose: it needs to drive two `asyncio.run` loops itself.
+    """
+    texts = _texts(8)
+    expected = [float(len(t)) for t in texts]
+    embedder = litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=1)
+
+    async def one_pass() -> list[float]:
+        # split_above=1 with a limit of 1 guarantees real waiters, which is
+        # what makes the semaphore latch onto the running loop.
+        probe = _ConcurrencyProbe(split_above=1)
+        with patch.object(litellm_module.litellm, "aembedding", new=probe):
+            out = await asyncio.wait_for(_split_runner(embedder)(texts), timeout=10.0)
+        failed = [v for v in out if isinstance(v, BatchItemFailure)]
+        assert not failed, f"sub-batch failed: {failed[0].error!r}"
+        assert probe.peak_inflight == 1
+        return [vec.tolist()[0] for vec in out]
+
+    assert asyncio.run(one_pass()) == expected  # loop A latches the semaphore
+    assert asyncio.run(one_pass()) == expected  # loop B: fresh loop, same embedder
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_rejects_non_positive_inflight_limit(litellm_module: Any, value: int) -> None:
+    with pytest.raises(ValueError, match="max_inflight_requests"):
+        litellm_module.LiteLLMEmbedder("fake-model", max_inflight_requests=value)

--- a/python/tests/ops/test_litellm_retry_delegation.py
+++ b/python/tests/ops/test_litellm_retry_delegation.py
@@ -1,13 +1,10 @@
 """Prove _retry_litellm_call delegates to the shared retry helper with the
-policy that preserves its historical behavior. Loads litellm.py with a fake
-`litellm` module so the test runs without the optional dependency."""
+policy that preserves its historical behavior. Runs against the stub
+``litellm`` module from the ``litellm_module`` fixture, so it needs neither
+the optional dependency nor a live backend."""
 
 from __future__ import annotations
 
-import importlib.util
-import pathlib
-import sys
-import types
 from datetime import timedelta
 from typing import Any
 
@@ -16,27 +13,12 @@ import pytest
 pytest.importorskip("numpy")
 
 
-def _load_litellm_module(monkeypatch: pytest.MonkeyPatch) -> Any:
-    fake_litellm: Any = types.ModuleType("litellm")
-    fake_litellm.aembedding = object()
-    fake_litellm.atranscription = object()
-    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
-
-    module_path = pathlib.Path(__file__).parents[2] / "cocoindex" / "ops" / "litellm.py"
-    module_name = f"_test_litellm_delegation_{id(monkeypatch)}"
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, module_name, module)
-    spec.loader.exec_module(module)
-    return module
-
-
 @pytest.mark.asyncio
 async def test_retry_litellm_call_delegates_with_historical_policy(
+    litellm_module: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load_litellm_module(monkeypatch)
+    module = litellm_module
     captured: dict[str, Any] = {}
 
     async def fake_retry_transient(fn: Any, **kwargs: Any) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -859,6 +859,7 @@ build-test = [
     { name = "testcontainers", extra = ["neo4j"], marker = "sys_platform != 'win32'" },
 ]
 ci = [
+    { name = "aiohttp" },
     { name = "aiomoto", extra = ["s3"] },
     { name = "asyncpg" },
     { name = "asyncpg-stubs" },
@@ -867,6 +868,7 @@ ci = [
     { name = "mypy" },
     { name = "neo4j" },
     { name = "pydantic" },
+    { name = "pymysql" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -874,11 +876,14 @@ ci = [
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
+    { name = "aiohttp" },
     { name = "asyncpg" },
     { name = "neo4j" },
     { name = "pydantic" },
+    { name = "pymysql" },
 ]
 dev = [
+    { name = "aiohttp" },
     { name = "aiomoto", extra = ["s3"] },
     { name = "asyncpg" },
     { name = "asyncpg-stubs" },
@@ -888,6 +893,7 @@ dev = [
     { name = "neo4j" },
     { name = "prek" },
     { name = "pydantic" },
+    { name = "pymysql" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -1001,6 +1007,7 @@ build-test = [
     { name = "testcontainers", extras = ["postgres", "neo4j"], marker = "sys_platform != 'win32'", specifier = ">=4.0.0" },
 ]
 ci = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "aiomoto", extras = ["s3"], specifier = ">=0.3.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "asyncpg-stubs" },
@@ -1009,6 +1016,7 @@ ci = [
     { name = "mypy" },
     { name = "neo4j", specifier = ">=5.18.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -1016,11 +1024,14 @@ ci = [
     { name = "types-psutil" },
 ]
 ci-enabled-optional-deps = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "neo4j", specifier = ">=5.18.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pymysql", specifier = ">=1.1.0" },
 ]
 dev = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "aiomoto", extras = ["s3"], specifier = ">=0.3.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "asyncpg-stubs" },
@@ -1030,6 +1041,7 @@ dev = [
     { name = "neo4j", specifier = ">=5.18.0" },
     { name = "prek" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -1266,37 +1278,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1325,7 +1337,7 @@ name = "docker"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "python_version < '0'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -4563,7 +4575,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4640,7 +4652,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- **Add `LiteLLMEmbedder(max_inflight_requests=N)`** — an opt-in cap on how many requests one embedder keeps open against the backend. Batching bounds how many texts ride in *one* request, never how many requests are open at once, and two things fan those out independently: the batcher forms as many batches as it has queued callers (2334 chunks from one 1.6MB file at `max_batch_size=64` produced 38 batches, **37 concurrent**), and a rejected batch splits into halves that run concurrently *inside that one dispatch* (a batch of 16 splitting to 2 becomes **8 simultaneous** requests while the batcher still sees one). Together these can bury a self-hosted endpoint in 429s.

- **The permit covers one backend request and nothing else** — taken inside the retry loop (so an attempt sleeping out a 30s backoff doesn't hold a slot it isn't using), inside the batch body rather than at the batcher (the split wrapper is applied before the runner reaches the batcher, so a batcher-level bound would cap top-level batches while sub-batches fanned out freely), and never held across a split (which would deadlock outright at a limit of 1).

- **The semaphore rebinds when the running loop changes.** An `asyncio.Semaphore` binds to the loop that first blocks on it, and an embedder routinely outlives a loop: the documented usage constructs one at module scope, while each `Environment` — and each pytest-asyncio test — brings up a fresh one. Without this, the second loop raised `RuntimeError: ... is bound to a different event loop`, surfacing as a failure for every text.

- **Default is `None` (no cap)**, so existing pipelines are unaffected. `LiteLLMTranscriber` gets no equivalent knob: transcription is one request per call with no batching and no splitting, so its request count tracks component concurrency directly rather than being multiplied by a batch fan-out.

- **Also refreshes `uv.lock`**, which was missing the `aiohttp` and `pymysql` entries that `pyproject.toml`'s `ci-enabled-optional-deps` has listed since the Doris connector work — `uv lock --check` rejected the committed file. Package resolution is otherwise unchanged (verified by diffing `uv tree --universal` and `uv export` before/after). Included because the branch is not internally consistent without it: prek's `uv-lock` hook fails on the stale file.

## Notes for review

A caller-side semaphore around `await embedder.embed(...)` looks equivalent and is not — it is held across the caller's wait in the batch queue, so it caps **batch size** rather than request concurrency. Measured at 2334 callers, `max_batch_size=64`: `Semaphore(8)` yields batches of 4 run one at a time, ~135x slower than no limit.

Known limitation, documented: the cap is per instance, so two embedders pointed at one endpoint get independent budgets. A shared limiter object (alongside the existing `RateLimiter`) is the eventual answer; `max_inflight_requests` can widen to accept one without a breaking change.

## Test plan

CI, plus:

- Each test was checked against the corresponding broken design and fails there: the permit moved around the retry loop; the permit held across the split (deadlock, caught by a 10s timeout); the un-rebound semaphore (`RuntimeError` on a second loop).
- The split-tree tests drive the split wrapper directly so the tree is exact (`[8, 4, 4, 2, 2, 2, 2]`) rather than depending on how many callers the batcher happens to coalesce — an earlier batcher-driven version was flaky under load. `test_limit_holds_through_the_public_api` covers the real `embed()` path with assertions that can't flake.
- Stress-verified 15/15 runs under 8-way CPU saturation; `prek run --all-files` green (18 hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
