### PR TITLE
fix: preserve StableKey variants through MessagePack decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
  "storekey 0.9.0",
@@ -9990,16 +9989,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ rmp = { version = "0.8.14" }
 rmp-serde = { version = "1.3.0" }
 rpds = { version = "1.2.0" }
 serde = { version = "1.0.228" }
-serde_bytes = "0.11.19"
 serde_json = "1.0.145"
 serde_path_to_error = "0.1.20"
 serde_with = { version = "3.16.0", features = ["base64"] }

--- a/benchmarks/file_summarization/rust/Cargo.lock
+++ b/benchmarks/file_summarization/rust/Cargo.lock
@@ -339,7 +339,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1920,16 +1919,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/amazon_s3_embedding/Cargo.lock
+++ b/examples/rust/amazon_s3_embedding/Cargo.lock
@@ -1126,7 +1126,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -4462,16 +4461,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/audio_to_text/Cargo.lock
+++ b/examples/rust/audio_to_text/Cargo.lock
@@ -368,7 +368,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2474,16 +2473,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding/Cargo.lock
+++ b/examples/rust/code_embedding/Cargo.lock
@@ -570,7 +570,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3549,16 +3548,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/code_embedding_lancedb/Cargo.lock
+++ b/examples/rust/code_embedding_lancedb/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -6032,16 +6031,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/conversation_to_knowledge/Cargo.lock
+++ b/examples/rust/conversation_to_knowledge/Cargo.lock
@@ -826,7 +826,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey 0.9.0",
  "tokio",
@@ -5152,16 +5151,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/csv_to_iggy/Cargo.lock
+++ b/examples/rust/csv_to_iggy/Cargo.lock
@@ -750,7 +750,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3872,16 +3871,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/csv_to_kafka/Cargo.lock
+++ b/examples/rust/csv_to_kafka/Cargo.lock
@@ -341,7 +341,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2060,16 +2059,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/files_to_sqlite/Cargo.lock
+++ b/examples/rust/files_to_sqlite/Cargo.lock
@@ -356,7 +356,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2259,16 +2258,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/files_transform/Cargo.lock
+++ b/examples/rust/files_transform/Cargo.lock
@@ -339,7 +339,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1946,16 +1945,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/gdrive_text_embedding/Cargo.lock
+++ b/examples/rust/gdrive_text_embedding/Cargo.lock
@@ -574,7 +574,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3554,16 +3553,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/hn_trending_topics/Cargo.lock
+++ b/examples/rust/hn_trending_topics/Cargo.lock
@@ -357,7 +357,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2464,16 +2463,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/image_search/Cargo.lock
+++ b/examples/rust/image_search/Cargo.lock
@@ -537,7 +537,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3482,16 +3481,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/image_search_colpali/Cargo.lock
+++ b/examples/rust/image_search_colpali/Cargo.lock
@@ -381,7 +381,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2538,16 +2537,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/kafka_consume/Cargo.lock
+++ b/examples/rust/kafka_consume/Cargo.lock
@@ -341,7 +341,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2035,16 +2034,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_falkordb/Cargo.lock
@@ -341,7 +341,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -1982,16 +1981,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
+++ b/examples/rust/meeting_notes_graph_neo4j/Cargo.lock
@@ -380,7 +380,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2176,16 +2175,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/multi_codebase_summarization/Cargo.lock
+++ b/examples/rust/multi_codebase_summarization/Cargo.lock
@@ -339,7 +339,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2136,16 +2135,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/oci_object_storage_embedding/Cargo.lock
+++ b/examples/rust/oci_object_storage_embedding/Cargo.lock
@@ -574,7 +574,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3554,16 +3553,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/paper_metadata/Cargo.lock
+++ b/examples/rust/paper_metadata/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3665,16 +3664,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/pdf_embedding/Cargo.lock
+++ b/examples/rust/pdf_embedding/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3663,16 +3662,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/pdf_to_markdown/Cargo.lock
+++ b/examples/rust/pdf_to_markdown/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -2133,16 +2132,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/postgres_source/Cargo.lock
+++ b/examples/rust/postgres_source/Cargo.lock
@@ -521,7 +521,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3488,16 +3487,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding/Cargo.lock
+++ b/examples/rust/text_embedding/Cargo.lock
@@ -570,7 +570,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3538,16 +3537,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_lancedb/Cargo.lock
+++ b/examples/rust/text_embedding_lancedb/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -6022,16 +6021,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_qdrant/Cargo.lock
+++ b/examples/rust/text_embedding_qdrant/Cargo.lock
@@ -586,7 +586,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3532,16 +3531,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/examples/rust/text_embedding_turbopuffer/Cargo.lock
+++ b/examples/rust/text_embedding_turbopuffer/Cargo.lock
@@ -554,7 +554,6 @@ dependencies = [
  "rmp-serde",
  "rpds",
  "serde",
- "serde_bytes",
  "serde_with",
  "storekey",
  "tokio",
@@ -3245,16 +3244,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/python/tests/cli/flat_target_app.py
+++ b/python/tests/cli/flat_target_app.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, Collection
 
 import cocoindex as coco
+from tests.cli.target_store import FlatTargetStore
 
 _HERE = pathlib.Path(__file__).resolve().parent
 DB_PATH = _HERE / "cocoindex.db"
@@ -13,40 +13,7 @@ DB_PATH = _HERE / "cocoindex.db"
 env = coco.Environment(coco.Settings.from_env(db_path=DB_PATH))
 
 
-class _FlatStore:
-    def __init__(self) -> None:
-        self.data: dict[str, Any] = {}
-
-    def _sink(
-        self,
-        context_provider: coco.ContextProvider,
-        actions: Collection[tuple[str, Any | coco.NonExistenceType]],
-        /,
-    ) -> None:
-        for key, value in actions:
-            if coco.is_non_existence(value):
-                self.data.pop(key, None)
-            else:
-                self.data[key] = value
-
-    def reconcile(
-        self,
-        key: coco.StableKey,
-        desired_state: Any | coco.NonExistenceType,
-        prev_possible_records: Collection[Any],
-        prev_may_be_missing: bool,
-    ) -> (
-        coco.TargetReconcileOutput[tuple[str, Any | coco.NonExistenceType], Any] | None
-    ):
-        assert isinstance(key, str)
-        return coco.TargetReconcileOutput(
-            action=(key, desired_state),
-            sink=coco.TargetActionSink.from_fn(self._sink),
-            tracking_record=desired_state,
-        )
-
-
-_flat_store = _FlatStore()
+_flat_store = FlatTargetStore()
 _provider = coco.register_root_target_states_provider(
     "test_cli/flat_preview", _flat_store
 )

--- a/python/tests/cli/target_store.py
+++ b/python/tests/cli/target_store.py
@@ -1,0 +1,38 @@
+"""Shared in-memory target store for CLI fixture apps."""
+
+from collections.abc import Collection
+
+import cocoindex as coco
+
+
+class FlatTargetStore:
+    """Like tests.common DictTargetStateStore, minus `prev` wrapping so `show`
+    output stays plain."""
+
+    def __init__(self) -> None:
+        self.data: dict[coco.StableKey, object] = {}
+
+    def _sink(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[coco.StableKey, object]],
+        /,
+    ) -> None:
+        for key, value in actions:
+            if coco.is_non_existence(value):
+                self.data.pop(key, None)
+            else:
+                self.data[key] = value
+
+    def reconcile(
+        self,
+        key: coco.StableKey,
+        desired_state: object,
+        prev_possible_records: Collection[object],
+        prev_may_be_missing: bool,
+    ) -> coco.TargetReconcileOutput[tuple[coco.StableKey, object], object] | None:
+        return coco.TargetReconcileOutput(
+            action=(key, desired_state),
+            sink=coco.TargetActionSink.from_fn(self._sink),
+            tracking_record=desired_state,
+        )

--- a/python/tests/cli/test_cli.py
+++ b/python/tests/cli/test_cli.py
@@ -1017,3 +1017,48 @@ class TestShowTargetStates:
             )
             assert result.returncode != 0
             assert "cannot be combined" in result.stderr.lower()
+
+
+class TestShowTargetStatesTypedKeys:
+    """Tuple/bytes component paths and target-state keys in `show`.
+
+    Regression for the MessagePack `StableKey` decoder: tuple segments used to
+    read back as bytes and UTF-8 bytes as strings, so the owner lookup missed
+    and entries rendered as `#fingerprint` marked `[dangling]`.
+    """
+
+    @staticmethod
+    def _assert_typed_keys_rendered(stdout: str) -> None:
+        assert "@test_cli/typed_keys/[1,2]" in stdout
+        assert '@test_cli/typed_keys/b"abc"' in stdout
+        # Owners render with their own tuple/bytes component segments.
+        assert 'owner:/"process"/[1,2]' in stdout
+        assert 'owner:/"process"/b"abc"' in stdout
+        assert "/#" not in stdout
+        assert "[dangling]" not in stdout
+
+    def test_show_target_states_renders_tuple_and_bytes_keys(self) -> None:
+        run_cli("update", "./typed_key_app.py")
+
+        result = run_cli("show", "./typed_key_app.py", "--target-states")
+
+        self._assert_typed_keys_rendered(result.stdout)
+
+    def test_show_target_states_typed_keys_from_database(self) -> None:
+        """Same rendering from the database alone, without the app module.
+
+        Leaf keys come from tracking info; the root provider segment comes from
+        the persisted segment-name entries.
+        """
+        run_cli("update", "./typed_key_app.py")
+
+        result = run_cli(
+            "show",
+            "--db",
+            "./cocoindex.db",
+            "--app-name",
+            "TypedKeyApp",
+            "--target-states",
+        )
+
+        self._assert_typed_keys_rendered(result.stdout)

