### PR TITLE
fix(target_state): key sink identity by type and reject non-weakref-able callbacks

### DIFF
--- a/dev/agent-skills/target-connector/SKILL.md
+++ b/dev/agent-skills/target-connector/SKILL.md
@@ -215,13 +215,13 @@ def _apply_actions(
 _shared_sink = coco.TargetActionSink.from_fn(_apply_actions)
 ```
 
-Sink identity is **value-based**: sinks whose callbacks compare equal share one
-batching identity, meaning their actions are batched and applied together (and
-a batch is the natural transaction boundary for transactional stores). For a
-sink scoped to an external resource — e.g. one sink per database so all of that
-database's writes share a transaction — make the callback a frozen dataclass
-keyed by the resource and construct it on the fly in `reconcile()`; no
-module-level sink registry is needed:
+Sink identity is **value-based**: sinks whose callbacks are of the same type and
+compare equal share one batching identity, meaning their actions are batched and
+applied together (and a batch is the natural transaction boundary for
+transactional stores). For a sink scoped to an external resource — e.g. one sink
+per database so all of that database's writes share a transaction — make the
+callback a frozen dataclass keyed by the resource and construct it on the fly in
+`reconcile()`; no module-level sink registry is needed:
 
 ```python
 @dataclasses.dataclass(frozen=True)
@@ -238,9 +238,23 @@ class _DbSink:
 sink = coco.TargetActionSink.from_async_fn(_DbSink(key.db_key))
 ```
 
-An idle sink identity (no live sink object, no pending actions) is released
-automatically, so per-resource sinks do not accumulate for the process
-lifetime.
+A value-keyed callback must have two properties, and the framework enforces
+both:
+
+- **Type-safe equality.** Identity is keyed by the callback's exact type as
+  well as `==`, so a callback only ever shares identity with instances of its
+  own class. Without this, a class with a permissive `__eq__` would silently
+  route another connector's actions to its `__call__`.
+- **Weak-referenceable.** An idle sink identity (no live sink object, no
+  pending actions) is released automatically, so per-resource sinks do not
+  accumulate for the process lifetime. That relies on referencing the
+  canonical callback only weakly, so `from_fn`/`from_async_fn` raise
+  `TypeError` for a callback that does not support weak references.
+
+A `tuple`/`NamedTuple` fails both (it compares equal to any same-shaped tuple
+and cannot be weakly referenced) and is rejected. The frozen dataclass above is
+the recommended shape; if you add `slots=True` to it, also pass
+`weakref_slot=True`.
 
 ### Input Safety
 

--- a/python/cocoindex/_internal/target_state.py
+++ b/python/cocoindex/_internal/target_state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import (
-    Callable,
     Collection,
     Generic,
     Literal,
@@ -155,10 +154,13 @@ class TargetActionSink(Generic[ActionT_contra, OptChildHandlerT_co]):
         """Create a sink from a sync callback.
 
         Sinks share one identity — actions reconciled to them are batched and
-        applied together — iff their callbacks compare equal. The same function
-        or bound method always yields the same identity; a callable with value
-        equality (e.g. a frozen dataclass implementing ``__call__``) may be
-        constructed on the fly at each ``reconcile()`` call.
+        applied together — iff their callbacks are of the same type and compare
+        equal. The same function or bound method always yields the same
+        identity; a callable with value equality (e.g. a frozen dataclass
+        implementing ``__call__``) may be constructed on the fly at each
+        ``reconcile()`` call. The callback must support weak references, so an
+        idle identity can be released; a tuple/NamedTuple callback is rejected
+        with ``TypeError``.
         """
         canonical = _SYNC_FN_DEDUPER.get_canonical(fn)
         return TargetActionSink(core.TargetActionSink.new_sync(canonical))
@@ -178,22 +180,34 @@ class TargetActionSink(Generic[ActionT_contra, OptChildHandlerT_co]):
 
 class _CanonicalKey:
     """Dict key for `_ObjectDeduper`: hashes by the referent's value without
-    (where possible) keeping the referent alive.
+    keeping the referent alive.
 
-    Holds a weak reference when the object supports one, else the object
-    itself. A key whose referent died compares equal only to itself, so an
-    expired entry can never satisfy a lookup by value.
+    Holds only a weak reference, so the referent must be weakref-able; one that
+    is not (e.g. a tuple/NamedTuple instance) is rejected at construction rather
+    than pinned for the process lifetime. A key whose referent died compares
+    equal only to itself, so an expired entry can never satisfy a lookup by
+    value.
+
+    Equality also requires the exact same type. ``==`` alone is not type-safe
+    (a NamedTuple equals any same-shaped tuple, and a user class may define a
+    permissive ``__eq__``), and canonicalizing across types would route one
+    type's actions to the other type's callback.
     """
 
     __slots__ = ("get", "_hash")
+    get: weakref.ref[Any]
+    _hash: int
 
     def __init__(self, obj: Any) -> None:
-        self.get: Callable[[], Any]
         try:
             self.get = weakref.ref(obj)
         except TypeError:
-            # Not weakref-able (e.g. a NamedTuple instance): pin the object.
-            self.get = lambda: obj
+            raise TypeError(
+                f"target action sink callback of type {qualified_name(type(obj))} "
+                "must support weak references; define it as a frozen dataclass "
+                "(with weakref_slot=True if it uses slots=True) rather than a "
+                "tuple/NamedTuple"
+            ) from None
         self._hash = hash(obj)
 
     def __hash__(self) -> int:
@@ -206,13 +220,14 @@ class _CanonicalKey:
         if obj is None:
             return False
         if isinstance(other, _CanonicalKey):
-            other_obj = other.get()
-            return other_obj is not None and bool(obj == other_obj)
-        return bool(obj == other)
+            other = other.get()
+            if other is None:
+                return False
+        return type(other) is type(obj) and bool(obj == other)
 
 
 class _ObjectDeduper:
-    """Canonicalize equal objects to one representative.
+    """Canonicalize equal objects of one type to one representative.
 
     `TargetActionSink.from_fn`/`from_async_fn` route callbacks through this so
     equal callbacks map to one canonical object, whose pointer the Rust side
@@ -220,11 +235,11 @@ class _ObjectDeduper:
     `rust/py/src/target_state.rs`) — together giving sinks value-based
     identity.
 
-    Entries reference the canonical only weakly where the object supports weak
-    references; the sink keeper holds its callback strongly, so a canonical
-    stays pinned exactly while some sink still uses it. Once nothing does, the
-    entry expires — a later equal object becomes the new canonical — and
-    expired entries are swept once the map grows past a doubling threshold.
+    Entries reference the canonical only weakly; the sink keeper holds its
+    callback strongly, so a canonical stays pinned exactly while some sink
+    still uses it. Once nothing does, the entry expires — a later equal object
+    becomes the new canonical — and expired entries are swept once the map
+    grows past a doubling threshold.
     """
 
     _MIN_PRUNE_AT = 64
@@ -247,11 +262,10 @@ class _ObjectDeduper:
                 if value is not None:
                     return value
 
+            key = _CanonicalKey(obj)
             if len(self._map) >= self._prune_at:
                 self._map = {k: k for k in self._map if k.get() is not None}
                 self._prune_at = max(self._MIN_PRUNE_AT, 2 * len(self._map))
-
-            key = _CanonicalKey(obj)
             self._map[key] = key
             return obj
 

--- a/python/tests/core/test_target_sink_identity.py
+++ b/python/tests/core/test_target_sink_identity.py
@@ -1,10 +1,11 @@
 """Tests for value-based ``TargetActionSink`` identity.
 
-Sinks built from callbacks that compare equal share one batching identity:
-their actions land in the same engine batch and are applied in one call, even
-when each ``reconcile()`` constructs a fresh (equal) callback. An idle
-identity — no live sink object, no pending actions — is released rather than
-pinned for the process lifetime.
+Sinks built from callbacks of the same type that compare equal share one
+batching identity: their actions land in the same engine batch and are applied
+in one call, even when each ``reconcile()`` constructs a fresh (equal)
+callback. An idle identity — no live sink object, no pending actions — is
+released rather than pinned for the process lifetime, which is why a callback
+must support weak references.
 """
 
 from __future__ import annotations
@@ -14,6 +15,8 @@ import threading
 import weakref
 from dataclasses import dataclass
 from typing import Any, Collection, NamedTuple
+
+import pytest
 
 import cocoindex as coco
 from tests import common
@@ -40,8 +43,50 @@ class _RecordingSink:
             _batches.append(list(actions))
 
 
+@dataclass(frozen=True)
+class _OtherRecordingSink:
+    """A distinct frozen-dataclass type with the same fields as ``_RecordingSink``."""
+
+    group: str
+
+    async def __call__(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[Any, Any]],
+        /,
+    ) -> None:
+        pass
+
+
+class _PermissiveSink:
+    """Weakref-able callback whose ``__eq__`` is not type-safe: it equals any
+    object carrying an equal ``group``, whatever that object's class."""
+
+    def __init__(self, group: str) -> None:
+        self.group = group
+
+    def __eq__(self, other: object) -> bool:
+        return getattr(other, "group", None) == self.group
+
+    def __hash__(self) -> int:
+        return hash(self.group)
+
+    async def __call__(
+        self,
+        context_provider: coco.ContextProvider,
+        actions: Collection[tuple[Any, Any]],
+        /,
+    ) -> None:
+        pass
+
+
+class _OtherPermissiveSink(_PermissiveSink):
+    """A distinct type whose instances compare equal to ``_PermissiveSink``'s."""
+
+
 class _NtSink(NamedTuple):
-    """NamedTuple variant: not weakref-able, exercising the deduper's fallback."""
+    """NamedTuple callback: equal to any same-shaped tuple and not weakref-able,
+    so the framework must reject it rather than canonicalize it."""
 
     group: str
 
@@ -141,12 +186,60 @@ def test_sink_identity_by_callback_value() -> None:
     assert hash(a1._core) == hash(a2._core)
     assert a1._core != b._core
 
-    # NamedTuple callables (not weakref-able) still canonicalize by value.
-    nt1 = coco.TargetActionSink.from_async_fn(_NtSink("a"))
-    nt2 = coco.TargetActionSink.from_async_fn(_NtSink("a"))
-    assert nt1._core == nt2._core
-    # ...and stay distinct from other callback types with equal field values.
-    assert nt1._core != a1._core
+
+def test_sink_identity_is_keyed_by_callback_type() -> None:
+    # Distinct frozen-dataclass types with equal field values: distinct identities.
+    assert (
+        coco.TargetActionSink.from_async_fn(_RecordingSink("a"))._core
+        != coco.TargetActionSink.from_async_fn(_OtherRecordingSink("a"))._core
+    )
+
+    # A permissive ``__eq__`` that holds across types must not merge identities
+    # either — the engine would otherwise route one type's actions to the
+    # other type's ``__call__``. Within one type, value equality still shares.
+    assert _PermissiveSink("a") == _OtherPermissiveSink("a")
+    p1 = coco.TargetActionSink.from_async_fn(_PermissiveSink("a"))
+    p2 = coco.TargetActionSink.from_async_fn(_PermissiveSink("a"))
+    other = coco.TargetActionSink.from_async_fn(_OtherPermissiveSink("a"))
+    assert p1._core == p2._core
+    assert p1._core != other._core
+
+
+def test_non_weakrefable_callback_is_rejected() -> None:
+    with pytest.raises(TypeError, match="must support weak references"):
+        coco.TargetActionSink.from_async_fn(_NtSink("a"))
+
+    @dataclass(frozen=True, slots=True)
+    class _SlotsSink:
+        group: str
+
+        def __call__(
+            self,
+            context_provider: coco.ContextProvider,
+            actions: Collection[tuple[Any, Any]],
+            /,
+        ) -> None:
+            pass
+
+    with pytest.raises(TypeError, match="weakref_slot=True"):
+        coco.TargetActionSink.from_fn(_SlotsSink("a"))
+
+    @dataclass(frozen=True, slots=True, weakref_slot=True)
+    class _WeakrefSlotsSink:
+        group: str
+
+        def __call__(
+            self,
+            context_provider: coco.ContextProvider,
+            actions: Collection[tuple[Any, Any]],
+            /,
+        ) -> None:
+            pass
+
+    assert (
+        coco.TargetActionSink.from_fn(_WeakrefSlotsSink("a"))._core
+        == coco.TargetActionSink.from_fn(_WeakrefSlotsSink("a"))._core
+    )
 
 
 def test_sync_sink_identity_and_async_separation() -> None:


### PR DESCRIPTION
## Summary

`TargetActionSink.from_fn` / `from_async_fn` give sinks value-based identity (#2368): callbacks that compare equal canonicalize to one object (`_ObjectDeduper`), and the Rust `SinkKeeperRegistry` interns one keeper per canonical pointer. That mechanism silently depended on two callback properties that were only stated as a guideline. This PR enforces both in the engine.

1. **Type-keyed canonicalization.** `_CanonicalKey.__eq__` now requires `type(a) is type(b)` in addition to `a == b`. Plain `==` is not type-safe: a `NamedTuple` equals any same-shaped tuple, so two connectors' sinks with equal field values would canonicalize to one keeper and the engine would route one connector's actions to the other's `__call__` silently. The type check is the general defense and also covers user classes with a permissive `__eq__`. Every existing pattern is preserved: same function, same-instance bound method, `functools.partial`, and equal frozen-dataclass instances still share identity.
2. **Reject non-weakref-able callbacks at construction.** The documented "idle sink identity is released automatically" lifetime relies on the deduper holding canonicals weakly. The old fallback pinned a non-weakref-able callback (`self.get = lambda: obj`) for the process lifetime, defeating the prune sweep. `_CanonicalKey.__init__` now raises `TypeError` naming the fix (frozen dataclass; `weakref_slot=True` if `slots=True`) instead, and `get` is always a `weakref.ref`.
3. **Tests.** `_NtSink(NamedTuple)` in `test_target_sink_identity.py` was presented as a valid shape "exercising the deduper's fallback"; it is now the negative case. New positive cross-type cases: two distinct frozen-dataclass types with equal fields, and two types whose permissive `__eq__` holds across them, both yield distinct `_core` identities. `@dataclass(frozen=True, slots=True)` is rejected; adding `weakref_slot=True` is accepted.
4. **Guideline.** The "Shared Action Sinks" section of `dev/agent-skills/target-connector/SKILL.md` now states both required properties, that `tuple`/`NamedTuple` fails both and is rejected, and the `weakref_slot=True` rule for `slots=True` dataclasses. `custom_target_connector.mdx` does not document value-based sinks yet, so there is nothing to mirror there.

No shipped connector is affected: every production caller passes a bound method or plain function.

## Coordination

#2240 declares `class _DbSink(NamedTuple)` and will fail the new construction check until it switches to `@dataclasses.dataclass(frozen=True)` (already requested in its review).

## Test plan

- [x] `uv run mypy`
- [x] `uv run pytest python/tests/core/test_target_sink_identity.py` (8 passed)
- [x] `prek run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
