### PR TITLE
fix: reference-count logic fingerprint registrations

### DIFF
--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -11,6 +11,7 @@ import pytest
 
 import cocoindex as coco
 from cocoindex._internal import core
+from cocoindex._internal.function import AsyncFunction, SyncFunction
 
 from tests import common
 from tests.common.environment import get_env_db_path
@@ -46,16 +47,23 @@ def _unload_module_functions(mod: ModuleType) -> None:
     """Unregister logic fingerprints for all coco functions in a module."""
     for attr_name in dir(mod):
         obj = getattr(mod, attr_name)
-        fp = getattr(obj, "_logic_fp", None)
-        if fp is not None:
-            core.unregister_logic_fingerprint(fp)
+        _release_logic_fp(obj)
         # Also scan class attributes for @coco.fn decorated methods.
         if isinstance(obj, type):
             for cls_attr_name in dir(obj):
-                cls_obj = getattr(obj, cls_attr_name, None)
-                cls_fp = getattr(cls_obj, "_logic_fp", None)
-                if cls_fp is not None:
-                    core.unregister_logic_fingerprint(cls_fp)
+                _release_logic_fp(getattr(obj, cls_attr_name, None))
+
+
+def _release_logic_fp(obj: object) -> None:
+    """Release a coco function's logic fingerprint registration now.
+
+    Clears ``_logic_fp`` so the object's ``__del__`` doesn't release it a second
+    time once the stale module is collected — that would drop the registration
+    held by an unchanged function in the next module version.
+    """
+    if isinstance(obj, (SyncFunction, AsyncFunction)) and obj._logic_fp is not None:
+        core.unregister_logic_fingerprint(obj._logic_fp)
+        obj._logic_fp = None
 
 
 def _load_module(
@@ -172,6 +180,73 @@ def test_component_memo_invalidated_on_logic_change() -> None:
     assert GlobalDictTarget.store.data["A"].data == "v2: value1"
 
     # v2: second run — component memo hit again
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+# ============================================================================
+# Redefining a function with identical code keeps its memo — e.g. a notebook
+# cell or `importlib.reload` re-running a `@coco.fn` definition. The new object
+# registers the same logic fingerprint before the old object is dropped, so
+# dropping the old one must not unregister it from under the new one.
+# ============================================================================
+
+
+def _define_sync_memo_fn(metrics: Metrics) -> SyncFunction[[str], None]:
+    @coco.fn(memo=True)
+    def sync_memo_fn(key: str) -> None:
+        metrics.increment(f"sync_memo_fn({key})")
+
+    return sync_memo_fn
+
+
+def _define_async_memo_fn(metrics: Metrics) -> AsyncFunction[[str], None]:
+    @coco.fn(memo=True)
+    async def async_memo_fn(key: str) -> None:
+        metrics.increment(f"async_memo_fn({key})")
+
+    return async_memo_fn
+
+
+def test_memo_hit_survives_redefining_fn_with_identical_code() -> None:
+    """Rebinding a memoized function's name to an identical redefinition keeps
+    both its function memo and its component memo."""
+    metrics = Metrics()
+    sync_memo_fn = _define_sync_memo_fn(metrics)
+    async_memo_fn = _define_async_memo_fn(metrics)
+
+    @coco.fn
+    async def app_main() -> None:
+        sync_memo_fn("call")
+        await async_memo_fn("call")
+        await coco.use_mount(coco.component_subpath("sync"), sync_memo_fn, "mount")
+        await coco.use_mount(coco.component_subpath("async"), async_memo_fn, "mount")
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_memo_hit_survives_redefining_fn_with_identical_code",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    app.update_blocking()
+    assert metrics.collect() == {
+        "sync_memo_fn(call)": 1,
+        "async_memo_fn(call)": 1,
+        "sync_memo_fn(mount)": 1,
+        "async_memo_fn(mount)": 1,
+    }
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    # Each call below registers the new object's fingerprint before the
+    # rebinding drops the old object; collect so the old object's finalizer
+    # has run before the next update.
+    sync_memo_fn = _define_sync_memo_fn(metrics)
+    async_memo_fn = _define_async_memo_fn(metrics)
+    gc.collect()
+
     app.update_blocking()
     assert metrics.collect() == {}
 
@@ -1101,7 +1176,6 @@ def test_deps_fingerprint_contract() -> None:
     different deps differ, ``__coco_memo_key__()`` is honored, and ``deps``
     composes correctly with ``version``.
     """
-    from cocoindex._internal.function import SyncFunction
 
     def my_fn(x: str) -> str:
         return x + " done"

--- a/rust/core/src/engine/logic_registry.rs
+++ b/rust/core/src/engine/logic_registry.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::{LazyLock, RwLock};
 
 use cocoindex_utils::fingerprint::Fingerprint;
@@ -6,23 +7,33 @@ use cocoindex_utils::fingerprint::Fingerprint;
 use super::environment::Environment;
 use super::profile::EngineProfile;
 
-static CURRENT_LOGIC_SET: LazyLock<RwLock<HashSet<Fingerprint>>> =
-    LazyLock::new(|| RwLock::new(HashSet::new()));
+/// The current logic set, as the number of live registrations of each
+/// fingerprint in it. Counted because several live objects can share one
+/// fingerprint (e.g. a function redefined with identical code registers it
+/// before the old definition is dropped), and releasing one of them must not
+/// remove the fingerprint while the others still hold it.
+static CURRENT_LOGIC_REF_COUNTS: LazyLock<RwLock<HashMap<Fingerprint, usize>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
-/// Register a logic fingerprint in the current logic set.
+/// Register a logic fingerprint in the current logic set. Balance each call
+/// with one [`unregister`] when the registering object goes away.
 pub fn register(fp: Fingerprint) {
-    CURRENT_LOGIC_SET.write().unwrap().insert(fp);
+    *CURRENT_LOGIC_REF_COUNTS
+        .write()
+        .unwrap()
+        .entry(fp)
+        .or_default() += 1;
 }
 
 /// Check if a single fingerprint is in the current logic set.
 pub fn contains(fp: &Fingerprint) -> bool {
-    CURRENT_LOGIC_SET.read().unwrap().contains(fp)
+    CURRENT_LOGIC_REF_COUNTS.read().unwrap().contains_key(fp)
 }
 
 /// Check if all fingerprints are in the current logic set.
 pub fn all_contained(fps: &[Fingerprint]) -> bool {
-    let set = CURRENT_LOGIC_SET.read().unwrap();
-    fps.iter().all(|fp| set.contains(fp))
+    let ref_counts = CURRENT_LOGIC_REF_COUNTS.read().unwrap();
+    fps.iter().all(|fp| ref_counts.contains_key(fp))
 }
 
 /// Check if all fingerprints are in the global logic set or the environment's logic set.
@@ -30,12 +41,45 @@ pub fn all_contained_with_env<Prof: EngineProfile>(
     fps: &[Fingerprint],
     env: &Environment<Prof>,
 ) -> bool {
-    let global_set = CURRENT_LOGIC_SET.read().unwrap();
+    let ref_counts = CURRENT_LOGIC_REF_COUNTS.read().unwrap();
     fps.iter()
-        .all(|fp| global_set.contains(fp) || env.logic_set_contains(fp))
+        .all(|fp| ref_counts.contains_key(fp) || env.logic_set_contains(fp))
 }
 
-/// Remove a logic fingerprint from the current logic set.
+/// Release one registration of a logic fingerprint. It leaves the current logic
+/// set when its last registration is released; releasing a fingerprint that is
+/// not registered is a no-op.
 pub fn unregister(fp: &Fingerprint) {
-    CURRENT_LOGIC_SET.write().unwrap().remove(fp);
+    let mut ref_counts = CURRENT_LOGIC_REF_COUNTS.write().unwrap();
+    if let Entry::Occupied(mut entry) = ref_counts.entry(*fp) {
+        *entry.get_mut() -= 1;
+        if *entry.get() == 0 {
+            entry.remove();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_stays_registered_until_its_last_registration_is_released() {
+        // The registry is process-global, so use a fingerprint no other test registers.
+        let fp = Fingerprint::from("logic_registry::tests::shared_fingerprint").unwrap();
+
+        // Releasing an unregistered fingerprint is a no-op: it must not offset
+        // a later registration.
+        unregister(&fp);
+        register(fp);
+        register(fp);
+
+        unregister(&fp);
+        assert!(contains(&fp));
+        assert!(all_contained(&[fp]));
+
+        unregister(&fp);
+        assert!(!contains(&fp));
+        assert!(!all_contained(&[fp]));
+    }
 }

--- a/rust/py/src/logic_registry.rs
+++ b/rust/py/src/logic_registry.rs
@@ -1,13 +1,15 @@
 use crate::fingerprint::PyFingerprint;
 use crate::prelude::*;
 
-/// Register a logic fingerprint in the global current logic set.
+/// Register a logic fingerprint in the global current logic set. Balance each
+/// call with one `unregister_logic_fingerprint`.
 #[pyfunction]
 pub fn register_logic_fingerprint(fp: PyFingerprint) {
     cocoindex_core::engine::logic_registry::register(fp.0);
 }
 
-/// Remove a logic fingerprint from the global current logic set.
+/// Release one registration of a logic fingerprint. It leaves the global current
+/// logic set when its last registration is released.
 #[pyfunction]
 pub fn unregister_logic_fingerprint(fp: PyFingerprint) {
     cocoindex_core::engine::logic_registry::unregister(&fp.0);

--- a/rust/sdk/cocoindex/src/logic.rs
+++ b/rust/sdk/cocoindex/src/logic.rs
@@ -14,6 +14,8 @@
 //! function (whose fingerprint changes on recompile) leaves the old, now-absent
 //! fingerprint in a stale entry — correctly invalidating it.
 
+use std::sync::Once;
+
 use cocoindex_core::engine::logic_registry;
 use cocoindex_utils::fingerprint::Fingerprint;
 
@@ -38,12 +40,16 @@ fn entry_fingerprint(e: &FnLogicEntry) -> Option<Fingerprint> {
 }
 
 /// Register every `#[coco::function]`'s logic fingerprint into the engine's
-/// logic set. Idempotent (the set is a `HashSet`), so it is safe to call on
-/// every app/environment build.
+/// logic set. The slice is fixed at link time and these registrations are held
+/// for the life of the process, so only the first call registers; later calls
+/// (one per app/environment build) are no-ops.
 pub(crate) fn register_all_fn_logic() {
-    for entry in COCO_FN_LOGIC {
-        if let Some(fp) = entry_fingerprint(entry) {
-            logic_registry::register(fp);
+    static REGISTERED: Once = Once::new();
+    REGISTERED.call_once(|| {
+        for entry in COCO_FN_LOGIC {
+            if let Some(fp) = entry_fingerprint(entry) {
+                logic_registry::register(fp);
+            }
         }
-    }
+    });
 }


### PR DESCRIPTION
## Summary

A memoized function could lose its memo when an identical copy of it was garbage-collected.

The global logic-fingerprint registry (`rust/core/src/engine/logic_registry.rs`) was a `HashSet`. Each `SyncFunction`/`AsyncFunction` registers its fingerprint in `__init__` and unregisters it in `__del__`. Two live function objects can share one fingerprint (same module, qualname and code). When one of them was dropped, the fingerprint was removed for both.

This happens when a `@coco.fn(memo=True)` function is redefined with identical code:
- a re-run notebook cell
- `importlib.reload`
- a factory that defines the function on each call, like `_build_typed_path_app` in `test_component_target_states.py` (noticed while reviewing #2403)

The new object registers first. When the old object is dropped, its `__del__` removes the shared fingerprint. The surviving function's memo entries then fail the logic-deps check and re-execute, which can be expensive (e.g. embeddings).

## Changes

- **Reference-counted registry.** `register` increments a per-fingerprint count; `unregister` decrements it and removes the fingerprint at zero. Releasing an unregistered fingerprint is still a no-op. `contains`, `all_contained` and `all_contained_with_env` still test membership. The Rust and Python APIs are unchanged, and the docs on the `register_logic_fingerprint`/`unregister_logic_fingerprint` Python bindings now describe the counting.
- **Rust SDK.** `register_all_fn_logic` used to re-register every link-time function on each `Environment::build`, relying on set idempotence. It now registers once per process (`std::sync::Once`), since those registrations are never released.
- **Test helper fix.** `_unload_module_functions` in `test_logic_change_detection.py` released each old function's registration by hand. The object's `__del__` released it again once the stale module was collected, which dropped the fingerprint of functions left unchanged in the next module version (e.g. `foo_self` in `mod_logic_self_v1`/`v2`). This was a latent flake, since tests passed only because that collection usually happens later. With a `gc.collect()` forced before every update, 9 tests in the file failed. The helper now clears `_logic_fp` when it releases, so each registration is released exactly once.

## `env.logic_set_contains` does not hide the bug

The per-environment logic set only ever holds change-detected context-value fingerprints. Those come from `ContextProvider.provide`/`set_core_env` and the Rust SDK's `ContextStore::register_logic`, never from function logic. So the env fallback in `all_contained_with_env` can't cover for a missing function fingerprint. A variant of the reproduction whose function uses a `detect_change=True` context key still re-executed on the unfixed build.

The function-memo cache (`FnMemoCache`) is rebuilt from storage on every component build, so there is no in-memory revalidation skip either. The bug only goes unnoticed when the old object is dropped *before* the new one registers, which is what `del app; gc.collect()` in `_build_typed_path_app` does.

## Tests

- `test_memo_hit_survives_redefining_fn_with_identical_code` rebinds a sync and an async `@coco.fn(memo=True)` to identical redefinitions. It checks both memo paths: a function call (`decode_stored_entry`) and a mounted component (`use_or_invalidate_component_memoization`). On the unfixed build all four re-execute; with the fix all four hit.
- A `logic_registry` unit test: a fingerprint registered twice stays contained until both registrations are released, and an extra release doesn't cancel a later registration.

## Verification

- `uv run maturin develop`
- `cargo test -p cocoindex_core`: 94 passed
- SDK tests `logic_tracking`, `pipeline`, `user_state`, `live_component`, `target_state`: all passed
- `cargo check --workspace --all-targets`: clean
- `uv run mypy`: clean
- `uv run pytest python/tests/core/test_logic_change_detection.py python/tests/core/test_component_target_states.py`: 49 passed, also with a `gc.collect()` forced before every update
- `uv run pytest python/`: 1095 passed, 279 skipped
- `prek run --all-files`: passed with `TESTCONTAINERS_RYUK_DISABLED=true`, as CI sets it. A first run without it errored in `test_postgres_source.py` fixture setup (testcontainers' Ryuk reaper "did not become running"), before any test code ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