--- a/python/tests/cli/typed_key_app.py
+++ b/python/tests/cli/typed_key_app.py
@@ -1,0 +1,40 @@
+"""Test app whose component paths and target-state keys use tuple/bytes keys.
+
+These segments ride through the state store as MessagePack; a codec that
+collapsed a tuple to bytes (or bytes to a string) broke owner resolution, which
+`show --target-states` surfaces as a `[dangling]` marker and a `#fingerprint`
+path instead of a readable one.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import cocoindex as coco
+from tests.cli.target_store import FlatTargetStore
+
+_HERE = pathlib.Path(__file__).resolve().parent
+DB_PATH = _HERE / "cocoindex.db"
+
+env = coco.Environment(coco.Settings.from_env(db_path=DB_PATH))
+
+_SEGMENTS: list[coco.StableKey] = [(1, 2), b"abc"]
+
+
+_store = FlatTargetStore()
+_provider = coco.register_root_target_states_provider("test_cli/typed_keys", _store)
+
+
+@coco.fn
+def _declare(segment: coco.StableKey) -> None:
+    coco.declare_target_state(_provider.target_state(segment, 42))
+
+
+@coco.fn
+async def build() -> None:
+    with coco.component_subpath("process"):
+        for segment in _SEGMENTS:
+            await coco.mount(coco.component_subpath(segment), _declare, segment)
+
+
+app = coco.App(coco.AppConfig(name="TypedKeyApp", environment=env), build)

--- a/python/tests/common/target_states.py
+++ b/python/tests/common/target_states.py
@@ -73,6 +73,13 @@ class AtMost:
     __hash__ = None  # type: ignore[assignment]
 
 
+# Component subpath segments that are *not* strings. These ride through the
+# state store as msgpack; a codec that collapsed a tuple segment to bytes (or
+# bytes to str) made the ownership guard resolve the wrong previous owner.
+TUPLE_SEGMENT: coco.StableKey = (1, 2)
+BYTES_SEGMENT: coco.StableKey = b"abc"
+
+
 class DictTargetStateStore:
     data: dict[str, DictDataWithPrev]
     metrics: Metrics

--- a/python/tests/core/test_component_target_states.py
+++ b/python/tests/core/test_component_target_states.py
@@ -5,14 +5,19 @@ import cocoindex.inspect as coco_inspect
 import pytest
 
 import dataclasses
+import gc
 from typing import Any, Collection, Generic
 
 from tests import common
 from tests.common.target_states import (
+    BYTES_SEGMENT,
+    TUPLE_SEGMENT,
     DictsTarget,
     DictDataWithPrev,
     AsyncDictsTarget,
     AtMost,
+    GlobalDictTarget,
+    Metrics,
 )
 
 coco_env = common.create_test_env(__file__)
@@ -1552,3 +1557,103 @@ def test_component_to_directory_transition() -> None:
     paths = coco_inspect.list_stable_paths_sync(app)
     assert old_component in paths
     assert deeper_component not in paths
+
+
+##################################################################################
+# Component paths whose segments are TUPLE_SEGMENT / BYTES_SEGMENT rather than
+# strings. The old codec broke the delete-time ownership guard for them, leaking
+# owner rows after the component was unmounted.
+
+# Maps a component subpath segment to the (target-state key, value) it declares.
+_typed_path_entry: dict[coco.StableKey, tuple[str, str]] = {}
+
+
+def _typed_path_owner(segment: coco.StableKey) -> coco.StablePath:
+    return coco.ROOT_PATH / "dict" / segment
+
+
+def _build_typed_path_app(db_name: str, calls: Metrics) -> coco.App[Any, Any]:
+    """Build an app over a fresh Environment on ``db_name``'s persisted store.
+
+    Returned so callers can drop it (and the env) to let LMDB reopen.
+    """
+
+    @coco.fn(memo=True)
+    def _process(key: str, value: str) -> None:
+        calls.increment(key)
+        coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+    @coco.fn
+    async def _app_main() -> None:
+        with coco.component_subpath("dict"):
+            for segment, (key, value) in _typed_path_entry.items():
+                await coco.mount(coco.component_subpath(segment), _process, key, value)
+
+    # Same `suffix` on every call means the same db_path, so a later call
+    # reopens the store the previous app persisted.
+    env = common.create_test_env(__file__, suffix=db_name)
+    return coco.App(coco.AppConfig(name=db_name, environment=env), _app_main)
+
+
+def test_typed_component_path_create_update_unmount() -> None:
+    """Create, unchanged re-run (memo hit), reopen, then unmount."""
+    GlobalDictTarget.store.clear()
+    _typed_path_entry.clear()
+    calls = Metrics()
+    db_name = "test_typed_component_path"
+
+    _typed_path_entry[TUPLE_SEGMENT] = ("from_tuple", "v1")
+    _typed_path_entry[BYTES_SEGMENT] = ("from_bytes", "v2")
+
+    expected_owners = {
+        '/@test_target_state/global_dict/"from_tuple"': _typed_path_owner(
+            TUPLE_SEGMENT
+        ),
+        '/@test_target_state/global_dict/"from_bytes"': _typed_path_owner(
+            BYTES_SEGMENT
+        ),
+    }
+    expected_paths = sorted(
+        [
+            coco.ROOT_PATH,
+            coco.ROOT_PATH / "dict",
+            _typed_path_owner(TUPLE_SEGMENT),
+            _typed_path_owner(BYTES_SEGMENT),
+        ],
+        key=str,
+    )
+
+    def stable_paths(app: coco.App[Any, Any]) -> list[coco.StablePath]:
+        return sorted(coco_inspect.list_stable_paths_sync(app), key=str)
+
+    # Run 1: create.
+    app = _build_typed_path_app(db_name, calls)
+    app.update_blocking()
+    assert GlobalDictTarget.store.data["from_tuple"].data == "v1"
+    assert GlobalDictTarget.store.data["from_bytes"].data == "v2"
+    assert calls.collect() == {"from_tuple": 1, "from_bytes": 1}
+    assert stable_paths(app) == expected_paths
+    assert common.list_target_state_owners_sync(app) == expected_owners
+
+    # Run 2: unchanged. Memo must hit, and ownership must not churn.
+    app.update_blocking()
+    assert calls.collect() == {}
+    assert common.list_target_state_owners_sync(app) == expected_owners
+    del app
+    gc.collect()
+
+    # Run 3: reopen the persisted store in a fresh Environment. Still a memo
+    # hit, and the owner rows must read back with their segment types intact.
+    app = _build_typed_path_app(db_name, calls)
+    app.update_blocking()
+    assert calls.collect() == {}
+    assert stable_paths(app) == expected_paths
+    assert common.list_target_state_owners_sync(app) == expected_owners
+
+    # Run 4: unmount both components. Target data, tracking paths and owner
+    # rows must all go.
+    _typed_path_entry.clear()
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
+    assert coco_inspect.list_stable_paths_sync(app) == [coco.ROOT_PATH]
+    assert common.list_target_state_owners_sync(app) == {}

--- a/python/tests/core/test_ownership_transfer.py
+++ b/python/tests/core/test_ownership_transfer.py
@@ -10,6 +10,8 @@ import pytest
 
 from tests import common
 from tests.common.target_states import (
+    BYTES_SEGMENT,
+    TUPLE_SEGMENT,
     AtMost,
     DictDataWithPrev,
     DictTargetStateStore,
@@ -62,9 +64,6 @@ _concurrent_claim_store = _BlockingSinkStore()
 _concurrent_claim_provider = coco.register_root_target_states_provider(
     "test_target_state/concurrent_claim", _concurrent_claim_store
 )
-_concurrent_claim_values: dict[str, int] = {}
-_allow_c3_mount: asyncio.Event | None = None
-_c3_declared: asyncio.Event | None = None
 
 
 @coco.fn
@@ -77,27 +76,6 @@ async def _process_component(name: str) -> None:
 async def _app_main() -> None:
     for name in sorted(_source_data):
         await coco.mount(coco.component_subpath(name), _process_component, name)
-
-
-@coco.fn
-async def _process_concurrent_claimant(name: str) -> None:
-    coco.declare_target_state(
-        _concurrent_claim_provider.target_state("x", _concurrent_claim_values[name])
-    )
-    if name == "C3":
-        assert _c3_declared is not None
-        _c3_declared.set()
-
-
-@coco.fn
-async def _app_main_concurrent_claimants() -> None:
-    for name in sorted(_concurrent_claim_values):
-        if name == "C3":
-            assert _allow_c3_mount is not None
-            await _allow_c3_mount.wait()
-        await coco.mount(
-            coco.component_subpath(name), _process_concurrent_claimant, name
-        )
 
 
 def test_ownership_transfer_basic() -> None:
@@ -216,35 +194,81 @@ def test_ownership_transfer_ordering_independence() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "owner, reclaimer, late",
+    [
+        pytest.param("C1", "C2", "C3", id="str-segments"),
+        # These tuple/bytes segments collided under the old decoder.
+        pytest.param((1, 2), b"\x01\x02", b"abc", id="tuple-and-bytes-segments"),
+    ],
+)
+@pytest.mark.parametrize(
+    "exhaust_pending", [False, True], ids=["same-update", "retry-exhaustion"]
+)
 @pytest.mark.asyncio
-async def test_concurrent_claimant_sees_owner_during_sink_apply() -> None:
-    """A later claimant must see the owner whose sink action is in flight."""
-    global _allow_c3_mount, _c3_declared
+async def test_concurrent_claimant_sees_owner_during_sink_apply(
+    owner: coco.StableKey,
+    reclaimer: coco.StableKey,
+    late: coco.StableKey,
+    exhaust_pending: bool,
+    request: pytest.FixtureRequest,
+) -> None:
+    """A concurrent claim can resume in this update or retry after exhaustion."""
+    source: dict[coco.StableKey, int] = {owner: 1}
+    allow_late_mount = asyncio.Event()
+    late_declared = asyncio.Event()
+    error_received = asyncio.Event()
+    errors: list[BaseException] = []
+
+    def record_error(exc: BaseException, ctx: coco.ExceptionContext) -> None:
+        errors.append(exc)
+        error_received.set()
+
+    @coco.fn
+    async def process_claimant(value: int, is_late: bool) -> None:
+        coco.declare_target_state(_concurrent_claim_provider.target_state("x", value))
+        if is_late:
+            late_declared.set()
+
+    @coco.fn
+    async def app_main() -> None:
+        handles: list[coco.ComponentMountHandle] = []
+        async with coco.exception_handler(record_error):
+            for segment, value in source.items():
+                is_late = segment == late
+                if is_late:
+                    await allow_late_mount.wait()
+                handles.append(
+                    await coco.mount(
+                        coco.component_subpath(segment),
+                        process_claimant,
+                        value,
+                        is_late,
+                    )
+                )
+        # Finish claims before root cleanup can delete the previous owner.
+        for handle in handles:
+            await handle.ready()
 
     _concurrent_claim_store.clear()
-    _concurrent_claim_values.clear()
-    test_env = common.create_test_env(
-        __file__, suffix="concurrent_claimant_sees_owner_during_sink_apply"
-    )
+    test_env = common.create_test_env(__file__, suffix=request.node.name)
     app = coco.App(
-        coco.AppConfig(
-            name="test_concurrent_claimant_sees_owner_during_sink_apply",
-            environment=test_env,
-        ),
-        _app_main_concurrent_claimants,
+        coco.AppConfig(name="concurrent_claimant", environment=test_env), app_main
     )
+    target_path = '/@test_target_state/concurrent_claim/"x"'
 
-    # Establish C1 as the committed owner.
-    _concurrent_claim_values["C1"] = 1
+    # Establish the first component as the committed owner.
     await app.update()
+    assert errors == []
     _concurrent_claim_store.metrics.collect()
+    assert await common.list_target_state_owners(app) == {
+        target_path: coco.ROOT_PATH / owner,
+    }
 
-    # C2 claims x in precommit, then pauses inside sink.apply. C3 is mounted
-    # only after we have observed that in-flight claim.
-    _concurrent_claim_values.clear()
-    _concurrent_claim_values.update(C2=2, C3=3)
-    _allow_c3_mount = asyncio.Event()
-    _c3_declared = asyncio.Event()
+    # The reclaimer claims x in precommit, then pauses inside sink.apply. The
+    # late claimant is mounted only after we have observed that in-flight claim.
+    source.clear()
+    source.update({reclaimer: 2, late: 3})
     _concurrent_claim_store.block_next_apply()
     update_task = asyncio.ensure_future(app.update())
     try:
@@ -252,24 +276,52 @@ async def test_concurrent_claimant_sees_owner_during_sink_apply() -> None:
             _concurrent_claim_store.wait_for_blocked_apply(), timeout=5.0
         )
         assert await common.list_target_state_owners(app) == {
-            '/@test_target_state/concurrent_claim/"x"': coco.ROOT_PATH / "C2",
+            target_path: coco.ROOT_PATH / reclaimer,
         }
-
-        # Let C3 enter submission while C2 is still in sink.apply. The current
-        # protocol makes C3 observe C2's live claim and retry behind it.
-        _allow_c3_mount.set()
-        await asyncio.wait_for(_c3_declared.wait(), timeout=5.0)
-        await asyncio.sleep(0)
+        allow_late_mount.set()
+        if exhaust_pending:
+            # This error proves precommit observed the in-flight owner and
+            # refused the takeover for every pending retry while the sink
+            # stayed blocked. Collect every error so extra failures cannot hide.
+            await asyncio.wait_for(error_received.wait(), timeout=5.0)
+            assert len(errors) == 1
+            assert "retries waiting for concurrent ownership transfer" in str(errors[0])
+            assert _concurrent_claim_store.data["x"].data == 1
+            assert _concurrent_claim_store.metrics.collect() == {}
+            assert await common.list_target_state_owners(app) == {
+                target_path: coco.ROOT_PATH / reclaimer,
+            }
+        else:
+            # Preserve the success case: release after the late declaration
+            # and require its transfer to finish within this same update. The
+            # exhaustion case above separately proves pending detection.
+            await asyncio.wait_for(late_declared.wait(), timeout=5.0)
     finally:
-        _allow_c3_mount.set()
+        allow_late_mount.set()
         _concurrent_claim_store.release_blocked_apply()
         await update_task
-        _allow_c3_mount = None
-        _c3_declared = None
 
-    assert _concurrent_claim_store.data["x"].data == 3
+    if exhaust_pending:
+        assert len(errors) == 1
+        assert _concurrent_claim_store.data["x"] == DictDataWithPrev(
+            data=2, prev=[1], prev_may_be_missing=False
+        )
+        assert await common.list_target_state_owners(app) == {
+            target_path: coco.ROOT_PATH / reclaimer,
+        }
+
+        # A subsequent update retries the failed claim using the committed
+        # previous state. No additional component errors are allowed.
+        errors.clear()
+        source.pop(reclaimer)
+        await app.update()
+
+    assert errors == []
+    assert _concurrent_claim_store.data["x"] == DictDataWithPrev(
+        data=3, prev=[2], prev_may_be_missing=False
+    )
     assert await common.list_target_state_owners(app) == {
-        '/@test_target_state/concurrent_claim/"x"': coco.ROOT_PATH / "C3",
+        target_path: coco.ROOT_PATH / late,
     }
 
 
@@ -549,4 +601,92 @@ def test_ownership_transfer_sink_failure_then_owner_deleted() -> None:
     app.update_blocking()
     assert GlobalDictTarget.store.data == {}
     assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "delete": 1}
+    assert common.list_target_state_owners_sync(app) == {}
+
+
+# Segment -> target states that component declares.
+_typed_path_source: dict[coco.StableKey, dict[str, object]] = {}
+
+
+@coco.fn
+async def _process_typed_path_component(entries: dict[str, object]) -> None:
+    for key, value in entries.items():
+        coco.declare_target_state(GlobalDictTarget.target_state(key, value))
+
+
+@coco.fn
+async def _app_main_typed_paths_await_ready() -> None:
+    """Awaits every child's ready() so transfer is a preempt, not delete+insert."""
+    handles = []
+    with coco.component_subpath("process"):
+        for segment in sorted(_typed_path_source, key=repr):
+            handles.append(
+                await coco.mount(
+                    coco.component_subpath(segment),
+                    _process_typed_path_component,
+                    _typed_path_source[segment],
+                )
+            )
+    for handle in handles:
+        await handle.ready()
+
+
+def _typed_owner(segment: coco.StableKey) -> coco.StablePath:
+    return coco.ROOT_PATH / "process" / segment
+
+
+def test_ownership_transfer_between_typed_component_paths() -> None:
+    """Transfer between a tuple-segment and a bytes-segment component path.
+
+    Checks the previous state reaches the new owner (a single upsert carrying
+    `prev`, not delete+insert), that the new owner's row is the one kept, and
+    that unmounting clears every row.
+    """
+    GlobalDictTarget.store.clear()
+    _typed_path_source.clear()
+
+    app = coco.App(
+        coco.AppConfig(name="test_typed_path_ownership_transfer", environment=coco_env),
+        _app_main_typed_paths_await_ready,
+    )
+
+    # Run 1: the tuple-segment component owns "x".
+    _typed_path_source[TUPLE_SEGMENT] = {"x": 1}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=1, prev=[], prev_may_be_missing=True),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': _typed_owner(TUPLE_SEGMENT),
+    }
+
+    # Run 2: the bytes-segment component takes over. Resolving the previous
+    # owner is what the decoder broke, so `prev` is the load-bearing assertion.
+    _typed_path_source.clear()
+    _typed_path_source[BYTES_SEGMENT] = {"x": 2}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=2, prev=[1], prev_may_be_missing=False),
+    }
+    assert GlobalDictTarget.store.metrics.collect() == {"sink": AtMost(1), "upsert": 1}
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': _typed_owner(BYTES_SEGMENT),
+    }
+
+    # Run 3: transfer back from the bytes-segment owner to the tuple segment.
+    _typed_path_source.clear()
+    _typed_path_source[TUPLE_SEGMENT] = {"x": 3}
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {
+        "x": DictDataWithPrev(data=3, prev=[2], prev_may_be_missing=False),
+    }
+    assert common.list_target_state_owners_sync(app) == {
+        '/@test_target_state/global_dict/"x"': _typed_owner(TUPLE_SEGMENT),
+    }
+
+    # Run 4: unmount. No owner row may survive its component.
+    _typed_path_source.clear()
+    app.update_blocking()
+    assert GlobalDictTarget.store.data == {}
     assert common.list_target_state_owners_sync(app) == {}

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -23,7 +23,6 @@ tokio-stream = { workspace = true }
 rmp = { workspace = true }
 rmp-serde = { workspace = true }
 rpds = { workspace = true }
