### PR TITLE
docs(litellm): one shared-behavior section for embedder and transcriber

### DIFF
--- a/docs/src/content/docs/ops/litellm.mdx
+++ b/docs/src/content/docs/ops/litellm.mdx
@@ -27,14 +27,14 @@ The `LiteLLMEmbedder` class is a wrapper around LiteLLM's embedding API that:
 - Implements `VectorSchemaProvider` for seamless integration with CocoIndex connectors
 - Supports 100+ embedding providers (OpenAI, Azure, Vertex AI, Cohere, Bedrock, etc.) through a unified API
 - Provides a simple async `embed()` method
-- Passes through all additional arguments to the LiteLLM embedding API
+- Passes through all additional arguments to the LiteLLM embedding API, except `timeout` and `max_inflight_requests`, which CocoIndex owns
 - Returns properly typed numpy arrays
 
 ## Basic usage
 
 ### Creating an embedder
 
-All extra keyword arguments are passed through to every `litellm.aembedding` call (`api_key`, `api_base`, `dimensions`, …). See [Supported providers](#supported-providers) for provider-specific model strings and configuration.
+All extra keyword arguments are passed through to every `litellm.aembedding` call (`api_key`, `api_base`, `dimensions`, …) — except `timeout` and `max_inflight_requests`, which are CocoIndex's own knobs (see [Timeout](#timeout) and [Limiting concurrent requests](#limiting-concurrent-requests)). See [Supported providers](#supported-providers) for provider-specific model strings and configuration.
 
 ```python
 from datetime import timedelta
@@ -68,10 +68,6 @@ embedding = await embedder.embed("Hello, world!")
 table.declare_row(row=DocEmbedding(text="Hello, world!", embedding=embedding))
 ```
 
-:::note[Built-in memoization]
-`embed()` is memoized (`memo=True`): inside a processing component, each distinct text's vector is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged text — this is what makes the common per-file-component pattern incremental. The memo stores one full vector per distinct text, so mind the [memoization placement rule](../programming_guide/function#when-to-memoize) if your components are already keyed by the embedded content. Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
-:::
-
 ### Limiting concurrent requests
 
 Concurrent `embed()` calls are batched: CocoIndex groups them into requests of
@@ -91,14 +87,6 @@ embedder = LiteLLMEmbedder(
 The default is `None` (no cap). The cap is per embedder instance: two
 embedders pointed at the same endpoint have independent limits, so share one
 instance when you want one limit.
-
-### Timeout
-
-`timeout` bounds each embedding request end to end; the default is 10 minutes. Transient failures (HTTP 429, 5xx, a dropped connection) are retried with backoff inside that window; a request that times out fails with `DeadlineExceededError` and is not retried. Requests carry up to 64 texts, so raise `timeout` for an endpoint that needs longer than the default to embed a full batch:
-
-```python
-embedder = LiteLLMEmbedder("text-embedding-3-small", timeout=timedelta(minutes=30))
-```
 
 ### Using as a type annotation
 
@@ -144,7 +132,7 @@ The `LiteLLMTranscriber` class is a wrapper around LiteLLM's transcription API t
 
 ### Creating a transcriber
 
-All extra keyword arguments are passed through to every `litellm.atranscription` call (`api_key`, `api_base`, `language`, `extra_body`, …) — except `timeout`, which is CocoIndex's own bound on the whole request (see [Transcription timeout](#transcription-timeout)).
+All extra keyword arguments are passed through to every `litellm.atranscription` call (`api_key`, `api_base`, `language`, `extra_body`, …) — except `timeout`, which is CocoIndex's own bound on the whole request (see [Timeout](#timeout)).
 
 ```python
 from datetime import timedelta
@@ -165,7 +153,7 @@ transcriber = LiteLLMTranscriber("whisper-1", timeout=timedelta(minutes=30))
 
 ### Transcribing audio
 
-The `transcribe()` method takes a `FileLike` object (such as a `localfs.File`) containing audio data and returns the transcribed text as a `str`. It's an async method — use `await` when calling it. Per-call keyword arguments override the defaults provided at construction time:
+The `transcribe()` method takes a `FileLike` object (such as a `localfs.File`) containing audio data and returns the transcribed text as a `str`. It's an async method — use `await` when calling it. Per-call keyword arguments override the defaults provided at construction time — except `timeout`, which is settable only on the constructor (see [Timeout](#timeout)):
 
 ```python
 # In a CocoIndex function, `file` is a FileLike (e.g. localfs.File)
@@ -176,16 +164,6 @@ transcript = await transcriber.transcribe(file, response_format="verbose_json")
 ```
 
 A complete pipeline that walks local audio files, transcribes each one, and stores the transcripts in Postgres is available in the [`audio_to_text` example](https://github.com/cocoindex-io/cocoindex/tree/main/examples/audio_to_text).
-
-### Transcription timeout
-
-`timeout` bounds each transcription request end to end, exactly as it does for [embedding](#timeout): the default is 10 minutes, transient failures (HTTP 429, 5xx, a dropped connection) are retried with backoff inside that window, and a request that times out fails with `DeadlineExceededError` rather than being retried. One request carries one whole audio file, so size it against the longest file you expect:
-
-```python
-transcriber = LiteLLMTranscriber("whisper-1", timeout=timedelta(minutes=30))
-```
-
-This is the only clock on the request: litellm's own per-request `timeout` is not forwarded, and passing `timeout` to `transcribe()` raises `TypeError` — it belongs on the constructor, where it applies to every call.
 
 ### Supported transcription providers
 
@@ -198,6 +176,50 @@ This is the only clock on the request: litellm's own per-request `timeout` is no
 | Groq Whisper Large V3 | `groq/whisper-large-v3` | `GROQ_API_KEY` |
 
 See the [LiteLLM audio transcription docs](https://docs.litellm.ai/docs/audio_transcription) for the full list of providers and model strings.
+
+## Shared behavior
+
+`LiteLLMEmbedder` and `LiteLLMTranscriber` reach their providers the same way: one retry loop, one clock, one memoization contract. Everything in this section applies to both.
+
+### Timeout
+
+`timeout` bounds each request end to end; the default is 10 minutes. Transient failures — HTTP 429, 5xx, a dropped connection, and [others below](#retries) — are retried with backoff inside that window; a request that times out fails with `DeadlineExceededError` and is not retried. It takes a `timedelta`, or seconds as a number.
+
+```python
+embedder = LiteLLMEmbedder("text-embedding-3-small", timeout=timedelta(minutes=30))
+transcriber = LiteLLMTranscriber("whisper-1", timeout=timedelta(minutes=30))
+```
+
+`timeout` is CocoIndex's own clock and the only one on the request — litellm's per-request `timeout` is not forwarded. What to size it against is where the two differ:
+
+- **Embedding** — one request carries up to 64 texts, so raise it for an endpoint that needs longer than the default to embed a full batch.
+- **Transcription** — one request carries one whole audio file, so size it against the longest file you expect. It is settable only on the constructor: passing `timeout` to `transcribe()`, alongside the per-call provider arguments, raises `TypeError`.
+
+### Retries
+
+Within the `timeout` window a failed request is retried with exponential backoff — 1s, doubling, capped at 30s. There is no attempt cap; time is the only brake.
+
+| Failure | Retried? |
+| --- | --- |
+| HTTP 408, 409, 425, 429, or any 5xx | Yes |
+| A refused, reset, or dropped connection | Yes |
+| A timeout — CocoIndex's, litellm's, or the HTTP client's | No — terminal |
+| Bad credentials, unknown model, permission denied | No — terminal |
+
+The 408 row and the timeout row look contradictory and aren't: an HTTP 408 *response* arrives quickly, so nothing has spent the budget, while a timeout we observed ourselves has by definition already spent its duration. Retrying that inside the request's own bound just re-spends what is left, and against an overloaded backend it amplifies the load that caused it. The remedy for a genuine timeout is a longer `timeout`, not more requests.
+
+A surrounding [`coco.timeout()`](../advanced_topics/timeouts) merges with this one by taking whichever is shorter, so it can only cut retries short — raising `timeout` is the only way to give a request longer.
+
+### Memoization
+
+`embed()` and `transcribe()` are both memoized (`memo=True`): inside a processing component, each distinct input's result is cached across that component's runs, so a caller that re-executes doesn't re-pay the API call for unchanged input. `timeout` and `max_inflight_requests` are deliberately absent from the memo key — they bound and pace requests but cannot change a result, so retuning them invalidates nothing.
+
+Mind the [memoization placement rule](../programming_guide/function#when-to-memoize); it lands differently on the two:
+
+- **Embedding** — the memo holds one full vector per distinct text. That is what makes the common per-file-component pattern incremental, but it is redundant when your components are already keyed by the embedded content.
+- **Transcription** — the memo holds one transcript per file: small entries standing in for an expensive call, which is the opposite trade from embedding. It hits whenever the enclosing component re-runs for a reason other than the audio changing — its code edited, its `version` bumped, another of its inputs changed — so it is usually worth keeping even in the per-file-component pattern, where an unchanged file skips the component entirely.
+
+Callsite control over an op's memoization is tracked in [#2275](https://github.com/cocoindex-io/cocoindex/issues/2275).
 
 ## Supported providers
 


### PR DESCRIPTION
## Summary

After #2394 and #2395, `LiteLLMEmbedder` and `LiteLLMTranscriber` reach their providers through the same code — `_resolve_timeout`, `_retry_litellm_call`, one classification of what is retryable. The page documented that once per class, and it had already drifted: `embed()` carried a memoization note while `transcribe()`, memoized by the same decorator, carried none, because there was nowhere shared to put it.

Adds a `## Shared behavior` section holding the three things that are genuinely one implementation:

- **Timeout** — moved out of the embedder section and generalized, with a two-bullet split for what actually differs (up to 64 texts per request vs. one whole audio file; constructor-only on the transcriber).
- **Retries** — new. The retryable/terminal classification was never written down anywhere; it existed only as a clause inside the embedder's timeout paragraph.
- **Memoization** — the embedder's note generalized to cover `transcribe()`, with the per-class nuance: per-chunk vectors are the case the [placement rule](https://cocoindex.io/docs/programming_guide/function/#when-to-memoize) warns about, while a transcript is a small entry standing in for an expensive call.

Also fixes an Overview bullet that went stale in #2394 — it still claimed all additional arguments pass through to litellm, which stopped being true when `timeout` left the passthrough.

Net +48/−26 in one file. No code changes.

## Test plan

- **Every row of the new Retries table was checked against `_is_retryable_litellm_error`**, not written from memory. All 12 match — including the pair that reads as self-contradictory and isn't: an HTTP 408 *response* is retried, while a timeout we observed ourselves is terminal, `litellm.Timeout` included despite it reporting status 408. Backoff (`1, 2, 4, 8, 16, 30, 30`), the 10-minute default, and both accepted `timeout` forms were confirmed the same way.
- **The `#timeout` anchor is preserved** across the move, so the cross-page link from `advanced_topics/timeouts.mdx` still resolves. Verified by running the `github-slugger` Astro uses against the heading texts — worth doing explicitly, since the lychee job runs with `fail: false` and would not have failed the build on a broken anchor.
- All in-page anchors re-validated after the edits; `prek run --all-files` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
