### PR TITLE
fix: copying a coco function returns the function itself

### DIFF
--- a/python/cocoindex/_internal/function.py
+++ b/python/cocoindex/_internal/function.py
@@ -24,6 +24,7 @@ from typing import (
     NamedTuple,
     ParamSpec,
     Protocol,
+    Self,
     TypeAlias,
     TypeVar,
     cast,
@@ -745,6 +746,15 @@ class SyncFunction(Function[P, R_co]):
         if fp is not None:
             core.unregister_logic_fingerprint(fp)
 
+    # Copying returns this same object, as `copy` does for plain functions. A
+    # distinct copy would share `_logic_fp` without having registered it, so its
+    # `__del__` would release the registration this object holds.
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
+        return self
+
     @overload
     def __get__(self, instance: None, owner: type) -> SyncFunction[P, R_co]: ...
     @overload
@@ -1290,6 +1300,16 @@ class AsyncFunction(Function[P, R_co]):
         fp = getattr(self, "_logic_fp", None)
         if fp is not None:
             core.unregister_logic_fingerprint(fp)
+
+    # Same as `SyncFunction.__copy__`. Without these, `copy` would fall back to
+    # `__reduce__`, whose module/qualname lookup fails for a function defined in
+    # a local scope and returns the undecorated function when it was decorated
+    # under another name.
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
+        return self
 
     @property
     def _any_fn(self) -> AnyCallable[P, R_co]:

--- a/python/tests/core/test_logic_change_detection.py
+++ b/python/tests/core/test_logic_change_detection.py
@@ -1,5 +1,6 @@
 """Tests for logic change detection: memoized results are invalidated when function code changes."""
 
+import copy
 import gc
 import pathlib
 import sys
@@ -245,6 +246,57 @@ def test_memo_hit_survives_redefining_fn_with_identical_code() -> None:
     # has run before the next update.
     sync_memo_fn = _define_sync_memo_fn(metrics)
     async_memo_fn = _define_async_memo_fn(metrics)
+    gc.collect()
+
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+
+# ============================================================================
+# Copying a function keeps its memo: dropping a copy must not release the logic
+# fingerprint registration held by the original.
+# ============================================================================
+
+
+def test_memo_hit_survives_dropping_copies_of_fn() -> None:
+    """Dropping a `copy.copy` or `copy.deepcopy` of a memoized function keeps
+    both its function memo and its component memo."""
+    metrics = Metrics()
+    sync_memo_fn = _define_sync_memo_fn(metrics)
+    async_memo_fn = _define_async_memo_fn(metrics)
+
+    @coco.fn
+    async def app_main() -> None:
+        sync_memo_fn("call")
+        await async_memo_fn("call")
+        await coco.use_mount(coco.component_subpath("sync"), sync_memo_fn, "mount")
+        await coco.use_mount(coco.component_subpath("async"), async_memo_fn, "mount")
+
+    app = coco.App(
+        coco.AppConfig(
+            name="test_memo_hit_survives_dropping_copies_of_fn",
+            environment=coco_env,
+        ),
+        app_main,
+    )
+
+    app.update_blocking()
+    assert metrics.collect() == {
+        "sync_memo_fn(call)": 1,
+        "async_memo_fn(call)": 1,
+        "sync_memo_fn(mount)": 1,
+        "async_memo_fn(mount)": 1,
+    }
+    app.update_blocking()
+    assert metrics.collect() == {}
+
+    copies = [
+        copy.copy(sync_memo_fn),
+        copy.deepcopy(sync_memo_fn),
+        copy.copy(async_memo_fn),
+        copy.deepcopy(async_memo_fn),
+    ]
+    del copies
     gc.collect()
 
     app.update_blocking()


### PR DESCRIPTION
## Summary

Dropping a copy of a memoized sync function made the original lose its memo.

`SyncFunction.__init__` takes one registration of the function's logic fingerprint in the process-global registry (`rust/core/src/engine/logic_registry.rs`), and `__del__` releases it. `SyncFunction` had no `__copy__`, so `copy.copy(fn)` built a new object from the slot state without running `__init__`. The copy shared `_logic_fp` but never registered it, and its `__del__` still unregistered it. Once the copy was dropped, the fingerprint left the registry while the original was still alive, and every memo entry that depended on it re-executed.

The reference counting from #2405 doesn't prevent this, because the copy releases a registration it never took. The set-based registry before #2405 failed the same way.

## Changes

`SyncFunction` and `AsyncFunction` now define `__copy__` and `__deepcopy__` that return `self`, the same way `copy` treats plain functions. A copy that is the original object has no `__del__` of its own, so registrations stay balanced.

What `copy.copy` / `copy.deepcopy` return:

| Function | Before | After |
|---|---|---|
| sync | a distinct copy with an unregistered fingerprint / `TypeError: cannot pickle 'builtins.ComponentProcessorInfo' object` | the function |
| async, module-level | the function (via `__reduce__`) | the function |
| async, defined in a local scope (e.g. a factory) | `AttributeError: 'function' object has no attribute '<locals>'` | the function |
| async, decorated under another name (`public = coco.fn(memo=True)(_impl)`) | the undecorated `_impl` | the function |

Without `__copy__`, `AsyncFunction` copies went through `__reduce__`, which looks the function up again by module and qualname. That lookup never built an unregistered `AsyncFunction`, so the registry was never affected, but it failed or returned the wrong object in the last two rows. Pickling still uses `__reduce__` and is unchanged.

## Tests

`test_memo_hit_survives_dropping_copies_of_fn` sits right after #2405's `test_memo_hit_survives_redefining_fn_with_identical_code` and reuses its function factories. It runs an app that calls and mounts a sync and an async `@coco.fn(memo=True)` function. It then drops a `copy.copy` and a `copy.deepcopy` of each, runs `gc.collect()`, updates again, and asserts that all four memo entries still hit.

Removing any one of the new methods makes the test fail:
- `SyncFunction.__copy__`: `sync_memo_fn(call)` and `sync_memo_fn(mount)` re-execute (the original bug)
- `SyncFunction.__deepcopy__`: `TypeError`
- `AsyncFunction.__copy__` or `AsyncFunction.__deepcopy__`: `AttributeError` (`<locals>`)

## Verification

- `uv run maturin develop`
- `uv run mypy`: clean
- `uv run pytest python/tests/core/test_logic_change_detection.py`: 26 passed
- `prek run --all-files` with `TESTCONTAINERS_RYUK_DISABLED=true`, as CI sets it: all hooks passed, including `cargo test`, the Rust examples/benchmarks check, and the full pytest run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
