### PR TITLE
fix(docs): correct EnvironmentBuilder type reference in localfs guide

### DIFF
--- a/docs/src/content/docs/connectors/localfs.mdx
+++ b/docs/src/content/docs/connectors/localfs.mdx
@@ -35,7 +35,7 @@ async def app_main() -> None:
         await process(file)
 
 # In your lifespan, provide the actual path:
-async def lifespan(builder: coco.EnvBuilder) -> None:
+async def lifespan(builder: coco.EnvironmentBuilder) -> None:
     builder.provide(SOURCE_DIR, pathlib.Path("./data"))
 ```
 


### PR DESCRIPTION
## Summary

Fix an invalid class reference in the `localfs` connector documentation example. The code snippet referenced `coco.EnvBuilder`, which does not exist in `cocoindex`.

**Before:** `async def lifespan(builder: coco.EnvBuilder) -> None:` (raises `AttributeError`)
**After:** `async def lifespan(builder: coco.EnvironmentBuilder) -> None:` (correct exported class)

## Root Cause

The class exported by `cocoindex` for configuring environments in lifespan handlers is `EnvironmentBuilder` (defined in `cocoindex._internal.environment` and re-exported at top-level via `cocoindex._internal.api`). `EnvBuilder` is an invalid shorthand that causes an `AttributeError` at runtime when copied by users.

All other guides (e.g. `programming_guide/app.mdx`, `advanced_topics/multiple_environments.mdx`) correctly use `coco.EnvironmentBuilder`.

## Fix

Change `coco.EnvBuilder` to `coco.EnvironmentBuilder` in `docs/src/content/docs/connectors/localfs.mdx`.

```diff
 # In your lifespan, provide the actual path:
-async def lifespan(builder: coco.EnvBuilder) -> None:
+async def lifespan(builder: coco.EnvironmentBuilder) -> None:
     builder.provide(SOURCE_DIR, pathlib.Path("./data"))
```

## Validation Performed

- Verified `EnvironmentBuilder` is exported in `python/cocoindex/_internal/api.py` (lines 90, 929) and has the `provide()` method called in the snippet.
- Verified `coco.EnvBuilder` does not exist and is not referenced anywhere else in the repository.
- Built documentation with `astro build` — verified `docs/dist/connectors/localfs/index.html` and companion markdown render correctly.
- Checked formatting and git diff with `git diff --check` (0 issues).
