### PR TITLE
test(sdk): serialize deadline tests that share the global test clock

### DIFF
--- a/rust/sdk/cocoindex/tests/deadline.rs
+++ b/rust/sdk/cocoindex/tests/deadline.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    Arc, Mutex,
+    Arc, Mutex, MutexGuard,
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::time::Duration;
@@ -16,12 +16,21 @@ use tokio::sync::Notify;
 
 static MEMO_CHILD_CALLS: AtomicUsize = AtomicUsize::new(0);
 
-struct TestClockGuard;
+// The deadline test clock is process-global and tests in this binary run on
+// parallel threads, so each `TestClockGuard` holds this lock for its lifetime.
+static TEST_CLOCK_LOCK: Mutex<()> = Mutex::new(());
+
+struct TestClockGuard {
+    _guard: MutexGuard<'static, ()>,
+}
 
 impl TestClockGuard {
     fn new() -> Self {
+        let guard = TEST_CLOCK_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         testing_reset_deadline_clock();
-        Self
+        Self { _guard: guard }
     }
 
     fn reset(&self) {


### PR DESCRIPTION
## Summary

Fixes the flaky `rust_sdk_deadline_conformance_subset` test. It failed on main in [CI run 34727252462](https://github.com/cocoindex-io/cocoindex/actions/runs/34727252462) for 75610ca4. That commit's Rust sources were identical to a PR head where the test passed. The failure was `unwrap_err()` on an `Ok` value at `tests/deadline.rs:269`.

**Root cause.** The deadline test clock lives in process-global statics in `rust/core/src/engine/deadline.rs`. Both tests in `tests/deadline.rs` run on parallel threads in the same binary. `mount_each_drains_started_siblings_on_deadline_error` builds and drops a `TestClockGuard`, which resets the clock and later disables it. If either step lands between a `testing_advance_deadline_clock(2s)` call and a deadline check in the conformance test, the 1s deadline never fires.

**Fix.** `TestClockGuard` now holds a file-level `Mutex` guard for its whole lifetime and recovers from poisoning. This is the same pattern the SDK unit tests in `src/ctx.rs` use. The core's own `testing_deadline_clock_lock()` is `#[cfg(test)] pub(crate)`, so integration tests can't use it.

- **Scope.** No other SDK integration test binary calls the `testing_*_deadline_clock` helpers. Test binaries run as separate processes, so only tests in the same binary can race.
- **No deadlock.** Each test builds exactly one guard, as its first statement. `reset()` doesn't take the lock. The guard is never moved into engine closures. A waiting test therefore blocks before it has created any engine state. Holding the `MutexGuard` across `.await` is fine because each `#[tokio::test]` owns its own runtime.

## Test plan

- [x] **Before the fix:** 1 of 100 local runs of the test binary failed with the same `unwrap_err()` on `Ok`, in the `use_mount` section.
- [x] **Race probe** (temporary, not committed): an extra test that loops `TestClockGuard::new()` and drop for 3s. With the old guard, 20/20 runs failed. With the new guard, 0/20 failed.
- [x] `cargo test -p cocoindex --test deadline`: 30/30 passed. Running the fixed test binary directly: 500/500 passed.
- [x] `prek run --all-files`: all hooks passed. The local Docker daemon was unresponsive, so pytest skipped the `requires_docker` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