-serde_bytes = { workspace = true }
 serde_with = { workspace = true }
 uuid = { workspace = true }
 indexmap = { workspace = true }

--- a/rust/core/src/inspect/db_inspect.rs
+++ b/rust/core/src/inspect/db_inspect.rs
@@ -1209,4 +1209,100 @@ mod tests {
         );
         assert_eq!(row_entry.owner_component_path, comp_d);
     }
+
+    /// Owner rows whose component path and target-state keys use tuple/bytes
+    /// stable keys must render readably, resolve through both the tracking
+    /// record and the persisted segment names, and never be marked dangling.
+    /// A codec that collapsed tuple->bytes broke the owner->tracking lookup,
+    /// which is exactly what the dangling marker reports.
+    #[tokio::test]
+    async fn resolves_tuple_and_bytes_segments_without_false_dangling() {
+        let (store, _dir) = make_test_store().await;
+
+        let root_fp = Fingerprint::from(&"root_target").unwrap();
+        let root_path = TargetStatePath::new(root_fp, None);
+        let tuple_key = StableKey::Array(Arc::from(vec![StableKey::Int(1), StableKey::Int(2)]));
+        let bytes_key = StableKey::Bytes(Arc::from(&b"abc"[..]));
+        let tuple_path = root_path.concat(&tuple_key);
+        let bytes_path = root_path.concat(&bytes_key);
+
+        // The owning component itself sits at `/"process"/[1,2]`.
+        let comp = StablePath(Arc::from(vec![
+            StableKey::Str(Arc::from("process")),
+            tuple_key.clone(),
+        ]));
+
+        commit_writes(
+            &store,
+            vec![(
+                comp.clone(),
+                tracking_bytes(vec![
+                    (with_pid(&tuple_path, None), tuple_key.clone()),
+                    (with_pid(&bytes_path, None), bytes_key.clone()),
+                ]),
+            )],
+            vec![
+                (tuple_path.clone(), comp.clone()),
+                (bytes_path.clone(), comp.clone()),
+            ],
+        )
+        .await;
+        commit_segment_names(
+            &store,
+            vec![(root_fp, StableKey::Symbol(Arc::from("root")))],
+        )
+        .await;
+
+        let db = store.db();
+        let txn = store.read_txn().await.unwrap();
+        let mut resolver = TargetKeyResolver::new(Default::default());
+        let entries = collect_target_states(&db, &txn, &mut resolver);
+        assert_eq!(entries.len(), 2);
+
+        for (path, expected_suffix) in [
+            (&tuple_path, "/@root/[1,2]"),
+            (&bytes_path, "/@root/b\"abc\""),
+        ] {
+            let entry = entries
+                .iter()
+                .find(|e| e.fingerprint_path == path.to_string())
+                .unwrap_or_else(|| panic!("no entry for {path}"));
+            assert_eq!(entry.readable_path, expected_suffix);
+            assert_eq!(entry.owner_component_path, comp);
+            assert!(!entry.dangling, "{expected_suffix} must not be dangling");
+        }
+
+        // Tuple/bytes segments must also render from the persisted segment
+        // names *alone*, the only source `cocoindex ls --db` has for a
+        // provider-only segment. These two paths carry no owner row and no
+        // tracking item, so nothing else can resolve them.
+        let name_only_tuple = StableKey::Array(Arc::from(vec![StableKey::Int(7)]));
+        let name_only_bytes = StableKey::Bytes(Arc::from(&b"xyz"[..]));
+        commit_segment_names(
+            &store,
+            vec![
+                (
+                    Fingerprint::from(&name_only_tuple).unwrap(),
+                    name_only_tuple.clone(),
+                ),
+                (
+                    Fingerprint::from(&name_only_bytes).unwrap(),
+                    name_only_bytes.clone(),
+                ),
+            ],
+        )
+        .await;
+        let txn = store.read_txn().await.unwrap();
+        for (key, expected) in [
+            (&name_only_tuple, "/@root/[7]"),
+            (&name_only_bytes, "/@root/b\"xyz\""),
+        ] {
+            let path = root_path.concat(key);
+            let mut resolver = TargetKeyResolver::new(Default::default());
+            assert_eq!(
+                resolver.render_path(&db, &txn, &path, None).unwrap(),
+                expected
+            );
+        }
+    }
 }

