### PR TITLE
feat(litellm): retry transcription requests under one timeout

### DIFF
--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -144,9 +144,11 @@ The `LiteLLMTranscriber` class is a wrapper around LiteLLM's transcription API t
 
 ### Creating a transcriber
 
-All extra keyword arguments are passed through to every `litellm.atranscription` call (e.g., `api_key`, `api_base`, `language`, `extra_body`).
+All extra keyword arguments are passed through to every `litellm.atranscription` call (`api_key`, `api_base`, `language`, `extra_body`, …) — except `timeout`, which is CocoIndex's own bound on the whole request (see [Transcription timeout](#transcription-timeout)).
 
 ```python
+from datetime import timedelta
+
 from cocoindex.ops.litellm import LiteLLMTranscriber
 
 transcriber = LiteLLMTranscriber("whisper-1")
@@ -156,6 +158,9 @@ transcriber = LiteLLMTranscriber("whisper-1", api_key="sk-...")
 
 # With a default language hint applied to every call
 transcriber = LiteLLMTranscriber("whisper-1", language="en")
+
+# With a longer timeout, for long audio or a slow endpoint
+transcriber = LiteLLMTranscriber("whisper-1", timeout=timedelta(minutes=30))
 ```
 
 ### Transcribing audio
@@ -171,6 +176,16 @@ transcript = await transcriber.transcribe(file, response_format="verbose_json")
 ```
 
 A complete pipeline that walks local audio files, transcribes each one, and stores the transcripts in Postgres is available in the [`audio_to_text` example](https://github.com/cocoindex-io/cocoindex/tree/main/examples/audio_to_text).
+
+### Transcription timeout
+
+`timeout` bounds each transcription request end to end, exactly as it does for [embedding](#timeout): the default is 10 minutes, transient failures (HTTP 429, 5xx, a dropped connection) are retried with backoff inside that window, and a request that times out fails with `DeadlineExceededError` rather than being retried. One request carries one whole audio file, so size it against the longest file you expect:
+
+```python
+transcriber = LiteLLMTranscriber("whisper-1", timeout=timedelta(minutes=30))
+```
+
+This is the only clock on the request: litellm's own per-request `timeout` is not forwarded, and passing `timeout` to `transcribe()` raises `TypeError` — it belongs on the constructor, where it applies to every call.
 
 ### Supported transcription providers
 

--- a/python/cocoindex/ops/litellm.py
+++ b/python/cocoindex/ops/litellm.py
@@ -38,9 +38,9 @@ from cocoindex.resources import schema as _schema
 _logger = _logging.getLogger(__name__)
 
 _T = _TypeVar("_T")
-_DEFAULT_EMBEDDING_TIMEOUT = _timedelta(minutes=10)
-_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
-_EMBEDDING_RETRY_MAX_BACKOFF_SECONDS = 30.0
+_DEFAULT_TIMEOUT = _timedelta(minutes=10)
+_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
+_RETRY_MAX_BACKOFF_SECONDS = 30.0
 _RETRYABLE_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
 # HTTP client packages whose exception classes the two name sets below refer to.
 _TRANSPORT_ERROR_PACKAGES = frozenset({"aiohttp", "httpcore", "httpx"})
@@ -194,6 +194,23 @@ def _is_retryable_litellm_error(error: BaseException) -> bool:
     ) or _is_transport_error(error)
 
 
+def _resolve_timeout(timeout: _timedelta | float | None) -> _timedelta:
+    """Normalize a caller-supplied request bound to a positive ``timedelta``.
+
+    Shared by both classes so ``timeout`` means one thing across the module:
+    a bound on the whole request, seconds when given as a bare number.
+    """
+    if timeout is None:
+        return _DEFAULT_TIMEOUT
+    if not isinstance(timeout, _timedelta):
+        # Seconds — the form litellm's own `timeout` kwarg took while it was
+        # the one passing through here.
+        timeout = _timedelta(seconds=timeout)
+    if timeout <= _timedelta(0):
+        raise ValueError(f"timeout must be positive, got {timeout!r}")
+    return timeout
+
+
 async def _retry_litellm_call(
     operation: _Callable[[], _Awaitable[_T]],
     operation_name: str,
@@ -210,9 +227,9 @@ async def _retry_litellm_call(
         retry_on=_is_retryable_litellm_error,
         timeout=timeout,
         backoff=_deadline.exponential_backoff(
-            initial=_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS,
+            initial=_RETRY_INITIAL_BACKOFF_SECONDS,
             multiplier=2.0,
-            max_delay=_EMBEDDING_RETRY_MAX_BACKOFF_SECONDS,
+            max_delay=_RETRY_MAX_BACKOFF_SECONDS,
         ),
         bound_attempt=True,
         operation_name=operation_name,
@@ -303,16 +320,8 @@ class LiteLLMEmbedder(_schema.VectorSchemaProvider):
                 "max_inflight_requests must be a positive int or None, got "
                 f"{max_inflight_requests!r}"
             )
-        if timeout is None:
-            timeout = _DEFAULT_EMBEDDING_TIMEOUT
-        elif not isinstance(timeout, _timedelta):
-            # Seconds — the form litellm's own `timeout` kwarg took while it
-            # was the one passing through here.
-            timeout = _timedelta(seconds=timeout)
-        if timeout <= _timedelta(0):
-            raise ValueError(f"timeout must be positive, got {timeout!r}")
         self._model = model
-        self._timeout = timeout
+        self._timeout = _resolve_timeout(timeout)
         self._kwargs = kwargs
         self._max_inflight_requests = max_inflight_requests
         self._dim: int | None = None
@@ -496,6 +505,14 @@ class LiteLLMTranscriber:
     Args:
         model: LiteLLM transcription model name (e.g., ``"whisper-1"``,
             ``"elevenlabs/scribe_v1"``).
+        timeout: Bound on each transcription request, end to end: fast
+            failures (429, 5xx, a refused or reset connection) are retried
+            with backoff inside it, a request that times out is not retried,
+            and expiry raises ``DeadlineExceededError``. A ``timedelta``, or
+            seconds as a number. Defaults to 10 minutes; raise it for long
+            audio, since one request carries a whole file. This is the only
+            clock on the request — litellm's own per-request ``timeout`` is
+            not forwarded.
         **kwargs: Additional keyword arguments passed through to every
             ``litellm.atranscription`` call (e.g., ``api_key``, ``api_base``,
             ``language``, ``extra_body``).
@@ -507,9 +524,16 @@ class LiteLLMTranscriber:
         >>> print(transcript)
     """
 
-    def __init__(self, model: str, **kwargs: _Any) -> None:
+    def __init__(
+        self,
+        model: str,
+        *,
+        timeout: _timedelta | float | None = None,
+        **kwargs: _Any,
+    ) -> None:
         """Initialize the LiteLLM transcriber."""
         self._model = model
+        self._timeout = _resolve_timeout(timeout)
         self._kwargs = kwargs
 
     @coco.fn(memo=True, version=1, logic_tracking="self")
@@ -518,6 +542,10 @@ class LiteLLMTranscriber:
 
         ``FileLike`` provides async read methods. The content is read into a
         binary file-like object before calling LiteLLM.
+
+        Fast failures (429, 5xx, a dropped connection) are retried with
+        backoff inside the instance's ``timeout``; a request that times out
+        is terminal — see :func:`_is_timeout_error`.
 
         Args:
             file: ``FileLike`` object containing audio data.
@@ -529,18 +557,39 @@ class LiteLLMTranscriber:
 
         Note:
             Per-call keyword arguments override defaults provided when the
-            transcriber was initialized.
+            transcriber was initialized. ``timeout`` is not among them: it is
+            CocoIndex's clock on the whole request rather than a provider
+            argument, and is settable only on the constructor.
         """
-        audio = _io.BytesIO(await file.read())
-        audio.name = file.file_path.name
+        if "timeout" in kwargs:
+            raise TypeError(
+                "timeout is not a per-call argument — pass it to "
+                "LiteLLMTranscriber(...) to bound every request"
+            )
+        content = await file.read()
+        name = file.file_path.name
         call_kwargs = dict(self._kwargs)
         call_kwargs.update(kwargs)
-        response = await litellm.atranscription(
-            model=self._model,
-            file=audio,
-            **call_kwargs,
+
+        async def _call() -> _Any:
+            # A fresh buffer per attempt: litellm reads the audio to EOF, so
+            # replaying one BytesIO would upload an empty body on the retry.
+            # The bytes themselves are read once, above.
+            audio = _io.BytesIO(content)
+            audio.name = name
+            return await litellm.atranscription(
+                model=self._model,
+                file=audio,
+                **call_kwargs,
+            )
+
+        response = await _retry_litellm_call(
+            _call, "litellm.atranscription", self._timeout
         )
         return response.text  # type: ignore[no-any-return]
 
     def __coco_memo_key__(self) -> object:
+        # `timeout` is deliberately absent: it bounds the request but cannot
+        # change a transcript, so tuning it must not invalidate every cached
+        # transcription.
         return (self._model, self._kwargs)

--- a/python/tests/ops/test_litellm_concurrency.py
+++ b/python/tests/ops/test_litellm_concurrency.py
@@ -157,7 +157,7 @@ async def test_releases_permit_during_retry_backoff(
     out until the first sub-batch had finished retrying — turning a 30s
     backoff into 30s of stalled throughput for everything else.
     """
-    monkeypatch.setattr(litellm_module, "_EMBEDDING_RETRY_INITIAL_BACKOFF_SECONDS", 0.3)
+    monkeypatch.setattr(litellm_module, "_RETRY_INITIAL_BACKOFF_SECONDS", 0.3)
     order: list[str] = []
     rate_limited = False
 

--- a/python/tests/ops/test_litellm_retry_delegation.py
+++ b/python/tests/ops/test_litellm_retry_delegation.py
@@ -1,12 +1,15 @@
 """Prove _retry_litellm_call delegates to the shared retry helper with the
-policy that preserves its historical behavior. Runs against the stub
+policy that preserves its historical behavior, and that both classes' per-
+instance ``timeout`` reaches it. Runs against the stub
 ``litellm`` module from the ``litellm_module`` fixture, so it needs neither
 the optional dependency nor a live backend."""
 
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -76,3 +79,38 @@ async def test_embedder_timeout_reaches_retry_transient(
         timedelta(seconds=42),  # seconds as a number, converted
         timedelta(minutes=10),
     ]
+
+
+@pytest.mark.asyncio
+async def test_transcriber_timeout_reaches_retry_transient(
+    litellm_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same wiring on the transcription side, under its own operation name."""
+    module = litellm_module
+    captured: list[dict[str, Any]] = []
+
+    async def fake_retry_transient(fn: Any, **kwargs: Any) -> Any:
+        captured.append(kwargs)
+        return SimpleNamespace(text="hello world")
+
+    monkeypatch.setattr(module._deadline, "retry_transient", fake_retry_transient)
+
+    def audio_file() -> Any:
+        return SimpleNamespace(
+            file_path=SimpleNamespace(name="segment.mp3"),
+            read=AsyncMock(return_value=b"fake-audio"),
+        )
+
+    await module.LiteLLMTranscriber(
+        "fake-model", timeout=timedelta(seconds=42)
+    ).transcribe(audio_file())
+    await module.LiteLLMTranscriber("fake-model", timeout=42).transcribe(audio_file())
+    await module.LiteLLMTranscriber("fake-model").transcribe(audio_file())
+
+    assert [c["timeout"] for c in captured] == [
+        timedelta(seconds=42),
+        timedelta(seconds=42),  # seconds as a number, converted
+        timedelta(minutes=10),
+    ]
+    assert {c["operation_name"] for c in captured} == {"litellm.atranscription"}

--- a/python/tests/ops/test_litellm_transcriber.py
+++ b/python/tests/ops/test_litellm_transcriber.py
@@ -1,38 +1,60 @@
-"""Lightweight tests for ``LiteLLMTranscriber`` (mocked LiteLLM)."""
+"""``LiteLLMTranscriber``: request plumbing, and the one clock on a request.
+
+``timeout`` bounds a transcription end to end — fast failures (429, 5xx, a
+dropped connection) are retried with backoff inside it, a timeout is terminal,
+and litellm's own per-request ``timeout`` is no longer forwarded. Same contract
+as ``LiteLLMEmbedder``; the difference is that one request carries one whole
+audio file, so there is no batch to split and the upload has to survive being
+replayed.
+
+Runs against the stub ``litellm`` module from the ``litellm_module`` fixture,
+so CI (which does not install the optional dependency) actually executes them.
+"""
 
 from __future__ import annotations
 
+import logging
+from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-pytest.importorskip("litellm", reason="litellm not installed")
+pytest.importorskip("numpy")
 
-from cocoindex.ops.litellm import LiteLLMTranscriber  # noqa: E402
-from cocoindex.resources.file import FileLike  # noqa: E402
+import cocoindex as coco  # noqa: E402
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code: int, message: str | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message or f"HTTP {status_code}")
+
+
+def _audio_file(content: bytes = b"fake-audio", name: str = "segment.mp3") -> Any:
+    """A minimal ``FileLike``: async ``read()`` plus a ``file_path.name``."""
+    return SimpleNamespace(
+        file_path=SimpleNamespace(name=name),
+        read=AsyncMock(return_value=content),
+    )
 
 
 @pytest.mark.asyncio
-async def test_litellm_transcriber_reads_file_and_merges_kwargs() -> None:
-    audio_bytes = b"fake-audio"
-    file_like = cast(
-        FileLike[Any],
-        SimpleNamespace(
-            file_path=SimpleNamespace(name="segment.mp3"),
-            read=AsyncMock(return_value=audio_bytes),
-        ),
+async def test_reads_file_and_merges_kwargs(litellm_module: Any) -> None:
+    transcriber = litellm_module.LiteLLMTranscriber(
+        "fake-model", api_key="k-default", language="en"
     )
-    transcriber = LiteLLMTranscriber("fake-model", api_key="k-default", language="en")
+    fake_response = SimpleNamespace(text="hello world")
 
-    fake_response = type("R", (), {"text": "hello world"})()
-
-    with patch(
-        "cocoindex.ops.litellm.litellm.atranscription",
+    with patch.object(
+        litellm_module.litellm,
+        "atranscription",
         new=AsyncMock(return_value=fake_response),
     ) as mocked:
-        text = await transcriber.transcribe(file_like, response_format="verbose_json")
+        text = await transcriber.transcribe(
+            _audio_file(), response_format="verbose_json"
+        )
 
     assert text == "hello world"
     mocked.assert_called_once()
@@ -44,4 +66,105 @@ async def test_litellm_transcriber_reads_file_and_merges_kwargs() -> None:
 
     sent_file = call_kwargs["file"]
     assert sent_file.name == "segment.mp3"
-    assert sent_file.read() == audio_bytes
+    assert sent_file.read() == b"fake-audio"
+
+
+@pytest.mark.asyncio
+async def test_retry_resends_the_whole_audio(litellm_module: Any) -> None:
+    """Each attempt uploads from a fresh buffer.
+
+    litellm reads the audio to EOF, so replaying one exhausted ``BytesIO``
+    would upload an empty body — the retry would "succeed" at transcribing
+    silence, which no assertion on the returned text would catch.
+    """
+    uploads: list[bytes] = []
+
+    async def flaky(*, model: str, file: Any, **kwargs: Any) -> Any:
+        uploads.append(file.read())
+        if len(uploads) == 1:
+            raise _FakeHTTPError(429, "slow down")
+        return SimpleNamespace(text="hello world")
+
+    transcriber = litellm_module.LiteLLMTranscriber("fake-model")
+
+    with (
+        patch.object(litellm_module.litellm, "atranscription", new=flaky),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        transcript = await transcriber.transcribe(_audio_file())
+
+    assert transcript == "hello world"
+    assert uploads == [b"fake-audio", b"fake-audio"]
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_terminal(
+    litellm_module: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A timeout has already spent its duration; retrying it inside the
+    request's own bound only re-spends what is left."""
+    transcriber = litellm_module.LiteLLMTranscriber("fake-model")
+    error = coco.DeadlineExceededError("CocoIndex timeout deadline exceeded")
+    mocked = AsyncMock(side_effect=error)
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(litellm_module.litellm, "atranscription", new=mocked),
+        patch("asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        with pytest.raises(coco.DeadlineExceededError):
+            await transcriber.transcribe(_audio_file())
+
+    mocked.assert_awaited_once()
+    sleep.assert_not_called()
+    assert "failed with transient error" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_not_forwarded_to_litellm(litellm_module: Any) -> None:
+    """One clock per request: `timeout` is CocoIndex's bound on the whole
+    request, not a provider argument."""
+    seen: list[dict[str, Any]] = []
+
+    async def record(*, model: str, file: Any, **kwargs: Any) -> Any:
+        seen.append(kwargs)
+        return SimpleNamespace(text="hello world")
+
+    transcriber = litellm_module.LiteLLMTranscriber(
+        "fake-model", timeout=timedelta(seconds=30), language="en"
+    )
+    with patch.object(litellm_module.litellm, "atranscription", new=record):
+        await transcriber.transcribe(_audio_file())
+
+    assert len(seen) == 1
+    assert "timeout" not in seen[0]
+    assert seen[0]["language"] == "en"  # other kwargs still pass through
+
+
+@pytest.mark.asyncio
+async def test_rejects_a_per_call_timeout(litellm_module: Any) -> None:
+    """Per-call kwargs are provider arguments, so a `timeout` among them would
+    reach litellm and put a second clock on the request."""
+    transcriber = litellm_module.LiteLLMTranscriber("fake-model")
+
+    with pytest.raises(TypeError, match="timeout is not a per-call argument"):
+        await transcriber.transcribe(_audio_file(), timeout=30)
+
+
+def test_timeout_is_not_part_of_the_memo_key(litellm_module: Any) -> None:
+    """Retuning the bound changes how long we wait, not which transcript we
+    get, so it must not invalidate memoized transcriptions."""
+    default = litellm_module.LiteLLMTranscriber("fake-model", api_key="k")
+    patient = litellm_module.LiteLLMTranscriber(
+        "fake-model", api_key="k", timeout=timedelta(hours=1)
+    )
+
+    assert default.__coco_memo_key__() == patient.__coco_memo_key__()
+
+
+@pytest.mark.parametrize("value", [timedelta(0), timedelta(seconds=-1), 0, -1.5])
+def test_rejects_non_positive_timeout(
+    litellm_module: Any, value: timedelta | float
+) -> None:
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        litellm_module.LiteLLMTranscriber("fake-model", timeout=value)


### PR DESCRIPTION
## Summary

- **Transcription requests are now retried.** `transcribe` called `litellm.atranscription` directly, so one transient failure (429, 5xx, reset connection) failed it outright. It now routes through the same `_retry_litellm_call` the embedder uses, under the contract [#2394](https://github.com/cocoindex-io/cocoindex/pull/2394) established: `LiteLLMTranscriber(timeout=...)` bounds one request end to end, fast failures retry with backoff inside it, and a timeout is terminal. The classification helpers were already model-agnostic and are unchanged.
- **A fresh upload buffer per attempt.** litellm reads the audio to EOF, so replaying one `BytesIO` would upload an empty body — the retry "succeeds" at transcribing silence, and nothing about the returned text says otherwise. The bytes are read once, the buffer rebuilt per attempt.
- **Per-call `timeout` raises `TypeError`.** Unlike the embedder, `transcribe` forwards per-call `**kwargs` to litellm, so a `timeout` among them would reach the provider as a second clock — exactly what #2394 removed. It points at the constructor instead.
- **Shared:** `_resolve_timeout` now holds the None-means-default / bare-number-means-seconds / must-be-positive rules that were inline in the embedder's `__init__`. `_DEFAULT_EMBEDDING_TIMEOUT` and the two `_EMBEDDING_RETRY_*_BACKOFF_SECONDS` constants lose the prefix — the retry helper serves both call paths now.
- **Docs:** a `Transcription timeout` section parallel to the embedder's `Timeout`, linking to it for the shared semantics rather than restating them.

### Behavior change

A transcriber constructed with `timeout=30` previously sent that to litellm as a per-request timeout; it now means CocoIndex's 30-second bound on the whole request. Same meaning shift #2394 took for the embedder — the contract the value always looked like it promised.

## Test plan

CI, plus:

- `test_litellm_transcriber.py` moves onto the stub `litellm_module` fixture. It was gated on `importorskip("litellm")`, an optional dependency CI does not install, so it was skipping locally **and** in CI — none of this behavior would have been covered where it matters. It never needed the real package; it patched `atranscription` regardless.
- Both non-obvious guards are mutation-tested: hoisting the buffer out of the per-attempt closure fails `test_retry_resends_the_whole_audio`; forwarding `timeout` to litellm fails `test_timeout_is_not_forwarded_to_litellm`.
- Locally: `prek run --all-files` green (all hooks), `uv run mypy` clean over 289 files, `uv run pytest python/` 1087 passed / 279 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
