### PR TITLE
fix(litellm): make embedding timeouts terminal, add timeout param

### DIFF
--- a/docs/src/content/docs/advanced_topics/timeouts.mdx
+++ b/docs/src/content/docs/advanced_topics/timeouts.mdx
@@ -55,7 +55,7 @@ A timeout follows work the caller is directly waiting for. It does not follow ba
 | `await coco.use_mount(child, ...)` | The child inherits the timeout because the parent needs the child's result. |
 | `await coco.mount(child, ...)` / `await coco.mount_each(...)` | The child does not inherit the parent's timeout. The caller's own waiting remains subject to the caller's timeout. |
 | `await coco.map(fn, items)` | Item tasks inherit the timeout. Already-started items are allowed to finish. |
-| Batched function body | Does not inherit any one caller's timeout because a batch can contain work from multiple callers. |
+| Batched function body | Does not inherit any one caller's timeout because a batch can contain work from multiple callers. A batched body that needs a bound carries its own — `LiteLLMEmbedder`, for example, bounds each request with its own [`timeout`](../ops/litellm#timeout). |
 | Target writes and connector sink calls | Do not inherit the processor timeout. Once processing has succeeded, CocoIndex lets target synchronization finish consistently. |
 | Long loop inside a processor | Add `coco.check_cancellation()` where you want the loop to stop promptly. |
 

--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -34,9 +34,11 @@ The `LiteLLMEmbedder` class is a wrapper around LiteLLM's embedding API that:
 
 ### Creating an embedder
 