--- a/rust/core/src/state/stable_path.rs
+++ b/rust/core/src/state/stable_path.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::{fmt::Write as FmtWrite, io::Write};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -45,8 +45,96 @@ impl Serialize for StableKey {
     }
 }
 
+/// Decodes one `StableKey` straight off a self-describing format, keeping the
+/// array / bin / str distinction the format already carries.
+struct StableKeyVisitor;
+
+impl<'de> de::Visitor<'de> for StableKeyVisitor {
+    type Value = StableKey;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a stable key")
+    }
+
+    fn visit_unit<E: de::Error>(self) -> std::result::Result<StableKey, E> {
+        Ok(StableKey::Null)
+    }
+
+    fn visit_bool<E: de::Error>(self, v: bool) -> std::result::Result<StableKey, E> {
+        Ok(StableKey::Bool(v))
+    }
+
+    fn visit_i64<E: de::Error>(self, v: i64) -> std::result::Result<StableKey, E> {
+        Ok(StableKey::Int(v))
+    }
+
+    fn visit_u64<E: de::Error>(self, v: u64) -> std::result::Result<StableKey, E> {
+        i64::try_from(v)
+            .map(StableKey::Int)
+            .map_err(|_| de::Error::custom(format!("integer {v} out of range for i64")))
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<StableKey, E> {
+        Ok(StableKey::Str(Arc::from(v)))
+    }
+
+    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> std::result::Result<StableKey, E> {
+        Ok(StableKey::Bytes(Arc::from(v)))
+    }
+
+    fn visit_seq<A: de::SeqAccess<'de>>(
+        self,
+        mut seq: A,
+    ) -> std::result::Result<StableKey, A::Error> {
+        let mut items = Vec::new();
+        while let Some(item) = seq.next_element::<StableKey>()? {
+            items.push(item);
+        }
+        Ok(StableKey::Array(Arc::from(items)))
+    }
+
+    /// Tagged variants are written as a one-entry map. Values are read through
+    /// `next_value` so `Uuid`/`Fingerprint` see the real format context instead
+    /// of a buffer that claims to be human-readable.
+    fn visit_map<A: de::MapAccess<'de>>(
+        self,
+        mut map: A,
+    ) -> std::result::Result<StableKey, A::Error> {
+        const TAGS: &[&str] = &["uuid", "fp", "sym"];
+        let Some(tag) = map.next_key::<String>()? else {
+            return Err(de::Error::invalid_length(0, &"a one-entry tagged map"));
+        };
+        let key = match tag.as_str() {
+            "uuid" => StableKey::Uuid(map.next_value()?),
+            "fp" => StableKey::Fingerprint(map.next_value()?),
+            "sym" => StableKey::Symbol(Arc::from(map.next_value::<String>()?)),
+            other => return Err(de::Error::unknown_field(other, TAGS)),
+        };
+        if map.next_key::<de::IgnoredAny>()?.is_some() {
+            return Err(de::Error::custom(
+                "tagged stable key must have exactly one entry",
+            ));
+        }
+        Ok(key)
+    }
+}
+
 impl<'de> Deserialize<'de> for StableKey {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        // Binary formats (msgpack, the state-store encoding) distinguish
+        // array / bin / str natively, so decode directly off the format.
+        // Untagged buffering erases that: a sequence is taken by `serde_bytes`
+        // before `Array` is tried, valid UTF-8 bytes are taken by `String`
+        // before `Bytes`, and the buffer reports a human-readable context that
+        // makes `Fingerprint` demand base64. Human-readable formats keep the
+        // untagged path below, where those ambiguities are unavoidable anyway.
+        // This check needs the original format context: an outer untagged or
+        // flatten adapter can lose it before reaching this method. Persisted
+        // stable keys must therefore be deserialized without such buffering.
+        if !deserializer.is_human_readable() {
+            return deserializer.deserialize_any(StableKeyVisitor);
+        }
+
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum Repr {
@@ -54,11 +142,10 @@ impl<'de> Deserialize<'de> for StableKey {
             Bool(bool),
             Int(i64),
             Str(String),
-            // Intentionally before Array to preserve StableKey::Bytes roundtrip in formats
-            // (like JSON) where bytes can be represented as a sequence of integers.
-            // `serde_bytes` makes this consume a native byte string too (msgpack
-            // `bin`, the state-store format) — a plain `Vec<u8>` only deserializes
-            // via `deserialize_seq`, so a `bin` would fail to match any variant.
+            // Intentionally before Array to preserve StableKey::Bytes roundtrip in
+            // human-readable formats (like JSON) where bytes serialize as a sequence
+            // of integers. Binary formats never reach this enum; see the
+            // `is_human_readable` branch above.
             #[serde(with = "serde_bytes")]
             Bytes(Vec<u8>),
             Uuid {
@@ -475,26 +562,344 @@ mod tests {
     }
 
     #[test]
-    fn serde_msgpack_bytes_roundtrip() {
-        // `StableKey::Bytes` must survive a serde msgpack round-trip — it rides
-        // inside component paths and target-state keys, which may embed raw
-        // bytes. msgpack serializes a `Vec<u8>` as a native `bin`, so the
-        // deserializer has to accept a `bin` (not just an int sequence).
-        for key in [
-            StableKey::Bytes(Arc::from(&b"\x00\x01\xff sha"[..])),
+    fn serde_msgpack_every_variant_roundtrip() {
+        // Every variant must survive the state store's msgpack encoding
+        // unchanged: ownership guards compare decoded component paths, so a
+        // variant swap (array->bytes, bytes->str) silently retargets them.
+        let arr = |items: Vec<StableKey>| StableKey::Array(Arc::from(items));
+        let cases = vec![
+            StableKey::Null,
+            StableKey::Bool(false),
+            StableKey::Bool(true),
+            StableKey::Int(0),
+            StableKey::Int(-1),
+            StableKey::Int(i64::MIN),
+            StableKey::Int(i64::MAX),
+            StableKey::Int(255),
+            StableKey::Int(256),
+            StableKey::Str(Arc::from("")),
+            StableKey::Str(Arc::from("process")),
+            StableKey::Str(Arc::from("\u{4e2d}\u{6587}/caf\u{e9}")),
+            StableKey::Str(Arc::from("nul\0inside")),
+            StableKey::Bytes(Arc::from(&b""[..])),
+            // Valid UTF-8 bytes must not decode as `Str`.
+            StableKey::Bytes(Arc::from(&b"abc"[..])),
+            StableKey::Bytes(Arc::from("\u{4e2d}\u{6587}".as_bytes())),
+            StableKey::Bytes(Arc::from(&b"nul\0inside"[..])),
+            StableKey::Bytes(Arc::from(&b"\x00\x01\xff"[..])),
+            StableKey::Uuid(uuid::Uuid::from_bytes([3u8; 16])),
+            StableKey::Fingerprint(utils::fingerprint::Fingerprint([7u8; 16])),
+            StableKey::Symbol(Arc::from("cocoindex/setup")),
+            // Arrays whose elements all fit in a byte must not decode as `Bytes`.
+            arr(vec![]),
+            arr(vec![StableKey::Int(1)]),
+            arr(vec![StableKey::Int(1), StableKey::Int(1)]),
+            arr(vec![StableKey::Int(1), StableKey::Int(2)]),
+            // Reordering must stay distinguishable from the case above.
+            arr(vec![StableKey::Int(2), StableKey::Int(1)]),
+            arr(vec![StableKey::Int(0), StableKey::Int(255)]),
+            arr(vec![StableKey::Int(-1), StableKey::Int(256)]),
+            arr(vec![
+                StableKey::Str(Arc::from("process")),
+                arr(vec![StableKey::Int(1), StableKey::Int(2)]),
+            ]),
             // A nested array carrying a symbol, strings, and a raw-bytes key.
-            StableKey::Array(Arc::from(vec![
-                StableKey::Array(Arc::from(vec![
+            arr(vec![
+                arr(vec![
                     StableKey::Symbol(Arc::from("obj")),
                     StableKey::Str(Arc::from("tenant")),
-                ])),
+                ]),
                 StableKey::Str(Arc::from("src/main.rs")),
                 StableKey::Bytes(Arc::from(&[0xde, 0xad, 0xbe, 0xef][..])),
-            ])),
-        ] {
+            ]),
+            arr(vec![
+                StableKey::Null,
+                StableKey::Bool(true),
+                StableKey::Bytes(Arc::from(&b"abc"[..])),
+                StableKey::Uuid(uuid::Uuid::from_bytes([9u8; 16])),
+                StableKey::Fingerprint(utils::fingerprint::Fingerprint([1u8; 16])),
+                StableKey::Symbol(Arc::from("sym")),
+                arr(vec![arr(vec![])]),
+            ]),
+        ];
+
+        for key in cases {
             let bytes = rmp_serde::to_vec_named(&key).expect("encode");
-            let decoded: StableKey = rmp_serde::from_slice(&bytes).expect("decode bytes key");
+            // Same wrapper the state store reads through.
+            let decoded: StableKey =
+                utils::deser::from_msgpack_slice(&bytes).expect("decode stable key");
+            assert_eq!(decoded, key, "round-trip changed variant for {key:?}");
+        }
+    }
+
+    /// The deserializer must read bytes the *unchanged* serializer produces, so
+    /// pin the wire shapes rather than only round-tripping through it.
+    #[test]
+    fn serde_msgpack_decodes_serializer_fixtures() {
+        let uuid = uuid::Uuid::from_bytes([3u8; 16]);
+        let fp = utils::fingerprint::Fingerprint([7u8; 16]);
+        let cases: Vec<(StableKey, Vec<u8>)> = vec![
+            (StableKey::Null, vec![0xc0]),
+            (StableKey::Bool(true), vec![0xc3]),
+            (StableKey::Int(1), vec![0x01]),
+            (StableKey::Int(-1), vec![0xff]),
+            // fixstr "ab"
+            (StableKey::Str(Arc::from("ab")), vec![0xa2, b'a', b'b']),
+            // bin8 of b"ab" -- distinct from the fixstr above.
+            (
+                StableKey::Bytes(Arc::from(&b"ab"[..])),
+                vec![0xc4, 0x02, b'a', b'b'],
+            ),
+            // fixarray of 2 ints -- the shape from the issue report.
+            (
+                StableKey::Array(Arc::from(vec![StableKey::Int(1), StableKey::Int(2)])),
+                vec![0x92, 0x01, 0x02],
+            ),
+            (StableKey::Array(Arc::from(vec![])), vec![0x90]),
+            (
+                StableKey::Uuid(uuid),
+                [
+                    &[0x81, 0xa4, b'u', b'u', b'i', b'd', 0xc4, 0x10][..],
+                    &[3u8; 16][..],
+                ]
+                .concat(),
+            ),
+            (
+                StableKey::Fingerprint(fp),
+                [&[0x81, 0xa2, b'f', b'p', 0xc4, 0x10][..], &[7u8; 16][..]].concat(),
+            ),
+            (
+                StableKey::Symbol(Arc::from("a")),
+                vec![0x81, 0xa3, b's', b'y', b'm', 0xa1, b'a'],
+            ),
+        ];
+
+        for (key, wire) in cases {
+            assert_eq!(
+                rmp_serde::to_vec_named(&key).expect("encode"),
+                wire,
+                "serializer shape changed for {key:?}"
+            );
+            let decoded: StableKey =
+                utils::deser::from_msgpack_slice(&wire).expect("decode fixture");
             assert_eq!(decoded, key);
         }
+    }
+
+    /// The root path and a path holding one empty-array segment are different
+    /// paths; msgpack must not flatten one into the other.
+    #[test]
+    fn serde_msgpack_root_path_differs_from_empty_array_segment() {
+        let root = StablePath::root();
+        let empty_segment = StablePath(Arc::from(vec![StableKey::Array(Arc::from(vec![]))]));
+        assert_ne!(root, empty_segment);
+
+        let root_bytes = rmp_serde::to_vec_named(&root).expect("encode root");
+        let segment_bytes = rmp_serde::to_vec_named(&empty_segment).expect("encode segment");
+        assert_ne!(root_bytes, segment_bytes);
+
+        assert_eq!(
+            utils::deser::from_msgpack_slice::<StablePath>(&root_bytes).expect("decode root"),
+            root
+        );
+        assert_eq!(
+            utils::deser::from_msgpack_slice::<StablePath>(&segment_bytes).expect("decode segment"),
+            empty_segment
+        );
+    }
+
+    /// Hand-rolled msgpack so the test can build shapes the serializer never
+    /// emits (duplicate keys, extra entries, malformed payloads).
+    fn msgpack_fixstr(s: &str) -> Vec<u8> {
+        assert!(s.len() < 32);
+        let mut out = vec![0xa0 | s.len() as u8];
+        out.extend_from_slice(s.as_bytes());
+        out
+    }
+
+    fn msgpack_bin(v: &[u8]) -> Vec<u8> {
+        assert!(v.len() < 256);
+        let mut out = vec![0xc4, v.len() as u8];
+        out.extend_from_slice(v);
+        out
+    }
+
+    fn msgpack_map(entries: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        assert!(entries.len() < 16);
+        let mut out = vec![0x80 | entries.len() as u8];
+        for (k, v) in entries {
+            out.extend_from_slice(&msgpack_fixstr(k));
+            out.extend_from_slice(v);
+        }
+        out
+    }
+
+    #[test]
+    fn serde_msgpack_tagged_map_accepts_only_one_known_tag() {
+        let uuid_payload = msgpack_bin(&[3u8; 16]);
+
+        // Each recognized tag alone decodes.
+        let accepted: Vec<(Vec<u8>, StableKey)> = vec![
+            (
+                msgpack_map(&[("uuid", uuid_payload.clone())]),
+                StableKey::Uuid(uuid::Uuid::from_bytes([3u8; 16])),
+            ),
+            (
+                msgpack_map(&[("fp", msgpack_bin(&[7u8; 16]))]),
+                StableKey::Fingerprint(utils::fingerprint::Fingerprint([7u8; 16])),
+            ),
+            (
+                msgpack_map(&[("sym", msgpack_fixstr("a"))]),
+                StableKey::Symbol(Arc::from("a")),
+            ),
+        ];
+        for (bytes, expected) in accepted {
+            assert_eq!(
+                utils::deser::from_msgpack_slice::<StableKey>(&bytes).expect("decode tagged"),
+                expected
+            );
+        }
+
+        let rejected: Vec<(&str, Vec<u8>)> = vec![
+            ("unknown tag", msgpack_map(&[("nope", vec![0x01])])),
+            ("missing tag (empty map)", msgpack_map(&[])),
+            // A recognized tag plus an extra entry is ambiguous; the previous
+            // decoder silently resolved such maps by enum priority.
+            (
+                "known tag plus extra",
+                msgpack_map(&[("sym", msgpack_fixstr("a")), ("zextra", vec![0x01])]),
+            ),
+            (
+                "extra before known tag",
+                msgpack_map(&[("zextra", vec![0x01]), ("sym", msgpack_fixstr("a"))]),
+            ),
+            (
+                "two recognized tags",
+                msgpack_map(&[("uuid", uuid_payload.clone()), ("sym", msgpack_fixstr("a"))]),
+            ),
+            (
+                "two recognized tags reversed",
+                msgpack_map(&[("sym", msgpack_fixstr("a")), ("uuid", uuid_payload)]),
+            ),
+            (
+                "duplicate tag",
+                msgpack_map(&[("sym", msgpack_fixstr("a")), ("sym", msgpack_fixstr("b"))]),
+            ),
+            ("null payload", msgpack_map(&[("uuid", vec![0xc0])])),
+            (
+                "uuid payload wrong length",
+                msgpack_map(&[("uuid", msgpack_bin(&[1u8; 4]))]),
+            ),
+            (
+                "fingerprint payload wrong length",
+                msgpack_map(&[("fp", msgpack_bin(&[1u8; 4]))]),
+            ),
+            (
+                "symbol payload not a string",
+                msgpack_map(&[("sym", vec![0x01])]),
+            ),
+        ];
+
+        for (label, bytes) in rejected {
+            assert!(
+                utils::deser::from_msgpack_slice::<StableKey>(&bytes).is_err(),
+                "{label} must be rejected"
+            );
+        }
+    }
+
+    /// The strict one-entry rule applies to binary formats only. JSON keeps
+    /// its prior lenient decoding, where unknown fields are ignored and a
+    /// recognized variant is chosen by enum priority.
+    #[test]
+    fn serde_json_tagged_map_stays_lenient() {
+        use serde_json::json;
+
+        let uuid = uuid::Uuid::from_bytes([3u8; 16]);
+        // Extra unknown field alongside a recognized tag.
+        let value = json!({ "sym": "a", "extra": 1 });
+        assert_eq!(
+            serde_json::from_value::<StableKey>(value).expect("lenient extra field"),
+            StableKey::Symbol(Arc::from("a"))
+        );
+        // Two recognized tags: `Uuid` precedes `Sym` in the untagged enum.
+        let value = json!({ "uuid": uuid.to_string(), "sym": "a" });
+        assert_eq!(
+            serde_json::from_value::<StableKey>(value).expect("lenient two tags"),
+            StableKey::Uuid(uuid)
+        );
+    }
+
+    #[test]
+    fn serde_json_tagged_map_payloads_and_duplicates() {
+        // Use raw JSON: constructing a serde_json::Value would discard
+        // duplicate fields before StableKey's deserializer sees them.
+        for json in [
+            r#"{"sym":"a","extra":1,"extra":2}"#,
+            r#"{"uuid":"invalid","sym":"a"}"#,
+            r#"{"sym":"a","uuid":"invalid"}"#,
+            r#"{"uuid":null,"sym":"a"}"#,
+            r#"{"fp":"invalid!","sym":"a"}"#,
+            r#"{"uuid":null,"uuid":null,"sym":"a"}"#,
+        ] {
+            assert_eq!(
+                serde_json::from_str::<StableKey>(json).expect("lenient tagged map"),
+                StableKey::Symbol(Arc::from("a")),
+                "unknown or invalid fields must not prevent a valid variant: {json}"
+            );
+        }
+
+        for json in [
+            r#"{}"#,
+            r#"{"unknown":1}"#,
+            r#"{"sym":"a","sym":"b"}"#,
+            r#"{"uuid":null}"#,
+            r#"{"fp":null}"#,
+            r#"{"sym":null}"#,
+            r#"{"uuid":"invalid"}"#,
+            r#"{"fp":"invalid!"}"#,
+            r#"{"fp":"AQ=="}"#,
+            r#"{"sym":1}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<StableKey>(json).is_err(),
+                "map without a valid tagged variant must be rejected: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn serde_msgpack_rejects_unrepresentable_and_malformed_input() {
+        // No `StableKey` variant holds an unsigned value above `i64::MAX` or a
+        // float, so both must fail rather than silently truncate.
+        let too_large = rmp_serde::to_vec_named(&u64::MAX).expect("encode u64");
+        assert!(utils::deser::from_msgpack_slice::<StableKey>(&too_large).is_err());
+        let float = rmp_serde::to_vec_named(&1.5f64).expect("encode f64");
+        assert!(utils::deser::from_msgpack_slice::<StableKey>(&float).is_err());
+        // 0xc1 is reserved and cannot begin a MessagePack value, including
+        // inside an otherwise valid array.
+        assert!(utils::deser::from_msgpack_slice::<StableKey>(&[0xc1]).is_err());
+        assert!(utils::deser::from_msgpack_slice::<StableKey>(&[0x91, 0xc1]).is_err());
+
+        // `i64::MAX` itself encodes as a uint64 and must still decode.
+        let max = rmp_serde::to_vec_named(&StableKey::Int(i64::MAX)).expect("encode i64::MAX");
+        assert_eq!(
+            utils::deser::from_msgpack_slice::<StableKey>(&max).expect("decode i64::MAX"),
+            StableKey::Int(i64::MAX)
+        );
+
+        // Truncated input at every prefix of a nested array.
+        let key = StableKey::Array(Arc::from(vec![
+            StableKey::Str(Arc::from("process")),
+            StableKey::Bytes(Arc::from(&b"\x00\x01"[..])),
+        ]));
+        let full = rmp_serde::to_vec_named(&key).expect("encode");
+        for len in 1..full.len() {
+            assert!(
+                utils::deser::from_msgpack_slice::<StableKey>(&full[..len]).is_err(),
+                "truncation to {len} bytes must be rejected"
+            );
+        }
+        assert!(utils::deser::from_msgpack_slice::<StableKey>(&[]).is_err());
     }
 }

--- a/rust/core/src/state/stable_path.rs
+++ b/rust/core/src/state/stable_path.rs
@@ -45,8 +45,10 @@ impl Serialize for StableKey {
     }
 }
 
-/// Decodes one `StableKey` straight off a self-describing format, keeping the
-/// array / bin / str distinction the format already carries.
+/// Decodes one `StableKey` straight off a self-describing format, reading
+/// exactly what the format carries: seq -> `Array`, bytes -> `Bytes`,
+/// str -> `Str`, one-entry map -> tagged variant (`Uuid` / `Fingerprint` /
+/// `Symbol`).
 struct StableKeyVisitor;
 
 impl<'de> de::Visitor<'de> for StableKeyVisitor {
@@ -86,7 +88,7 @@ impl<'de> de::Visitor<'de> for StableKeyVisitor {
         self,
         mut seq: A,
     ) -> std::result::Result<StableKey, A::Error> {
-        let mut items = Vec::new();
+        let mut items = Vec::with_capacity(seq.size_hint().unwrap_or(0));
         while let Some(item) = seq.next_element::<StableKey>()? {
             items.push(item);
         }
@@ -94,8 +96,8 @@ impl<'de> de::Visitor<'de> for StableKeyVisitor {
     }
 
     /// Tagged variants are written as a one-entry map. Values are read through
-    /// `next_value` so `Uuid`/`Fingerprint` see the real format context instead
-    /// of a buffer that claims to be human-readable.
+    /// `next_value` so `Uuid`/`Fingerprint` decode against the real format
+    /// (msgpack `bin` here, base64 text in human-readable formats).
     fn visit_map<A: de::MapAccess<'de>>(
         self,
         mut map: A,
@@ -120,68 +122,13 @@ impl<'de> de::Visitor<'de> for StableKeyVisitor {
 }
 
 impl<'de> Deserialize<'de> for StableKey {
+    /// Round trip is guaranteed only for formats that natively distinguish
+    /// array / bin / str, such as MessagePack, which is what the state store
+    /// uses. Formats without a bytes type (JSON) serialize `Bytes` as an
+    /// integer sequence and read it back as `Array`; nothing in production
+    /// deserializes a `StableKey` from such formats.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        // Binary formats (msgpack, the state-store encoding) distinguish
-        // array / bin / str natively, so decode directly off the format.
-        // Untagged buffering erases that: a sequence is taken by `serde_bytes`
-        // before `Array` is tried, valid UTF-8 bytes are taken by `String`
-        // before `Bytes`, and the buffer reports a human-readable context that
-        // makes `Fingerprint` demand base64. Human-readable formats keep the
-        // untagged path below, where those ambiguities are unavoidable anyway.
-        // This check needs the original format context: an outer untagged or
-        // flatten adapter can lose it before reaching this method. Persisted
-        // stable keys must therefore be deserialized without such buffering.
-        if !deserializer.is_human_readable() {
-            return deserializer.deserialize_any(StableKeyVisitor);
-        }
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Null(()),
-            Bool(bool),
-            Int(i64),
-            Str(String),
-            // Intentionally before Array to preserve StableKey::Bytes roundtrip in
-            // human-readable formats (like JSON) where bytes serialize as a sequence
-            // of integers. Binary formats never reach this enum; see the
-            // `is_human_readable` branch above.
-            #[serde(with = "serde_bytes")]
-            Bytes(Vec<u8>),
-            Uuid {
-                uuid: uuid::Uuid,
-            },
-            Fp {
-                fp: utils::fingerprint::Fingerprint,
-            },
-            Sym {
-                sym: String,
-            },
-            Array(Vec<Repr>),
-        }
-
-        impl Repr {
-            fn into_stable_key(self) -> StableKey {
-                match self {
-                    Repr::Null(()) => StableKey::Null,
-                    Repr::Bool(b) => StableKey::Bool(b),
-                    Repr::Int(i) => StableKey::Int(i),
-                    Repr::Str(s) => StableKey::Str(Arc::from(s)),
-                    Repr::Bytes(b) => StableKey::Bytes(Arc::from(b)),
-                    Repr::Uuid { uuid } => StableKey::Uuid(uuid),
-                    Repr::Fp { fp } => StableKey::Fingerprint(fp),
-                    Repr::Sym { sym } => StableKey::Symbol(Arc::from(sym)),
-                    Repr::Array(items) => StableKey::Array(Arc::from(
-                        items
-                            .into_iter()
-                            .map(Repr::into_stable_key)
-                            .collect::<Vec<_>>(),
-                    )),
-                }
-            }
-        }
-
-        Ok(Repr::deserialize(deserializer)?.into_stable_key())
+        deserializer.deserialize_any(StableKeyVisitor)
     }
 }
 
@@ -492,6 +439,8 @@ mod tests {
         assert_eq!(decoded_empty, empty);
     }
 
+    /// JSON has no bytes type, so `Bytes` serializes as an integer sequence
+    /// and decodes as `Array`; every other variant round-trips unchanged.
     #[test]
     fn stable_key_serde_json_shape() {
         use serde_json::{Value, json};
@@ -499,23 +448,39 @@ mod tests {
         let uuid = uuid::Uuid::from_bytes([3u8; 16]);
         let fp = utils::fingerprint::Fingerprint([7u8; 16]);
 
-        let cases: Vec<(StableKey, Value)> = vec![
-            (StableKey::Null, Value::Null),
-            (StableKey::Bool(true), json!(true)),
-            (StableKey::Int(-7), json!(-7)),
-            (StableKey::Str(Arc::from("hi")), json!("hi")),
+        // (key, expected JSON, expected decoded key)
+        let cases: Vec<(StableKey, Value, StableKey)> = vec![
+            (StableKey::Null, Value::Null, StableKey::Null),
+            (StableKey::Bool(true), json!(true), StableKey::Bool(true)),
+            (StableKey::Int(-7), json!(-7), StableKey::Int(-7)),
+            (
+                StableKey::Str(Arc::from("hi")),
+                json!("hi"),
+                StableKey::Str(Arc::from("hi")),
+            ),
             (
                 StableKey::Bytes(Arc::from(&b"\x00\x01\xff"[..])),
                 json!([0, 1, 255]),
+                StableKey::Array(Arc::from([
+                    StableKey::Int(0),
+                    StableKey::Int(1),
+                    StableKey::Int(255),
+                ])),
             ),
-            (StableKey::Uuid(uuid), json!({ "uuid": uuid.to_string() })),
+            (
+                StableKey::Uuid(uuid),
+                json!({ "uuid": uuid.to_string() }),
+                StableKey::Uuid(uuid),
+            ),
             (
                 StableKey::Fingerprint(fp),
                 json!({ "fp": serde_json::to_value(fp).expect("fp to value") }),
+                StableKey::Fingerprint(fp),
             ),
             (
                 StableKey::Symbol(Arc::from("cocoindex/setup")),
                 json!({ "sym": "cocoindex/setup" }),
+                StableKey::Symbol(Arc::from("cocoindex/setup")),
             ),
             (
                 StableKey::Array(Arc::from([
@@ -523,14 +488,18 @@ mod tests {
                     StableKey::Str(Arc::from("a")),
                 ])),
                 json!([1, "a"]),
+                StableKey::Array(Arc::from([
+                    StableKey::Int(1),
+                    StableKey::Str(Arc::from("a")),
+                ])),
             ),
         ];
 
-        for (key, expected) in cases {
+        for (key, expected, expected_decoded) in cases {
             let got = serde_json::to_value(&key).expect("serialize");
             assert_eq!(got, expected);
-            let roundtrip: StableKey = serde_json::from_value(got).expect("deserialize");
-            assert_eq!(roundtrip, key);
+            let decoded: StableKey = serde_json::from_value(got).expect("deserialize");
+            assert_eq!(decoded, expected_decoded, "decoded shape for {key:?}");
         }
     }
 
@@ -557,8 +526,22 @@ mod tests {
         ]);
         assert_eq!(got, expected);
 
-        let roundtrip: StablePath = serde_json::from_value(got).expect("deserialize");
-        assert_eq!(roundtrip, path);
+        // The `Bytes` segment comes back as an `Array` of `Int`: JSON carries
+        // no bytes type, so the decoder reads the integer sequence it finds.
+        let expected_decoded = StablePath(Arc::from(vec![
+            StableKey::Int(42),
+            StableKey::Array(Arc::from([
+                StableKey::Int(0),
+                StableKey::Int(116),
+                StableKey::Int(101),
+                StableKey::Int(114),
+                StableKey::Int(109),
+            ])),
+            StableKey::Uuid(uuid),
+            StableKey::Fingerprint(fp),
+        ]));
+        let decoded: StablePath = serde_json::from_value(got).expect("deserialize");
+        assert_eq!(decoded, expected_decoded);
     }
 
     #[test]
@@ -785,14 +768,40 @@ mod tests {
                 "duplicate tag",
                 msgpack_map(&[("sym", msgpack_fixstr("a")), ("sym", msgpack_fixstr("b"))]),
             ),
-            ("null payload", msgpack_map(&[("uuid", vec![0xc0])])),
+            // A malformed or null payload must fail even when a valid tagged
+            // entry follows it; nothing falls through to the next entry.
+            (
+                "malformed payload before known tag",
+                msgpack_map(&[
+                    ("uuid", msgpack_fixstr("invalid")),
+                    ("sym", msgpack_fixstr("a")),
+                ]),
+            ),
+            (
+                "null payload before known tag",
+                msgpack_map(&[("uuid", vec![0xc0]), ("sym", msgpack_fixstr("a"))]),
+            ),
+            ("uuid null payload", msgpack_map(&[("uuid", vec![0xc0])])),
+            (
+                "fingerprint null payload",
+                msgpack_map(&[("fp", vec![0xc0])]),
+            ),
+            ("symbol null payload", msgpack_map(&[("sym", vec![0xc0])])),
             (
                 "uuid payload wrong length",
                 msgpack_map(&[("uuid", msgpack_bin(&[1u8; 4]))]),
             ),
             (
+                "uuid payload not bytes",
+                msgpack_map(&[("uuid", msgpack_fixstr("invalid"))]),
+            ),
+            (
                 "fingerprint payload wrong length",
                 msgpack_map(&[("fp", msgpack_bin(&[1u8; 4]))]),
+            ),
+            (
+                "fingerprint payload not bytes",
+                msgpack_map(&[("fp", msgpack_fixstr("invalid!"))]),
             ),
             (
                 "symbol payload not a string",
@@ -804,66 +813,6 @@ mod tests {
             assert!(
                 utils::deser::from_msgpack_slice::<StableKey>(&bytes).is_err(),
                 "{label} must be rejected"
-            );
-        }
-    }
-
-    /// The strict one-entry rule applies to binary formats only. JSON keeps
-    /// its prior lenient decoding, where unknown fields are ignored and a
-    /// recognized variant is chosen by enum priority.
-    #[test]
-    fn serde_json_tagged_map_stays_lenient() {
-        use serde_json::json;
-
-        let uuid = uuid::Uuid::from_bytes([3u8; 16]);
-        // Extra unknown field alongside a recognized tag.
-        let value = json!({ "sym": "a", "extra": 1 });
-        assert_eq!(
-            serde_json::from_value::<StableKey>(value).expect("lenient extra field"),
-            StableKey::Symbol(Arc::from("a"))
-        );
-        // Two recognized tags: `Uuid` precedes `Sym` in the untagged enum.
-        let value = json!({ "uuid": uuid.to_string(), "sym": "a" });
-        assert_eq!(
-            serde_json::from_value::<StableKey>(value).expect("lenient two tags"),
-            StableKey::Uuid(uuid)
-        );
-    }
-
-    #[test]
-    fn serde_json_tagged_map_payloads_and_duplicates() {
-        // Use raw JSON: constructing a serde_json::Value would discard
-        // duplicate fields before StableKey's deserializer sees them.
-        for json in [
-            r#"{"sym":"a","extra":1,"extra":2}"#,
-            r#"{"uuid":"invalid","sym":"a"}"#,
-            r#"{"sym":"a","uuid":"invalid"}"#,
-            r#"{"uuid":null,"sym":"a"}"#,
-            r#"{"fp":"invalid!","sym":"a"}"#,
-            r#"{"uuid":null,"uuid":null,"sym":"a"}"#,
-        ] {
-            assert_eq!(
-                serde_json::from_str::<StableKey>(json).expect("lenient tagged map"),
-                StableKey::Symbol(Arc::from("a")),
-                "unknown or invalid fields must not prevent a valid variant: {json}"
-            );
-        }
-
-        for json in [
-            r#"{}"#,
-            r#"{"unknown":1}"#,
-            r#"{"sym":"a","sym":"b"}"#,
-            r#"{"uuid":null}"#,
-            r#"{"fp":null}"#,
-            r#"{"sym":null}"#,
-            r#"{"uuid":"invalid"}"#,
-            r#"{"fp":"invalid!"}"#,
-            r#"{"fp":"AQ=="}"#,
-            r#"{"sym":1}"#,
-        ] {
-            assert!(
-                serde_json::from_str::<StableKey>(json).is_err(),
-                "map without a valid tagged variant must be rejected: {json}"
             );
         }
     }

--- a/rust/core/src/state/stable_path.rs
+++ b/rust/core/src/state/stable_path.rs
@@ -88,7 +88,7 @@ impl<'de> de::Visitor<'de> for StableKeyVisitor {
         self,
         mut seq: A,
     ) -> std::result::Result<StableKey, A::Error> {
-        let mut items = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        let mut items = Vec::new();
         while let Some(item) = seq.next_element::<StableKey>()? {
             items.push(item);
         }

--- a/rust/core/tests/target_owner_cleanup.rs
+++ b/rust/core/tests/target_owner_cleanup.rs
@@ -29,6 +29,14 @@ fn comp_path(name: &str) -> StablePath {
     StablePath(Arc::from(vec![StableKey::Str(Arc::from(name))]))
 }
 
+/// `/"process"/<segment>`: a component path whose last segment is not a `Str`.
+fn typed_comp_path(segment: StableKey) -> StablePath {
+    StablePath(Arc::from(vec![
+        StableKey::Str(Arc::from("process")),
+        segment,
+    ]))
+}
+
 fn target_path(name: &str) -> TargetStatePath {
     TargetStatePath::new(Fingerprint::from(name).unwrap(), None)
 }
@@ -109,4 +117,78 @@ async fn delete_preserves_owner_row_preempted_by_other_component() {
     commit_owner_deletes(&store, &old_owner, vec![tsp.clone()]).await;
 
     assert_eq!(read_owner(&storage, &store, &tsp).await, Some(new_owner));
+}
+
+/// A component whose path contains a tuple segment must be able to delete its
+/// own owner row. Before the msgpack codec fix the stored path decoded as
+/// bytes, the equality guard failed, and the row leaked.
+#[tokio::test]
+async fn delete_removes_own_owner_row_with_non_str_segments() {
+    let (storage, store, _dir) = make_test_store().await;
+    for (label, owner) in [
+        (
+            "tuple",
+            typed_comp_path(StableKey::Array(Arc::from(vec![
+                StableKey::Int(1),
+                StableKey::Int(2),
+            ]))),
+        ),
+        (
+            "utf8 bytes",
+            typed_comp_path(StableKey::Bytes(Arc::from(&b"abc"[..]))),
+        ),
+        (
+            "empty tuple",
+            typed_comp_path(StableKey::Array(Arc::from(vec![]))),
+        ),
+    ] {
+        let tsp = target_path(label);
+        upsert_owner(&storage, &store, &tsp, &owner).await;
+        assert_eq!(
+            read_owner(&storage, &store, &tsp).await,
+            Some(owner.clone()),
+            "{label}: owner path must read back unchanged"
+        );
+
+        commit_owner_deletes(&store, &owner, vec![tsp.clone()]).await;
+        assert_eq!(
+            read_owner(&storage, &store, &tsp).await,
+            None,
+            "{label}: own owner row must be deleted"
+        );
+    }
+}
+
+/// Paths that differ only by segment *type* are different components, so a
+/// delete issued from one must never drop the other's owner row. The msgpack
+/// codec used to collapse array->bytes and bytes->string, making the
+/// ownership guard treat these pairs as equal.
+#[tokio::test]
+async fn delete_preserves_owner_row_differing_only_by_segment_type() {
+    let (storage, store, _dir) = make_test_store().await;
+    let tuple = StableKey::Array(Arc::from(vec![StableKey::Int(1), StableKey::Int(2)]));
+    let tuple_as_bytes = StableKey::Bytes(Arc::from(&[1u8, 2u8][..]));
+    let text = StableKey::Str(Arc::from("abc"));
+    let text_as_bytes = StableKey::Bytes(Arc::from(&b"abc"[..]));
+
+    for (label, owner_segment, deleter_segment) in [
+        ("tuple owner, bytes deleter", &tuple, &tuple_as_bytes),
+        ("bytes owner, tuple deleter", &tuple_as_bytes, &tuple),
+        ("str owner, bytes deleter", &text, &text_as_bytes),
+        ("bytes owner, str deleter", &text_as_bytes, &text),
+    ] {
+        let owner = typed_comp_path(owner_segment.clone());
+        let deleter = typed_comp_path(deleter_segment.clone());
+        assert_ne!(owner, deleter);
+        let tsp = target_path(label);
+
+        upsert_owner(&storage, &store, &tsp, &owner).await;
+        commit_owner_deletes(&store, &deleter, vec![tsp.clone()]).await;
+
+        assert_eq!(
+            read_owner(&storage, &store, &tsp).await,
+            Some(owner),
+            "{label}: another component's owner row must survive"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #2401.

## Problem

`StableKey::deserialize` used an untagged `Repr` enum. Serde's untagged buffering erases distinctions MessagePack already encodes:

- arrays are consumed by `serde_bytes` before `Array` is tried, so `/"process"/[1,2]` read back as `/"process"/b"\x01\x02"`
- valid-UTF-8 bytes are consumed by `String` before `Bytes`, so `b"abc"` read back as `"abc"`
- the buffer reports a human-readable context, so `Fingerprint` demands base64 and fails to deserialize at all

The state store embeds `StableKey` in its MessagePack values, so the effects were not limited to display:

- `AppStore::commit()` drops an owner row only when its decoded component path equals the deleting component's path. Tuple and UTF-8-bytes paths failed that comparison and leaked their rows.
- Two components whose paths differ only by segment type compared equal, so one could delete the other's owner row.
- Ownership transfer, the pending-operation check and inspection all resolve the previous owner through the same decoded path, so they could miss the real owner or mark a live row `[dangling]`.

## Fix

`rust/core/src/state/stable_path.rs` is the only production code change. `StableKey::deserialize` now decodes straight off the format with a visitor for every format instead of buffering. The untagged `Repr` enum is deleted, and with it the `serde_bytes` dependency.

`Serialize`, storekey encoding, fingerprints and the ownership guards are unchanged, and rows written by earlier versions stay readable, so there is no storage-schema or cache-version bump.

## Compatibility decisions

The issue asked for these two to be settled explicitly.

1. **One decode path for every format.** Round trip is guaranteed only for formats that natively distinguish array / bin / str, which is what the state store uses (MessagePack). JSON has no bytes type, so `Bytes` serializes as an integer sequence and decodes as `Array`. Nothing in production deserializes a `StableKey` from JSON, so no second set of decoding rules is kept for it. `stable_key_serde_json_shape` / `stable_path_serde_json_shape` keep their serialization assertions and now assert that decoded form explicitly.
2. **Tagged maps are strict under every format:** exactly one entry, keyed `uuid`, `fp` or `sym`. Unknown keys, extra entries, duplicate keys, empty maps and null or malformed payloads are rejected rather than resolved by enum priority (the old behaviour let a valid `uuid` plus a `sym` silently decode as a UUID). No first-key-wins fallback. The serializer only ever writes one entry, so nothing previously written is affected.

## Tests

Covers the issue's test plan across six files. The tuple and bytes segments under test are shared constants in `python/tests/common/target_states.py`.

- `rust/core/src/state/stable_path.rs`: round trips through `from_msgpack_slice` for every variant; empty/singleton/repeated/reordered arrays; integer boundaries `0`, `255`, `-1`, `256`, `i64::MIN/MAX`; nested and heterogeneous arrays; empty, ASCII, Unicode, NUL-containing and invalid-UTF-8 bytes; root path versus an empty-array segment; hard-coded wire fixtures including the issue's `[0x92, 0x01, 0x02]`, asserted against the unchanged serializer; the tagged-map accept/reject matrix; rejection of `u64` above `i64::MAX`, floats, every truncation prefix and empty input; JSON shape, including `Bytes` decoding as `Array`.
- `rust/core/tests/target_owner_cleanup.rs`: owner round trip and own-row deletion for tuple, UTF-8-bytes and empty-tuple paths; the preempted-owner guard extended over tuple/bytes, bytes/tuple, str/bytes and bytes/str pairs.
- `rust/core/src/inspect/db_inspect.rs`: tuple/bytes owner rendering, no false dangling marker, and segment-name-only resolution for paths with no owner or tracking record.
- `python/tests/core/test_component_target_states.py`: create, unchanged re-run under `@coco.fn(memo=True)`, reopening the persisted store in a fresh `Environment`, then unmount; asserts target data, tracking paths and `list_target_state_owners`.
- `python/tests/core/test_ownership_transfer.py`: ordered transfer between tuple-segment and bytes-segment components, asserting the previous state reaches the new owner as a single upsert carrying `prev`. The blocked-sink concurrent-claim test is parametrized two ways: over string segments and over tuple/bytes segments (where the reclaimer's segment is exactly the bytes a collapsing codec would produce from the owner's tuple), and over resuming in the same update versus exhausting the pending-transfer retries. The exhaustion variant is what proves precommit observed the in-flight owner and refused the takeover; it also checks the next update completes the transfer with no further errors.
- `python/tests/cli/test_cli.py` plus a new `python/tests/cli/typed_key_app.py`: `show --target-states` renders `[1,2]` and `b"abc"` with their owners, no `#fingerprint` and no `[dangling]`, both with the app module loaded and from the database alone via `--db/--app-name`. The flat in-memory store both CLI fixture apps use moved to `python/tests/cli/target_store.py` so it accepts non-string keys.

Every new test was checked to fail against the previous untagged decoder and pass with the visitor. The one exception is the malformed-input rejection test, which holds on both paths; it covers input validation the issue asked for rather than the regression itself.

## Verification

`prek run --all-files` passes in full, which includes `cargo test`, `cargo check` for the Rust examples and benchmarks, `mypy`, `ruff format` and the whole `pytest` suite.

## Not in scope

The decoder fix does not recreate owner rows that were already incorrectly removed, nor remove rows already orphaned by a previous run. As the issue notes, a repair or GC sweep is separate work.