-All extra keyword arguments are passed through to every `litellm.aembedding` call. See [Supported providers](#supported-providers) for provider-specific model strings and configuration.
+All extra keyword arguments are passed through to every `litellm.aembedding` call (`api_key`, `api_base`, `dimensions`, …). See [Supported providers](#supported-providers) for provider-specific model strings and configuration.
 
 ```python
+from datetime import timedelta
+
 from cocoindex.ops.litellm import LiteLLMEmbedder
 
 embedder = LiteLLMEmbedder("text-embedding-3-small")
@@ -47,11 +49,11 @@ embedder = LiteLLMEmbedder("text-embedding-3-small", api_key="sk-...", api_base=
 # With custom dimensions (OpenAI text-embedding-3 models)
 embedder = LiteLLMEmbedder("text-embedding-3-small", dimensions=512)
 
-# With a timeout (seconds)
-embedder = LiteLLMEmbedder("text-embedding-3-small", timeout=30)
-
 # With a cap on concurrent requests to the backend
 embedder = LiteLLMEmbedder("text-embedding-3-small", max_inflight_requests=8)
+
+# With a longer timeout, for a slow self-hosted endpoint
+embedder = LiteLLMEmbedder("openai/bge-m3", api_base="http://localhost:7997", timeout=timedelta(minutes=30))
 ```
 
 ### Embedding text
@@ -89,6 +91,14 @@ embedder = LiteLLMEmbedder(
 The default is `None` (no cap). The cap is per embedder instance: two
 embedders pointed at the same endpoint have independent limits, so share one
 instance when you want one limit.
+
+### Timeout
+
+`timeout` bounds each embedding request end to end; the default is 10 minutes. Transient failures (HTTP 429, 5xx, a dropped connection) are retried with backoff inside that window; a request that times out fails with `DeadlineExceededError` and is not retried. Requests carry up to 64 texts, so raise `timeout` for an endpoint that needs longer than the default to embed a full batch:
+
+```python
+embedder = LiteLLMEmbedder("text-embedding-3-small", timeout=timedelta(minutes=30))
+```
 
 ### Using as a type annotation
 

--- a/python/cocoindex/_internal/deadline.py
+++ b/python/cocoindex/_internal/deadline.py
@@ -150,7 +150,8 @@ async def retry_transient(
     - Time limits are deadlines, and there is exactly one time concept:
       ``timeout`` is sugar for running the loop inside a
       ``coco.timeout(...)`` scope, merging with any ambient deadline by
-      min-nesting. Expiry raises ``DeadlineExceededError``.
+      min-nesting. Expiry raises ``DeadlineExceededError``, which is never
+      retried however broad ``retry_on`` is.
 
     Deadline enforcement is best-effort-or-better: no attempt starts past
     the deadline, no result is accepted past it (checked after each attempt
@@ -207,6 +208,11 @@ async def retry_transient(
                 # Deliberately Exception, not BaseException: cancellation,
                 # KeyboardInterrupt, and SystemExit always propagate
                 # untouched, regardless of how broad retry_on is.
+                if isinstance(error, DeadlineExceededError):
+                    # The loop never retries its own brake: a broad retry_on
+                    # would otherwise spend the rest of the budget re-running
+                    # work whose deadline has already passed.
+                    raise
                 if not _should_retry(retry_on, error):
                     raise
                 last_error = error

--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -38,21 +38,33 @@ from cocoindex.resources import schema as _schema
 _logger = _logging.getLogger(__name__)
 
 _T = _TypeVar("_T")
-_EMBEDDING_RETRY_TIMEOUT_SECONDS = 10 * 60
+_DEFAULT_EMBEDDING_TIMEOUT = _timedelta(minutes=10)
 _EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
 _EMBEDDING_RETRY_MAX_BACKOFF_SECONDS = 30.0
 _RETRYABLE_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+# HTTP client packages whose exception classes the two name sets below refer to.
+_TRANSPORT_ERROR_PACKAGES = frozenset({"aiohttp", "httpcore", "httpx"})
+# Fast transport failures — a refused or reset connection, a broken read or
+# write — worth another try. Timeouts are deliberately absent from this set;
+# they live in `_TIMEOUT_TRANSPORT_ERROR_CLASS_NAMES` and are terminal.
 _RETRYABLE_TRANSPORT_ERROR_CLASS_NAMES = frozenset(
     {
         "ClientConnectorError",
         "ConnectError",
-        "ConnectTimeout",
-        "PoolTimeout",
         "ReadError",
-        "ReadTimeout",
         "RemoteProtocolError",
         "ServerDisconnectedError",
         "WriteError",
+    }
+)
+# httpx/httpcore timeout classes, matched by name because they subclass
+# neither builtin `TimeoutError` nor anything else we can key on. (aiohttp's
+# timeout classes need no entry here: they subclass `TimeoutError` already.)
+_TIMEOUT_TRANSPORT_ERROR_CLASS_NAMES = frozenset(
+    {
+        "ConnectTimeout",
+        "PoolTimeout",
+        "ReadTimeout",
         "WriteTimeout",
     }
 )
@@ -93,8 +105,9 @@ _RETRYABLE_LITELLM_EXCEPTION_CLASSES = _litellm_exception_classes(
     "InternalServerError",
     "RateLimitError",
     "ServiceUnavailableError",
-    "Timeout",
 )
+
+_TIMEOUT_LITELLM_EXCEPTION_CLASSES = _litellm_exception_classes("Timeout")
 
 # Errors about who we are or what we asked for (credentials, permissions,
 # unknown model, exhausted budget) — batch composition can't affect them, so
@@ -125,18 +138,52 @@ def _http_status_code(error: BaseException) -> int | None:
     return None
 
 
-def _is_transport_error(error: BaseException) -> bool:
-    if isinstance(error, (TimeoutError, ConnectionError)):
-        return True
+def _is_transport_error_named(error: BaseException, names: frozenset[str]) -> bool:
+    # Matched on the root package because these libraries are inconsistent
+    # about where their exceptions claim to live: httpx and httpcore rewrite
+    # `__module__` to the bare package name, aiohttp leaves it on the
+    # defining submodule.
     error_type = type(error)
-    module = error_type.__module__
     return (
-        module.startswith(("aiohttp.", "httpcore.", "httpx."))
-        and error_type.__name__ in _RETRYABLE_TRANSPORT_ERROR_CLASS_NAMES
+        error_type.__module__.partition(".")[0] in _TRANSPORT_ERROR_PACKAGES
+        and error_type.__name__ in names
+    )
+
+
+def _is_timeout_error(error: BaseException) -> bool:
+    """Every timeout this module can recognize, in one place.
+
+    Timeouts are terminal for embedding — never retried, never a reason to
+    split the batch. A timeout has by definition already spent its duration,
+    so retrying it inside a time budget mostly re-spends what is left, and
+    against an overloaded backend it amplifies the very load that caused it.
+    The remedy for a genuine timeout is a longer ``LiteLLMEmbedder(timeout=...)``,
+    not more requests.
+
+    Covers CocoIndex's own deadline expiry (``DeadlineExceededError``), raw
+    asyncio timeouts and aiohttp's timeouts through builtin ``TimeoutError``,
+    litellm's ``Timeout``, and the httpx/httpcore timeout classes that
+    subclass neither.
+    """
+    return (
+        isinstance(error, TimeoutError)
+        or isinstance(error, _TIMEOUT_LITELLM_EXCEPTION_CLASSES)
+        or _is_transport_error_named(error, _TIMEOUT_TRANSPORT_ERROR_CLASS_NAMES)
+    )
+
+
+def _is_transport_error(error: BaseException) -> bool:
+    return isinstance(error, ConnectionError) or _is_transport_error_named(
+        error, _RETRYABLE_TRANSPORT_ERROR_CLASS_NAMES
     )
 
 
 def _is_retryable_litellm_error(error: BaseException) -> bool:
+    # Timeouts first, ahead of every other rule: each one below would
+    # otherwise let a timeout back in — `litellm.Timeout` reports HTTP 408,
+    # and both it and the httpx timeouts descend from retryable parents.
+    if _is_timeout_error(error):
+        return False
     if _message_indicates_non_retryable_credentials_error(str(error)):
         return False
     status_code = _http_status_code(error)
@@ -150,16 +197,18 @@ def _is_retryable_litellm_error(error: BaseException) -> bool:
 async def _retry_litellm_call(
     operation: _Callable[[], _Awaitable[_T]],
     operation_name: str,
+    timeout: _timedelta,
 ) -> _T:
-    # Time is the brake here (no attempt cap): retry transient failures
-    # inside a 10-minute deadline scope, with each in-flight attempt
-    # bounded to the remaining time. An ambient coco.timeout() merges by
-    # min-nesting and can only stop retries sooner. Exhaustion raises
+    # Time is the brake here (no attempt cap): retry fast transient failures
+    # inside a `timeout` deadline scope, with each in-flight attempt bounded
+    # to the remaining time. Timeouts are not among them — see
+    # `_is_timeout_error`. An ambient coco.timeout() merges by min-nesting
+    # and can only stop retries sooner. Exhaustion raises
     # DeadlineExceededError (one time concept: the deadline system).
     return await _deadline.retry_transient(
         operation,
         retry_on=_is_retryable_litellm_error,
-        timeout=_timedelta(seconds=_EMBEDDING_RETRY_TIMEOUT_SECONDS),
+        timeout=timeout,
         backoff=_deadline.exponential_backoff(
             initial=_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS,
             multiplier=2.0,
@@ -215,6 +264,14 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
             open against the backend at once, or ``None`` (the default) for
             no cap. Useful for self-hosted endpoints that reject bursts with
             429s. The cap is per instance.
+        timeout: Bound on each embedding request, end to end: fast failures
+            (429, 5xx, a refused or reset connection) are retried with
+            backoff inside it, a request that times out is not retried, and
+            expiry raises ``DeadlineExceededError``. A ``timedelta``, or
+            seconds as a number. Defaults to 10 minutes; raise it for a slow
+            endpoint, since one request carries up to 64 texts. This is the
+            only clock on the request — litellm's own per-request ``timeout``
+            is not forwarded.
         **kwargs: Additional keyword arguments passed through to every
             ``litellm.aembedding`` call (e.g., ``api_key``, ``api_base``,
             ``dimensions``).
@@ -237,6 +294,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         model: str,
         *,
         max_inflight_requests: int | None = None,
+        timeout: _timedelta | float | None = None,
         **kwargs: _Any,
     ) -> None:
         """Initialize the LiteLLM embedder."""
@@ -245,7 +303,16 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
                 "max_inflight_requests must be a positive int or None, got "
                 f"{max_inflight_requests!r}"
             )
+        if timeout is None:
+            timeout = _DEFAULT_EMBEDDING_TIMEOUT
+        elif not isinstance(timeout, _timedelta):
+            # Seconds — the form litellm's own `timeout` kwarg took while it
+            # was the one passing through here.
+            timeout = _timedelta(seconds=timeout)
+        if timeout <= _timedelta(0):
+            raise ValueError(f"timeout must be positive, got {timeout!r}")
         self._model = model
+        self._timeout = timeout
         self._kwargs = kwargs
         self._max_inflight_requests = max_inflight_requests
         self._dim: int | None = None
@@ -320,7 +387,7 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
                     **self._build_call_kwargs(**extra),
                 )
 
-        return await _retry_litellm_call(_call, "litellm.aembedding")
+        return await _retry_litellm_call(_call, "litellm.aembedding", self._timeout)
 
     async def _get_dim(self) -> int:
         """Get embedding dimension, caching the result.
@@ -363,19 +430,22 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         try:
             response = await self._aembedding_with_retry(texts, **extra)
         except Exception as e:
-            # Anything reaching here is either global (credentials/model —
-            # splitting can't help) or has already exhausted its same-size
-            # retry budget above. For the latter, ask the engine to halve the
-            # batch and retry: smaller requests may pass where the big one
-            # couldn't (a provider's token/payload cap, one rejected input,
-            # or a timeout on an oversized payload). If the error is actually
-            # global after all, splitting still terminates: every item fails
-            # with it at size 1, at the cost of the sub-batches' retries.
-            # (No batch-size check needed — at size 1 the engine unwraps the
-            # signal and raises the original error.)
-            if not _is_global_litellm_error(e):
-                raise coco.RetryWithSmallerBatch() from e
-            raise
+            # Two kinds of error propagate untouched. Global ones
+            # (credentials/model) can't be fixed by batch composition. And a
+            # timeout — including this batch exhausting its own `timeout` —
+            # must not fan out: every sub-batch would take a fresh full
+            # timeout, turning one expired request into a tree of them
+            # against a backend that is already too slow. A longer `timeout`
+            # (or lower concurrency) is the remedy.
+            #
+            # Anything else gets halved and retried: a smaller request may
+            # pass where the big one couldn't (a provider's token/payload cap
+            # or one rejected input). Splitting terminates either way — at
+            # size 1 the engine unwraps the signal and raises the original
+            # error, so no batch-size check is needed here.
+            if _is_timeout_error(e) or _is_global_litellm_error(e):
+                raise
+            raise coco.RetryWithSmallerBatch() from e
         return _aligned_embeddings(response.data, len(texts))
 
     @coco.fn(memo=True, version=1, logic_tracking="self")
@@ -411,9 +481,9 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
         return _schema.VectorSchema(dtype=_np.dtype(_np.float32), size=dim)
 
     def __coco_memo_key__(self) -> object:
-        # `max_inflight_requests` is deliberately absent: it paces requests
-        # but cannot change an embedding, so tuning it must not invalidate
-        # every cached vector.
+        # `max_inflight_requests` and `timeout` are deliberately absent: they
+        # pace and bound requests but cannot change an embedding, so tuning
+        # either must not invalidate every cached vector.
         return (self._model, self._kwargs)
 
 

--- a/python/tests/ops/test_embedder_refactor.py
+++ b/python/tests/ops/test_embedder_refactor.py
@@ -17,8 +17,15 @@ import numpy as np
 import pytest
 
 pytest.importorskip("litellm", reason="litellm not installed")
+# Arrives with litellm; imported through importorskip so this module skips
+# rather than failing collection where neither is installed.
+httpx = pytest.importorskip("httpx", reason="httpx not installed")
 
-from litellm.exceptions import AuthenticationError  # noqa: E402
+from litellm.exceptions import (  # noqa: E402
+    APIConnectionError,
+    AuthenticationError,
+    Timeout,
+)
 
 import cocoindex as coco  # noqa: E402
 from cocoindex.ops.litellm import LiteLLMEmbedder, _aligned_embeddings  # noqa: E402
@@ -221,23 +228,67 @@ async def test_litellm_embedder_single_text_error_surfaces_original() -> None:
             await embedder.embed("only")
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_calls"),
+    [
+        # litellm.Timeout is terminal even though it reports HTTP 408 and
+        # descends from openai's APIConnectionError — both of which the
+        # classification would otherwise treat as retryable.
+        pytest.param(
+            Timeout(message="too slow", model="fake-model", llm_provider="openai"),
+            1,
+            id="litellm-timeout",
+        ),
+        # A refused/reset connection is a fast failure: still retried.
+        pytest.param(
+            APIConnectionError(
+                message="connection refused", model="fake-model", llm_provider="openai"
+            ),
+            3,
+            id="litellm-connection-error",
+        ),
+        # httpx timeouts subclass neither TimeoutError nor litellm.Timeout;
+        # they are matched by name.
+        pytest.param(httpx.ReadTimeout("stalled"), 1, id="httpx-read-timeout"),
+        pytest.param(httpx.PoolTimeout("no free slot"), 1, id="httpx-pool-timeout"),
+        pytest.param(httpx.ConnectError("refused"), 3, id="httpx-connect-error"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_litellm_embedder_splits_after_transient_retries_exhausted(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_litellm_embedder_retries_fast_failures_but_not_timeouts(
+    error: Exception, expected_calls: int
 ) -> None:
-    """A transient error that survives the same-size retry budget is still
-    splittable — a smaller request may pass where the large one timed out."""
-    # Near-zero retry budget: the retry wrapper exhausts its deadline almost
-    # immediately (DeadlineExceededError, a TimeoutError subclass).
-    monkeypatch.setattr("cocoindex.ops.litellm._EMBEDDING_RETRY_TIMEOUT_SECONDS", 0.05)
+    fake_response = type("R", (), {"data": [{"embedding": [0.1]}]})()
     embedder = LiteLLMEmbedder("fake-model")
+    mocked_embedding = AsyncMock(side_effect=[error, error, fake_response])
+
+    with (
+        patch("cocoindex.ops.litellm.litellm.aembedding", new=mocked_embedding),
+        patch("cocoindex.ops.litellm._asyncio.sleep", new=AsyncMock()),
+    ):
+        if expected_calls == 1:
+            with pytest.raises(type(error)):
+                await embedder.embed("hello")
+        else:
+            await embedder.embed("hello")
+
+    assert mocked_embedding.await_count == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedder_does_not_split_timeouts() -> None:
+    """A multi-text batch that times out propagates the timeout; splitting
+    would only re-spend a budget the backend already failed to meet."""
+    embedder = LiteLLMEmbedder("fake-model")
+    timeout_error = Timeout(
+        message="too slow", model="fake-model", llm_provider="openai"
+    )
     with patch(
         "cocoindex.ops.litellm.litellm.aembedding",
-        new=AsyncMock(side_effect=_FakeHTTPError(429)),
+        new=AsyncMock(side_effect=timeout_error),
     ):
-        with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+        with pytest.raises(Timeout):
             await embedder._embed._execute_orig_async_fn(["a", "b"])
-    assert isinstance(exc_info.value.__cause__, TimeoutError)
 
 
 @pytest.mark.asyncio

--- a/python/tests/ops/test_litellm_retry_delegation.py
+++ b/python/tests/ops/test_litellm_retry_delegation.py
@@ -30,10 +30,12 @@ async def test_retry_litellm_call_delegates_with_historical_policy(
     async def op() -> str:
         return "unused"
 
-    result = await module._retry_litellm_call(op, "embedding call")
+    result = await module._retry_litellm_call(
+        op, "embedding call", timedelta(seconds=600)
+    )
     assert result == "result"
 
-    # Time is the brake (no attempt cap), a 10-minute deadline scope,
+    # Time is the brake (no attempt cap), the caller's deadline scope,
     # bounded attempts, the transient-classification predicate, and the
     # historical backoff schedule (1s doubling, capped at 30s).
     assert "max_attempts" not in captured  # default None: no attempt cap
@@ -43,3 +45,34 @@ async def test_retry_litellm_call_delegates_with_historical_policy(
     assert captured["operation_name"] == "embedding call"
     backoff = captured["backoff"]  # stateful: successive calls advance it
     assert [backoff(n) for n in range(7)] == [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0]
+
+
+@pytest.mark.asyncio
+async def test_embedder_timeout_reaches_retry_transient(
+    litellm_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-instance timeout is what bounds the embedder's retry loop;
+    omitting it falls back to the 10-minute default."""
+    module = litellm_module
+    captured: list[timedelta | None] = []
+
+    async def fake_retry_transient(fn: Any, **kwargs: Any) -> str:
+        captured.append(kwargs["timeout"])
+        return "result"
+
+    monkeypatch.setattr(module._deadline, "retry_transient", fake_retry_transient)
+
+    await module.LiteLLMEmbedder(
+        "fake-model", timeout=timedelta(seconds=42)
+    )._aembedding_with_retry(["hello"])
+    await module.LiteLLMEmbedder("fake-model", timeout=42)._aembedding_with_retry(
+        ["hello"]
+    )
+    await module.LiteLLMEmbedder("fake-model")._aembedding_with_retry(["hello"])
+
+    assert captured == [
+        timedelta(seconds=42),
+        timedelta(seconds=42),  # seconds as a number, converted
+        timedelta(minutes=10),
+    ]

--- a/python/tests/ops/test_litellm_timeouts.py
+++ b/python/tests/ops/test_litellm_timeouts.py
@@ -1,0 +1,204 @@
+"""Timeouts are terminal for embedding: never retried, never split.
+
+A timeout has by definition already spent its duration, so retrying it inside
+the request's own time bound re-spends what is left — and splitting the batch
+on one is worse still, because every sub-batch takes a *fresh* full timeout.
+That turns one expired request into a tree of them aimed at a backend that is
+already too slow, which is exactly the amplification these tests pin shut.
+
+``LiteLLMEmbedder(timeout=...)`` is the one clock on a request: litellm's own
+per-request ``timeout`` kwarg is no longer forwarded.
+
+Runs against the stub ``litellm`` module from the ``litellm_module`` fixture,
+so CI (which does not install the optional dependency) actually executes
+them. The cases that need real provider classes — ``litellm.Timeout``, the
+httpx timeouts — live in ``test_embedder_refactor.py``, since a hand-rolled
+stand-in for those would only prove the stand-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("numpy")
+
+import cocoindex as coco  # noqa: E402
+from cocoindex._internal.batching import wrap_batch_fn_async  # noqa: E402
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code: int, message: str | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message or f"HTTP {status_code}")
+
+
+class _CallRecorder:
+    """Fake ``litellm.aembedding`` that always fails, recording batch sizes."""
+
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+        self.batch_sizes: list[int] = []
+
+    async def __call__(self, *, model: str, input: list[str], **kwargs: Any) -> Any:
+        self.batch_sizes.append(len(input))
+        raise self._error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(
+            coco.DeadlineExceededError("CocoIndex timeout deadline exceeded"),
+            id="deadline-exceeded",
+        ),
+        # asyncio.TimeoutError is builtin TimeoutError on 3.11+.
+        pytest.param(asyncio.TimeoutError("slow"), id="asyncio-timeout"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_timeout_is_not_retried(
+    litellm_module: Any, caplog: pytest.LogCaptureFixture, error: BaseException
+) -> None:
+    """Terminal on the first attempt — and silent. The bogus "retrying in
+    0.0s" warning was the visible symptom of the old classification."""
+    embedder = litellm_module.LiteLLMEmbedder("fake-model")
+    mocked = AsyncMock(side_effect=error)
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(litellm_module.litellm, "aembedding", new=mocked),
+        patch("asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        with pytest.raises(type(error)):
+            await embedder.embed("hello")
+
+    mocked.assert_awaited_once()
+    sleep.assert_not_called()
+    assert "failed with transient error" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_timeout_propagates_instead_of_splitting(litellm_module: Any) -> None:
+    """The batch body raises the timeout rather than the split signal."""
+    embedder = litellm_module.LiteLLMEmbedder("fake-model")
+    error = coco.DeadlineExceededError("CocoIndex timeout deadline exceeded")
+
+    with patch.object(
+        litellm_module.litellm, "aembedding", new=AsyncMock(side_effect=error)
+    ):
+        with pytest.raises(coco.DeadlineExceededError):
+            await embedder._embed._execute_orig_async_fn(["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_non_timeout_error_still_splits(litellm_module: Any) -> None:
+    """Control: a non-timeout, non-global failure is still splittable — a
+    smaller request may pass a provider's token or payload cap."""
+    embedder = litellm_module.LiteLLMEmbedder("fake-model")
+    provider_error = _FakeHTTPError(400, "batch exceeds maximum context length")
+
+    with patch.object(
+        litellm_module.litellm, "aembedding", new=AsyncMock(side_effect=provider_error)
+    ):
+        with pytest.raises(coco.RetryWithSmallerBatch) as exc_info:
+            await embedder._embed._execute_orig_async_fn(["a", "b"])
+    assert exc_info.value.__cause__ is provider_error
+
+
+# Seconds as a number is the form litellm's `timeout` kwarg took while it was
+# the one passing through, so existing `timeout=30` calls keep working.
+@pytest.mark.parametrize(
+    "timeout",
+    [
+        pytest.param(timedelta(seconds=0.05), id="timedelta"),
+        pytest.param(0.05, id="seconds"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_expired_timeout_does_not_fan_out(
+    litellm_module: Any, timeout: timedelta | float
+) -> None:
+    """The bug this fixes end to end: a batch whose timeout expires must not
+    become a split tree, each node taking a fresh full timeout.
+
+    Driven through the engine's split driver — the same thing one batcher
+    dispatch runs — so the tree is exact. A backend that is merely slow (429
+    forever, timeout too short) must be hit at the original batch size only.
+    """
+    recorder = _CallRecorder(_FakeHTTPError(429))
+    embedder = litellm_module.LiteLLMEmbedder("fake-model", timeout=timeout)
+
+    with patch.object(litellm_module.litellm, "aembedding", new=recorder):
+        with pytest.raises(coco.DeadlineExceededError):
+            await asyncio.wait_for(
+                wrap_batch_fn_async(embedder._embed._execute_orig_async_fn)(
+                    ["a", "b", "c", "d"]
+                ),
+                timeout=10.0,
+            )
+
+    # Retries within the one timeout are fine; sub-batches are not.
+    assert recorder.batch_sizes, "the backend was never called"
+    assert set(recorder.batch_sizes) == {4}, (
+        f"expected only full-size attempts, saw sizes {recorder.batch_sizes}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeout_bounds_a_slow_backend(litellm_module: Any) -> None:
+    """A short timeout cuts a hung request where the 10-minute default would
+    still be waiting."""
+    embedder = litellm_module.LiteLLMEmbedder(
+        "fake-model", timeout=timedelta(seconds=0.05)
+    )
+    attempts = 0
+
+    async def too_slow(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        # Far longer than the timeout: the attempt is cut at the deadline, so
+        # this never returns.
+        await asyncio.sleep(5.0)
+
+    with patch.object(litellm_module.litellm, "aembedding", new=too_slow):
+        with pytest.raises(coco.DeadlineExceededError):
+            await asyncio.wait_for(embedder.embed("hello"), timeout=10.0)
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_not_forwarded_to_litellm(litellm_module: Any) -> None:
+    """One clock per request. `timeout` is CocoIndex's bound on the whole
+    request; forwarding it to litellm as well would put a second, per-attempt
+    clock on the same call."""
+    seen: list[dict[str, Any]] = []
+
+    async def record(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        seen.append(kwargs)
+        return SimpleNamespace(data=[{"embedding": [1.0]} for _ in input])
+
+    embedder = litellm_module.LiteLLMEmbedder(
+        "fake-model", timeout=timedelta(seconds=30), api_base="http://x"
+    )
+    with patch.object(litellm_module.litellm, "aembedding", new=record):
+        await embedder.embed("hello")
+
+    assert len(seen) == 1
+    assert "timeout" not in seen[0]
+    assert seen[0]["api_base"] == "http://x"  # other kwargs still pass through
+
+
+@pytest.mark.parametrize("value", [timedelta(0), timedelta(seconds=-1), 0, -1.5])
+def test_rejects_non_positive_timeout(
+    litellm_module: Any, value: timedelta | float
+) -> None:
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        litellm_module.LiteLLMEmbedder("fake-model", timeout=value)


### PR DESCRIPTION
## The decision

CocoIndex owns exactly **one clock** on an embedding request: `LiteLLMEmbedder(timeout=...)`, a bound on the whole request end to end. Within it, fast failures (429, 5xx, a refused or reset connection) are retried with backoff. Timeouts are terminal — a timeout has by definition already spent its duration, so retrying it inside the request's own bound re-spends what is left, and splitting the batch on one is worse still, because every sub-batch takes a *fresh* full timeout.

The two halves ship together because either alone is incoherent: a configurable bound that still gets retried and split past, or terminal timeouts with no knob to raise.

## What went wrong

A 1.6MB C++ file produced 2334 chunks against a self-hosted Infinity endpoint. `DeadlineExceededError` subclasses builtin `TimeoutError`, which `_is_transport_error` reported as transient — so the budget's own expiry read as a retryable error:

```
WARNING litellm.aembedding failed with transient error on attempt 1;
        retrying in 0.0s: CocoIndex timeout deadline exceeded
```

…then a 64 → 32 → … → 1 split tree, each node re-entering the retry wrapper with a fresh 10-minute budget. ~70 minutes worst case, and up to 64 concurrent requests from one batch, aimed at a backend already too slow to answer.

## Part A — timeouts terminal

"Not a timeout" turned out to be three places, none subclassing builtin `TimeoutError`:

| | Why it slipped through |
|---|---|
| `litellm.Timeout` | Reports `status_code` 408, which `_http_status_code` matches **before** any class check — so dropping it from the retryable tuple was not enough. (It also descends from *openai's* `APIConnectionError`, a second way back in on a future litellm.) |
| httpx `ConnectTimeout` / `ReadTimeout` / `WriteTimeout` / `PoolTimeout` | Matched by name; subclass `httpx.TimeoutException`, not `TimeoutError`. |
| Builtin `TimeoutError` | Covers `DeadlineExceededError` and raw asyncio timeouts. aiohttp's timeout classes subclass it already. |

`_is_timeout_error` defines all of it once, and both decisions consult it — `_is_retryable_litellm_error` (never retry, checked ahead of the status-code lookup) and the `_embed` except block (never split). `retry_transient` additionally refuses to retry its own `DeadlineExceededError` whatever `retry_on` says, so a future caller with a broad predicate cannot regress this.

An HTTP 408 *response* stays retryable: it arrives fast, so nothing has spent the budget. Only timeouts we observed ourselves — which have already burned their duration — are terminal.

### Found while here

The transport-name gate was `startswith(("aiohttp.", "httpcore.", "httpx."))` — but httpx and httpcore rewrite `__module__` to the bare package name (`"httpx"`, no dot), so **all four httpx entries had always been dead**. The terminal-timeout rule could not have worked for them. Matching on the root package makes them live, which also makes the set's non-timeout httpx entries (`ConnectError`, `ReadError`, …) retryable as the names always intended.

## Part B — `timeout`, a named parameter with its own semantics

The remedy for a genuine timeout is a longer one, so the bound is settable: `LiteLLMEmbedder(timeout=...)`, a `timedelta` (or seconds as a number), defaulting to the previous 10 minutes.

It is an explicit keyword-only parameter, **not** a pass-through. litellm's per-request `timeout` kwarg used to ride through `**kwargs` and is no longer forwarded — a test pins that `litellm.aembedding` never receives one. Part A is what makes this possible: before, litellm's per-attempt cutoff and our retry window were genuinely different clocks (cut a hung attempt at 30s, then retry it for 10 minutes). With timeouts terminal, a per-attempt cutoff is just an end-to-end cutoff that fires slightly earlier, and two knobs for one concept would only confuse.

**For anyone already passing `timeout=30`:** the call keeps working, and the meaning changes from "30s per attempt, retried for up to 10 minutes" to "30s, full stop" — the contract the value always looked like it promised. It also drops out of `__coco_memo_key__` alongside `max_inflight_requests` (a timeout can't change an embedding), which is a one-time re-embed for those users.

## Docs

The `timeout=30` example that presented litellm's kwarg as a CocoIndex knob is replaced by a `timeout=timedelta(...)` example, and a three-sentence **Timeout** section sits beside #2392's **Limiting concurrent requests**. No retry vocabulary in user docs — that's mechanism, not contract. `advanced_topics/timeouts.mdx` now points readers from batch-body isolation to the knob that actually bounds it.

## Tests

New stub-based `test_litellm_timeouts.py`, so CI — which does not install the optional dependency — actually runs them; the cases needing real provider classes (`litellm.Timeout`, the httpx timeouts) stay in `test_embedder_refactor.py`, behind `importorskip` so that module skips rather than failing collection where neither is installed. Verified against a simulated CI environment with both modules blocked: the real-dependency module skips, and all 10 stub-based tests run.

Each was verified to fail against the corresponding broken design. Under the full pre-fix classification the deadline tests reproduce the original warning verbatim and take **91s instead of 0.17s** — the amplification, measured. With only the `_embed` guard reverted, the batch fans out into sub-batches.

## Not in scope

`LiteLLMTranscriber` still forwards `**kwargs` verbatim (its `timeout` is still litellm's) and has no retry wrapper at all. Left alone here — it is one request per call, with no batching and no splitting — and should adopt the same `timeout` name when it gets one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
